### PR TITLE
Add support for filter operator

### DIFF
--- a/packages/jinja/src/ast.ts
+++ b/packages/jinja/src/ast.ts
@@ -151,6 +151,21 @@ export class BinaryExpression extends Expression {
 }
 
 /**
+ * An operation with two sides, separated by the | operator.
+ * Operator precedence: https://github.com/pallets/jinja/issues/379#issuecomment-168076202
+ */
+export class FilterExpression extends Expression {
+	override type = "FilterExpression";
+
+	constructor(
+		public operand: Expression,
+		public filter: Identifier // TODO: Add support for non-identifier filters
+	) {
+		super();
+	}
+}
+
+/**
  * An operation with one side (operator on the left).
  */
 export class UnaryExpression extends Expression {

--- a/packages/jinja/src/lexer.ts
+++ b/packages/jinja/src/lexer.ts
@@ -20,6 +20,7 @@ export const TOKEN_TYPES = Object.freeze({
 	Comma: "Comma", // ,
 	Dot: "Dot", // .
 	Colon: "Colon", // :
+	Pipe: "Pipe", // |
 
 	CallOperator: "CallOperator", // ()
 	AdditiveBinaryOperator: "AdditiveBinaryOperator", // + -
@@ -106,6 +107,7 @@ const ORDERED_MAPPING_TABLE: [string, TokenType][] = [
 	[",", TOKEN_TYPES.Comma],
 	[".", TOKEN_TYPES.Dot],
 	[":", TOKEN_TYPES.Colon],
+	["|", TOKEN_TYPES.Pipe],
 	// Comparison operators
 	["<=", TOKEN_TYPES.ComparisonBinaryOperator],
 	[">=", TOKEN_TYPES.ComparisonBinaryOperator],

--- a/packages/jinja/test/templates.test.js
+++ b/packages/jinja/test/templates.test.js
@@ -66,6 +66,9 @@ const TEST_STRINGS = {
 
 	// Substring inclusion
 	SUBSTRING_INCLUSION: `|{{ '' in 'abc' }}|{{ 'a' in 'abc' }}|{{ 'd' in 'abc' }}|{{ 'ab' in 'abc' }}|{{ 'ac' in 'abc' }}|{{ 'abc' in 'abc' }}|{{ 'abcd' in 'abc' }}|`,
+
+	// Filter operator
+	FILTER_OPERATOR: `{{ arr | length }}{{ 1 + arr | length }}{{ 2 + arr | sort | length }}{{ (arr | sort)[0] }}`,
 };
 
 const TEST_PARSED = {
@@ -1094,6 +1097,41 @@ const TEST_PARSED = {
 		{ value: "}}", type: "CloseExpression" },
 		{ value: "|", type: "Text" },
 	],
+
+	// Filter operator
+	FILTER_OPERATOR: [
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "arr", type: "Identifier" },
+		{ value: "|", type: "Pipe" },
+		{ value: "length", type: "Identifier" },
+		{ value: "}}", type: "CloseExpression" },
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "1", type: "NumericLiteral" },
+		{ value: "+", type: "AdditiveBinaryOperator" },
+		{ value: "arr", type: "Identifier" },
+		{ value: "|", type: "Pipe" },
+		{ value: "length", type: "Identifier" },
+		{ value: "}}", type: "CloseExpression" },
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "2", type: "NumericLiteral" },
+		{ value: "+", type: "AdditiveBinaryOperator" },
+		{ value: "arr", type: "Identifier" },
+		{ value: "|", type: "Pipe" },
+		{ value: "sort", type: "Identifier" },
+		{ value: "|", type: "Pipe" },
+		{ value: "length", type: "Identifier" },
+		{ value: "}}", type: "CloseExpression" },
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "(", type: "OpenParen" },
+		{ value: "arr", type: "Identifier" },
+		{ value: "|", type: "Pipe" },
+		{ value: "sort", type: "Identifier" },
+		{ value: ")", type: "CloseParen" },
+		{ value: "[", type: "OpenSquareBracket" },
+		{ value: "0", type: "NumericLiteral" },
+		{ value: "]", type: "CloseSquareBracket" },
+		{ value: "}}", type: "CloseExpression" },
+	],
 };
 
 const TEST_CONTEXT = {
@@ -1196,6 +1234,11 @@ const TEST_CONTEXT = {
 
 	// Substring inclusion
 	SUBSTRING_INCLUSION: {},
+
+	// Filter operator
+	FILTER_OPERATOR: {
+		arr: [3, 2, 1],
+	},
 };
 
 const EXPECTED_OUTPUTS = {
@@ -1262,6 +1305,9 @@ const EXPECTED_OUTPUTS = {
 
 	// Substring inclusion
 	SUBSTRING_INCLUSION: `|true|true|false|true|false|true|false|`,
+
+	// Filter operator
+	FILTER_OPERATOR: `3451`,
 };
 
 describe("Templates", () => {


### PR DESCRIPTION
Adds support for the filter/pipe operator:
- `{{ arr | length }}` gets array length
- `{{ 1 + arr | length }}` computes 1 + (array length), order important.
- `{{ 2 + arr | sort | length }}` computes 2 + ((array sort) length), order important
- `{{ (arr | sort)[0] }}` computes (array sort)[0]

Needed for [this](https://discuss.huggingface.co/t/issue-with-llama-2-chat-template-and-out-of-date-documentation/61645/3) complicated chat template. (cc @Rocketknight1)


At the moment, we don't support user-defined or non-identifier filter functions, but could be added in future. Especially after we add user-defined functions.