### PR TITLE
💚 (again) Fix sync of inference widgets demo

### DIFF
--- a/.github/workflows/sync-widgets-demo.yml
+++ b/.github/workflows/sync-widgets-demo.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           rm -rf inference-widgets/packages
           mkdir -p inference-widgets/packages
+          cp -r local-demo/packages/shared inference-widgets/shared
           cp -r local-demo/packages/widgets inference-widgets/packages
           cp -r local-demo/packages/tasks inference-widgets/packages
           cp -r local-demo/packages/inference inference-widgets/packages


### PR DESCRIPTION
https://huggingface.co/spaces/huggingfacejs/inference-widgets is broken again 😅 

Follow-up of https://github.com/huggingface/huggingface.js/pull/512, looks like the shared folder is missing.

See https://huggingface.co/spaces/huggingfacejs/inference-widgets/tree/main/packages?logs=build

cc @SBrandeis 