### PR TITLE
Change Maximize text to Minimize when it is already maximized

### DIFF
--- a/packages/widgets/src/lib/components/InferenceWidget/shared/WidgetFooter/WidgetFooter.svelte
+++ b/packages/widgets/src/lib/components/InferenceWidget/shared/WidgetFooter/WidgetFooter.svelte
@@ -2,7 +2,6 @@
 	import IconCode from "../../..//Icons/IconCode.svelte";
 	import IconMaximize from "../../..//Icons/IconMaximize.svelte";
 
-	export let onClickMaximizeBtn: () => void;
 	export let isMaximized = false;
 	export let outputJson: string;
 	export let isDisabled = false;
@@ -23,7 +22,7 @@
 			JSON Output
 		</button>
 	{/if}
-	<button class="ml-auto flex items-center" on:click|preventDefault={onClickMaximizeBtn}>
+	<button class="ml-auto flex items-center" on:click|preventDefault={() => (isMaximized = !isMaximized)}>
 		<IconMaximize classNames="mr-1" />
 		{#if !isMaximized}
 			Maximize

--- a/packages/widgets/src/lib/components/InferenceWidget/shared/WidgetFooter/WidgetFooter.svelte
+++ b/packages/widgets/src/lib/components/InferenceWidget/shared/WidgetFooter/WidgetFooter.svelte
@@ -3,6 +3,7 @@
 	import IconMaximize from "../../..//Icons/IconMaximize.svelte";
 
 	export let onClickMaximizeBtn: () => void;
+	export let isMaximized = false;
 	export let outputJson: string;
 	export let isDisabled = false;
 
@@ -24,7 +25,11 @@
 	{/if}
 	<button class="ml-auto flex items-center" on:click|preventDefault={onClickMaximizeBtn}>
 		<IconMaximize classNames="mr-1" />
-		Maximize
+		{#if !isMaximized}
+			Maximize
+		{:else}
+			Minimize
+		{/if}
 	</button>
 </div>
 {#if outputJson && isOutputJsonVisible}

--- a/packages/widgets/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/packages/widgets/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -150,6 +150,6 @@
 			<WidgetModelLoading estimatedTime={modelLoading.estimatedTime} />
 		{/if}
 		<slot name="bottom" />
-		<WidgetFooter {onClickMaximizeBtn} {outputJson} {isDisabled} />
+		<WidgetFooter {onClickMaximizeBtn} {isMaximized} {outputJson} {isDisabled} />
 	</div>
 {/if}

--- a/packages/widgets/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
+++ b/packages/widgets/src/lib/components/InferenceWidget/shared/WidgetWrapper/WidgetWrapper.svelte
@@ -104,10 +104,6 @@
 			}
 		})();
 	});
-
-	function onClickMaximizeBtn() {
-		isMaximized = !isMaximized;
-	}
 </script>
 
 {#if isDisabled && !inputSamples.length}
@@ -120,7 +116,7 @@
 		 {!modelLoadInfo ? 'hidden' : ''}"
 	>
 		{#if isMaximized}
-			<button class="absolute right-12 top-6" on:click={onClickMaximizeBtn}>
+			<button class="absolute right-12 top-6" on:click={() => (isMaximized = !isMaximized)}>
 				<IconCross classNames="text-xl text-gray-500 hover:text-black" />
 			</button>
 		{/if}
@@ -150,6 +146,6 @@
 			<WidgetModelLoading estimatedTime={modelLoading.estimatedTime} />
 		{/if}
 		<slot name="bottom" />
-		<WidgetFooter {onClickMaximizeBtn} {isMaximized} {outputJson} {isDisabled} />
+		<WidgetFooter bind:isMaximized {outputJson} {isDisabled} />
 	</div>
 {/if}


### PR DESCRIPTION
Change the text from `Maximize` to `Minimize` in the model cards when they are already Maximized.

Minimized Card:
![image](https://github.com/huggingface/hub-docs/assets/43399374/52e19963-52c2-4a21-b06a-79bfc5431b54)

Maximized Card: 
![image](https://github.com/huggingface/hub-docs/assets/43399374/caa0925f-ed83-41cd-92b8-a7e1ff1fc505)

> Whereas in the maximized version, the button should have text of `Minimize`

(Example Link: https://huggingface.co/facebook/musicgen-stereo-large?text=peaceful+music+for+studying)

Old PR (before the js files were removed from hub-docs): https://github.com/huggingface/hub-docs/pull/1138