### PR TITLE
🐛  Add support for v1 gguf

### DIFF
--- a/packages/gguf/src/gguf.spec.ts
+++ b/packages/gguf/src/gguf.spec.ts
@@ -7,7 +7,8 @@ const URL_MISTRAL_7B =
 const URL_GEMMA_2B = "https://huggingface.co/lmstudio-ai/gemma-2b-it-GGUF/resolve/a0b140b/gemma-2b-it-q4_k_m.gguf";
 const URL_BIG_ENDIAN =
 	"https://huggingface.co/ggml-org/models/resolve/1213976/bert-bge-small/ggml-model-f16-big-endian.gguf";
-const URL_V1 = "https://huggingface.co/tmadge/testing/resolve/main/tinyllamas-stories-260k-f32.gguf";
+const URL_V1 =
+	"https://huggingface.co/tmadge/testing/resolve/66c078028d1ff92d7a9264a1590bc61ba6437933/tinyllamas-stories-260k-f32.gguf";
 
 describe("gguf", () => {
 	it("should parse a llama2 7b", async () => {

--- a/packages/gguf/src/gguf.spec.ts
+++ b/packages/gguf/src/gguf.spec.ts
@@ -7,6 +7,7 @@ const URL_MISTRAL_7B =
 const URL_GEMMA_2B = "https://huggingface.co/lmstudio-ai/gemma-2b-it-GGUF/resolve/a0b140b/gemma-2b-it-q4_k_m.gguf";
 const URL_BIG_ENDIAN =
 	"https://huggingface.co/ggml-org/models/resolve/1213976/bert-bge-small/ggml-model-f16-big-endian.gguf";
+const URL_V1 = "https://huggingface.co/tmadge/testing/resolve/main/tinyllamas-stories-260k-f32.gguf";
 
 describe("gguf", () => {
 	it("should parse a llama2 7b", async () => {
@@ -175,6 +176,47 @@ describe("gguf", () => {
 			name: "blk.9.ffn_down.weight",
 			shape: [1536n, 384n],
 			dtype: GGMLQuantizationType.F16,
+		});
+	});
+
+	it("should parse a v1 file", async () => {
+		const { metadata, tensorInfos } = await gguf(URL_V1);
+
+		/// metadata
+
+		expect(metadata).toMatchObject({
+			version: 1,
+			tensor_count: 48n,
+			kv_count: 18n,
+			"general.architecture": "llama",
+			"general.name": "tinyllamas-stories-260k",
+			"llama.attention.head_count": 8,
+			"llama.attention.head_count_kv": 4,
+			"llama.attention.layer_norm_rms_epsilon": 0.000009999999747378752,
+			"llama.block_count": 5,
+			"llama.context_length": 512,
+			"llama.embedding_length": 64,
+			"llama.feed_forward_length": 172,
+			"llama.rope.dimension_count": 8,
+			"llama.tensor_data_layout": "Meta AI original pth",
+			"tokenizer.ggml.bos_token_id": 1,
+			"tokenizer.ggml.eos_token_id": 2,
+			"tokenizer.ggml.model": "llama",
+			"tokenizer.ggml.padding_token_id": 0,
+		});
+
+		/// Tensor infos
+
+		expect(tensorInfos.length).toEqual(48);
+		expect(tensorInfos[0]).toMatchObject({
+			name: "token_embd.weight",
+			shape: [64n, 512n],
+			dtype: GGMLQuantizationType.F32,
+		});
+		expect(tensorInfos[tensorInfos.length - 1]).toMatchObject({
+			name: "output.weight",
+			shape: [64n, 512n],
+			dtype: GGMLQuantizationType.F32,
 		});
 	});
 });

--- a/packages/gguf/src/gguf.ts
+++ b/packages/gguf/src/gguf.ts
@@ -82,20 +82,30 @@ class RangeView {
  * Note: A good article about binary data in JS: https://javascript.info/arraybuffer-binary-arrays
  */
 
-function readVersionedSize(view: DataView, byteOffset: number, version: Version, littleEndian: boolean): {value: bigint, offset: number} {
+function readVersionedSize(
+	view: DataView,
+	byteOffset: number,
+	version: Version,
+	littleEndian: boolean
+): { value: bigint; offset: number } {
 	switch (version) {
 		case 1: {
 			const n = view.getUint32(byteOffset, littleEndian);
-			return {value: BigInt(n), offset: 4};
+			return { value: BigInt(n), offset: 4 };
 		}
 		case 2:
 		case 3: {
-			return {value: view.getBigUint64(byteOffset, littleEndian), offset: 8};
+			return { value: view.getBigUint64(byteOffset, littleEndian), offset: 8 };
 		}
 	}
 }
 
-function readString(view: DataView, offset: number, version, littleEndian: boolean): { value: string; length: number } {
+function readString(
+	view: DataView,
+	offset: number,
+	version: Version,
+	littleEndian: boolean
+): { value: string; length: number } {
 	const length = readVersionedSize(view, offset, version, littleEndian);
 	const off = length.offset;
 	const value = new TextDecoder().decode(view.buffer.slice(offset + off, offset + off + Number(length.value)));
@@ -130,7 +140,7 @@ function readMetadataValue(
 			return readString(view, offset, version, littleEndian);
 		case GGUFValueType.ARRAY: {
 			const arrayType = view.getUint32(offset, littleEndian);
-			const arrayLength = readVersionedSize(view,offset + 4, version, littleEndian);
+			const arrayLength = readVersionedSize(view, offset + 4, version, littleEndian);
 			let length = 4 + arrayLength.offset;
 			const arrayValues: MetadataValue[] = [];
 			for (let i = 0; i < arrayLength.value; i++) {
@@ -247,7 +257,7 @@ export async function gguf(
 
 		const shape: bigint[] = [];
 		for (let dim = 0; dim < nDims; dim++) {
-			let shape_dim = readVersionedSize(r.view, offset, version, littleEndian);
+			const shape_dim = readVersionedSize(r.view, offset, version, littleEndian);
 			shape.push(shape_dim.value);
 			offset += shape_dim.offset;
 		}

--- a/packages/gguf/src/gguf.ts
+++ b/packages/gguf/src/gguf.ts
@@ -257,9 +257,9 @@ export async function gguf(
 
 		const shape: bigint[] = [];
 		for (let dim = 0; dim < nDims; dim++) {
-			const shape_dim = readVersionedSize(r.view, offset, version, littleEndian);
-			shape.push(shape_dim.value);
-			offset += shape_dim.offset;
+			const shapeDim = readVersionedSize(r.view, offset, version, littleEndian);
+			shape.push(shapeDim.value);
+			offset += shapeDim.offset;
 		}
 
 		const type = r.view.getUint32(offset, littleEndian);


### PR DESCRIPTION
It seems that v1 gguf was never supported. This pr addresses that by selectively reading bytes as Uint32 for v1 and UInt64 for v2 and v3.

Fixes https://github.com/huggingface/huggingface.js/issues/568