### PR TITLE
🦺 Make sure latest version of jina is published when pubishing widgets

### DIFF
--- a/.github/workflows/widgets-publish.yml
+++ b/.github/workflows/widgets-publish.yml
@@ -87,6 +87,43 @@ jobs:
           echo "Checksum Verification Successful: The local and remote @huggingface/tasks packages are consistent. Proceeding with the @huggingface/widgets package release. Local Checksum: $LOCAL_CHECKSUM, Remote Checksum: $REMOTE_CHECKSUM."
         working-directory: packages/tasks
 
+      - name: Make sure that the latest version of @huggingface/jinja is consistent with the local version
+        run: |
+          LOCAL_JINJA_VERSION=$(node -p "require('./package.json').version")
+          REMOTE_JINJA_VERSION=$(npm view @huggingface/jinja version)
+
+          # If the versions are different, error 
+          if [ "$LOCAL_JINJA_VERSION" != "$REMOTE_JINJA_VERSION" ]; then
+            echo "Error: The local @huggingface/jinja package version ($LOCAL_JINJA_VERSION) differs from the remote version ($REMOTE_JINJA_VERSION). Release halted."
+            exit 1
+          fi
+
+          npm pack @huggingface/jinja
+          mv huggingface-jinja-$LOCAL_JINJA_VERSION.tgz jinja-local.tgz
+
+          npm pack @huggingface/jinja@$REMOTE_JINJA_VERSION
+          mv huggingface-jinja-$REMOTE_JINJA_VERSION.tgz jinja-remote.tgz
+
+          # Compute checksum of local tar. We need to extract both tar since the remote compression might be different
+          tar -xf jinja-local.tgz
+          LOCAL_CHECKSUM=$(cd package && tar --mtime='1970-01-01' --mode=755 -cf - . | sha256sum | cut -d' ' -f1)
+          echo "Local package checksum: $LOCAL_CHECKSUM"
+
+          rm -Rf package
+
+          tar -xf jinja-remote.tgz
+          REMOTE_CHECKSUM=$(cd package && tar --mtime='1970-01-01' --mode=755 -cf - . | sha256sum | cut -d' ' -f1)
+          echo "Remote package checksum: $REMOTE_CHECKSUM"
+
+          rm -Rf package
+
+          if [ "$LOCAL_CHECKSUM" != "$REMOTE_CHECKSUM" ]; then
+            echo "Checksum Verification Failed: The local @huggingface/jinja package differs from the remote version. Release halted. Local Checksum: $LOCAL_CHECKSUM, Remote Checksum: $REMOTE_CHECKSUM"
+            exit 1
+          fi
+          echo "Checksum Verification Successful: The local and remote @huggingface/jinja packages are consistent. Proceeding with the @huggingface/widgets package release. Local Checksum: $LOCAL_CHECKSUM, Remote Checksum: $REMOTE_CHECKSUM."
+        working-directory: packages/jinja
+
       - run: pnpm publish --no-git-checks .
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/jinja/package.json
+++ b/packages/jinja/package.json
@@ -28,6 +28,7 @@
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
 		"prepublishOnly": "pnpm run build",
+		"prepare": "pnpm run build",
 		"build": "tsup src/index.ts --format cjs,esm --clean --dts",
 		"test": "vitest run",
 		"test:browser": "vitest run --browser.name=chrome --browser.headless",


### PR DESCRIPTION
cc @Wauplin 

@SBrandeis will probably need to do the same with inference if/when adding it as a dep to widgets (we could probably streamline it with a matrix or separate github action that we can call)