### PR TITLE
fix: fetch options for getDefaultTask

### DIFF
--- a/packages/inference/src/lib/getDefaultTask.ts
+++ b/packages/inference/src/lib/getDefaultTask.ts
@@ -10,13 +10,17 @@ const CACHE_DURATION = 10 * 60 * 1000;
 const MAX_CACHE_ITEMS = 1000;
 export const HF_HUB_URL = "https://huggingface.co";
 
+export interface DefaultTaskOptions {
+	fetch?: typeof fetch
+}
+
 /**
  * Get the default task. Use a LRU cache of 1000 items with 10 minutes expiration
  * to avoid making too many calls to the HF hub.
  *
  * @returns The default task for the model, or `null` if it was impossible to get it
  */
-export async function getDefaultTask(model: string, accessToken: string | undefined): Promise<string | null> {
+export async function getDefaultTask(model: string, accessToken: string | undefined, options?: DefaultTaskOptions): Promise<string | null> {
 	if (isUrl(model)) {
 		return null;
 	}
@@ -30,7 +34,7 @@ export async function getDefaultTask(model: string, accessToken: string | undefi
 	}
 
 	if (cachedTask === undefined) {
-		const modelTask = await fetch(`${HF_HUB_URL}/api/models/${model}?expand[]=pipeline_tag`, {
+		const modelTask = await (options?.fetch ?? fetch)(`${HF_HUB_URL}/api/models/${model}?expand[]=pipeline_tag`, {
 			headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
 		})
 			.then((resp) => resp.json())

--- a/packages/inference/src/tasks/nlp/featureExtraction.ts
+++ b/packages/inference/src/tasks/nlp/featureExtraction.ts
@@ -25,7 +25,7 @@ export async function featureExtraction(
 	args: FeatureExtractionArgs,
 	options?: Options
 ): Promise<FeatureExtractionOutput> {
-	const defaultTask = args.model ? await getDefaultTask(args.model, args.accessToken) : undefined;
+	const defaultTask = args.model ? await getDefaultTask(args.model, args.accessToken, options) : undefined;
 
 	const res = await request<FeatureExtractionOutput>(args, {
 		...options,

--- a/packages/inference/src/tasks/nlp/sentenceSimilarity.ts
+++ b/packages/inference/src/tasks/nlp/sentenceSimilarity.ts
@@ -25,7 +25,7 @@ export async function sentenceSimilarity(
 	args: SentenceSimilarityArgs,
 	options?: Options
 ): Promise<SentenceSimilarityOutput> {
-	const defaultTask = args.model ? await getDefaultTask(args.model, args.accessToken) : undefined;
+	const defaultTask = args.model ? await getDefaultTask(args.model, args.accessToken, options) : undefined;
 	const res = await request<SentenceSimilarityOutput>(args, {
 		...options,
 		taskHint: "sentence-similarity",


### PR DESCRIPTION
The `fetch` function call should use the `fetch` options from the callee.