### PR TITLE
[safetensors] Fix RE_SAFETENSORS_SHARD_FILE

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -115,7 +115,8 @@ describe("parseSafetensorsMetadata", () => {
 		const match = safetensorsFilename.match(RE_SAFETENSORS_SHARD_FILE);
 
 		assert.strictEqual(RE_SAFETENSORS_SHARD_FILE.test(safetensorsFilename), true);
-		assert.strictEqual(match?.groups?.prefix, "model");
+		assert.strictEqual(match?.groups?.prefix, "model_");
+		assert.strictEqual(match?.groups?.basePrefix, "model");
 		assert.strictEqual(match?.groups?.shard, "00005");
 		assert.strictEqual(match?.groups?.total, "00072");
 	});

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -14,7 +14,8 @@ export const SAFETENSORS_INDEX_FILE = "model.safetensors.index.json";
 /// but in some situations safetensors weights have different filenames.
 export const RE_SAFETENSORS_FILE = /\.safetensors$/;
 export const RE_SAFETENSORS_INDEX_FILE = /\.safetensors\.index\.json$/;
-export const RE_SAFETENSORS_SHARD_FILE = /^(?<prefix>(?<basePrefix>.*?)[_-])(?<shard>\d{5})-of-(?<total>\d{5})\.safetensors$/;
+export const RE_SAFETENSORS_SHARD_FILE =
+	/^(?<prefix>(?<basePrefix>.*?)[_-])(?<shard>\d{5})-of-(?<total>\d{5})\.safetensors$/;
 const PARALLEL_DOWNLOADS = 20;
 const MAX_HEADER_LENGTH = 25_000_000;
 

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -14,7 +14,7 @@ export const SAFETENSORS_INDEX_FILE = "model.safetensors.index.json";
 /// but in some situations safetensors weights have different filenames.
 export const RE_SAFETENSORS_FILE = /\.safetensors$/;
 export const RE_SAFETENSORS_INDEX_FILE = /\.safetensors\.index\.json$/;
-export const RE_SAFETENSORS_SHARD_FILE = /^(?<prefix>.*?)[_-]?(?<shard>\d{5})-of-(?<total>\d{5})\.safetensors$/;
+export const RE_SAFETENSORS_SHARD_FILE = /^(?<prefix>(?<basePrefix>.*?)[_-])(?<shard>\d{5})-of-(?<total>\d{5})\.safetensors$/;
 const PARALLEL_DOWNLOADS = 20;
 const MAX_HEADER_LENGTH = 25_000_000;
 


### PR DESCRIPTION
follow up to https://github.com/huggingface/huggingface.js/pull/622#discussion_r1562398324

> but that was my point, the -_ is not optional
> we do want to enforce some level of convention