### PR TITLE
🩹 Fix focus issue with reset btn in `ConversationalWidget`

### DIFF
--- a/packages/widgets/src/lib/components/InferenceWidget/shared/WidgetHeader/WidgetHeader.svelte
+++ b/packages/widgets/src/lib/components/InferenceWidget/shared/WidgetHeader/WidgetHeader.svelte
@@ -83,7 +83,12 @@
 
 	<div class="flex gap-2 ml-auto">
 		{#if showReset && !isDisabled}
-			<button class="flex items-center mb-1.5 text-gray-400" on:click={() => dispatch("reset")} transition:fade>
+			<button
+				class="flex items-center mb-1.5 text-gray-400"
+				type="button"
+				on:click|preventDefault={() => dispatch("reset")}
+				transition:fade
+			>
 				<IconRefresh />
 			</button>
 		{/if}


### PR DESCRIPTION
Currently, hitting `enter` to submit a new message triggers the `reset` button when visible