### PR TITLE
[Safetensors parser] Support optional file path

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -66,7 +66,7 @@ describe("parseSafetensorsMetadata", () => {
 		const parse = await parseSafetensorsMetadata({
 			repo: "CompVis/stable-diffusion-v1-4",
 			computeParametersCount: true,
-			filePath: "unet/diffusion_pytorch_model.safetensors"
+			path: "unet/diffusion_pytorch_model.safetensors",
 		});
 
 		assert(!parse.sharded);
@@ -76,11 +76,11 @@ describe("parseSafetensorsMetadata", () => {
 
 		assert.deepStrictEqual(parse.header["up_blocks.3.resnets.0.norm2.bias"], {
 			dtype: "F32",
-			shape: [ 320 ],
-			data_offsets: [ 3_409_382_416, 3_409_383_696 ],
+			shape: [320],
+			data_offsets: [3_409_382_416, 3_409_383_696],
 		});
 
-		console.log(parse.header)
+		console.log(parse.header);
 
 		assert.deepStrictEqual(parse.parameterCount, { F32: 859_520_964 });
 		assert.deepStrictEqual(sum(Object.values(parse.parameterCount)), 859_520_964);

--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -3,7 +3,7 @@ import { parseSafetensorsMetadata } from "./parse-safetensors-metadata";
 import { sum } from "../utils/sum";
 
 describe("parseSafetensorsMetadata", () => {
-	it("fetch info for single-file", async () => {
+	it("fetch info for single-file (with the default conventional filename)", async () => {
 		const parse = await parseSafetensorsMetadata({
 			repo: "bert-base-uncased",
 			computeParametersCount: true,
@@ -25,7 +25,7 @@ describe("parseSafetensorsMetadata", () => {
 		// total params = 110m
 	});
 
-	it("fetch info for sharded", async () => {
+	it("fetch info for sharded (with the default conventional filename)", async () => {
 		const parse = await parseSafetensorsMetadata({
 			repo: "bigscience/bloom",
 			computeParametersCount: true,

--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -61,4 +61,28 @@ describe("parseSafetensorsMetadata", () => {
 		assert.deepStrictEqual(sum(Object.values(parse.parameterCount)), 124_697_947);
 		// total params = 124m
 	});
+
+	it("fetch info for single-file with file path", async () => {
+		const parse = await parseSafetensorsMetadata({
+			repo: "CompVis/stable-diffusion-v1-4",
+			computeParametersCount: true,
+			filePath: "unet/diffusion_pytorch_model.safetensors"
+		});
+
+		assert(!parse.sharded);
+		assert.deepStrictEqual(parse.header.__metadata__, { format: "pt" });
+
+		// Example of one tensor (the header contains many tensors)
+
+		assert.deepStrictEqual(parse.header["up_blocks.3.resnets.0.norm2.bias"], {
+			dtype: "F32",
+			shape: [ 320 ],
+			data_offsets: [ 3_409_382_416, 3_409_383_696 ],
+		});
+
+		console.log(parse.header)
+
+		assert.deepStrictEqual(parse.parameterCount, { F32: 859_520_964 });
+		assert.deepStrictEqual(sum(Object.values(parse.parameterCount)), 859_520_964);
+	});
 });

--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -80,8 +80,6 @@ describe("parseSafetensorsMetadata", () => {
 			data_offsets: [3_409_382_416, 3_409_383_696],
 		});
 
-		console.log(parse.header);
-
 		assert.deepStrictEqual(parse.parameterCount, { F32: 859_520_964 });
 		assert.deepStrictEqual(sum(Object.values(parse.parameterCount)), 859_520_964);
 	});

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -8,8 +8,10 @@ import { downloadFile } from "./download-file";
 import { fileExists } from "./file-exists";
 import { promisesQueue } from "../utils/promisesQueue";
 
-const SINGLE_FILE = "model.safetensors";
-const INDEX_FILE = "model.safetensors.index.json";
+export const SINGLE_FILE = "model.safetensors";
+export const INDEX_FILE = "model.safetensors.index.json";
+export const RE_SINGLE_FILE = /.+\.safetensors$/;
+export const RE_INDEX_FILE = /.+\.index\.json$/;
 const PARALLEL_DOWNLOADS = 5;
 const MAX_HEADER_LENGTH = 25_000_000;
 
@@ -159,6 +161,7 @@ export async function parseSafetensorsMetadata(params: {
 	 *
 	 * @default false
 	 */
+	filePath?: string;
 	computeParametersCount: true;
 	hubUrl?: string;
 	credentials?: Credentials;
@@ -176,6 +179,7 @@ export async function parseSafetensorsMetadata(params: {
 	 *
 	 * @default false
 	 */
+	filePath?: string;
 	computeParametersCount?: boolean;
 	hubUrl?: string;
 	credentials?: Credentials;
@@ -187,6 +191,7 @@ export async function parseSafetensorsMetadata(params: {
 }): Promise<SafetensorsParseFromRepo>;
 export async function parseSafetensorsMetadata(params: {
 	repo: RepoDesignation;
+	filePath?: string;
 	computeParametersCount?: boolean;
 	hubUrl?: string;
 	credentials?: Credentials;
@@ -203,8 +208,8 @@ export async function parseSafetensorsMetadata(params: {
 		throw new TypeError("Only model repos should contain safetensors files.");
 	}
 
-	if (await fileExists({ ...params, path: SINGLE_FILE })) {
-		const header = await parseSingleFile(SINGLE_FILE, params);
+	if (RE_SINGLE_FILE.test(params.filePath ?? "") || (await fileExists({ ...params, path: SINGLE_FILE }))) {
+		const header = await parseSingleFile(params.filePath ?? SINGLE_FILE, params);
 		return {
 			sharded: false,
 			header,
@@ -212,8 +217,8 @@ export async function parseSafetensorsMetadata(params: {
 				parameterCount: computeNumOfParamsByDtypeSingleFile(header),
 			}),
 		};
-	} else if (await fileExists({ ...params, path: INDEX_FILE })) {
-		const { index, headers } = await parseShardedIndex(INDEX_FILE, params);
+	} else if (RE_INDEX_FILE.test(params.filePath ?? "") || (await fileExists({ ...params, path: INDEX_FILE }))) {
+		const { index, headers } = await parseShardedIndex(params.filePath ?? INDEX_FILE, params);
 		return {
 			sharded: true,
 			index,

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -220,7 +220,10 @@ export async function parseSafetensorsMetadata(params: {
 				parameterCount: computeNumOfParamsByDtypeSingleFile(header),
 			}),
 		};
-	} else if (RE_SAFETENSORS_INDEX_FILE.test(params.path ?? "") || (await fileExists({ ...params, path: SAFETENSORS_INDEX_FILE }))) {
+	} else if (
+		RE_SAFETENSORS_INDEX_FILE.test(params.path ?? "") ||
+		(await fileExists({ ...params, path: SAFETENSORS_INDEX_FILE }))
+	) {
 		const { index, headers } = await parseShardedIndex(params.path ?? SAFETENSORS_INDEX_FILE, params);
 		return {
 			sharded: true,

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -157,11 +157,14 @@ export async function parseSafetensorsMetadata(params: {
 	/** Only models are supported */
 	repo: RepoDesignation;
 	/**
+	 * Relative file path to safetensors file inside `repo`. Defaults to `SINGLE_FILE` or `INDEX_FILE` (whichever one exists).
+	 */
+	path?: string;
+	/**
 	 * Will include SafetensorsParseFromRepo["parameterCount"], an object containing the number of parameters for each DType
 	 *
 	 * @default false
 	 */
-	filePath?: string;
 	computeParametersCount: true;
 	hubUrl?: string;
 	credentials?: Credentials;
@@ -179,7 +182,7 @@ export async function parseSafetensorsMetadata(params: {
 	 *
 	 * @default false
 	 */
-	filePath?: string;
+	path?: string;
 	computeParametersCount?: boolean;
 	hubUrl?: string;
 	credentials?: Credentials;
@@ -191,7 +194,7 @@ export async function parseSafetensorsMetadata(params: {
 }): Promise<SafetensorsParseFromRepo>;
 export async function parseSafetensorsMetadata(params: {
 	repo: RepoDesignation;
-	filePath?: string;
+	path?: string;
 	computeParametersCount?: boolean;
 	hubUrl?: string;
 	credentials?: Credentials;
@@ -208,8 +211,8 @@ export async function parseSafetensorsMetadata(params: {
 		throw new TypeError("Only model repos should contain safetensors files.");
 	}
 
-	if (RE_SINGLE_FILE.test(params.filePath ?? "") || (await fileExists({ ...params, path: SINGLE_FILE }))) {
-		const header = await parseSingleFile(params.filePath ?? SINGLE_FILE, params);
+	if (RE_SINGLE_FILE.test(params.path ?? "") || (await fileExists({ ...params, path: SINGLE_FILE }))) {
+		const header = await parseSingleFile(params.path ?? SINGLE_FILE, params);
 		return {
 			sharded: false,
 			header,
@@ -217,8 +220,8 @@ export async function parseSafetensorsMetadata(params: {
 				parameterCount: computeNumOfParamsByDtypeSingleFile(header),
 			}),
 		};
-	} else if (RE_INDEX_FILE.test(params.filePath ?? "") || (await fileExists({ ...params, path: INDEX_FILE }))) {
-		const { index, headers } = await parseShardedIndex(params.filePath ?? INDEX_FILE, params);
+	} else if (RE_INDEX_FILE.test(params.path ?? "") || (await fileExists({ ...params, path: INDEX_FILE }))) {
+		const { index, headers } = await parseShardedIndex(params.path ?? INDEX_FILE, params);
 		return {
 			sharded: true,
 			index,

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -10,8 +10,8 @@ import { promisesQueue } from "../utils/promisesQueue";
 
 export const SINGLE_FILE = "model.safetensors";
 export const INDEX_FILE = "model.safetensors.index.json";
-export const RE_SINGLE_FILE = /.+\.safetensors$/;
-export const RE_INDEX_FILE = /.+\.index\.json$/;
+export const RE_SINGLE_FILE = /\.safetensors$/;
+export const RE_INDEX_FILE = /\.index\.json$/;
 const PARALLEL_DOWNLOADS = 5;
 const MAX_HEADER_LENGTH = 25_000_000;
 

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -8,10 +8,10 @@ import { downloadFile } from "./download-file";
 import { fileExists } from "./file-exists";
 import { promisesQueue } from "../utils/promisesQueue";
 
-export const SINGLE_FILE = "model.safetensors";
-export const INDEX_FILE = "model.safetensors.index.json";
-export const RE_SINGLE_FILE = /\.safetensors$/;
-export const RE_INDEX_FILE = /\.index\.json$/;
+export const SAFETENSORS_FILE = "model.safetensors";
+export const SAFETENSORS_INDEX_FILE = "model.safetensors.index.json";
+export const RE_SAFETENSORS_FILE = /\.safetensors$/;
+export const RE_SAFETENSORS_INDEX_FILE = /\.index\.json$/;
 const PARALLEL_DOWNLOADS = 5;
 const MAX_HEADER_LENGTH = 25_000_000;
 
@@ -211,8 +211,8 @@ export async function parseSafetensorsMetadata(params: {
 		throw new TypeError("Only model repos should contain safetensors files.");
 	}
 
-	if (RE_SINGLE_FILE.test(params.path ?? "") || (await fileExists({ ...params, path: SINGLE_FILE }))) {
-		const header = await parseSingleFile(params.path ?? SINGLE_FILE, params);
+	if (RE_SAFETENSORS_FILE.test(params.path ?? "") || (await fileExists({ ...params, path: SAFETENSORS_FILE }))) {
+		const header = await parseSingleFile(params.path ?? SAFETENSORS_FILE, params);
 		return {
 			sharded: false,
 			header,
@@ -220,8 +220,8 @@ export async function parseSafetensorsMetadata(params: {
 				parameterCount: computeNumOfParamsByDtypeSingleFile(header),
 			}),
 		};
-	} else if (RE_INDEX_FILE.test(params.path ?? "") || (await fileExists({ ...params, path: INDEX_FILE }))) {
-		const { index, headers } = await parseShardedIndex(params.path ?? INDEX_FILE, params);
+	} else if (RE_SAFETENSORS_INDEX_FILE.test(params.path ?? "") || (await fileExists({ ...params, path: SAFETENSORS_INDEX_FILE }))) {
+		const { index, headers } = await parseShardedIndex(params.path ?? SAFETENSORS_INDEX_FILE, params);
 		return {
 			sharded: true,
 			index,

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -10,8 +10,10 @@ import { promisesQueue } from "../utils/promisesQueue";
 
 export const SAFETENSORS_FILE = "model.safetensors";
 export const SAFETENSORS_INDEX_FILE = "model.safetensors.index.json";
+/// We advise model/library authors to use the filenames above for convention inside model repos,
+/// but in some situations safetensors weights have different filenames.
 export const RE_SAFETENSORS_FILE = /\.safetensors$/;
-export const RE_SAFETENSORS_INDEX_FILE = /\.index\.json$/;
+export const RE_SAFETENSORS_INDEX_FILE = /\.safetensors\.index\.json$/;
 const PARALLEL_DOWNLOADS = 5;
 const MAX_HEADER_LENGTH = 25_000_000;
 
@@ -157,7 +159,7 @@ export async function parseSafetensorsMetadata(params: {
 	/** Only models are supported */
 	repo: RepoDesignation;
 	/**
-	 * Relative file path to safetensors file inside `repo`. Defaults to `SINGLE_FILE` or `INDEX_FILE` (whichever one exists).
+	 * Relative file path to safetensors file inside `repo`. Defaults to `SAFETENSORS_FILE` or `SAFETENSORS_INDEX_FILE` (whichever one exists).
 	 */
 	path?: string;
 	/**


### PR DESCRIPTION
### Before

Safetensors parser was in assumption that safetensors files are strictly named `model.safetensors`, which is not the case always.

### This PR

Support optional file names so that other names like `llama3.safetensors` would still work