### PR TITLE
Add 3D tasks

### DIFF
--- a/packages/hub/src/types/public.d.ts
+++ b/packages/hub/src/types/public.d.ts
@@ -85,6 +85,8 @@ export type Task =
 	| "document-question-answering"
 	| "zero-shot-image-classification"
 	| "graph-ml"
+	| "text-to-3d"
+	| "image-to-3d"
 	| "other";
 
 export interface SpaceRuntime {

--- a/packages/tasks/src/pipelines.ts
+++ b/packages/tasks/src/pipelines.ts
@@ -635,6 +635,16 @@ export const PIPELINE_DATA = {
 		modality: "cv",
 		color: "yellow",
 	},
+	"text-to-3d": {
+		name: "Text-to-3D",
+		modality: "multimodal",
+		color: "yellow",
+	},
+	"image-to-3d": {
+		name: "Image-to-3D",
+		modality: "multimodal",
+		color: "green",
+	},
 	other: {
 		name: "Other",
 		modality: "other",

--- a/packages/tasks/src/tasks/index.ts
+++ b/packages/tasks/src/tasks/index.ts
@@ -94,6 +94,8 @@ export const TASKS_MODEL_LIBRARIES: Record<PipelineType, ModelLibraryKey[]> = {
 	"zero-shot-classification": ["transformers", "transformers.js"],
 	"zero-shot-image-classification": ["transformers", "transformers.js"],
 	"zero-shot-object-detection": ["transformers", "transformers.js"],
+	"text-to-3d": [],
+	"image-to-3d": [],
 };
 
 /**
@@ -161,6 +163,8 @@ export const TASKS_DATA: Record<PipelineType, TaskData | undefined> = {
 	"zero-shot-classification": getData("zero-shot-classification", zeroShotClassification),
 	"zero-shot-image-classification": getData("zero-shot-image-classification", zeroShotImageClassification),
 	"zero-shot-object-detection": getData("zero-shot-object-detection", placeholder),
+	"text-to-3d": getData("text-to-3d", placeholder),
+	"image-to-3d": getData("image-to-3d", placeholder),
 } as const;
 
 export interface ExampleRepo {

--- a/packages/widgets/src/lib/components/Icons/IconImageTo3D.svelte
+++ b/packages/widgets/src/lib/components/Icons/IconImageTo3D.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	export let classNames = "";
+</script>
+
+<svg
+	class={classNames}
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	aria-hidden="true"
+	fill="currentColor"
+	focusable="false"
+	role="img"
+	width="1em"
+	height="1em"
+	preserveAspectRatio="xMidYMid meet"
+	viewBox="0 0 32 32"
+>
+	<path d="M11 2H2v9h2V4h7V2z" fill="currentColor" />
+	<path d="M2 21v9h9v-2H4v-7H2z" fill="currentColor" />
+	<path d="M30 11V2h-9v2h7v7h2z" fill="currentColor" />
+	<path d="M21 30h9v-9h-2v7h-7v2z" fill="currentColor" />
+	<path
+		d="M25.49 10.13l-9-5a1 1 0 0 0-1 0l-9 5A1 1 0 0 0 6 11v10a1 1 0 0 0 .51.87l9 5a1 1 0 0 0 1 0l9-5A1 1 0 0 0 26 21V11a1 1 0 0 0-.51-.87zM16 7.14L22.94 11L16 14.86L9.06 11zM8 12.7l7 3.89v7.71l-7-3.89zm9 11.6v-7.71l7-3.89v7.71z"
+		fill="currentColor"
+	/>
+</svg>

--- a/packages/widgets/src/lib/components/Icons/IconTextTo3D.svelte
+++ b/packages/widgets/src/lib/components/Icons/IconTextTo3D.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	export let classNames = "";
+</script>
+
+<svg
+	class={classNames}
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	aria-hidden="true"
+	fill="currentColor"
+	focusable="false"
+	role="img"
+	width="1em"
+	height="1em"
+	preserveAspectRatio="xMidYMid meet"
+	viewBox="0 0 32 32"
+>
+	<path
+		d="M21.49 13.115l-9-5a1 1 0 0 0-1 0l-9 5A1.008 1.008 0 0 0 2 14v9.995a1 1 0 0 0 .52.87l9 5A1.004 1.004 0 0 0 12 30a1.056 1.056 0 0 0 .49-.135l9-5A.992.992 0 0 0 22 24V14a1.008 1.008 0 0 0-.51-.885zM11 27.295l-7-3.89v-7.72l7 3.89zm1-9.45L5.06 14L12 10.135l6.94 3.86zm8 5.56l-7 3.89v-7.72l7-3.89z"
+		fill="currentColor"
+	/>
+	<path d="M30 6h-4V2h-2v4h-4v2h4v4h2V8h4V6z" fill="currentColor" />
+</svg>

--- a/packages/widgets/src/lib/components/PipelineIcon/PipelineIcon.svelte
+++ b/packages/widgets/src/lib/components/PipelineIcon/PipelineIcon.svelte
@@ -38,6 +38,8 @@
 	import IconGraphML from "../Icons/IconGraphML.svelte";
 	import IconZeroShotObjectDetection from "../Icons/IconZeroShotClassification.svelte";
 	import IconMaskGeneration from "../Icons/IconMaskGeneration.svelte";
+	import IconTextTo3D from "../Icons/IconTextTo3D.svelte";
+	import IconImageTo3D from "../Icons/IconImageTo3D.svelte";
 	import type { PipelineType } from "@huggingface/tasks";
 
 	export let classNames = "";
@@ -86,6 +88,8 @@
 		"document-question-answering": IconDocumentQuestionAnswering,
 		"mask-generation": IconMaskGeneration,
 		"zero-shot-object-detection": IconZeroShotObjectDetection,
+		"text-to-3d": IconTextTo3D,
+		"image-to-3d": IconImageTo3D,
 	};
 
 	$: iconComponent =


### PR DESCRIPTION
Adding `text-to-3D` and `image-to-3D` tasks.

The output could be
- A mesh file. This could be `.obj`, `.gltf`, or `.glb`. OBJ and GLTF formats, by convention, have other files in the same directory with the same name. GLB is fully self-contained.
- A splat file. This could be `.ply` or `.splat`. PLY is the large, lossless format introduced with Gaussian Splatting, while `.splat` is an emerging compression format.

Current Models
- [shap-e](https://huggingface.co/openai/shap-e)
- [zero123](https://huggingface.co/bennyguo/zero123-xl-diffusers)

Demos
- [shap-e](https://huggingface.co/spaces/hysts/Shap-E)
- [One-2-3-45](https://huggingface.co/spaces/One-2-3-45/One-2-3-45)