### PR TITLE
fix streaming test

### DIFF
--- a/packages/inference/src/HfInference.ts
+++ b/packages/inference/src/HfInference.ts
@@ -1048,6 +1048,12 @@ export class HfInference {
 
 		if (options?.blob) {
 			if (!response.ok) {
+				if (response.headers.get("Content-Type")?.startsWith("application/json")) {
+					const output = await response.json();
+					if (output.error) {
+						throw new Error(output.error);
+					}
+				}
 				throw new Error("An error occurred while fetching the blob");
 			}
 			return (await response.blob()) as T;

--- a/packages/inference/test/HfInference.spec.ts
+++ b/packages/inference/test/HfInference.spec.ts
@@ -144,14 +144,14 @@ describe.concurrent(
 				inputs: `repeat "${phrase}"`,
 			});
 
-			const makeExpectedReturn = (tokenText: string, fullPhrase: string): TextGenerationStreamReturn => {
+			const makeExpectedReturn = (tokenText: string, index: number, fullPhrase: string): TextGenerationStreamReturn => {
 				const eot = tokenText === "</s>";
 				return {
 					details: null,
 					token: {
 						id: expect.any(Number),
 						logprob: expect.any(Number),
-						text: eot ? tokenText : " " + tokenText,
+						text: eot || index === 0 ? tokenText : " " + tokenText,
 						special: eot,
 					},
 					generated_text: eot ? fullPhrase : null,
@@ -161,11 +161,12 @@ describe.concurrent(
 			const expectedTokens = phrase.split(" ");
 			// eot token
 			expectedTokens.push("</s>");
-
+			let index = 0;
 			for await (const ret of response) {
 				const expectedToken = expectedTokens.shift();
 				assert(expectedToken);
-				expect(ret).toMatchObject(makeExpectedReturn(expectedToken, phrase));
+				expect(ret).toMatchObject(makeExpectedReturn(expectedToken, index, phrase));
+				index++;
 			}
 		});
 

--- a/packages/inference/test/HfInference.spec.ts
+++ b/packages/inference/test/HfInference.spec.ts
@@ -144,14 +144,14 @@ describe.concurrent(
 				inputs: `repeat "${phrase}"`,
 			});
 
-			const makeExpectedReturn = (tokenText: string, index: number, fullPhrase: string): TextGenerationStreamReturn => {
+			const makeExpectedReturn = (tokenText: string, fullPhrase: string): TextGenerationStreamReturn => {
 				const eot = tokenText === "</s>";
 				return {
 					details: null,
 					token: {
 						id: expect.any(Number),
 						logprob: expect.any(Number),
-						text: eot || index === 0 ? tokenText : " " + tokenText,
+						text: expect.stringContaining(tokenText),
 						special: eot,
 					},
 					generated_text: eot ? fullPhrase : null,
@@ -161,12 +161,11 @@ describe.concurrent(
 			const expectedTokens = phrase.split(" ");
 			// eot token
 			expectedTokens.push("</s>");
-			let index = 0;
+
 			for await (const ret of response) {
 				const expectedToken = expectedTokens.shift();
 				assert(expectedToken);
-				expect(ret).toMatchObject(makeExpectedReturn(expectedToken, index, phrase));
-				index++;
+				expect(ret).toMatchObject(makeExpectedReturn(expectedToken, phrase));
 			}
 		});
 

--- a/packages/inference/test/tapes.json
+++ b/packages/inference/test/tapes.json
@@ -68,7 +68,7 @@
       "method": "POST"
     },
     "response": {
-      "body": "[{\"generated_text\":\"The answer to the universe is this: it is all of history.\\n\\nIt's time to reclaim our right to see it as we see it. It's time to take back the right to think and to make our opinions heard in the process\"}]",
+      "body": "[{\"generated_text\":\"The answer to the universe is the fundamental property of space, but we're dealing only with the simplest possible set of answers, which is why we need to talk about how we come to know and understand what sets matter.\\n\\nLet's take a\"}]",
       "status": 200,
       "statusText": "OK",
       "headers": {
@@ -378,7 +378,7 @@
       "method": "POST"
     },
     "response": {
-      "body": "data:{\"token\":{\"id\":80,\"text\":\" one\",\"logprob\":-0.75390625,\"special\":false},\"generated_text\":null,\"details\":null}\n\ndata:{\"token\":{\"id\":192,\"text\":\" two\",\"logprob\":-0.01940918,\"special\":false},\"generated_text\":null,\"details\":null}\n\ndata:{\"token\":{\"id\":386,\"text\":\" three\",\"logprob\":-0.015197754,\"special\":false},\"generated_text\":null,\"details\":null}\n\ndata:{\"token\":{\"id\":662,\"text\":\" four\",\"logprob\":-0.01940918,\"special\":false},\"generated_text\":null,\"details\":null}\n\ndata:{\"token\":{\"id\":1,\"text\":\"</s>\",\"logprob\":-0.030883789,\"special\":true},\"generated_text\":\"one two three four\",\"details\":null}\n\n",
+      "body": "data:{\"token\":{\"id\":80,\"text\":\"one\",\"logprob\":-0.75390625,\"special\":false},\"generated_text\":null,\"details\":null}\n\ndata:{\"token\":{\"id\":192,\"text\":\" two\",\"logprob\":-0.01940918,\"special\":false},\"generated_text\":null,\"details\":null}\n\ndata:{\"token\":{\"id\":386,\"text\":\" three\",\"logprob\":-0.015197754,\"special\":false},\"generated_text\":null,\"details\":null}\n\ndata:{\"token\":{\"id\":662,\"text\":\" four\",\"logprob\":-0.01940918,\"special\":false},\"generated_text\":null,\"details\":null}\n\ndata:{\"token\":{\"id\":1,\"text\":\"</s>\",\"logprob\":-0.030883789,\"special\":true},\"generated_text\":\"one two three four\",\"details\":null}\n\n",
       "status": 200,
       "statusText": "OK",
       "headers": {


### PR DESCRIPTION
Not sure if this is due to the non-deterministic of text generation, however the space before the `" one"` keep making the test fail.  So I've added the index to add the space WDYT @vvmnnnkv 

```
Array(5) [
  0: Object {
  token: Object {id: 80, text: "one", logprob: -0.75390625, special: false}
  generated_text: null
  details: null
}
  1: Object {
  token: Object {id: 192, text: " two", logprob: -0.01940918, special: false}
  generated_text: null
  details: null
}
  2: Object {
  token: Object {id: 386, text: " three", logprob: -0.015197754, special: false}
  generated_text: null
  details: null
}
  3: Object {
  token: Object {id: 662, text: " four", logprob: -0.01940918, special: false}
  generated_text: null
  details: null
}
  4: Object {
  token: Object {id: 1, text: "</s>", logprob: -0.030883789, special: true}
  generated_text: "one two three four"
  details: null
}
]
```