### PR TITLE
[`integration`] Add GLiNER as a library on the Hub

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -140,6 +140,12 @@ export const flair = (model: ModelData): string[] => [
 tagger = SequenceTagger.load("${model.id}")`,
 ];
 
+export const gliner = (model: ModelData): string[] => [
+	`from model import GLiNER
+
+model = GLiNER.from_pretrained("${model.id}")`,
+];
+
 export const keras = (model: ModelData): string[] => [
 	`from huggingface_hub import from_pretrained_keras
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -161,7 +161,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "GLiNER",
 		repoName: "GLiNER",
 		repoUrl: "https://github.com/urchade/GLiNER",
-		snippets: snippets.flair,
+		snippets: snippets.gliner,
 		filter: false,
 		countDownloads: {
 			term: { path: "gliner_config.json" },

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -157,6 +157,16 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 			term: { path: "pytorch_model.bin" },
 		},
 	},
+	gliner: {
+		prettyLabel: "GLiNER",
+		repoName: "GLiNER",
+		repoUrl: "https://github.com/urchade/GLiNER",
+		snippets: snippets.flair,
+		filter: false,
+		countDownloads: {
+			term: { path: "gliner_config.json" },
+		},
+	},
 	keras: {
 		prettyLabel: "Keras",
 		repoName: "Keras",


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add GLiNER as a library on the Hub
  * Including snippet

## Links
* Repository: https://github.com/urchade/GLiNER
* Paper: https://arxiv.org/abs/2311.08526
* Demo: https://huggingface.co/spaces/tomaarsen/gliner_base
* Models: https://huggingface.co/models?search=gliner (and one more with a different name, I believe).

## Details
Some of the GLiNER models have been trending recently:
![image](https://github.com/huggingface/huggingface.js/assets/37621491/957343a4-54a0-4a98-b916-ee35d544868a)

cc @urchade for context: this should add a "Use with GLiNER" button in the top right of all models on the Hub that have `library_name: gliner` in the model card metadata. 

- Tom Aarsen