### PR TITLE
👷 Allow using secrets in inference tests in forks

### DIFF
--- a/.github/workflows/inference-test.yml
+++ b/.github/workflows/inference-test.yml
@@ -6,7 +6,7 @@ on:
       - "packages/inference/**"
     branches:
       - main
-  pull_request:
+  pull_request_target:
     paths:
       - ".github/workflows/inference-test.yml"
       - "packages/inference/**"


### PR DESCRIPTION
This should fix issues encountered in #27 (cc @Quatton)