### PR TITLE
[safetensors metadata] 8x faster parsing for sharded

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -15,7 +15,7 @@ export const SAFETENSORS_INDEX_FILE = "model.safetensors.index.json";
 export const RE_SAFETENSORS_FILE = /\.safetensors$/;
 export const RE_SAFETENSORS_INDEX_FILE = /\.safetensors\.index\.json$/;
 export const RE_SAFETENSORS_SHARD_FILE = /\d{5}-of-\d{5}\.safetensors$/;
-const PARALLEL_DOWNLOADS = 5;
+const PARALLEL_DOWNLOADS = 40;
 const MAX_HEADER_LENGTH = 25_000_000;
 
 class SafetensorParseError extends Error {}

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -15,7 +15,7 @@ export const SAFETENSORS_INDEX_FILE = "model.safetensors.index.json";
 export const RE_SAFETENSORS_FILE = /\.safetensors$/;
 export const RE_SAFETENSORS_INDEX_FILE = /\.safetensors\.index\.json$/;
 export const RE_SAFETENSORS_SHARD_FILE = /\d{5}-of-\d{5}\.safetensors$/;
-const PARALLEL_DOWNLOADS = 40;
+const PARALLEL_DOWNLOADS = 20;
 const MAX_HEADER_LENGTH = 25_000_000;
 
 class SafetensorParseError extends Error {}


### PR DESCRIPTION
https://huggingface.co/databricks/dbrx-instruct?show_tensors=model.safetensors.index.json is being quite slow because it needs to parse headers of [61 files](https://huggingface.co/databricks/dbrx-instruct/tree/main).

This PR increases concurrent requests from 5 to 40 for 8x throughput. The tests pass without giving any error (in regards to rate-limit)