### PR TITLE
:lock: move test creds constants in a separate file

### DIFF
--- a/packages/hub/src/consts.ts
+++ b/packages/hub/src/consts.ts
@@ -1,4 +1,1 @@
 export const HUB_URL = "https://huggingface.co";
-export const TEST_HUB_URL = "https://hub-ci.huggingface.co";
-export const TEST_USER = "hub.js";
-export const TEST_ACCESS_TOKEN = "hf_hub.js";

--- a/packages/hub/src/lib/commit.spec.ts
+++ b/packages/hub/src/lib/commit.spec.ts
@@ -1,6 +1,6 @@
 import { assert, it, describe } from "vitest";
 
-import { TEST_HUB_URL, TEST_ACCESS_TOKEN, TEST_USER } from "../consts";
+import { TEST_HUB_URL, TEST_ACCESS_TOKEN, TEST_USER } from "../test/consts";
 import type { RepoId } from "../types/public";
 import type { CommitFile } from "./commit";
 import { commit } from "./commit";

--- a/packages/hub/src/lib/create-repo.spec.ts
+++ b/packages/hub/src/lib/create-repo.spec.ts
@@ -1,6 +1,6 @@
 import { assert, it, describe, expect } from "vitest";
 
-import { TEST_HUB_URL, TEST_ACCESS_TOKEN, TEST_USER } from "../consts";
+import { TEST_HUB_URL, TEST_ACCESS_TOKEN, TEST_USER } from "../test/consts";
 import { insecureRandomString } from "../utils/insecureRandomString";
 import { createRepo } from "./create-repo";
 import { deleteRepo } from "./delete-repo";

--- a/packages/hub/src/lib/delete-file.spec.ts
+++ b/packages/hub/src/lib/delete-file.spec.ts
@@ -1,6 +1,6 @@
 import { assert, it, describe } from "vitest";
 
-import { TEST_ACCESS_TOKEN, TEST_HUB_URL, TEST_USER } from "../consts";
+import { TEST_ACCESS_TOKEN, TEST_HUB_URL, TEST_USER } from "../test/consts";
 import type { RepoId } from "../types/public";
 import { insecureRandomString } from "../utils/insecureRandomString";
 import { createRepo } from "./create-repo";

--- a/packages/hub/src/lib/delete-files.spec.ts
+++ b/packages/hub/src/lib/delete-files.spec.ts
@@ -1,6 +1,6 @@
 import { assert, it, describe } from "vitest";
 
-import { TEST_HUB_URL, TEST_ACCESS_TOKEN, TEST_USER } from "../consts";
+import { TEST_HUB_URL, TEST_ACCESS_TOKEN, TEST_USER } from "../test/consts";
 import type { RepoId } from "../types/public";
 import { insecureRandomString } from "../utils/insecureRandomString";
 import { createRepo } from "./create-repo";

--- a/packages/hub/src/lib/upload-file.spec.ts
+++ b/packages/hub/src/lib/upload-file.spec.ts
@@ -1,6 +1,6 @@
 import { assert, it, describe } from "vitest";
 
-import { TEST_ACCESS_TOKEN, TEST_HUB_URL, TEST_USER } from "../consts";
+import { TEST_ACCESS_TOKEN, TEST_HUB_URL, TEST_USER } from "../test/consts";
 import type { RepoId } from "../types/public";
 import { insecureRandomString } from "../utils/insecureRandomString";
 import { createRepo } from "./create-repo";

--- a/packages/hub/src/lib/upload-files-with-progress.spec.ts
+++ b/packages/hub/src/lib/upload-files-with-progress.spec.ts
@@ -1,6 +1,6 @@
 import { assert, it, describe } from "vitest";
 
-import { TEST_HUB_URL, TEST_ACCESS_TOKEN, TEST_USER } from "../consts";
+import { TEST_HUB_URL, TEST_ACCESS_TOKEN, TEST_USER } from "../test/consts";
 import type { RepoId } from "../types/public";
 import { insecureRandomString } from "../utils/insecureRandomString";
 import { createRepo } from "./create-repo";

--- a/packages/hub/src/lib/upload-files.spec.ts
+++ b/packages/hub/src/lib/upload-files.spec.ts
@@ -1,6 +1,6 @@
 import { assert, it, describe } from "vitest";
 
-import { TEST_ACCESS_TOKEN, TEST_HUB_URL, TEST_USER } from "../consts";
+import { TEST_ACCESS_TOKEN, TEST_HUB_URL, TEST_USER } from "../test/consts";
 import type { RepoId } from "../types/public";
 import { insecureRandomString } from "../utils/insecureRandomString";
 import { createRepo } from "./create-repo";

--- a/packages/hub/src/lib/who-am-i.spec.ts
+++ b/packages/hub/src/lib/who-am-i.spec.ts
@@ -1,5 +1,5 @@
 import { assert, it, describe } from "vitest";
-import { TEST_ACCESS_TOKEN, TEST_HUB_URL } from "../consts";
+import { TEST_ACCESS_TOKEN, TEST_HUB_URL } from "../test/consts";
 import { whoAmI } from "./who-am-i";
 
 describe("whoAmI", () => {

--- a/packages/hub/src/test/consts.ts
+++ b/packages/hub/src/test/consts.ts
@@ -1,0 +1,3 @@
+export const TEST_HUB_URL = "https://hub-ci.huggingface.co";
+export const TEST_USER = "hub.js";
+export const TEST_ACCESS_TOKEN = "hf_hub.js";


### PR DESCRIPTION
Not sure if this change makes a lot of sense, but when the test creds are split into `test` folder, it just feels better to dismiss following alert choosing "Used in tests, This alert is not in production code" :)
https://github.com/huggingface/huggingface.js/security/code-scanning/1