### PR TITLE
`createRepo` return the repo's URL

### DIFF
--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -31,7 +31,7 @@ export interface CommitFile {
 	// forceLfs?: boolean
 }
 
-// TODO: find a nice way to handle LFS & non-LFS files in an uniform manner, see https://github.com/huggingface/moon-landing/issues/4370y
+// TODO: find a nice way to handle LFS & non-LFS files in an uniform manner, see https://github.com/huggingface/moon-landing/issues/4370
 // export type CommitRenameFile = {
 // 	operation: "rename";
 // 	path:      string;

--- a/packages/hub/src/lib/create-repo.spec.ts
+++ b/packages/hub/src/lib/create-repo.spec.ts
@@ -1,7 +1,7 @@
 import { assert, it, describe } from "vitest";
 
 import { randomBytes } from "crypto";
-import { TEST_ACCESS_TOKEN, TEST_USER } from "../consts";
+import { HUB_URL, TEST_ACCESS_TOKEN, TEST_USER } from "../consts";
 import { createRepo } from "./create-repo";
 import { deleteRepo } from "./delete-repo";
 import { downloadFile } from "./download-file";
@@ -10,7 +10,7 @@ describe("createRepo", () => {
 	it("should create a repo", async () => {
 		const repoName = `${TEST_USER}/TEST-${randomBytes(10).toString("hex")}`;
 
-		await createRepo({
+		const result = await createRepo({
 			credentials: {
 				accessToken: TEST_ACCESS_TOKEN,
 			},
@@ -19,6 +19,10 @@ describe("createRepo", () => {
 				type: "model",
 			},
 			files: [{ path: ".gitattributes", content: new Blob(["*.html filter=lfs diff=lfs merge=lfs -text"]) }],
+		});
+
+		assert.deepStrictEqual(result, {
+			repoUrl: `${HUB_URL}/${repoName}`,
 		});
 
 		const content = await downloadFile({

--- a/packages/hub/src/lib/create-repo.ts
+++ b/packages/hub/src/lib/create-repo.ts
@@ -15,7 +15,7 @@ export async function createRepo(params: {
 	/** @required for when {@link repo.type} === "space" */
 	sdk?:        SpaceSdk;
 	hubUrl?:     string;
-}): Promise<{ repoUrl: string; }> {
+}): Promise<{ repoUrl: string }> {
 	const [namespace, repoName] = params.repo.name.split("/");
 
 	const res = await fetch(`${params.hubUrl ?? HUB_URL}/api/repos/create`, {

--- a/packages/hub/src/lib/create-repo.ts
+++ b/packages/hub/src/lib/create-repo.ts
@@ -15,7 +15,7 @@ export async function createRepo(params: {
 	/** @required for when {@link repo.type} === "space" */
 	sdk?:        SpaceSdk;
 	hubUrl?:     string;
-}): Promise<string> {
+}): Promise<{ repoUrl: string; }> {
 	const [namespace, repoName] = params.repo.name.split("/");
 
 	const res = await fetch(`${params.hubUrl ?? HUB_URL}/api/repos/create`, {
@@ -55,5 +55,5 @@ export async function createRepo(params: {
 		throw await createApiError(res);
 	}
 	const output = await res.json();
-	return output.url;
+	return { repoUrl: output.url };
 }

--- a/packages/hub/src/lib/create-repo.ts
+++ b/packages/hub/src/lib/create-repo.ts
@@ -15,7 +15,7 @@ export async function createRepo(params: {
 	/** @required for when {@link repo.type} === "space" */
 	sdk?:        SpaceSdk;
 	hubUrl?:     string;
-}): Promise<void> {
+}): Promise<string> {
 	const [namespace, repoName] = params.repo.name.split("/");
 
 	const res = await fetch(`${params.hubUrl ?? HUB_URL}/api/repos/create`, {
@@ -54,4 +54,6 @@ export async function createRepo(params: {
 	if (!res.ok) {
 		throw await createApiError(res);
 	}
+	const output = await res.json();
+	return output.url;
 }


### PR DESCRIPTION
we could also do something fancier like `huggingface_hub` i.E. separate the namespace, repo_type etc.: https://github.com/huggingface/huggingface_hub/blob/599647c4d728f8954c6e285ba11aa3d316a6af36/src/huggingface_hub/hf_api.py#L254

but probably overkill
