### PR TITLE
📝 Add links to Scrimba AI Engineer path tutorials 

### DIFF
--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -27,6 +27,8 @@ Check out the [full documentation](https://huggingface.co/docs/huggingface.js/hu
 
 For some of the calls, you need to create an account and generate an [access token](https://huggingface.co/settings/tokens).
 
+Learn how to find free models using the hub package in this [interactive tutorial](https://scrimba.com/scrim/c7BbVPcd?pl=pkVnrP7uP).
+
 ```ts
 import { createRepo, uploadFiles, uploadFilesWithProgress, deleteFile, deleteRepo, listFiles, whoAmI } from "@huggingface/hub";
 import type { RepoDesignation, Credentials } from "@huggingface/hub";

--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -261,6 +261,8 @@ await hf.audioClassification({
 
 Generates natural-sounding speech from text input.
 
+Check out an [inetractive tutorial](https://scrimba.com/scrim/co8da4d23b49b648f77f4848a?pl=pkVnrP7uP)
+
 ```typescript
 await hf.textToSpeech({
   model: 'espnet/kan-bayashi_ljspeech_vits',
@@ -348,6 +350,8 @@ await hf.textToImage({
 ### Image To Image
 
 Image-to-image is the task of transforming a source image to match the characteristics of a target image or a target image domain.
+
+Check out an [inetractive tutorial](https://scrimba.com/scrim/co4834bf9a91cc81cfab07969?pl=pkVnrP7uP)
 
 ```typescript
 await hf.imageToImage({


### PR DESCRIPTION
This PR adds 3 Scrimba tutorial links: 

[Transforming Images with HuggingFace.js Inference 🤗](https://scrimba.com/scrim/co4834bf9a91cc81cfab07969?pl=pkVnrP7uP) to `packages/inference/README.md` under **Image To Image**
[Text To Speech With HuggingFace.js Inference 🤗 ](https://scrimba.com/scrim/co8da4d23b49b648f77f4848a?pl=pkVnrP7uP) to `packages/inference/README.md` under **Text To Speech**
[Finding Free Models With The HuggingFace.js Hub 🤗](https://scrimba.com/scrim/c7BbVPcd?pl=pkVnrP7uP) to `packages/hub/README.md` under **Usage**
