### PR TITLE
Get rid of default models on some tools

### DIFF
--- a/packages/agents/src/tools/imageToText.ts
+++ b/packages/agents/src/tools/imageToText.ts
@@ -18,7 +18,6 @@ export const imageToTextTool: Tool = {
 			await inference.imageToText(
 				{
 					data,
-					model: "nlpconnect/vit-gpt2-image-captioning",
 				},
 				{ wait_for_model: true }
 			)

--- a/packages/agents/src/tools/speechToText.ts
+++ b/packages/agents/src/tools/speechToText.ts
@@ -18,7 +18,6 @@ export const speechToTextTool: Tool = {
 			await inference.automaticSpeechRecognition(
 				{
 					data,
-					model: "facebook/wav2vec2-large-960h-lv60-self",
 				},
 				{ wait_for_model: true }
 			)

--- a/packages/agents/src/tools/textToImage.ts
+++ b/packages/agents/src/tools/textToImage.ts
@@ -22,7 +22,6 @@ export const textToImageTool: Tool = {
 		return await inference.textToImage(
 			{
 				inputs: data,
-				model: "stabilityai/stable-diffusion-2",
 			},
 			{ wait_for_model: true }
 		);


### PR DESCRIPTION
The models I hardcoded were outdated for certain tools so I removed them. Now the tools will use the model suggestions from the API instead so we're always up to date.

I left the hardcoded model on `textToSpeech` since the suggested models in the API don't work for now. (See [this pr](https://github.com/huggingface/transformers/pull/24952))