### PR TITLE
[Widget] fix computation device label

### DIFF
--- a/packages/widgets/src/lib/components/InferenceWidget/shared/helpers.ts
+++ b/packages/widgets/src/lib/components/InferenceWidget/shared/helpers.ts
@@ -184,7 +184,7 @@ export async function getModelLoadInfo(
 		const compute_type =
 			typeof output.compute_type === "string"
 				? output.compute_type
-				: (Object.keys(output.compute_type)[0] as ComputeType);
+				: output.compute_type["gpu"] ? ("gpu" as const) : ("cpu" as const);
 		return { compute_type, state: output.state };
 	} else {
 		console.warn(response.status, output.error);

--- a/packages/widgets/src/lib/components/InferenceWidget/shared/helpers.ts
+++ b/packages/widgets/src/lib/components/InferenceWidget/shared/helpers.ts
@@ -1,6 +1,6 @@
 import type { ModelData, WidgetExampleAttribute } from "@huggingface/tasks";
 import { parseJSON } from "../../../utils/ViewUtils.js";
-import type { ComputeType, ModelLoadInfo, TableData } from "./types.js";
+import { ComputeType, type ModelLoadInfo, type TableData } from "./types.js";
 import { LoadState } from "./types.js";
 
 const KEYS_TEXT: WidgetExampleAttribute[] = ["text", "context", "candidate_labels"];
@@ -184,7 +184,9 @@ export async function getModelLoadInfo(
 		const compute_type =
 			typeof output.compute_type === "string"
 				? output.compute_type
-				: output.compute_type["gpu"] ? ("gpu" as const) : ("cpu" as const);
+				: output.compute_type["gpu"]
+				  ? ComputeType.GPU
+				  : ComputeType.CPU;
 		return { compute_type, state: output.state };
 	} else {
 		console.warn(response.status, output.error);

--- a/packages/widgets/src/routes/+page.svelte
+++ b/packages/widgets/src/routes/+page.svelte
@@ -78,6 +78,11 @@
 			],
 		},
 		{
+			id: "google/gemma-7b",
+			pipeline_tag: "text-generation",
+			inference: InferenceDisplayability.Yes,
+		},
+		{
 			id: "microsoft/phi-2",
 			pipeline_tag: "text-generation",
 			inference: InferenceDisplayability.Yes,


### PR DESCRIPTION
Closes https://github.com/huggingface/huggingface.js/issues/565

I guess there was a change in the shape of output from from api-inference status endpoints. For instance:
```
curl https://api-inference.huggingface.co/status/google/gemma-7b
```
would give:
```
{"loaded":false,"state":"Loadable","compute_type":{"gpu":{"gpu":"a10-g","count":4}}
```

Widget frontend/UI assumption was that `compute_type` field would only have string value of `cpu` or `gpu`. However, you can see un the curl that, it can be `{"gpu":{"gpu":"a10-g","count":4}`.

Therefore, this PR handles this possible shape change


<img width="527" alt="Screenshot 2024-03-25 at 3 00 04 PM" src="https://github.com/huggingface/huggingface.js/assets/11827707/4d3b2958-db8d-458a-9248-86bb63ba77fa">
