### PR TITLE
Add stop sequences as a parameter in TextGenerationArgs

### DIFF
--- a/packages/inference/src/tasks/nlp/textGeneration.ts
+++ b/packages/inference/src/tasks/nlp/textGeneration.ts
@@ -48,6 +48,10 @@ export type TextGenerationArgs = BaseArgs & {
 		 * (Default: None). Integer. The maximum number of tokens from the input.
 		 */
 		truncate?: number;
+		/**
+		 * (Default: []) List of strings. The model will stop generating text when one of the strings in the list is generated.
+		 * **/
+		stop_sequences?: string[];
 	};
 };
 


### PR DESCRIPTION
Seems like the param was available in the python lib but not the JS one. I think it only needed to be added there, but please check  :grin: 