### PR TITLE
remove authentication header when no api key is provided

### DIFF
--- a/packages/inference/src/HfInference.ts
+++ b/packages/inference/src/HfInference.ts
@@ -689,10 +689,6 @@ export class HfInference {
 			headers["X-Wait-For-Model"] = "true";
 		}
 
-		if (options?.binary && mergedOptions.wait_for_model) {
-			headers["X-Wait-For-Model"] = "true";
-		}
-
 		const response = await fetch(`https://api-inference.huggingface.co/models/${model}`, {
 			headers,
 			method: "POST",

--- a/packages/inference/src/HfInference.ts
+++ b/packages/inference/src/HfInference.ts
@@ -503,7 +503,7 @@ export class HfInference {
 	private readonly apiKey:         string;
 	private readonly defaultOptions: Options;
 
-	constructor(apiKey: string, defaultOptions: Options = {}) {
+	constructor(apiKey = "", defaultOptions: Options = {}) {
 		this.apiKey = apiKey;
 		this.defaultOptions = defaultOptions;
 	}
@@ -680,13 +680,18 @@ export class HfInference {
 		const mergedOptions = { ...this.defaultOptions, ...options };
 		const { model, ...otherArgs } = args;
 
-    const headers = {
-      Authorization: `Bearer ${this.apiKey}`,
-    }
+		const headers = {};
+		if (this.apiKey) {
+			headers["Authorization"] = `Bearer ${this.apiKey}`;
+		}
 
-    if (options?.binary && mergedOptions.wait_for_model) {
-      headers["X-Wait-For-Model"] = "true";
-    }
+		if (options?.binary && mergedOptions.wait_for_model) {
+			headers["X-Wait-For-Model"] = "true";
+		}
+
+		if (options?.binary && mergedOptions.wait_for_model) {
+			headers["X-Wait-For-Model"] = "true";
+		}
 
 		const response = await fetch(`https://api-inference.huggingface.co/models/${model}`, {
 			headers,

--- a/packages/inference/test/HfInference.test.ts
+++ b/packages/inference/test/HfInference.test.ts
@@ -7,6 +7,20 @@ import { readFileSync } from "fs";
 
 jest.setTimeout(60000 * 3);
 
+describe("HfInference without Autentication", () => {
+	// Testing rate limte without authentication
+	const hf = new HfInference();
+	it("should throw a rate limit too  many requests", async () => {
+		const model = "bert-base-uncased";
+		const input = "[MASK] world!";
+		const promises = [];
+		for (let i = 0; i < 100; i++) {
+			promises.push(hf.fillMask({ model, inputs: input }));
+		}
+		await expect(Promise.all(promises)).rejects.toThrowError("Rate limit reached. Please log in or use your apiToken");
+	});
+});
+
 if (!process.env.HF_ACCESS_TOKEN) {
 	throw new Error("Set HF_ACCESS_TOKEN in the env to run the tests");
 }


### PR DESCRIPTION
* remove header when token is not present
* simple test to check rate limit 
* formatting was done via `npm run format`
fix #28 