### PR TITLE
👷 Prevent publishing several packages at the same time

### DIFF
--- a/.github/workflows/agents-publish.yml
+++ b/.github/workflows/agents-publish.yml
@@ -7,6 +7,9 @@ on:
         description: "Semantic Version Bump Type (major minor patch)"
         default: patch
 
+concurrency:
+  group: "push-to-main"
+
 defaults:
   run:
     working-directory: packages/agents

--- a/.github/workflows/hub-publish.yml
+++ b/.github/workflows/hub-publish.yml
@@ -7,6 +7,9 @@ on:
         description: "Semantic Version Bump Type (major minor patch)"
         default: patch
 
+concurrency:
+  group: "push-to-main"
+
 defaults:
   run:
     working-directory: packages/hub

--- a/.github/workflows/inference-publish.yml
+++ b/.github/workflows/inference-publish.yml
@@ -7,6 +7,9 @@ on:
         description: "Semantic Version Bump Type (major minor patch)"
         default: patch
 
+concurrency:
+  group: "push-to-main"
+
 defaults:
   run:
     working-directory: packages/inference

--- a/.github/workflows/languages-publish.yml
+++ b/.github/workflows/languages-publish.yml
@@ -7,6 +7,9 @@ on:
         description: "Semantic Version Bump Type (major minor patch)"
         default: patch
 
+concurrency:
+  group: "push-to-main"
+
 defaults:
   run:
     working-directory: packages/languages

--- a/.github/workflows/tasks-publish.yml
+++ b/.github/workflows/tasks-publish.yml
@@ -7,6 +7,9 @@ on:
         description: "Semantic Version Bump Type (major minor patch)"
         default: patch
 
+concurrency:
+  group: "push-to-main"
+
 defaults:
   run:
     working-directory: packages/tasks

--- a/.github/workflows/widgets-publish.yml
+++ b/.github/workflows/widgets-publish.yml
@@ -11,6 +11,9 @@ defaults:
   run:
     working-directory: packages/widgets
 
+concurrency:
+  group: "push-to-main"
+
 jobs:
   version_and_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Because they push to main, there can be conflict if the actions run at the same time