### PR TITLE
 Exclude Autogenerated Files for Accurate Checksum in CI Workflow

### DIFF
--- a/.github/workflows/widgets-publish.yml
+++ b/.github/workflows/widgets-publish.yml
@@ -38,14 +38,12 @@ jobs:
           git commit . -m "🔖 @huggingface/widgets $BUMPED_VERSION"
           git tag "widgets-v$BUMPED_VERSION"
       - run: |
-
           # Clean up the workspace
           rm -rf ../tasks/node_modules ../tasks/dist
 
           # Calculate checksum of the cleaned package
           echo "Calculating checksum of local @huggingface/tasks package..."
           LOCAL_CHECKSUM=$(cd ../tasks && tar --mtime='1970-01-01' --mode=755 -cf - . | sha256sum | cut -d' ' -f1)
-
           echo "Local package checksum: $LOCAL_CHECKSUM"
 
           # Fetch the latest published version of @huggingface/tasks from npm
@@ -63,15 +61,12 @@ jobs:
             exit 1
           fi
 
-
           # Extract and remove dist and node_modules directories before checksum calculation
           mkdir -p /tmp/tasks
           tar -xf huggingface-tasks-$LATEST_PUBLISHED_VERSION.tgz -C /tmp/tasks
           rm -rf /tmp/tasks/dist /tmp/tasks/node_modules
 
           REMOTE_CHECKSUM=$(cd /tmp/tasks && tar --mtime='1970-01-01' --mode=755 -cf - . | sha256sum | cut -d' ' -f1)
-
-
           echo "Remote package checksum: $REMOTE_CHECKSUM"
 
           if [ "$LOCAL_CHECKSUM" != "$REMOTE_CHECKSUM" ]; then


### PR DESCRIPTION
Follow up #368 
Fixes #361 
This PR resolves inconsistent checksums in  GitHub Actions for @huggingface/tasks by excluding `node_modules `and `dist` files from checksum calculations. These changes ensure checksum consistency across environments, as demonstrated in multiple workflow runs: 

In both screenshots, it's evident that the checksums are consistently matched, with identical values for Local and Remote in each respective run.

[Run 1 job/19077519008](https://github.com/kohsheen1234/huggingface.js/actions/runs/7012643832/job/19077519008), 
<img width="1451" alt="Screenshot 2023-11-27 at 7 54 03 PM" src="https://github.com/huggingface/huggingface.js/assets/22408440/6fc02534-65dd-4dc3-ab90-6bd5677838fb">


[Run 2 job/19077523195](https://github.com/kohsheen1234/huggingface.js/actions/runs/7012645392/job/19077523195). 
<img width="1512" alt="Screenshot 2023-11-27 at 7 54 24 PM" src="https://github.com/huggingface/huggingface.js/assets/22408440/6c722ae9-0dfc-4f02-9212-ba06d9f63398">

