### PR TITLE
Fix extractSpecialTokensMap if added token

### DIFF
--- a/packages/tasks/src/tokenizer-data.ts
+++ b/packages/tasks/src/tokenizer-data.ts
@@ -12,8 +12,16 @@ export const SPECIAL_TOKENS_ATTRIBUTES = [
 /**
  * Public interface for a tokenizer's special tokens mapping
  */
+export interface AddedToken {
+	__type?: "AddedToken";
+	content?: string;
+	lstrip?: boolean;
+	normalized?: boolean;
+	rstrip?: boolean;
+	single_word?: boolean;
+}
 export type SpecialTokensMap = {
-	[key in (typeof SPECIAL_TOKENS_ATTRIBUTES)[number]]?: string;
+	[key in (typeof SPECIAL_TOKENS_ATTRIBUTES)[number]]?: string | AddedToken;
 };
 /**
  * Public interface for tokenizer config

--- a/packages/widgets/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
+++ b/packages/widgets/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
@@ -11,7 +11,7 @@
 		WidgetExampleChatInput,
 		WidgetExample,
 	} from "@huggingface/tasks";
-	import { SPECIAL_TOKENS_ATTRIBUTES } from "@huggingface/tasks";
+	import { AddedToken, SPECIAL_TOKENS_ATTRIBUTES } from "@huggingface/tasks";
 	import { HfInference } from "@huggingface/inference";
 
 	import type { ChatMessage } from "@huggingface/tasks";
@@ -186,6 +186,8 @@
 			const value = tokenizerConfig[key];
 			if (typeof value === "string") {
 				specialTokensMap[key] = value;
+			} else if (value instanceof AddedToken && value?.content) {
+				specialTokensMap[key] = value.content;
 			}
 		}
 		return specialTokensMap;


### PR DESCRIPTION
In tokenizer_config.json, special tokens can be defined as an [AddedToken](https://github.com/huggingface/transformers/blob/0ad770c3733f9478a8d9d0bc18cc6143877b47a2/src/transformers/tokenization_utils_base.py#L82):

```js
  "bos_token": {
    "__type": "AddedToken",
    "content": "<s>",
    "lstrip": false,
    "normalized": false,
    "rstrip": false,
    "single_word": false
  },
```

This PR add support for those tokens in the ConvoWidget. Currently such tokens are ignored which prevents from formatting the chat template.

See [here](https://github.com/huggingface/moon-landing/pull/9104#discussion_r1507547542) (internal issue) and [slack convo](https://huggingface.slack.com/archives/C03A68GJ84C/p1709212449029279) (internal).