### PR TITLE
Fix non-unique hashlinks problem

### DIFF
--- a/.github/workflows/pr-documentation.yml
+++ b/.github/workflows/pr-documentation.yml
@@ -6,6 +6,7 @@ on:
       - "README.md"
       - "docs/**"
       - "packages/hub/README.md"
+      - "packages/doc-internal/**"
       - "packages/inference/README.md"
 
 concurrency:

--- a/packages/doc-internal/fix-md-headinghashlinks.ts
+++ b/packages/doc-internal/fix-md-headinghashlinks.ts
@@ -1,0 +1,53 @@
+import { readFileSync, writeFileSync } from "fs";
+import glob from "glob";
+import { join } from "path";
+
+const regex = /^(#+)\s+(.*)/gm;
+const LEVEL_3 = 3 as const;
+const LEVEL_4 = 4 as const;
+const NON_UNIQUE_HEADINGS = new Set([
+	"Defined in",
+	"Parameters",
+	"Returns",
+	"Type parameters",
+	"Type declaration",
+	"Overrides",
+	"Inherited from",
+]);
+
+// same rule as defined in https://github.com/huggingface/doc-builder#anchor-link
+function createHtmlId(mdHeading: string): string {
+	return mdHeading
+		.toLowerCase()
+		.replaceAll(" ", "-")
+		.replace(/[^a-z0-9-]/g, "");
+}
+
+// this script fixes a problem where same markdown headings generates html elements
+// with same id (non-unique id) (ex: all `#### Returns` headings become `<h4 id="returns">Returns</h4>`)
+// to fix this non-unique id problem, doc builder provides a syntax `# {heading_text}[[{custom_id}]]`
+// read more https://github.com/huggingface/doc-builder#anchor-link
+// (ex: `### Returns` now becomes `#### Returns[[some-function-name.returns]]`)
+for (const mdFile of await glob("**/*.md", { cwd: "../../docs" })) {
+	const content = readFileSync(join("../../docs", mdFile)).toString();
+	let modifiedMarkdown = content;
+	let offset = 0;
+	let match;
+	let current_level_3: string | undefined = undefined;
+	while ((match = regex.exec(content)) !== null) {
+		const headingLevel = match[1].length;
+		const headingText = match[2];
+		if (headingLevel === LEVEL_3) {
+			current_level_3 = headingText;
+		} else if (headingLevel === LEVEL_4 && NON_UNIQUE_HEADINGS.has(headingText) && current_level_3) {
+			const matchText = match[0];
+			const matchIndex = match.index + offset;
+			const replacement = matchText + `[[${createHtmlId(current_level_3)}.${createHtmlId(headingText)}]]`;
+			modifiedMarkdown =
+				modifiedMarkdown.slice(0, matchIndex) + replacement + modifiedMarkdown.slice(matchIndex + matchText.length);
+			offset += replacement.length - matchText.length;
+		}
+	}
+
+	writeFileSync(join("../../docs", mdFile), modifiedMarkdown);
+}

--- a/packages/doc-internal/fix-md-headinghashlinks.ts
+++ b/packages/doc-internal/fix-md-headinghashlinks.ts
@@ -36,7 +36,8 @@ for (const mdFile of await glob("**/*.md", { cwd: "../../docs" })) {
 		const headingLevel = match[1].length;
 		const headingText = match[2];
 		headings[headingLevel] = headingText;
-		const parentHeading = headings[headingLevel - 1];
+		const parentHeading =
+			headings[headingLevel - 1] !== "Type declaration" ? headings[headingLevel - 1] : headings[headingLevel - 2];
 		if (NON_UNIQUE_HEADINGS.has(headingText) && parentHeading) {
 			const matchText = match[0];
 			const matchIndex = match.index + offset;

--- a/packages/doc-internal/fix-md-headinghashlinks.ts
+++ b/packages/doc-internal/fix-md-headinghashlinks.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync } from "fs";
 import glob from "glob";
 import { join } from "path";
 
-const regex = /^(#+)\s+(.*)/gm;
+const RE_MD_HEADING = /^(#+)\s+(.*)/gm;
 const LEVEL_3 = 3 as const;
 const LEVEL_4 = 4 as const;
 const NON_UNIQUE_HEADINGS = new Set([
@@ -34,7 +34,7 @@ for (const mdFile of await glob("**/*.md", { cwd: "../../docs" })) {
 	let offset = 0;
 	let match;
 	let current_level_3: string | undefined = undefined;
-	while ((match = regex.exec(content)) !== null) {
+	while ((match = RE_MD_HEADING.exec(content)) !== null) {
 		const headingLevel = match[1].length;
 		const headingText = match[2];
 		if (headingLevel === LEVEL_3) {

--- a/packages/doc-internal/package.json
+++ b/packages/doc-internal/package.json
@@ -5,18 +5,19 @@
 	"description": "Package to generate doc for other @huggingface packages",
 	"private": true,
 	"scripts": {
-		"start": "pnpm run fix-cdn-versions && pnpm run doc-hub && pnpm run doc-inference && cp ../../README.md ../../docs/index.md && pnpm run update-toc && pnpm run fix-md-links",
+		"start": "pnpm run fix-cdn-versions && pnpm run doc-hub && pnpm run doc-inference && cp ../../README.md ../../docs/index.md && pnpm run update-toc && pnpm run fix-md-links && pnpm run fix-md-headinghashlinks",
 		"lint": "eslint --quiet --fix --ext .cjs,.ts .",
 		"lint:check": "eslint --ext .cjs,.ts .",
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
-		"prepublish-hub": "pnpm run fix-cdn-versions && pnpm run doc-hub && cp ../../README.md ../../docs/index.md && pnpm run update-toc && pnpm run fix-md-links",
-		"prepublish-inference": "pnpm run fix-cdn-versions && pnpm run doc-inference && cp ../../README.md ../../docs/index.md && pnpm run update-toc && pnpm run fix-md-links",
+		"prepublish-hub": "pnpm run fix-cdn-versions && pnpm run doc-hub && cp ../../README.md ../../docs/index.md && pnpm run update-toc && pnpm run fix-md-links && pnpm run fix-md-headinghashlinks",
+		"prepublish-inference": "pnpm run fix-cdn-versions && pnpm run doc-inference && cp ../../README.md ../../docs/index.md && pnpm run update-toc && pnpm run fix-md-links && pnpm run fix-md-headinghashlinks",
 		"doc-hub": "typedoc --tsconfig ../hub/tsconfig.json --githubPages false --plugin typedoc-plugin-markdown --out ../../docs/hub --hideBreadcrumbs --hideInPageTOC --sourceLinkTemplate https://github.com/huggingface/huggingface.js/blob/main/{path}#L{line} ../hub/index.ts",
 		"doc-inference": "typedoc --tsconfig ../inference/tsconfig.json --githubPages false --plugin typedoc-plugin-markdown --out ../../docs/inference --hideBreadcrumbs --hideInPageTOC --sourceLinkTemplate https://github.com/huggingface/huggingface.js/blob/main/{path}#L{line} ../inference/src/index.ts",
 		"update-toc": "ts-node --esm update-toc.ts",
 		"fix-cdn-versions": "ts-node --esm fix-cdn-versions.ts",
-		"fix-md-links": "ts-node --esm fix-md-links.ts"
+		"fix-md-links": "ts-node --esm fix-md-links.ts",
+		"fix-md-headinghashlinks": "ts-node --esm fix-md-headinghashlinks"
 	},
 	"type": "module",
 	"license": "MIT",

--- a/packages/doc-internal/package.json
+++ b/packages/doc-internal/package.json
@@ -17,7 +17,7 @@
 		"update-toc": "ts-node --esm update-toc.ts",
 		"fix-cdn-versions": "ts-node --esm fix-cdn-versions.ts",
 		"fix-md-links": "ts-node --esm fix-md-links.ts",
-		"fix-md-headinghashlinks": "ts-node --esm fix-md-headinghashlinks"
+		"fix-md-headinghashlinks": "ts-node --esm fix-md-headinghashlinks.ts"
 	},
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
### Problem

doc-builder turns markdown headings into html ids by replacing space with `-` (for example: `## Defined in` -> `id="defined-in"`) and this becomes a problem when there are same markdown headings -> multiple elements with same ids. Right navbar navigation breaks https://huggingface.co/docs/huggingface.js/hub/modules#downloadfile

### Solution

Doc-builder provides [syntax](https://github.com/huggingface/doc-builder#anchor-link) to customize element ids. 

#### Example

before:
```
# Interface: Credentials
## Properties
### accessToken
• **accessToken**: `string`
#### Defined in
hub/src/types/public.d.ts:16
```

after:
```
# Interface: Credentials
## Properties
### accessToken
• **accessToken**: `string`
#### Defined in[[accesstoken.defined-in]]
hub/src/types/public.d.ts:16
```