### PR TITLE
Fixed upload-pr-documentation.yml to include branch of the remote job build

### DIFF
--- a/.github/workflows/upload-pr-documentation.yml
+++ b/.github/workflows/upload-pr-documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@main
     with:
       package_name: huggingface.js
     secrets:


### PR DESCRIPTION
Error in the `upload-pr-documentation.yml`. Added the version/branch for the remote workflow file.

An example of failed action run: https://github.com/huggingface/huggingface.js/actions/runs/7017833220
![image](https://github.com/huggingface/huggingface.js/assets/43399374/9d225dd7-7407-4f88-9665-0737b25eaec8)
