### PR TITLE
[`tasks`] Update gliner snippet import now that gliner is on pypi

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -141,7 +141,7 @@ tagger = SequenceTagger.load("${model.id}")`,
 ];
 
 export const gliner = (model: ModelData): string[] => [
-	`from model import GLiNER
+	`from gliner import GLiNER
 
 model = GLiNER.from_pretrained("${model.id}")`,
 ];


### PR DESCRIPTION
Hello!

## Pull Request overview
* Update gliner snippet import now that gliner is on pypi

## Details
As of 2 days ago, [gliner](https://github.com/urchade/GLiNER) has been added to PyPI, which has resulted in an updated snippet.

Also, I believe that the GLiNER library on the Hub went live yesterday-ish. Can I expect to see download statistics starting tomorrow-ish?

- Tom Aarsen