### PR TITLE
🐛 Fix browser detection

### DIFF
--- a/packages/hub/src/utils/sha256.ts
+++ b/packages/hub/src/utils/sha256.ts
@@ -13,7 +13,12 @@ export async function sha256(buffer: Blob): Promise<string> {
 		);
 	}
 
-	if (typeof __filename === undefined) {
+	const isBrowser = typeof window !== "undefined" && typeof window.document !== "undefined";
+
+	const isWebWorker =
+		typeof self === "object" && self.constructor && self.constructor.name === "DedicatedWorkerGlobalScope";
+
+	if (isBrowser || isWebWorker) {
 		if (!wasmModule) {
 			wasmModule = await import("hash-wasm");
 		}


### PR DESCRIPTION
Fix #85 

Actually `__filename` is not a valid check because of rollup