### PR TITLE
Check if api inference output is correct

### DIFF
--- a/packages/inference/src/HfInference.ts
+++ b/packages/inference/src/HfInference.ts
@@ -670,7 +670,7 @@ export class HfInference {
 					Array.isArray(x.labels) &&
 					x.labels.every((_label) => typeof _label === "string") &&
 					Array.isArray(x.scores) &&
-					x.labels.every((_score) => typeof _score === "number") &&
+					x.scores.every((_score) => typeof _score === "number") &&
 					typeof x.sequence === "string"
 			);
 		if (!isValidOutput) {


### PR DESCRIPTION
This PR adds checks to api inference calls:
1. Checks if api inference outputs are as expected (for example, TextClaissification api output should be `array<{score: number, label: string}>`)
2. If not, throw `new TypeError`