### PR TITLE
Add support for KerasNLP library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -185,6 +185,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: true,
 		countDownloads: { term: { path: "saved_model.pb" } },
 	},
+	"keras-nlp": {
+		prettyLabel: "KerasNLP",
+		repoName: "KerasNLP",
+		repoUrl: "https://keras.io/keras_nlp/",
+		docsUrl: "https://github.com/keras-team/keras-nlp",
+	},
 	k2: {
 		prettyLabel: "K2",
 		repoName: "k2",


### PR DESCRIPTION
Following recent work to integrate KerasNLP library with the Hub, let's add it in our libraries list. KerasNLP is based on Keras3 but for now let's focus on the KerasNLP side of things (we also have on-going work for Keras but that's orthogonal).

This PR will add a pretty name for "KerasNLP" tag + add urls to official docs and github repo. 
We will be able to generate code snippet in the future as well but [it should be clarified](https://github.com/keras-team/keras-nlp/issues/1529#issuecomment-2040722487) first. I suggest that we merge this PR "as-is" and add support for code snippets later when it's ready. 

About download counts, KerasNLP uses a `config.json` file so it should already count correctly. 

Bonus: first KerasNLP models on the Hub? https://huggingface.co/google/gemma-2b-it-keras/discussions/2. Model can be loaded with:
```py
import keras_nlp

gemma_lm = keras_nlp.models.GemmaCausalLM.from_preset("hf://google/gemma-2b-it-keras")
```
:tada: 