### PR TITLE
Switch order of docs

### DIFF
--- a/docs/_toctree.yml
+++ b/docs/_toctree.yml
@@ -1,16 +1,16 @@
 - local: index
   title: 🤗 Hugging Face JS Libraries
-- title: "@huggingface/hub"
-  isExpanded: true
-  sections:
-    - local: hub/README
-      title: Interact with the Hub
-    - local: hub/modules
-      title: API Reference
 - title: "@huggingface/inference"
   isExpanded: true
   sections:
     - local: inference/README
       title: Use the Inference API
     - local: inference/modules
+      title: API Reference
+- title: "@huggingface/hub"
+  isExpanded: true
+  sections:
+    - local: hub/README
+      title: Interact with the Hub
+    - local: hub/modules
       title: API Reference


### PR DESCRIPTION
First show Inference API, then Hub utilities