### PR TITLE
🔖 @hugginface/tasks 0.5.0

### DIFF
--- a/packages/tasks/package.json
+++ b/packages/tasks/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@huggingface/tasks",
 	"packageManager": "pnpm@8.10.5",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"description": "List of ML tasks for huggingface.co/tasks",
 	"repository": "https://github.com/huggingface/huggingface.js.git",
 	"publishConfig": {


### PR DESCRIPTION
The release job failed resulting in a "corrupted" state which prevents releasing anything that depends on `@huggingface/tasks`

The version has been released on `npm` successfully: https://www.npmjs.com/package/@huggingface/tasks/v/0.5.0

Failed job: https://github.com/huggingface/huggingface.js/actions/runs/8112316242/job/22173356794

(apparently not robust to PRs being merged concurrently with the job running)