### PR TITLE
Remove `use_auth_token` from paddlenlp snippets

### DIFF
--- a/packages/tasks/src/library-ui-elements.ts
+++ b/packages/tasks/src/library-ui-elements.ts
@@ -187,12 +187,8 @@ const paddlenlp = (model: ModelData) => {
 			[
 				`from paddlenlp.transformers import AutoTokenizer, ${architecture}`,
 				"",
-				`tokenizer = AutoTokenizer.from_pretrained("${model.id}"${
-					model.private ? ", use_auth_token=True" : ""
-				}, from_hf_hub=True)`,
-				`model = ${architecture}.from_pretrained("${model.id}"${
-					model.private ? ", use_auth_token=True" : ""
-				}, from_hf_hub=True)`,
+				`tokenizer = AutoTokenizer.from_pretrained("${model.id}, from_hf_hub=True)`,
+				`model = ${architecture}.from_pretrained("${model.id}, from_hf_hub=True)`,
 			].join("\n"),
 		];
 	} else {
@@ -201,12 +197,8 @@ const paddlenlp = (model: ModelData) => {
 				`# ⚠️ Type of model unknown`,
 				`from paddlenlp.transformers import AutoTokenizer, AutoModel`,
 				"",
-				`tokenizer = AutoTokenizer.from_pretrained("${model.id}"${
-					model.private ? ", use_auth_token=True" : ""
-				}, from_hf_hub=True)`,
-				`model = AutoModel.from_pretrained("${model.id}"${
-					model.private ? ", use_auth_token=True" : ""
-				}, from_hf_hub=True)`,
+				`tokenizer = AutoTokenizer.from_pretrained("${model.id}, from_hf_hub=True)`,
+				`model = AutoModel.from_pretrained("${model.id}, from_hf_hub=True)`,
 			].join("\n"),
 		];
 	}

--- a/packages/tasks/src/library-ui-elements.ts
+++ b/packages/tasks/src/library-ui-elements.ts
@@ -187,8 +187,8 @@ const paddlenlp = (model: ModelData) => {
 			[
 				`from paddlenlp.transformers import AutoTokenizer, ${architecture}`,
 				"",
-				`tokenizer = AutoTokenizer.from_pretrained("${model.id}, from_hf_hub=True)`,
-				`model = ${architecture}.from_pretrained("${model.id}, from_hf_hub=True)`,
+				`tokenizer = AutoTokenizer.from_pretrained("${model.id}", from_hf_hub=True)`,
+				`model = ${architecture}.from_pretrained("${model.id}", from_hf_hub=True)`,
 			].join("\n"),
 		];
 	} else {
@@ -197,8 +197,8 @@ const paddlenlp = (model: ModelData) => {
 				`# ⚠️ Type of model unknown`,
 				`from paddlenlp.transformers import AutoTokenizer, AutoModel`,
 				"",
-				`tokenizer = AutoTokenizer.from_pretrained("${model.id}, from_hf_hub=True)`,
-				`model = AutoModel.from_pretrained("${model.id}, from_hf_hub=True)`,
+				`tokenizer = AutoTokenizer.from_pretrained("${model.id}", from_hf_hub=True)`,
+				`model = AutoModel.from_pretrained("${model.id}", from_hf_hub=True)`,
 			].join("\n"),
 		];
 	}


### PR DESCRIPTION
Vaguely related to [slack thread](https://huggingface.slack.com/archives/C021H1P1HKR/p1701773657353989?thread_ts=1701719404.424999&cid=C021H1P1HKR) (private).

For paddlenlp, if a model is private, the code snippet will suggest to use `use_auth_token=True`. This is not needed anymore since the token is send on every request anyway now (since ~1y ago).

I have quickly reviewed paddlenlp source code and they seem to be correctly using `huggingface_hub` (so don't need `use_auth_token=True`). Cc @osanseviero @julien-c please let me know if I'm missing some context otherwise we can review/merge this PR.