### PR TITLE
`speechbrain_interface` instead of `speechbrain?.interface`

### DIFF
--- a/packages/tasks/src/library-ui-elements.ts
+++ b/packages/tasks/src/library-ui-elements.ts
@@ -400,14 +400,14 @@ const speechBrainMethod = (speechbrainInterface: string) => {
 };
 
 const speechbrain = (model: ModelData) => {
-	const speechbrainInterface = model.config?.speechbrain?.interface;
+	const speechbrainInterface = model.config?.speechbrain_interface;
 	if (speechbrainInterface === undefined) {
-		return [`# interface not specified in config.json`];
+		return [`# speechbrain_interface not specified in config.json`];
 	}
 
 	const speechbrainMethod = speechBrainMethod(speechbrainInterface);
 	if (speechbrainMethod === undefined) {
-		return [`# interface in config.json invalid`];
+		return [`# speechbrain_interface in config.json invalid`];
 	}
 
 	return [


### PR DESCRIPTION
Models seem to use `speechbrain_interface`, for example: https://huggingface.co/TalTechNLP/voxlingua107-epaca-tdnn/blob/main/config.json?library=speechbrain#L2, https://huggingface.co/speechbrain/asr-crdnn-commonvoice-de/blob/main/config.json