### PR TITLE
:recycle: Change library name: Adapter-Transformers -> Adapters

### DIFF
--- a/packages/tasks/src/library-ui-elements.ts
+++ b/packages/tasks/src/library-ui-elements.ts
@@ -35,11 +35,11 @@ function nameWithoutNamespace(modelId: string): string {
 
 //#region snippets
 
-const adapter_transformers = (model: ModelData) => [
-	`from transformers import ${model.config?.adapter_transformers?.model_class}
+const adapters = (model: ModelData) => [
+	`from adapters import AutoAdapterModel
 
-model = ${model.config?.adapter_transformers?.model_class}.from_pretrained("${model.config?.adapter_transformers?.model_name}")
-model.load_adapter("${model.id}", source="hf")`,
+model = AutoAdapterModel.from_pretrained("${model.config?.adapter_transformers?.model_name}")
+model.load_adapter("${model.id}", set_active=True)`,
 ];
 
 const allennlpUnknown = (model: ModelData) => [
@@ -576,11 +576,11 @@ model = AutoModel.load_from_hf_hub("${model.id}")`,
 
 export const MODEL_LIBRARIES_UI_ELEMENTS: Partial<Record<ModelLibraryKey, LibraryUiElement>> = {
 	"adapter-transformers": {
-		btnLabel: "Adapter Transformers",
-		repoName: "adapter-transformers",
-		repoUrl: "https://github.com/Adapter-Hub/adapter-transformers",
-		docsUrl: "https://huggingface.co/docs/hub/adapter-transformers",
-		snippets: adapter_transformers,
+		btnLabel: "Adapters",
+		repoName: "adapters",
+		repoUrl: "https://github.com/Adapter-Hub/adapters",
+		docsUrl: "https://huggingface.co/docs/hub/adapters",
+		snippets: adapters,
 	},
 	allennlp: {
 		btnLabel: "AllenNLP",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -5,7 +5,7 @@
  * File formats live in an enum inside the internal codebase.
  */
 export enum ModelLibrary {
-	"adapter-transformers" = "Adapter Transformers",
+	"adapter-transformers" = "Adapters",
 	"allennlp" = "allenNLP",
 	"asteroid" = "Asteroid",
 	"bertopic" = "BERTopic",


### PR DESCRIPTION
Updated from `adapter-transformers` library to the newly released _Adapters_ library. Related to https://github.com/huggingface/hub-docs/pull/1184.

Open Questions:

I haven't updated the library key from "adapter-transformers" as this is also the tag used on the hub. I'm not sure what the best way to handle this is? Should the tag stay the same, can we support both "adapters" and "adapter-transformers" or is it possible to automatically rename all tags?