### PR TITLE
💥 Return Blob instead of ArrayBuffer for images

### DIFF
--- a/packages/inference/src/HfInference.ts
+++ b/packages/inference/src/HfInference.ts
@@ -498,7 +498,7 @@ export type TextToImageArgs = Args & {
 	negative_prompt?: string;
 };
 
-export type TextToImageReturn = ArrayBuffer;
+export type TextToImageReturn = Blob;
 
 export class HfInference {
 	private readonly apiKey:         string;
@@ -712,20 +712,17 @@ export class HfInference {
 			});
 		}
 
-		let output;
-
 		if (options?.blob) {
 			if (!response.ok) {
 				throw new Error("An error occurred while fetching the blob");
 			}
-			return await response.arrayBuffer();
-		} else {
-			output = await response.json();
-			if (output.error) {
-				throw new Error(output.error);
-			}
+			return await response.blob();
 		}
 
+		const output = await response.json();
+		if (output.error) {
+			throw new Error(output.error);
+		}
 		return output;
 	}
 

--- a/packages/inference/test/HfInference.spec.ts
+++ b/packages/inference/test/HfInference.spec.ts
@@ -334,7 +334,7 @@ describe.concurrent(
 				model:           "stabilityai/stable-diffusion-2",
 			});
 
-			expect(res).toBeInstanceOf(ArrayBuffer);
+			expect(res).toBeInstanceOf(Blob);
 		});
 	},
 	TIMEOUT


### PR DESCRIPTION
cc @hpssjellis, should fix #93 

It's a breaking change but given the relative newness of the lib + arraybuffer endpoint, let's make it a minor version after merging