### PR TITLE
📝 Move hub before agents in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ await inference.textToImage({
 This is a collection of JS libraries to interact with the Hugging Face API, with TS types included.
 
 - [@huggingface/inference](packages/inference/README.md): Use the Inference API to make calls to 100,000+ Machine Learning models, or your own [inference endpoints](https://hf.co/docs/inference-endpoints/)!
-- [@huggingface/agents](packages/agents/README.md): Interact with HF models through a natural language interface
 - [@huggingface/hub](packages/hub/README.md): Interact with huggingface.co to create or delete repos and commit / download files
+- [@huggingface/agents](packages/agents/README.md): Interact with HF models through a natural language interface
 
 
 With more to come, like `@huggingface/endpoints` to manage your HF Endpoints!

--- a/docs/_toctree.yml
+++ b/docs/_toctree.yml
@@ -7,17 +7,17 @@
       title: Use the Inference API
     - local: inference/modules
       title: API Reference
-- title: "@huggingface/agent"
-  isExpanded: true
-  sections:
-    - local: agents/README
-      title: Use Agents to run multi-modal workflows from a natural language API
-    - local: agents/modules
-      title: API Reference
 - title: "@huggingface/hub"
   isExpanded: true
   sections:
     - local: hub/README
       title: Interact with the Hub
     - local: hub/modules
+      title: API Reference
+- title: "@huggingface/agent"
+  isExpanded: true
+  sections:
+    - local: agents/README
+      title: Use Agents to run multi-modal workflows from a natural language API
+    - local: agents/modules
       title: API Reference


### PR DESCRIPTION
Due to `oauthLogin` recently added to `hub` & low activity on `agents`

cc @nsarrazin @osanseviero 