### PR TITLE
👷 Remove shared dependency (again!)

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -57,10 +57,10 @@ jobs:
           HF_ACCESS_TOKEN: ${{ secrets.HF_ACCESS_TOKEN }}
 
       - name: E2E - start mock npm registry
-        working-directory: e2e
         run: |
           npm i -g verdaccio verdaccio-memory verdaccio-auth-memory
-          npx verdaccio --listen 4874 --config mock-registry-config.yaml &
+          echo "//localhost:4874/:_authToken=1FlYaQkIdHsIztXCHmqu9g==" >> .npmrc
+          npx verdaccio --listen 4874 --config e2e/mock-registry-config.yaml &
 
       - name: E2E test - publish packages to mock repo
         working-directory: e2e

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -91,8 +91,8 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: vx.x.x
-      - name: E2E - deno import from npm
+      - name: E2E test - deno import from npm
         working-directory: e2e/deno
         run: deno run --allow-net index.ts
         env:
-          NPM_CONFIG_REGISTRY=http://localhost:4873/
+          NPM_CONFIG_REGISTRY: http://localhost:4873/

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -56,12 +56,28 @@ jobs:
         env:
           HF_ACCESS_TOKEN: ${{ secrets.HF_ACCESS_TOKEN }}
 
+      - name: E2E - start mock npm registry
+        working-directory: e2e
+        run: |
+          pnpm i -g verdaccio verdaccio-memory verdaccio-auth-memory
+          pnpm exec verdaccio --config e2e/mock-registry-config.yaml &
+
+      - name: E2E test - publish packages to mock repo
+        working-directory: e2e
+        run: |
+          sleep 3
+          pnpm i --filter inference --filter hub --frozen-lockfile
+          pnpm --filter inference --filter hub publish --force --no-git-checks --registry http://localhost:4873/
+
+      - name: E2E test - test yarn install
+        working-directory: e2e/ts
+        run: |
+          yarn install --registry http://localhost:4873/
+
       - name: E2E test - typescript node project
         working-directory: e2e/ts
         run: |
-          pnpm i --filter inference --filter hub --frozen-lockfile
-          pnpm --filter inference --filter hub build
-          pnpm i --ignore-workspace --node-linker=hoisted
+          pnpm i --ignore-workspace --registry http://localhost:4873/
           pnpm start
         env:
           token: ${{ secrets.HF_ACCESS_TOKEN }}
@@ -69,7 +85,14 @@ jobs:
       - name: E2E test - svelte app build
         working-directory: e2e/svelte
         run: |
-          pnpm i --filter inference --filter hub --frozen-lockfile
-          pnpm --filter inference --filter hub build
-          pnpm i --ignore-workspace --node-linker=hoisted
+          pnpm i --ignore-workspace --registry http://localhost:4873/
           pnpm build
+
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: vx.x.x
+      - name: E2E - deno import from npm
+        working-directory: e2e/deno
+        run: deno run --allow-net index.ts
+        env:
+          NPM_CONFIG_REGISTRY=http://localhost:4873/

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -33,6 +33,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - run: |
+          pnpm setup
           pnpm install --frozen-lockfile --filter .
           pnpm install --frozen-lockfile --filter ...[${{ steps.since.outputs.SINCE }}]
       - name: "Checking lint errors"

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -59,6 +59,7 @@ jobs:
       - name: E2E - start mock npm registry
         run: |
           npm i -g verdaccio verdaccio-memory verdaccio-auth-memory
+          echo >> .npmrc
           echo "//localhost:4874/:_authToken=1FlYaQkIdHsIztXCHmqu9g==" >> .npmrc
           npx verdaccio --listen 4874 --config e2e/mock-registry-config.yaml &
 

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -60,24 +60,24 @@ jobs:
         working-directory: e2e
         run: |
           npm i -g verdaccio verdaccio-memory verdaccio-auth-memory
-          npx verdaccio --config e2e/mock-registry-config.yaml &
+          npx verdaccio --listen 4874 --config mock-registry-config.yaml &
 
       - name: E2E test - publish packages to mock repo
         working-directory: e2e
         run: |
           sleep 3
           pnpm i --filter inference --filter hub --frozen-lockfile
-          pnpm --filter inference --filter hub publish --force --no-git-checks --registry http://localhost:4873/
+          pnpm --filter inference --filter hub publish --force --no-git-checks --registry http://localhost:4874/
 
       - name: E2E test - test yarn install
         working-directory: e2e/ts
         run: |
-          yarn install --registry http://localhost:4873/
+          yarn install --registry http://localhost:4874/
 
       - name: E2E test - typescript node project
         working-directory: e2e/ts
         run: |
-          pnpm i --ignore-workspace --registry http://localhost:4873/
+          pnpm i --ignore-workspace --registry http://localhost:4874/
           pnpm start
         env:
           token: ${{ secrets.HF_ACCESS_TOKEN }}
@@ -85,7 +85,7 @@ jobs:
       - name: E2E test - svelte app build
         working-directory: e2e/svelte
         run: |
-          pnpm i --ignore-workspace --registry http://localhost:4873/
+          pnpm i --ignore-workspace --registry http://localhost:4874/
           pnpm build
 
       - uses: denoland/setup-deno@v1
@@ -95,4 +95,4 @@ jobs:
         working-directory: e2e/deno
         run: deno run --allow-net index.ts
         env:
-          NPM_CONFIG_REGISTRY: http://localhost:4873/
+          NPM_CONFIG_REGISTRY: http://localhost:4874/

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -33,7 +33,6 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
       - run: |
-          pnpm setup
           pnpm install --frozen-lockfile --filter .
           pnpm install --frozen-lockfile --filter ...[${{ steps.since.outputs.SINCE }}]
       - name: "Checking lint errors"
@@ -60,8 +59,8 @@ jobs:
       - name: E2E - start mock npm registry
         working-directory: e2e
         run: |
-          pnpm i -g verdaccio verdaccio-memory verdaccio-auth-memory
-          pnpm exec verdaccio --config e2e/mock-registry-config.yaml &
+          npm i -g verdaccio verdaccio-memory verdaccio-auth-memory
+          npx verdaccio --config e2e/mock-registry-config.yaml &
 
       - name: E2E test - publish packages to mock repo
         working-directory: e2e

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -73,6 +73,7 @@ jobs:
       - name: E2E test - test yarn install
         working-directory: e2e/ts
         run: |
+          npm i -g yarn --force
           yarn install --registry http://localhost:4874/
 
       - name: E2E test - typescript node project

--- a/README.md
+++ b/README.md
@@ -71,10 +71,14 @@ You can run our packages with vanilla JS, without any bundler, by using a CDN or
 ### Deno
 
 ```ts
-import { HfInference } from "https://esm.sh/@huggingface/inference@2.3.2"
+// esm.sh
+import { HfInference } from "https://esm.sh/@huggingface/inference"
+import { createRepo, commit, deleteRepo, listFiles } from "https://esm.sh/@huggingface/hub"
+// or npm:
+import { HfInference } from "npm:@huggingface/inference"
+import { createRepo, commit, deleteRepo, listFiles } from "npm:@huggingface/hub"
 ```
 
-This is not yet supported for `@huggingface/hub`, open an issue if you need it!
 
 ## Usage examples
 

--- a/e2e/deno/index.ts
+++ b/e2e/deno/index.ts
@@ -1,0 +1,22 @@
+import {HfInference} from "npm:@huggingface/inference@*";
+import {whoAmI, listFiles} from "npm:@huggingface/hub@*";
+
+const hf = new HfInference();
+
+const info = await whoAmI({credentials: {accessToken: "hf_hub.js"}, hubUrl: "https://hub-ci.huggingface.co"});
+console.log(info);
+
+for await (const file of listFiles({credentials: {accessToken: 'hf_hub.js'}, repo: 'gpt2'})) {
+    console.log(file);
+}
+
+const sum = await hf.summarization({
+    model: "facebook/bart-large-cnn",
+    inputs:
+        "The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building, and the tallest structure in Paris. Its base is square, measuring 125 metres (410 ft) on each side. During its construction, the Eiffel Tower surpassed the Washington Monument to become the tallest man-made structure in the world, a title it held for 41 years until the Chrysler Building in New York City was finished in 1930.",
+    parameters: {
+        max_length: 100,
+    },
+});
+
+console.log(sum);

--- a/e2e/mock-registry-config.yaml
+++ b/e2e/mock-registry-config.yaml
@@ -1,0 +1,21 @@
+auth:
+  auth-memory:
+    users:
+      foo:
+        name: test
+        password: test
+store:
+  memory:
+    limit: 1000
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+packages:
+  '@huggingface/*':
+    access: $all
+    publish: $all
+  '**':
+    access: $all
+    proxy: npmjs
+log:
+ - {type: stdout, format: pretty, level: trace}

--- a/e2e/svelte/package.json
+++ b/e2e/svelte/package.json
@@ -20,7 +20,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@huggingface/hub": "file:../../packages/hub",
-		"@huggingface/inference": "file:../../packages/inference"
+		"@huggingface/inference": "*",
+		"@huggingface/hub": "*"
 	}
 }

--- a/e2e/ts/package.json
+++ b/e2e/ts/package.json
@@ -14,7 +14,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "@huggingface/inference": "file://../../packages/inference",
-    "@huggingface/hub": "file://../../packages/hub"
+    "@huggingface/inference": "*",
+    "@huggingface/hub": "*"
   }
 }

--- a/e2e/yarn/package.json
+++ b/e2e/yarn/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "yarn",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "@huggingface/inference": "*",
+    "@huggingface/hub": "*"
+  }
+}

--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -2,8 +2,23 @@
 
 Official utilities to use the Hugging Face hub API, still very experimental.
 
-```
+## Install
+
+```console
+pnpm add @huggingface/hub
+
 npm add @huggingface/hub
+
+yarn add @huggingface/hub
+```
+
+### Deno
+
+```ts
+// esm.sh
+import { HfInference } from "https://esm.sh/@huggingface/hub"
+// or npm:
+import { HfInference } from "npm:@huggingface/hub"
 ```
 
 Check out the [full documentation](https://huggingface.co/docs/huggingface.js/hub/README).

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -9,7 +9,7 @@
 	},
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
-	"types": "./index.ts",
+	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
 			"types": "./index.ts",
@@ -55,16 +55,11 @@
 	"author": "Hugging Face",
 	"license": "MIT",
 	"devDependencies": {
-		"@huggingface/shared": "workspace:*",
 		"@types/node": "^18.13.0",
 		"type-fest": "^3.9.0",
 		"typescript": "^5.0.4"
 	},
 	"dependencies": {
 		"hash-wasm": "^4.9.0"
-	},
-	"bundledDependencies": [
-		"@huggingface/shared",
-		"type-fest"
-	]
+	}
 }

--- a/packages/hub/pnpm-lock.yaml
+++ b/packages/hub/pnpm-lock.yaml
@@ -6,9 +6,6 @@ dependencies:
     version: 4.9.0
 
 devDependencies:
-  '@huggingface/shared':
-    specifier: workspace:*
-    version: link:../shared
   '@types/node':
     specifier: ^18.13.0
     version: 18.13.0

--- a/packages/hub/src/lib/commit.spec.ts
+++ b/packages/hub/src/lib/commit.spec.ts
@@ -9,7 +9,7 @@ import { deleteRepo } from "./delete-repo";
 import { downloadFile } from "./download-file";
 import { fileDownloadInfo } from "./file-download-info";
 import { insecureRandomString } from "../utils/insecureRandomString";
-import { isFrontend } from "@huggingface/shared";
+import { isFrontend } from "../../../shared";
 
 const lfsContent = "O123456789".repeat(100_000);
 

--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -1,4 +1,4 @@
-import { isFrontend, base64FromBytes } from "@huggingface/shared";
+import { isFrontend, base64FromBytes } from "../../../shared";
 import { HUB_URL } from "../consts";
 import { HubApiError, createApiError, InvalidApiResponseFormatError } from "../error";
 import type {

--- a/packages/hub/src/lib/create-repo.ts
+++ b/packages/hub/src/lib/create-repo.ts
@@ -2,7 +2,7 @@ import { HUB_URL } from "../consts";
 import { createApiError } from "../error";
 import type { ApiCreateRepoPayload } from "../types/api/api-create-repo";
 import type { Credentials, RepoDesignation, SpaceSdk } from "../types/public";
-import { base64FromBytes } from "@huggingface/shared";
+import { base64FromBytes } from "../../../shared";
 import { checkCredentials } from "../utils/checkCredentials";
 import { toRepoId } from "../utils/toRepoId";
 

--- a/packages/hub/src/utils/WebBlob.spec.ts
+++ b/packages/hub/src/utils/WebBlob.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { base64FromBytes } from "@huggingface/shared";
+import { base64FromBytes } from "../../../shared";
 import { WebBlob } from "./WebBlob";
 
 describe("WebBlob", async () => {

--- a/packages/hub/src/utils/createBlob.ts
+++ b/packages/hub/src/utils/createBlob.ts
@@ -1,4 +1,4 @@
-import { isFrontend } from "@huggingface/shared";
+import { isFrontend } from "../../../shared";
 import { WebBlob } from "./WebBlob";
 
 /**

--- a/packages/hub/src/utils/sha256.ts
+++ b/packages/hub/src/utils/sha256.ts
@@ -1,4 +1,4 @@
-import { isFrontend } from "@huggingface/shared";
+import { isFrontend } from "../../../shared";
 import { hexFromBytes } from "./hexFromBytes";
 
 /**

--- a/packages/hub/tsup.config.ts
+++ b/packages/hub/tsup.config.ts
@@ -6,7 +6,7 @@ const baseConfig: Options = {
 	outDir: "dist",
 	clean: true,
 	dts: {
-		resolve: true
+		resolve: true,
 	},
 };
 

--- a/packages/hub/tsup.config.ts
+++ b/packages/hub/tsup.config.ts
@@ -5,7 +5,9 @@ const baseConfig: Options = {
 	format: ["cjs", "esm"],
 	outDir: "dist",
 	clean: true,
-	dts: false,
+	dts: {
+		resolve: true
+	},
 };
 
 const nodeConfig: Options = {

--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -12,14 +12,17 @@ You can also try out a live [interactive notebook](https://observablehq.com/@hug
 npm install @huggingface/inference
 
 pnpm add @huggingface/inference
-```
 
-`yarn` doesn't work because it tries to get dev dependencies, one of which is private.
+yarn add @huggingface/inference
+```
 
 ### Deno
 
 ```ts
-import { HfInference } from "https://esm.sh/@huggingface/inference@2.3.2"
+// esm.sh
+import { HfInference } from "https://esm.sh/@huggingface/inference"
+// or npm:
+import { HfInference } from "npm:@huggingface/inference"
 ```
 
 ## Usage

--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -50,15 +50,11 @@
 		"type-check": "tsc"
 	},
 	"devDependencies": {
-		"@huggingface/shared": "workspace:*",
 		"@types/node": "18.13.0",
 		"ts-node": "^10.9.1",
 		"typescript": "^5.0.4",
 		"vite": "^4.1.4",
 		"vitest": "^0.29.8"
 	},
-	"bundledDependencies": [
-		"@huggingface/shared"
-	],
 	"resolutions": {}
 }

--- a/packages/inference/pnpm-lock.yaml
+++ b/packages/inference/pnpm-lock.yaml
@@ -1,9 +1,6 @@
 lockfileVersion: '6.0'
 
 devDependencies:
-  '@huggingface/shared':
-    specifier: workspace:*
-    version: link:../shared
   '@types/node':
     specifier: 18.13.0
     version: 18.13.0

--- a/packages/inference/src/tasks/cv/imageToImage.ts
+++ b/packages/inference/src/tasks/cv/imageToImage.ts
@@ -1,7 +1,7 @@
 import { InferenceOutputError } from "../../lib/InferenceOutputError";
 import type { BaseArgs, Options, RequestArgs } from "../../types";
 import { request } from "../custom/request";
-import { base64FromBytes } from "@huggingface/shared";
+import { base64FromBytes } from "../../../../shared";
 
 export type ImageToImageArgs = BaseArgs & {
 	/**

--- a/packages/inference/src/tasks/multimodal/documentQuestionAnswering.ts
+++ b/packages/inference/src/tasks/multimodal/documentQuestionAnswering.ts
@@ -2,7 +2,7 @@ import { InferenceOutputError } from "../../lib/InferenceOutputError";
 import type { BaseArgs, Options } from "../../types";
 import { request } from "../custom/request";
 import type { RequestArgs } from "../../types";
-import { base64FromBytes } from "@huggingface/shared";
+import { base64FromBytes } from "../../../../shared";
 import { toArray } from "../../utils/toArray";
 
 export type DocumentQuestionAnsweringArgs = BaseArgs & {

--- a/packages/inference/src/tasks/multimodal/visualQuestionAnswering.ts
+++ b/packages/inference/src/tasks/multimodal/visualQuestionAnswering.ts
@@ -1,7 +1,7 @@
 import { InferenceOutputError } from "../../lib/InferenceOutputError";
 import type { BaseArgs, Options, RequestArgs } from "../../types";
 import { request } from "../custom/request";
-import { base64FromBytes } from "@huggingface/shared";
+import { base64FromBytes } from "../../../../shared";
 
 export type VisualQuestionAnsweringArgs = BaseArgs & {
 	inputs: {

--- a/packages/inference/test/vcr.ts
+++ b/packages/inference/test/vcr.ts
@@ -1,5 +1,5 @@
 import { omit } from "../src/utils/omit";
-import { isBackend, isFrontend } from "@huggingface/shared";
+import { isBackend, isFrontend } from "../../shared";
 
 const TAPES_FILE = "./tapes.json";
 const BASE64_PREFIX = "data:application/octet-stream;base64,";


### PR DESCRIPTION
It turned out that shared workspace dependency must be public in order to work with yarn.
Also yarn & deno still try to resolve bundledDependencies.
So we're back to imports from relative path.
However, since package.json's `types` of hub & inference now point to compiled d.ts, this doesn't lead to missing imports problem when using npm packages.
Note that types imported from `type-fest` are resolved into d.ts.
