### PR TITLE
🐛 wait_for_model fix and reanable imageSegmentation test

### DIFF
--- a/packages/inference/src/HfInference.ts
+++ b/packages/inference/src/HfInference.ts
@@ -653,10 +653,19 @@ export class HfInference {
 	): Promise<any> {
 		const mergedOptions = { ...this.defaultOptions, ...options };
 		const { model, ...otherArgs } = args;
+
+    const headers = {
+      Authorization: `Bearer ${this.apiKey}`,
+    }
+
+    if (mergedOptions.wait_for_model) {
+      headers["X-Wait-For-Model"] = "true";
+    }
+
 		const response = await fetch(`https://api-inference.huggingface.co/models/${model}`, {
-			headers: { Authorization: `Bearer ${this.apiKey}` },
-			method:  "POST",
-			body:    options?.binary
+			headers,
+			method: "POST",
+			body:   options?.binary
 				? args.data
 				: JSON.stringify({
 						...otherArgs,

--- a/packages/inference/src/HfInference.ts
+++ b/packages/inference/src/HfInference.ts
@@ -658,7 +658,7 @@ export class HfInference {
       Authorization: `Bearer ${this.apiKey}`,
     }
 
-    if (mergedOptions.wait_for_model) {
+    if (options?.binary && mergedOptions.wait_for_model) {
       headers["X-Wait-For-Model"] = "true";
     }
 

--- a/packages/inference/test/HfInference.test.ts
+++ b/packages/inference/test/HfInference.test.ts
@@ -9,7 +9,7 @@ jest.setTimeout(60000 * 3);
 if (!process.env.HF_ACCESS_TOKEN) {
 	throw new Error("Set HF_ACCESS_TOKEN in the env to run the tests")
 }
- 
+
 describe("HfInference", () => {
 	// Individual tests can be ran without providing an api key, however running all tests without an api key will result in rate limiting error.
 	const hf = new HfInference(process.env.HF_ACCESS_TOKEN);
@@ -254,7 +254,7 @@ describe("HfInference", () => {
 			])
 		);
 	});
-	xit("imageSegmentation", async () => {
+	it("imageSegmentation", async () => {
 		expect(
 			await hf.imageClassification({
 				data:  readFileSync("test/cats.png"),


### PR DESCRIPTION
Closes #4 

I noticed that in the code-sample provided in #7 the "wait for model" functionality is activated via the header `X-Wait-For-Model` instead of being sent in the body of the `POST` request. There is a discrepancy with the documentation in this regard https://huggingface.co/docs/api-inference/detailed_parameters

This made me wonder: should other options such as `use_cache` also be sent as headers?