### PR TITLE
[Widget fix] Check for instance of Blob rather than File

### DIFF
--- a/packages/widgets/src/lib/components/InferenceWidget/shared/helpers.ts
+++ b/packages/widgets/src/lib/components/InferenceWidget/shared/helpers.ts
@@ -124,8 +124,9 @@ export async function callInferenceApi<T>(
 		headers.set("X-Load-Model", "0");
 	}
 
-	const reqBody: File | string =
-		"file" in requestBody && requestBody["file"] instanceof File ? requestBody.file : JSON.stringify(requestBody);
+	// `File` is a subtype of `Blob`: therefore, checking for instanceof `Blob` also checks for instanceof `File`
+	const reqBody: Blob | string =
+		"file" in requestBody && requestBody["file"] instanceof Blob ? requestBody.file : JSON.stringify(requestBody);
 
 	const response = await fetch(`${url}/models/${repoId}`, {
 		method: "POST",


### PR DESCRIPTION
Closes #404 Follow up to #297

Widgets can send work with either `Blob` or `File`. For instance, [here](https://github.com/huggingface/huggingface.js/blob/fix_blob_check/packages/widgets/src/lib/components/InferenceWidget/widgets/ObjectDetectionWidget/ObjectDetectionWidget.svelte#L138-L139) blob is created. However, the previous [instanceof check](https://github.com/huggingface/huggingface.js/pull/406/files) was checking for `File` only. When the instanceof `Blob`, the check was failing;