### PR TITLE
Allows usage of `URL` pointing to a local file in file operations

### DIFF
--- a/packages/hub/src/lib/commit.spec.ts
+++ b/packages/hub/src/lib/commit.spec.ts
@@ -1,6 +1,7 @@
 import { assert, it, describe } from "vitest";
 
 import { readFileSync } from "fs";
+import { pathToFileURL } from "url";
 import { randomBytes } from "crypto";
 import { HUB_URL, TEST_ACCESS_TOKEN, TEST_USER } from "../consts";
 import type { RepoId } from "../types/public";
@@ -31,7 +32,7 @@ describe("commit", () => {
 		const readme1 = await downloadFile({ repo, path: "README.md" });
 		assert.strictEqual(readme1?.status, 200);
 
-		const lazyBlob = await LazyBlob.create("./package.json");
+		const lazyBlob = await LazyBlob.create(pathToFileURL("./package.json"));
 
 		try {
 			await commit({

--- a/packages/hub/src/lib/commit.spec.ts
+++ b/packages/hub/src/lib/commit.spec.ts
@@ -41,21 +41,21 @@ describe("commit", () => {
 					accessToken: TEST_ACCESS_TOKEN,
 				},
 				operations: [
-					// {
-					// 	operation: "addOrUpdate",
-					// 	content: new Blob(["This is me"]),
-					// 	path: "test.txt",
-					// },
-					// {
-					// 	operation: "addOrUpdate",
-					// 	content: new Blob([lfsContent]),
-					// 	path: "test.lfs.txt",
-					// },
-					// {
-					// 	operation: "addOrUpdate",
-					// 	content: lazyBlob,
-					// 	path: "package.json",
-					// },
+					{
+						operation: "addOrUpdate",
+						content: new Blob(["This is me"]),
+						path: "test.txt",
+					},
+					{
+						operation: "addOrUpdate",
+						content: new Blob([lfsContent]),
+						path: "test.lfs.txt",
+					},
+					{
+						operation: "addOrUpdate",
+						content: lazyBlob,
+						path: "package.json",
+					},
 					{
 						operation: "addOrUpdate",
 						content: new URL("file://tsconfig.json"),

--- a/packages/hub/src/lib/commit.spec.ts
+++ b/packages/hub/src/lib/commit.spec.ts
@@ -41,21 +41,21 @@ describe("commit", () => {
 					accessToken: TEST_ACCESS_TOKEN,
 				},
 				operations: [
-					{
-						operation: "addOrUpdate",
-						content: new Blob(["This is me"]),
-						path: "test.txt",
-					},
-					{
-						operation: "addOrUpdate",
-						content: new Blob([lfsContent]),
-						path: "test.lfs.txt",
-					},
-					{
-						operation: "addOrUpdate",
-						content: lazyBlob,
-						path: "package.json",
-					},
+					// {
+					// 	operation: "addOrUpdate",
+					// 	content: new Blob(["This is me"]),
+					// 	path: "test.txt",
+					// },
+					// {
+					// 	operation: "addOrUpdate",
+					// 	content: new Blob([lfsContent]),
+					// 	path: "test.lfs.txt",
+					// },
+					// {
+					// 	operation: "addOrUpdate",
+					// 	content: lazyBlob,
+					// 	path: "package.json",
+					// },
 					{
 						operation: "addOrUpdate",
 						content: new URL("file://tsconfig.json"),

--- a/packages/hub/src/lib/commit.spec.ts
+++ b/packages/hub/src/lib/commit.spec.ts
@@ -1,5 +1,6 @@
 import { assert, it, describe } from "vitest";
 
+import { readFileSync } from "fs";
 import { randomBytes } from "crypto";
 import { HUB_URL, TEST_ACCESS_TOKEN, TEST_USER } from "../consts";
 import type { RepoId } from "../types/public";
@@ -56,6 +57,11 @@ describe("commit", () => {
 						path: "package.json",
 					},
 					{
+						operation: "addOrUpdate",
+						content: new URL("file://tsconfig.json"),
+						path: "tsconfig.json",
+					},
+					{
 						operation: "delete",
 						path: "README.md",
 					},
@@ -70,9 +76,13 @@ describe("commit", () => {
 			assert.strictEqual(lfsFileContent?.status, 200);
 			assert.strictEqual(await lfsFileContent?.text(), lfsContent);
 
-			const packageJsonContent = await downloadFile({ repo, path: "package.json" });
-			assert.strictEqual(packageJsonContent?.status, 200);
-			assert.strictEqual(await packageJsonContent?.text(), await lazyBlob.text());
+			const lazyBlobContent = await downloadFile({ repo, path: "package.json" });
+			assert.strictEqual(lazyBlobContent?.status, 200);
+			assert.strictEqual(await lazyBlobContent?.text(), await lazyBlob.text());
+
+			const fileUrlContent = await downloadFile({ repo, path: "tsconfig.json" });
+			assert.strictEqual(fileUrlContent?.status, 200);
+			assert.strictEqual(await fileUrlContent?.text(), readFileSync("./tsconfig.json", "utf-8"));
 
 			const lfsFilePointer = await fetch(`${HUB_URL}/${repoName}/raw/main/test.lfs.txt`);
 			assert.strictEqual(lfsFilePointer.status, 200);

--- a/packages/hub/src/lib/commit.spec.ts
+++ b/packages/hub/src/lib/commit.spec.ts
@@ -32,7 +32,7 @@ describe("commit", () => {
 		const readme1 = await downloadFile({ repo, path: "README.md" });
 		assert.strictEqual(readme1?.status, 200);
 
-		const lazyBlob = await LazyBlob.create(pathToFileURL("./package.json"));
+		const lazyBlob = await LazyBlob.create("./package.json");
 
 		try {
 			await commit({
@@ -59,7 +59,7 @@ describe("commit", () => {
 					},
 					{
 						operation: "addOrUpdate",
-						content: new URL("file://tsconfig.json"),
+						content: pathToFileURL("./tsconfig.json"),
 						path: "tsconfig.json",
 					},
 					{

--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -134,12 +134,12 @@ async function* commitIter(params: CommitParams): AsyncGenerator<unknown, Commit
 
 	for (const operations of chunk(allOperations.filter(isFileOperation), 100)) {
 		const payload: ApiPreuploadRequest = {
-			gitAttributes: gitAttributes && (await (gitAttributes as Blob).text()),
+			gitAttributes: gitAttributes && (await gitAttributes.text()),
 			files: await Promise.all(
 				operations.map(async (operation) => ({
 					path: operation.path,
-					size: (operation.content as Blob).size,
-					sample: base64FromBytes(new Uint8Array(await (operation.content as Blob).slice(0, 512).arrayBuffer())),
+					size: operation.content.size,
+					sample: base64FromBytes(new Uint8Array(await operation.content.slice(0, 512).arrayBuffer())),
 				}))
 			),
 		};

--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -103,10 +103,6 @@ async function* commitIter(params: CommitParams): AsyncGenerator<unknown, Commit
 					throw new TypeError('Only "file://" protocol is supported for now');
 				}
 
-				if (!isNode) {
-					throw new Error("URls pointing to local files can only be loaded with Node.js");
-				}
-
 				if (!isBackend) {
 					throw new TypeError("File URLs are not supported in browsers");
 				}

--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -105,7 +105,11 @@ async function* commitIter(params: CommitParams): AsyncGenerator<unknown, Commit
 		params.operations.map(async (operation) => {
 			if (isFileOperation(operation) && operation.content instanceof URL) {
 				if (operation.content.protocol !== "file:") {
-					throw TypeError('Only "file://" protocol is supported for now');
+					throw new TypeError('Only "file://" protocol is supported for now');
+				}
+
+				if (!isNode) {
+					throw new Error("URls pointing to local files can only be loaded with Node.js");
 				}
 
 				// Ignore the "file://" at the beginning and the trailing slash

--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -132,11 +132,11 @@ async function* commitIter(params: CommitParams): AsyncGenerator<unknown, Commit
 
 	const gitAttributes = allOperations.filter(isFileOperation).find((op) => op.path === ".gitattributes")?.content;
 
-	for (const operationsChunk of chunk(allOperations.filter(isFileOperation), 100)) {
+	for (const operations of chunk(allOperations.filter(isFileOperation), 100)) {
 		const payload: ApiPreuploadRequest = {
 			gitAttributes: gitAttributes && (await (gitAttributes as Blob).text()),
 			files: await Promise.all(
-				operationsChunk.map(async (operation) => ({
+				operations.map(async (operation) => ({
 					path: operation.path,
 					size: (operation.content as Blob).size,
 					sample: base64FromBytes(new Uint8Array(await (operation.content as Blob).slice(0, 512).arrayBuffer())),

--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -27,7 +27,7 @@ export interface CommitDeletedEntry {
 	path: string;
 }
 
-type ContentSource = Blob; // Todo: offer a smart Blob wrapper around (filePath + size) for Node.js
+type ContentSource = Blob;
 
 export interface CommitFile {
 	operation: "addOrUpdate";

--- a/packages/hub/src/utils/LazyBlob.spec.ts
+++ b/packages/hub/src/utils/LazyBlob.spec.ts
@@ -1,6 +1,7 @@
 import { open, stat } from "node:fs/promises";
 import { TextDecoder } from "node:util";
 import { describe, expect, it } from "vitest";
+import { pathToFileURL } from "url";
 import { LazyBlob } from "./LazyBlob";
 
 describe("LazyBlob", () => {
@@ -8,7 +9,7 @@ describe("LazyBlob", () => {
 		const file = await open("package.json", "r");
 		const { size } = await stat("package.json");
 
-		const lazyBlob = await LazyBlob.create("package.json");
+		const lazyBlob = await LazyBlob.create(pathToFileURL("package.json"));
 
 		expect(lazyBlob).toMatchObject({
 			path: "package.json",
@@ -26,7 +27,7 @@ describe("LazyBlob", () => {
 
 	it("should create a slice on the file", async () => {
 		const file = await open("package.json", "r");
-		const lazyBlob = await LazyBlob.create("package.json");
+		const lazyBlob = await LazyBlob.create(pathToFileURL("package.json"));
 
 		const slice = lazyBlob.slice(10, 20);
 

--- a/packages/hub/src/utils/LazyBlob.spec.ts
+++ b/packages/hub/src/utils/LazyBlob.spec.ts
@@ -1,0 +1,45 @@
+import { open, stat } from "node:fs/promises";
+import { TextDecoder } from "node:util";
+import { describe, expect, it } from "vitest";
+import { LazyBlob } from "./LazyBlob";
+
+describe("LazyBlob", () => {
+	it("should create a LazyBlob with a slice on the entire file", async () => {
+		const file = await open("package.json", "r");
+		const { size } = await stat("package.json");
+
+		const lazyBlob = await LazyBlob.create("package.json");
+
+		expect(lazyBlob).toMatchObject({
+			path: "package.json",
+			start: 0,
+			end: size,
+		});
+		expect(lazyBlob.size).toBe(size);
+		expect(lazyBlob.type).toBe("");
+		const text = await lazyBlob.text();
+		const expectedText = (await file.read(Buffer.alloc(size), 0, size)).buffer.toString("utf8");
+		expect(text).toBe(expectedText);
+		const result = await lazyBlob.stream().getReader().read();
+		expect(new TextDecoder().decode(result.value)).toBe(expectedText);
+	});
+
+	it("should create a slice on the file", async () => {
+		const file = await open("package.json", "r");
+		const lazyBlob = await LazyBlob.create("package.json");
+
+		const slice = lazyBlob.slice(10, 20);
+
+		expect(slice).toMatchObject({
+			path: "package.json",
+			start: 10,
+			end: 20,
+		});
+		expect(slice.size).toBe(10);
+		const sliceText = await slice.text();
+		const expectedText = (await file.read(Buffer.alloc(10), 0, 10, 10)).buffer.toString("utf8");
+		expect(sliceText).toBe(expectedText);
+		const result = await slice.stream().getReader().read();
+		expect(new TextDecoder().decode(result.value)).toBe(expectedText);
+	});
+});

--- a/packages/hub/src/utils/LazyBlob.spec.ts
+++ b/packages/hub/src/utils/LazyBlob.spec.ts
@@ -11,11 +11,6 @@ describe("LazyBlob", () => {
 
 		const lazyBlob = await LazyBlob.create(pathToFileURL("package.json"));
 
-		expect(lazyBlob).toMatchObject({
-			path: "package.json",
-			start: 0,
-			end: size,
-		});
 		expect(lazyBlob.size).toBe(size);
 		expect(lazyBlob.type).toBe("");
 		const text = await lazyBlob.text();
@@ -31,11 +26,6 @@ describe("LazyBlob", () => {
 
 		const slice = lazyBlob.slice(10, 20);
 
-		expect(slice).toMatchObject({
-			path: "package.json",
-			start: 10,
-			end: 20,
-		});
 		expect(slice.size).toBe(10);
 		const sliceText = await slice.text();
 		const expectedText = (await file.read(Buffer.alloc(10), 0, 10, 10)).buffer.toString("utf8");

--- a/packages/hub/src/utils/LazyBlob.spec.ts
+++ b/packages/hub/src/utils/LazyBlob.spec.ts
@@ -3,6 +3,7 @@ import { TextDecoder } from "node:util";
 import { describe, expect, it } from "vitest";
 import { pathToFileURL } from "url";
 import { LazyBlob } from "./LazyBlob";
+import { resolve } from "node:path";
 
 describe("LazyBlob", () => {
 	it("should create a LazyBlob with a slice on the entire file", async () => {
@@ -10,6 +11,12 @@ describe("LazyBlob", () => {
 		const { size } = await stat("package.json");
 
 		const lazyBlob = await LazyBlob.create(pathToFileURL("package.json"));
+
+		expect(lazyBlob).toMatchObject({
+			path: resolve("package.json"),
+			start: 0,
+			end: size,
+		});
 
 		expect(lazyBlob.size).toBe(size);
 		expect(lazyBlob.type).toBe("");
@@ -25,6 +32,12 @@ describe("LazyBlob", () => {
 		const lazyBlob = await LazyBlob.create(pathToFileURL("package.json"));
 
 		const slice = lazyBlob.slice(10, 20);
+
+		expect(slice).toMatchObject({
+			path: resolve("package.json"),
+			start: 10,
+			end: 20,
+		});
 
 		expect(slice.size).toBe(10);
 		const sliceText = await slice.text();

--- a/packages/hub/src/utils/LazyBlob.spec.ts
+++ b/packages/hub/src/utils/LazyBlob.spec.ts
@@ -1,23 +1,20 @@
 import { open, stat } from "node:fs/promises";
 import { TextDecoder } from "node:util";
 import { describe, expect, it } from "vitest";
-import { pathToFileURL } from "url";
 import { LazyBlob } from "./LazyBlob";
-import { resolve } from "node:path";
 
 describe("LazyBlob", () => {
 	it("should create a LazyBlob with a slice on the entire file", async () => {
 		const file = await open("package.json", "r");
 		const { size } = await stat("package.json");
 
-		const lazyBlob = await LazyBlob.create(pathToFileURL("package.json"));
+		const lazyBlob = await LazyBlob.create("package.json");
 
 		expect(lazyBlob).toMatchObject({
-			path: resolve("package.json"),
+			path: "package.json",
 			start: 0,
 			end: size,
 		});
-
 		expect(lazyBlob.size).toBe(size);
 		expect(lazyBlob.type).toBe("");
 		const text = await lazyBlob.text();
@@ -29,16 +26,15 @@ describe("LazyBlob", () => {
 
 	it("should create a slice on the file", async () => {
 		const file = await open("package.json", "r");
-		const lazyBlob = await LazyBlob.create(pathToFileURL("package.json"));
+		const lazyBlob = await LazyBlob.create("package.json");
 
 		const slice = lazyBlob.slice(10, 20);
 
 		expect(slice).toMatchObject({
-			path: resolve("package.json"),
+			path: "package.json",
 			start: 10,
 			end: 20,
 		});
-
 		expect(slice.size).toBe(10);
 		const sliceText = await slice.text();
 		const expectedText = (await file.read(Buffer.alloc(10), 0, 10, 10)).buffer.toString("utf8");

--- a/packages/hub/src/utils/LazyBlob.ts
+++ b/packages/hub/src/utils/LazyBlob.ts
@@ -24,7 +24,7 @@ export class LazyBlob extends Blob {
 	 *
 	 * @param path Path to the file to be lazy readed
 	 */
-	static async create(path: string): Promise<LazyBlob> {
+	static async create(path: URL): Promise<LazyBlob> {
 		const { size } = await stat(path);
 
 		const lazyBlob = new LazyBlob(path, 0, size);
@@ -32,11 +32,11 @@ export class LazyBlob extends Blob {
 		return lazyBlob;
 	}
 
-	private path: string;
+	private path: URL;
 	private start: number;
 	private end: number;
 
-	private constructor(path: string, start: number, end: number) {
+	private constructor(path: URL, start: number, end: number) {
 		super();
 
 		this.path = path;

--- a/packages/hub/src/utils/LazyBlob.ts
+++ b/packages/hub/src/utils/LazyBlob.ts
@@ -1,0 +1,123 @@
+import { createReadStream } from "node:fs";
+import { open, stat } from "node:fs/promises";
+import { Readable } from "node:stream";
+import type { FileHandle } from "node:fs/promises";
+
+/**
+ * @internal
+ *
+ * A LazyBlob is a replacement for the Blob class that allows to lazy read files
+ * in order to preserve memory.
+ *
+ * It is a drop-in replacement for the Blob class, so you can use it as a Blob.
+ *
+ * The main difference is the instantiation, which is done asynchronously using the `LazyBlob.create` method.
+ *
+ * @example
+ * const lazyBlob = await LazyBlob.create("path/to/package.json");
+ *
+ * await fetch("https://aschen.tech", { method: "POST", body: lazyBlob });
+ */
+export class LazyBlob extends Blob {
+	/**
+	 * Creates a new LazyBlob on the provided file.
+	 *
+	 * @param path Path to the file to be lazy readed
+	 */
+	static async create(path: string): Promise<LazyBlob> {
+		const { size } = await stat(path);
+
+		const lazyBlob = new LazyBlob(path, 0, size);
+
+		return lazyBlob;
+	}
+
+	private path: string;
+	private start: number;
+	private end: number;
+
+	private constructor(path: string, start: number, end: number) {
+		super();
+
+		this.path = path;
+		this.start = start;
+		this.end = end;
+	}
+
+	/**
+	 * Returns the size of the blob.
+	 */
+	get size(): number {
+		return this.end - this.start;
+	}
+
+	/**
+	 * Returns an empty string.
+	 * (This is a required property of the Blob class)
+	 */
+	get type(): string {
+		return "";
+	}
+
+	/**
+	 * Returns a new instance of LazyBlob that is a slice of the current one.
+	 *
+	 * The slice is inclusive of the start and exclusive of the end.
+	 *
+	 * The slice method does not supports negative start/end.
+	 *
+	 * @param start beginning of the slice
+	 * @param end end of the slice
+	 */
+	slice(start = 0, end = this.size): LazyBlob {
+		if (start < 0 || end < 0) {
+			new TypeError("Unsupported negative start/end on LazyBlob.slice");
+		}
+
+		const slice = new LazyBlob(this.path, this.start + start, Math.min(this.start + end, this.end));
+
+		return slice;
+	}
+
+	/**
+	 * Read the part of the file delimited by the LazyBlob and returns it as an ArrayBuffer.
+	 */
+	async arrayBuffer(): Promise<ArrayBuffer> {
+		const slice = await this.execute((file) => file.read(Buffer.alloc(this.size), 0, this.size, this.start));
+
+		return slice.buffer;
+	}
+
+	/**
+	 * Read the part of the file delimited by the LazyBlob and returns it as a string.
+	 */
+	async text(): Promise<string> {
+		const buffer = (await this.arrayBuffer()) as Buffer;
+
+		return buffer.toString("utf8");
+	}
+
+	/**
+	 * Returns a stream around the part of the file delimited by the LazyBlob.
+	 */
+	stream(): ReturnType<Blob["stream"]> {
+		return Readable.toWeb(createReadStream(this.path, { start: this.start, end: this.end - 1 })) as ReturnType<
+			Blob["stream"]
+		>;
+	}
+
+	/**
+	 * We are opening and closing the file for each action to prevent file descriptor leaks.
+	 *
+	 * It is an intended choice of developer experience over performances.
+	 */
+	private async execute<T>(action: (file: FileHandle) => Promise<T>) {
+		const file = await open(this.path, "r");
+
+		const ret = await action(file);
+
+		await file.close();
+
+		return ret;
+	}
+}

--- a/packages/hub/src/utils/LazyBlob.ts
+++ b/packages/hub/src/utils/LazyBlob.ts
@@ -2,6 +2,7 @@ import { createReadStream } from "node:fs";
 import { open, stat } from "node:fs/promises";
 import { Readable } from "node:stream";
 import type { FileHandle } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 
 /**
  * @internal
@@ -24,7 +25,9 @@ export class LazyBlob extends Blob {
 	 *
 	 * @param path Path to the file to be lazy readed
 	 */
-	static async create(path: URL): Promise<LazyBlob> {
+	static async create(path: string | URL): Promise<LazyBlob> {
+		path = path instanceof URL ? fileURLToPath(path) : path;
+
 		const { size } = await stat(path);
 
 		const lazyBlob = new LazyBlob(path, 0, size);
@@ -32,11 +35,11 @@ export class LazyBlob extends Blob {
 		return lazyBlob;
 	}
 
-	private path: URL;
+	private path: string;
 	private start: number;
 	private end: number;
 
-	private constructor(path: URL, start: number, end: number) {
+	private constructor(path: string, start: number, end: number) {
 		super();
 
 		this.path = path;
@@ -49,14 +52,6 @@ export class LazyBlob extends Blob {
 	 */
 	get size(): number {
 		return this.end - this.start;
-	}
-
-	/**
-	 * Returns an empty string.
-	 * (This is a required property of the Blob class)
-	 */
-	get type(): string {
-		return "";
 	}
 
 	/**

--- a/packages/hub/src/utils/env-predicates.ts
+++ b/packages/hub/src/utils/env-predicates.ts
@@ -1,0 +1,6 @@
+export const isBrowser = typeof window !== "undefined" && typeof window.document !== "undefined";
+
+export const isWebWorker =
+	typeof self === "object" && self.constructor && self.constructor.name === "DedicatedWorkerGlobalScope";
+
+export const isNode = !isBrowser && !isWebWorker;

--- a/packages/hub/src/utils/env-predicates.ts
+++ b/packages/hub/src/utils/env-predicates.ts
@@ -1,6 +1,7 @@
-export const isBrowser = typeof window !== "undefined" && typeof window.document !== "undefined";
+const isBrowser = typeof window !== "undefined" && typeof window.document !== "undefined";
 
-export const isWebWorker =
+const isWebWorker =
 	typeof self === "object" && self.constructor && self.constructor.name === "DedicatedWorkerGlobalScope";
 
-export const isNode = !isBrowser && !isWebWorker;
+export const isFrontend = isBrowser || isWebWorker;
+export const isBackend = !isBrowser && !isWebWorker;

--- a/packages/hub/src/utils/sha256.ts
+++ b/packages/hub/src/utils/sha256.ts
@@ -44,6 +44,7 @@ export async function sha256(buffer: Blob): Promise<string> {
 	if (!cryptoModule) {
 		cryptoModule = await import("./sha256-node");
 	}
+
 	return cryptoModule.sha256Node(buffer);
 }
 

--- a/packages/hub/src/utils/sha256.ts
+++ b/packages/hub/src/utils/sha256.ts
@@ -1,4 +1,4 @@
-import { isBrowser, isWebWorker } from "./env-predicates";
+import { isFrontend } from "./env-predicates";
 import { hexFromBytes } from "./hexFromBytes";
 
 /**
@@ -14,7 +14,7 @@ export async function sha256(buffer: Blob): Promise<string> {
 		);
 	}
 
-	if (isBrowser || isWebWorker) {
+	if (isFrontend) {
 		if (!wasmModule) {
 			wasmModule = await import("hash-wasm");
 		}

--- a/packages/hub/src/utils/sha256.ts
+++ b/packages/hub/src/utils/sha256.ts
@@ -1,3 +1,4 @@
+import { isBrowser, isWebWorker } from "./env-predicates";
 import { hexFromBytes } from "./hexFromBytes";
 
 /**
@@ -12,11 +13,6 @@ export async function sha256(buffer: Blob): Promise<string> {
 			)
 		);
 	}
-
-	const isBrowser = typeof window !== "undefined" && typeof window.document !== "undefined";
-
-	const isWebWorker =
-		typeof self === "object" && self.constructor && self.constructor.name === "DedicatedWorkerGlobalScope";
 
 	if (isBrowser || isWebWorker) {
 		if (!wasmModule) {


### PR DESCRIPTION
## Description

Allows to provide an `URL` object pointing to a local file with `CommitFile` operation.

Providing a non-local file will throw an error.

This is not available in the browser.

Fix https://github.com/huggingface/huggingface.js/issues/106

```
await commit({
  repo,
  title: "Some commit",
  credentials: {
    accessToken: TEST_ACCESS_TOKEN,
  },
  operations: [
    {
      operation: "addOrUpdate",
      content: new URL("file://tsconfig.json"),
      path: "tsconfig.json",
    },
  ],
});
```
 