### PR TITLE
👷 Use "choice" to select version bump type

### DIFF
--- a/.github/workflows/agents-publish.yml
+++ b/.github/workflows/agents-publish.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       newversion:
-        description: "Semantic Version Bump Type (major minor patch)"
+        type: choice
+        description: "Semantic Version Bump Type"
         default: patch
+        options:
+          - patch
+          - minor
+          - major
 
 concurrency:
   group: "push-to-main"

--- a/.github/workflows/hub-publish.yml
+++ b/.github/workflows/hub-publish.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       newversion:
-        description: "Semantic Version Bump Type (major minor patch)"
+        type: choice
+        description: "Semantic Version Bump Type"
         default: patch
+        options:
+          - patch
+          - minor
+          - major
 
 concurrency:
   group: "push-to-main"

--- a/.github/workflows/inference-publish.yml
+++ b/.github/workflows/inference-publish.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       newversion:
-        description: "Semantic Version Bump Type (major minor patch)"
+        type: choice
+        description: "Semantic Version Bump Type"
         default: patch
+        options:
+          - patch
+          - minor
+          - major
 
 concurrency:
   group: "push-to-main"

--- a/.github/workflows/jinja-publish.yml
+++ b/.github/workflows/jinja-publish.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       newversion:
-        description: "Semantic Version Bump Type (major minor patch)"
+        type: choice
+        description: "Semantic Version Bump Type"
         default: patch
+        options:
+          - patch
+          - minor
+          - major
 
 concurrency:
   group: "push-to-main"

--- a/.github/workflows/languages-publish.yml
+++ b/.github/workflows/languages-publish.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       newversion:
-        description: "Semantic Version Bump Type (major minor patch)"
+        type: choice
+        description: "Semantic Version Bump Type"
         default: patch
+        options:
+          - patch
+          - minor
+          - major
 
 concurrency:
   group: "push-to-main"

--- a/.github/workflows/tasks-publish.yml
+++ b/.github/workflows/tasks-publish.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       newversion:
-        description: "Semantic Version Bump Type (major minor patch)"
+        type: choice
+        description: "Semantic Version Bump Type"
         default: patch
+        options:
+          - patch
+          - minor
+          - major
 
 concurrency:
   group: "push-to-main"

--- a/.github/workflows/widgets-publish.yml
+++ b/.github/workflows/widgets-publish.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       newversion:
-        description: "Semantic Version Bump Type (major minor patch)"
+        type: choice
+        description: "Semantic Version Bump Type"
         default: patch
+        options:
+          - patch
+          - minor
+          - major
 
 defaults:
   run:


### PR DESCRIPTION
Better publish interface, using a select instead of a text input