### PR TITLE
🐛 Add guard on `process`

### DIFF
--- a/packages/hub/src/consts.ts
+++ b/packages/hub/src/consts.ts
@@ -1,3 +1,6 @@
-export const HUB_URL = process.env.NODE_ENV === "test" ? "https://hub-ci.huggingface.co" : "https://huggingface.co";
+export const HUB_URL =
+	typeof process !== undefined && process.env.NODE_ENV === "test"
+		? "https://hub-ci.huggingface.co"
+		: "https://huggingface.co";
 export const TEST_USER = "hub.js";
 export const TEST_ACCESS_TOKEN = "hf_hub.js";


### PR DESCRIPTION
Currently, trying to use https://unpkg.com/@huggingface/hub@0.3.0/dist/index.mjs throws an error because `process` is undefined