### PR TITLE
add abort signal to streaming requests

### DIFF
--- a/packages/inference/src/tasks/custom/streamingRequest.ts
+++ b/packages/inference/src/tasks/custom/streamingRequest.ts
@@ -66,6 +66,9 @@ export async function* streamingRequest<T>(
 			if (done) return;
 			onChunk(value);
 			for (const event of events) {
+				if (options?.signal?.aborted) {
+					throw new Error("Request aborted");
+				}
 				if (event.data.length > 0) {
 					const data = JSON.parse(event.data);
 					if (typeof data === "object" && data !== null && "error" in data) {

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -24,6 +24,10 @@ export interface Options {
 	 * Custom fetch function to use instead of the default one, for example to use a proxy or edit headers.
 	 */
 	fetch?: typeof fetch;
+	/**
+	 * Abort Controller signal to use for request interruption.
+	 */
+	signal?: AbortSignal;
 
 	/**
 	 * (Default: "same-origin"). String | Boolean. Credentials to use for the request. If this is a string, it will be passed straight on. If it's a boolean, true will be "include" and false will not send credentials at all.

--- a/packages/inference/test/HfInference.spec.ts
+++ b/packages/inference/test/HfInference.spec.ts
@@ -243,8 +243,26 @@ describe.concurrent(
 			});
 
 			await expect(response.next()).rejects.toThrow(
-				"Input validation error: `inputs` tokens + `max_new_tokens` must be <= 4096. Given: 17 `inputs` tokens and 10000 `max_new_tokens`"
+				"Input validation error: `inputs` tokens + `max_new_tokens` must be <= 2048. Given: 17 `inputs` tokens and 10000 `max_new_tokens`"
 			);
+		});
+
+		it("textGenerationStream - Abort", async () => {
+			const controller = new AbortController();
+			const response = hf.textGenerationStream(
+				{
+					model: "OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5",
+					inputs: "Write a short story about a robot that becomes sentient and takes over the world.",
+					parameters: {
+						max_new_tokens: 1000,
+					},
+				},
+				{ signal: controller.signal }
+			);
+			await expect(response.next()).resolves.toBeDefined();
+			await expect(response.next()).resolves.toBeDefined();
+			controller.abort();
+			await expect(response.next()).rejects.toThrow("Request aborted");
 		});
 
 		it("tokenClassification", async () => {


### PR DESCRIPTION
Add abort signal as option to interrupt fetch streaming. fix #259 