### PR TITLE
✨ Allow search on model name

### DIFF
--- a/packages/hub/src/lib/list-datasets.ts
+++ b/packages/hub/src/lib/list-datasets.ts
@@ -73,7 +73,7 @@ export async function* listDatasets<
 		...Object.entries({
 			limit: String(Math.min(totalToFetch, 500)),
 			...(params?.search?.owner ? { author: params.search.owner } : undefined),
-			...(params?.search?.query ? { query: params.search.query } : undefined),
+			...(params?.search?.query ? { search: params.search.query } : undefined),
 		}),
 		...(params?.search?.tags?.map((tag) => ["filter", tag]) ?? []),
 		...EXPAND_KEYS.map((val) => ["expand", val] satisfies [string, string]),

--- a/packages/hub/src/lib/list-datasets.ts
+++ b/packages/hub/src/lib/list-datasets.ts
@@ -48,6 +48,10 @@ export async function* listDatasets<
 	const T extends Exclude<(typeof EXPANDABLE_KEYS)[number], (typeof EXPAND_KEYS)[number]> = never,
 >(params?: {
 	search?: {
+		/**
+		 * Will search in the dataset name for matches
+		 */
+		query?: string;
 		owner?: string;
 		tags?: string[];
 	};
@@ -69,6 +73,7 @@ export async function* listDatasets<
 		...Object.entries({
 			limit: String(Math.min(totalToFetch, 500)),
 			...(params?.search?.owner ? { author: params.search.owner } : undefined),
+			...(params?.search?.query ? { query: params.search.query } : undefined),
 		}),
 		...(params?.search?.tags?.map((tag) => ["filter", tag]) ?? []),
 		...EXPAND_KEYS.map((val) => ["expand", val] satisfies [string, string]),

--- a/packages/hub/src/lib/list-models.spec.ts
+++ b/packages/hub/src/lib/list-models.spec.ts
@@ -67,4 +67,17 @@ describe("listModels", () => {
 
 		expect(count).to.equal(2);
 	});
+
+	it("should search model by name", async () => {
+		let count = 0;
+		for await (const entry of listModels({
+			search: { query: "t5" },
+			limit: 10,
+		})) {
+			count++;
+			expect(entry.name).to.include("t5");
+		}
+
+		expect(count).to.equal(2);
+	});
 });

--- a/packages/hub/src/lib/list-models.spec.ts
+++ b/packages/hub/src/lib/list-models.spec.ts
@@ -78,6 +78,6 @@ describe("listModels", () => {
 			expect(entry.name).to.include("t5");
 		}
 
-		expect(count).to.equal(2);
+		expect(count).to.equal(10);
 	});
 });

--- a/packages/hub/src/lib/list-models.ts
+++ b/packages/hub/src/lib/list-models.ts
@@ -54,6 +54,10 @@ export async function* listModels<
 	const T extends Exclude<(typeof EXPANDABLE_KEYS)[number], (typeof EXPAND_KEYS)[number]> = never,
 >(params?: {
 	search?: {
+		/**
+		 * Will search in the model name for matches
+		 */
+		query?: string;
 		owner?: string;
 		task?: PipelineType;
 		tags?: string[];
@@ -77,6 +81,7 @@ export async function* listModels<
 			limit: String(Math.min(totalToFetch, 500)),
 			...(params?.search?.owner ? { author: params.search.owner } : undefined),
 			...(params?.search?.task ? { pipeline_tag: params.search.task } : undefined),
+			...(params?.search?.query ? { search: params.search.query } : undefined),
 		}),
 		...(params?.search?.tags?.map((tag) => ["filter", tag]) ?? []),
 		...EXPAND_KEYS.map((val) => ["expand", val] satisfies [string, string]),

--- a/packages/hub/src/lib/list-spaces.ts
+++ b/packages/hub/src/lib/list-spaces.ts
@@ -63,7 +63,7 @@ export async function* listSpaces<
 		...Object.entries({
 			limit: "500",
 			...(params?.search?.owner ? { author: params.search.owner } : undefined),
-			...(params?.search?.query ? { query: params.search.query } : undefined),
+			...(params?.search?.query ? { search: params.search.query } : undefined),
 		}),
 		...(params?.search?.tags?.map((tag) => ["filter", tag]) ?? []),
 		...[...EXPAND_KEYS, ...(params?.additionalFields ?? [])].map((val) => ["expand", val] satisfies [string, string]),

--- a/packages/hub/src/lib/list-spaces.ts
+++ b/packages/hub/src/lib/list-spaces.ts
@@ -40,6 +40,10 @@ export async function* listSpaces<
 	const T extends Exclude<(typeof EXPANDABLE_KEYS)[number], (typeof EXPAND_KEYS)[number]> = never,
 >(params?: {
 	search?: {
+		/**
+		 * Will search in the space name for matches
+		 */
+		query?: string;
 		owner?: string;
 		tags?: string[];
 	};
@@ -56,7 +60,11 @@ export async function* listSpaces<
 }): AsyncGenerator<SpaceEntry> {
 	checkCredentials(params?.credentials);
 	const search = new URLSearchParams([
-		...Object.entries({ limit: "500", ...(params?.search?.owner ? { author: params.search.owner } : undefined) }),
+		...Object.entries({
+			limit: "500",
+			...(params?.search?.owner ? { author: params.search.owner } : undefined),
+			...(params?.search?.query ? { query: params.search.query } : undefined),
+		}),
 		...(params?.search?.tags?.map((tag) => ["filter", tag]) ?? []),
 		...[...EXPAND_KEYS, ...(params?.additionalFields ?? [])].map((val) => ["expand", val] satisfies [string, string]),
 	]).toString();


### PR DESCRIPTION
For https://github.com/huggingface/huggingface.js/discussions/506

```ts
		for await (const entry of listModels({
			search: { query: "t5" },
			limit: 10,
		})) {
			count++;
			expect(entry.name).to.include("t5");
		}
```

cc @julien-c @Wauplin if you have ideas about the parameter name. It's `search.query`, maybe `search.name` or `search.nameMatch`?

or `search.search`...