### PR TITLE
🧑‍💻 Add aliases for repo names

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,25 +55,31 @@ You can run our packages with vanilla JS, without any bundler, by using a CDN or
 ## Usage example
 
 ```ts
-import { createRepo, uploadFile } from "@huggingface/hub";
+import { createRepo, uploadFile, deleteFiles } from "@huggingface/hub";
 import { HfInference } from "@huggingface/inference";
 
 // use an access token from your free account
 const HF_ACCESS_TOKEN = "hf_...";
 
 await createRepo({
-  repo: {type: "model", name: "my-user/nlp-test"},
+  repo: "my-user/nlp-model", // or {type: "model", name: "my-user/nlp-test"},
   credentials: {accessToken: HF_ACCESS_TOKEN}
 });
 
 await uploadFile({
-  repo: {type: "model", name: "my-user/nlp-test"},
+  repo: "my-user/nlp-model",
   credentials: {accessToken: HF_ACCESS_TOKEN},
   // Can work with native File in browsers
   file: {
     path: "pytorch_model.bin",
     content: new Blob(...) 
   }
+});
+
+await deleteFiles({
+  repo: {type: "space", name: "my-user/my-space"}, // or "spaces/my-user/my-space"
+  credentials: {accessToken: HF_ACCESS_TOKEN},
+  paths: ["README.md", ".gitattributes"]
 });
 
 const inference = new HfInference(HF_ACCESS_TOKEN);

--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -14,9 +14,9 @@ For some of the calls, you need to create an account and generate an [access tok
 
 ```ts
 import { createRepo, uploadFiles, deleteFile, deleteRepo, listFiles, whoAmI } from "@huggingface/hub";
-import type { RepoId, Credentials } from "@huggingface/hub";
+import type { RepoDesignation, Credentials } from "@huggingface/hub";
 
-const repo: RepoId = { type: "model", name: "myname/some-model" };
+const repo: RepoDesignation = { type: "model", name: "myname/some-model" };
 const credentials: Credentials = { accessToken: "hf_..." };
 
 const {name: username} = await whoAmI({credentials});

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -5,6 +5,8 @@ export type {
 	AccessTokenRole,
 	AuthType,
 	Credentials,
+	RepoDesignation,
+	RepoFullName,
 	RepoId,
 	RepoType,
 	SpaceHardwareFlavor,

--- a/packages/hub/src/lib/create-repo.spec.ts
+++ b/packages/hub/src/lib/create-repo.spec.ts
@@ -53,4 +53,49 @@ describe("createRepo", () => {
 
 		await expect(tryCreate).rejects.toBeInstanceOf(TypeError);
 	});
+
+	it("should create a model with a string as name", async () => {
+		const repoName = `${TEST_USER}/TEST-${insecureRandomString()}`;
+
+		const result = await createRepo({
+			credentials: {
+				accessToken: TEST_ACCESS_TOKEN,
+			},
+			repo: repoName,
+			files: [{ path: ".gitattributes", content: new Blob(["*.html filter=lfs diff=lfs merge=lfs -text"]) }],
+		});
+
+		assert.deepStrictEqual(result, {
+			repoUrl: `${HUB_URL}/${repoName}`,
+		});
+
+		await deleteRepo({
+			repo: {
+				name: repoName,
+				type: "model",
+			},
+			credentials: { accessToken: TEST_ACCESS_TOKEN },
+		});
+	});
+
+	it("should create a dataset with a string as name", async () => {
+		const repoName = `datasets/${TEST_USER}/TEST-${insecureRandomString()}`;
+
+		const result = await createRepo({
+			credentials: {
+				accessToken: TEST_ACCESS_TOKEN,
+			},
+			repo: repoName,
+			files: [{ path: ".gitattributes", content: new Blob(["*.html filter=lfs diff=lfs merge=lfs -text"]) }],
+		});
+
+		assert.deepStrictEqual(result, {
+			repoUrl: `${HUB_URL}/${repoName}`,
+		});
+
+		await deleteRepo({
+			repo: repoName,
+			credentials: { accessToken: TEST_ACCESS_TOKEN },
+		});
+	});
 });

--- a/packages/hub/src/lib/delete-repo.ts
+++ b/packages/hub/src/lib/delete-repo.ts
@@ -1,18 +1,24 @@
 import { HUB_URL } from "../consts";
 import { createApiError } from "../error";
-import type { Credentials, RepoId } from "../types/public";
+import type { Credentials, RepoDesignation } from "../types/public";
 import { checkCredentials } from "../utils/checkCredentials";
+import { toRepoId } from "../utils/toRepoId";
 
-export async function deleteRepo(params: { repo: RepoId; credentials: Credentials; hubUrl?: string }): Promise<void> {
+export async function deleteRepo(params: {
+	repo: RepoDesignation;
+	credentials: Credentials;
+	hubUrl?: string;
+}): Promise<void> {
 	checkCredentials(params.credentials);
-	const [namespace, repoName] = params.repo.name.split("/");
+	const repoId = toRepoId(params.repo);
+	const [namespace, repoName] = repoId.name.split("/");
 
 	const res = await fetch(`${params.hubUrl ?? HUB_URL}/api/repos/delete`, {
 		method: "DELETE",
 		body: JSON.stringify({
 			name: repoName,
 			organization: namespace,
-			type: params.repo.type,
+			type: repoId.type,
 		}),
 		headers: {
 			Authorization: `Bearer ${params.credentials.accessToken}`,

--- a/packages/hub/src/lib/deleteFile.ts
+++ b/packages/hub/src/lib/deleteFile.ts
@@ -1,10 +1,10 @@
-import type { Credentials, RepoId } from "../types/public";
+import type { Credentials } from "../types/public";
 import type { CommitOutput, CommitParams } from "./commit";
 import { commit } from "./commit";
 
 export function deleteFile(params: {
 	credentials: Credentials;
-	repo: RepoId;
+	repo: CommitParams["repo"];
 	path: string;
 	commitTitle?: CommitParams["title"];
 	commitDescription?: CommitParams["description"];

--- a/packages/hub/src/lib/deleteFiles.ts
+++ b/packages/hub/src/lib/deleteFiles.ts
@@ -1,10 +1,10 @@
-import type { Credentials, RepoId } from "../types/public";
+import type { Credentials } from "../types/public";
 import type { CommitOutput, CommitParams } from "./commit";
 import { commit } from "./commit";
 
 export function deleteFiles(params: {
 	credentials: Credentials;
-	repo: RepoId;
+	repo: CommitParams["repo"];
 	paths: string[];
 	commitTitle?: CommitParams["title"];
 	commitDescription?: CommitParams["description"];

--- a/packages/hub/src/lib/download-file.ts
+++ b/packages/hub/src/lib/download-file.ts
@@ -1,13 +1,14 @@
 import { HUB_URL } from "../consts";
 import { createApiError } from "../error";
-import type { Credentials, RepoId } from "../types/public";
+import type { Credentials, RepoDesignation } from "../types/public";
 import { checkCredentials } from "../utils/checkCredentials";
+import { toRepoId } from "../utils/toRepoId";
 
 /**
  * @returns null when the file doesn't exist
  */
 export async function downloadFile(params: {
-	repo: RepoId;
+	repo: RepoDesignation;
 	path: string;
 	/**
 	 * If true, will download the raw git file.
@@ -20,9 +21,10 @@ export async function downloadFile(params: {
 	hubUrl?: string;
 }): Promise<Response | null> {
 	checkCredentials(params.credentials);
-	const url = `${params.hubUrl ?? HUB_URL}/${params.repo.type === "model" ? "" : `${params.repo.type}s/`}${
-		params.repo.name
-	}/${params.raw ? "raw" : "resolve"}/${encodeURIComponent(params.revision ?? "main")}/${params.path}`;
+	const repoId = toRepoId(params.repo);
+	const url = `${params.hubUrl ?? HUB_URL}/${repoId.type === "model" ? "" : `${repoId.type}s/`}${repoId.name}/${
+		params.raw ? "raw" : "resolve"
+	}/${encodeURIComponent(params.revision ?? "main")}/${params.path}`;
 
 	const resp = await fetch(url, {
 		headers: params.credentials

--- a/packages/hub/src/lib/file-download-info.ts
+++ b/packages/hub/src/lib/file-download-info.ts
@@ -1,7 +1,8 @@
 import { HUB_URL } from "../consts";
 import { createApiError, InvalidApiResponseFormatError } from "../error";
-import type { Credentials, RepoId } from "../types/public";
+import type { Credentials, RepoDesignation } from "../types/public";
 import { checkCredentials } from "../utils/checkCredentials";
+import { toRepoId } from "../utils/toRepoId";
 
 export interface FileDownloadInfoOutput {
 	size: number;
@@ -15,7 +16,7 @@ export interface FileDownloadInfoOutput {
  * @returns null when the file doesn't exist
  */
 export async function fileDownloadInfo(params: {
-	repo: RepoId;
+	repo: RepoDesignation;
 	path: string;
 	revision?: string;
 	credentials?: Credentials;
@@ -32,10 +33,11 @@ export async function fileDownloadInfo(params: {
 	noContentDisposition?: boolean;
 }): Promise<FileDownloadInfoOutput | null> {
 	checkCredentials(params.credentials);
+	const repoId = toRepoId(params.repo);
 
 	const hubUrl = params.hubUrl ?? HUB_URL;
 	const url =
-		`${hubUrl}/${params.repo.type === "model" ? "" : `${params.repo.type}s/`}${params.repo.name}/${
+		`${hubUrl}/${repoId.type === "model" ? "" : `${repoId.type}s/`}${repoId.name}/${
 			params.raw ? "raw" : "resolve"
 		}/${encodeURIComponent(params.revision ?? "main")}/${params.path}` +
 		(params.noContentDisposition ? "?noContentDisposition=1" : "");

--- a/packages/hub/src/lib/list-files.ts
+++ b/packages/hub/src/lib/list-files.ts
@@ -1,9 +1,10 @@
 import { HUB_URL } from "../consts";
 import { createApiError } from "../error";
 import type { ApiIndexTreeEntry } from "../types/api/api-index-tree";
-import type { Credentials, RepoId } from "../types/public";
+import type { Credentials, RepoDesignation } from "../types/public";
 import { checkCredentials } from "../utils/checkCredentials";
 import { parseLinkHeader } from "../utils/parseLinkHeader";
+import { toRepoId } from "../utils/toRepoId";
 
 export interface ListFileEntry {
 	type: "file" | "directory" | "unknown";
@@ -29,7 +30,7 @@ export interface ListFileEntry {
  * with {@link params.recursive} set to `true`.
  */
 export async function* listFiles(params: {
-	repo: RepoId;
+	repo: RepoDesignation;
 	/**
 	 * Do we want to list files in subdirectories?
 	 */
@@ -44,7 +45,8 @@ export async function* listFiles(params: {
 	hubUrl?: string;
 }): AsyncGenerator<ListFileEntry> {
 	checkCredentials(params.credentials);
-	let url: string | undefined = `${params.hubUrl || HUB_URL}/api/${params.repo.type}s/${params.repo.name}/tree/${
+	const repoId = toRepoId(params.repo);
+	let url: string | undefined = `${params.hubUrl || HUB_URL}/api/${repoId.type}s/${repoId.name}/tree/${
 		params.revision || "main"
 	}${params.path ? "/" + params.path : ""}${params.recursive ? "?recursive=true" : ""}`;
 

--- a/packages/hub/src/lib/uploadFile.ts
+++ b/packages/hub/src/lib/uploadFile.ts
@@ -1,10 +1,10 @@
-import type { Credentials, RepoId } from "../types/public";
+import type { Credentials } from "../types/public";
 import type { CommitOutput, CommitParams, ContentSource } from "./commit";
 import { commit } from "./commit";
 
 export function uploadFile(params: {
 	credentials: Credentials;
-	repo: RepoId;
+	repo: CommitParams["repo"];
 	file: URL | File | { path: string; content: ContentSource };
 	commitTitle?: CommitParams["title"];
 	commitDescription?: CommitParams["description"];

--- a/packages/hub/src/lib/uploadFiles.ts
+++ b/packages/hub/src/lib/uploadFiles.ts
@@ -1,10 +1,10 @@
-import type { Credentials, RepoId } from "../types/public";
+import type { Credentials } from "../types/public";
 import type { CommitOutput, CommitParams, ContentSource } from "./commit";
 import { commit } from "./commit";
 
 export function uploadFiles(params: {
 	credentials: Credentials;
-	repo: RepoId;
+	repo: CommitParams["repo"];
 	files: Array<URL | File | { path: string; content: ContentSource }>;
 	commitTitle?: CommitParams["title"];
 	commitDescription?: CommitParams["description"];

--- a/packages/hub/src/types/public.d.ts
+++ b/packages/hub/src/types/public.d.ts
@@ -5,6 +5,10 @@ export interface RepoId {
 	type: RepoType;
 }
 
+export type RepoFullName = string | `spaces/${string}` | `datasets/${string}`;
+
+export type RepoDesignation = RepoId | RepoFullName;
+
 /** Actually `hf_${string}`, but for convenience, using the string type */
 export type AccessToken = string;
 

--- a/packages/hub/src/utils/toRepoId.ts
+++ b/packages/hub/src/utils/toRepoId.ts
@@ -1,0 +1,54 @@
+import type { RepoDesignation, RepoId } from "../types/public";
+
+export function toRepoId(repo: RepoDesignation): RepoId {
+	if (typeof repo !== "string") {
+		return repo;
+	}
+
+	if (repo.startsWith("model/") || repo.startsWith("models/")) {
+		throw new TypeError(
+			"A repo designation for a model should not start with 'models/', directly specify the model namespace / name"
+		);
+	}
+
+	if (repo.startsWith("space/")) {
+		throw new TypeError("Spaces should start with 'spaces/', plural, not 'space/'");
+	}
+
+	if (repo.startsWith("dataset/")) {
+		throw new TypeError("Datasets should start with 'dataset/', plural, not 'dataset/'");
+	}
+
+	const slashes = repo.split("/").length;
+
+	if (repo.startsWith("spaces/")) {
+		if (slashes !== 2) {
+			throw new TypeError("Space Id must include namespace and name of the space");
+		}
+
+		return {
+			type: "space",
+			name: repo.slice("spaces/".length),
+		};
+	}
+
+	if (repo.startsWith("datasets/")) {
+		if (slashes > 2) {
+			throw new TypeError("Too many slashes in repo designation: " + repo);
+		}
+
+		return {
+			type: "dataset",
+			name: repo.slice("datasets/".length),
+		};
+	}
+
+	if (slashes > 1) {
+		throw new TypeError("Too many slashes in repo designation: " + repo);
+	}
+
+	return {
+		type: "model",
+		name: repo,
+	};
+}

--- a/packages/hub/src/utils/toRepoId.ts
+++ b/packages/hub/src/utils/toRepoId.ts
@@ -19,7 +19,7 @@ export function toRepoId(repo: RepoDesignation): RepoId {
 		throw new TypeError("Datasets should start with 'dataset/', plural, not 'dataset/'");
 	}
 
-	const slashes = repo.split("/").length;
+	const slashes = repo.split("/").length - 1;
 
 	if (repo.startsWith("spaces/")) {
 		if (slashes !== 2) {


### PR DESCRIPTION
Eg instead of specifying `{type: "model", name: "coyotte508/my-model"}` and `{type: "space", name: "coyotte508/my-space"}`, the aliases `"coyotte508/my-model"` and `"spaces/coyotte508/my-space"` work too