### PR TITLE
✨ textToImage inference

### DIFF
--- a/packages/inference/LICENSE
+++ b/packages/inference/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 TimMikeladze
+Copyright (c) 2022 Tim Mikeladze
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -775,5 +775,5 @@ type TextToImageArgs = Args & {
    */
   negative_prompt?: string
 };
-type TextToImageReturn = Buffer
+type TextToImageReturn = ArrayBuffer
 ```

--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -137,6 +137,12 @@ await hf.imageSegmentation({
   data: readFileSync('test/cats.png'),
   model: 'facebook/detr-resnet-50-panoptic'
 })
+
+await hf.textToImage({
+  inputs: 'award winning high resolution photo of a giant tortoise/((ladybird)) hybrid, [trending on artstation]',
+  negative_prompt: 'blurry',
+  model: 'stabilityai/stable-diffusion-2',
+})
 ```
 
 ## Supported APIs
@@ -167,6 +173,7 @@ await hf.imageSegmentation({
 - [x] Image classification
 - [x] Object detection
 - [x] Image segmentation
+- [x] Text to image
 
 ## Running tests
 
@@ -296,6 +303,12 @@ export declare class HfInference {
     args: ImageSegmentationArgs,
     options?: Options
   ): Promise<ImageSegmentationReturn>
+
+  /**
+   * This task reads some text input and outputs an image.
+   * Recommended model: stabilityai/stable-diffusion-2
+   */
+  textToImage(args: TextToImageArgs, options?: Options): Promise<TextToImageReturn>;
   request(
     args: Args & {
       data?: any
@@ -752,4 +765,15 @@ export declare type AudioClassificationReturnValue = {
   score: number
 }
 export declare type AudioClassificationReturn = AudioClassificationReturnValue[]
+type TextToImageArgs = Args & {
+  /**
+   * The text to generate an image from
+   */
+  inputs: string
+  /**
+   * An optional negative prompt for the image generation
+   */
+  negative_prompt?: string
+};
+type TextToImageReturn = Buffer
 ```

--- a/packages/inference/src/HfInference.ts
+++ b/packages/inference/src/HfInference.ts
@@ -497,7 +497,7 @@ export type TextToImageArgs = Args & {
 	negative_prompt?: string;
 };
 
-export type TextToImageReturn = Buffer;
+export type TextToImageReturn = ArrayBuffer;
 
 export class HfInference {
 	private readonly apiKey:         string;
@@ -712,7 +712,7 @@ export class HfInference {
 			if (!response.ok) {
 				throw new Error("An error occurred while fetching the blob");
 			}
-			return Buffer.from(await response.arrayBuffer());
+			return await response.arrayBuffer();
 		} else {
 			output = await response.json();
 			if (output.error) {

--- a/packages/inference/test/HfInference.test.ts
+++ b/packages/inference/test/HfInference.test.ts
@@ -1,13 +1,14 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { jest } from "@jest/globals"; // 3 minute
 
-import { HfInference} from "../src";
+import { HfInference } from "../src";
 import { readFileSync } from "fs";
 
 jest.setTimeout(60000 * 3);
 
 if (!process.env.HF_ACCESS_TOKEN) {
-	throw new Error("Set HF_ACCESS_TOKEN in the env to run the tests")
+	throw new Error("Set HF_ACCESS_TOKEN in the env to run the tests");
 }
 
 describe("HfInference", () => {
@@ -269,5 +270,16 @@ describe("HfInference", () => {
 				}),
 			])
 		);
+	});
+	it("textToImage", async () => {
+		const res = await hf.textToImage({
+			inputs:          "award winning high resolution photo of a giant tortoise/((ladybird)) hybrid, [trending on artstation]",
+			negative_prompt: "blurry",
+			model:           "stabilityai/stable-diffusion-2",
+		});
+
+		expect(res).toBeInstanceOf(Buffer);
+
+		expect(res.toString("base64")).toBeTruthy();
 	});
 });

--- a/packages/inference/test/HfInference.test.ts
+++ b/packages/inference/test/HfInference.test.ts
@@ -278,8 +278,6 @@ describe("HfInference", () => {
 			model:           "stabilityai/stable-diffusion-2",
 		});
 
-		expect(res).toBeInstanceOf(Buffer);
-
-		expect(res.toString("base64")).toBeTruthy();
+		expect(res).toBeInstanceOf(ArrayBuffer);
 	});
 });


### PR DESCRIPTION
Closes #7 

Adds `text-to-image` support to the inference api. `textToImage` returns a `Buffer`. The consumer can then call `.toString('base64')` to get the generated image for usage in the browser, etc.

```ts
 await hf.textToImage({
			inputs:          "award winning high resolution photo of a giant tortoise/((ladybird)) hybrid, [trending on artstation]",
			negative_prompt: "blurry",
			model:           "stabilityai/stable-diffusion-2",
		});
```