### PR TITLE
Change ML-Agents to Unity-ML-Agents + update library link

### DIFF
--- a/packages/tasks/src/library-ui-elements.ts
+++ b/packages/tasks/src/library-ui-elements.ts
@@ -767,7 +767,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS: Partial<Record<ModelLibraryKey, Librar
 		docsUrl: "https://huggingface.co/docs/hub/stable-baselines3",
 		snippets: stableBaselines3,
 	},
-	"unity-ml-agents": {
+	"ml-agents": {
 		btnLabel: "unity-ml-agents",
 		repoName: "ml-agents",
 		repoUrl: "https://github.com/Unity-Technologies/ml-agents",

--- a/packages/tasks/src/library-ui-elements.ts
+++ b/packages/tasks/src/library-ui-elements.ts
@@ -770,7 +770,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS: Partial<Record<ModelLibraryKey, Librar
 	"unity-ml-agents": {
 		btnLabel: "unity-ml-agents",
 		repoName: "ml-agents",
-		repoUrl: "https://github.com/huggingface/ml-agents",
+		repoUrl: "https://github.com/Unity-Technologies/ml-agents",
 		docsUrl: "https://huggingface.co/docs/hub/ml-agents",
 		snippets: mlAgents,
 	},

--- a/packages/tasks/src/library-ui-elements.ts
+++ b/packages/tasks/src/library-ui-elements.ts
@@ -768,7 +768,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS: Partial<Record<ModelLibraryKey, Librar
 		snippets: stableBaselines3,
 	},
 	"ml-agents": {
-		btnLabel: "unity-ml-agents",
+		btnLabel: "ml-agents",
 		repoName: "ml-agents",
 		repoUrl: "https://github.com/Unity-Technologies/ml-agents",
 		docsUrl: "https://huggingface.co/docs/hub/ml-agents",

--- a/packages/tasks/src/library-ui-elements.ts
+++ b/packages/tasks/src/library-ui-elements.ts
@@ -767,8 +767,8 @@ export const MODEL_LIBRARIES_UI_ELEMENTS: Partial<Record<ModelLibraryKey, Librar
 		docsUrl: "https://huggingface.co/docs/hub/stable-baselines3",
 		snippets: stableBaselines3,
 	},
-	"ml-agents": {
-		btnLabel: "ml-agents",
+	"unity-ml-agents": {
+		btnLabel: "unity-ml-agents",
 		repoName: "ml-agents",
 		repoUrl: "https://github.com/huggingface/ml-agents",
 		docsUrl: "https://huggingface.co/docs/hub/ml-agents",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -37,7 +37,7 @@ export enum ModelLibrary {
 	"stanza" = "Stanza",
 	"fasttext" = "fastText",
 	"stable-baselines3" = "Stable-Baselines3",
-	"unity-ml-agents" = "Unity ML-Agents",
+	"ml-agents" = "Unity ML-Agents",
 	"pythae" = "Pythae",
 	"mindspore" = "MindSpore",
 }

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -37,7 +37,7 @@ export enum ModelLibrary {
 	"stanza" = "Stanza",
 	"fasttext" = "fastText",
 	"stable-baselines3" = "Stable-Baselines3",
-	"ml-agents" = "ML-Agents",
+	"unity-ml-agents" = "Unity ML-Agents",
 	"pythae" = "Pythae",
 	"mindspore" = "MindSpore",
 }


### PR DESCRIPTION
Context:
- Unity team wants to change the library name in Hugging Face from ML-Agents to Unity-ML-Agents.

