### PR TITLE
Add missing pipelines disabled for the widgets

### DIFF
--- a/packages/tasks/src/library-to-tasks.ts
+++ b/packages/tasks/src/library-to-tasks.ts
@@ -6,7 +6,7 @@ import type { PipelineType } from "./pipelines";
  * Inference API (serverless) should be disabled for all other (library, task) pairs beyond this mapping.
  * This mapping is partially generated automatically by "python-api-export-tasks" action in
  * huggingface/api-inference-community repo upon merge. For transformers, the mapping is manually
- * based on api-inference.
+ * based on api-inference (hf_types.rs).
  */
 export const LIBRARY_TASK_MAPPING: Partial<Record<ModelLibraryKey, PipelineType[]>> = {
 	"adapter-transformers": ["question-answering", "text-classification", "token-classification"],
@@ -53,12 +53,20 @@ export const LIBRARY_TASK_MAPPING: Partial<Record<ModelLibraryKey, PipelineType[
 		"fill-mask",
 		"image-classification",
 		"image-segmentation",
-		"image-to-text",
 		"image-to-image",
+		"image-to-text",
 		"object-detection",
 		"question-answering",
-		"text-generation",
+		"summarization",
+		"table-question-answering",
 		"text2text-generation",
+		"text-classification",
+		"text-generation",
+		"text-to-audio",
+		"text-to-speech",
+		"token-classification",
+		"translation",
+		"video-classification",
 		"visual-question-answering",
 		"zero-shot-classification",
 		"zero-shot-image-classification",


### PR DESCRIPTION
I matched existing pipelines in https://huggingface.co/docs/transformers/en/main_classes/pipelines with https://github.com/huggingface/api-inference/blob/main/master-rs/src/data/hf_types.rs