### PR TITLE
Add snippets to KerasNLP models

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -156,8 +156,8 @@ model = from_pretrained_keras("${model.id}")
 export const keras_nlp = (model: ModelData): string[] => [
 	`import keras_nlp
 
-tokenizer = keras_nlp.models.Tokenizer.from_preset("${model.id}")
-backbone = keras_nlp.models.Backbone.from_preset("${model.id}")
+tokenizer = keras_nlp.models.Tokenizer.from_preset("hf://${model.id}")
+backbone = keras_nlp.models.Backbone.from_preset("hf://${model.id}")
 `,
 ];
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -153,6 +153,14 @@ model = from_pretrained_keras("${model.id}")
 `,
 ];
 
+export const keras_nlp = (model: ModelData): string[] => [
+	`import keras_nlp
+
+tokenizer = keras_nlp.models.Tokenizer.from_preset("${model.id}")
+backbone = keras_nlp.models.Backbone.from_preset("${model.id}")
+`,
+];
+
 export const open_clip = (model: ModelData): string[] => [
 	`import open_clip
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -190,6 +190,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "KerasNLP",
 		repoUrl: "https://keras.io/keras_nlp/",
 		docsUrl: "https://github.com/keras-team/keras-nlp",
+		snippets: snippets.keras_nlp,
 	},
 	k2: {
 		prettyLabel: "K2",


### PR DESCRIPTION
In https://github.com/huggingface/huggingface.js/pull/616 we added basic support for the `keras-nlp` library. This PR adds a code snippet for KerasNLP models. I just got confirmation from @mattdangerw that models can be loaded with:

```py
import keras_nlp

tokenizer = keras_nlp.models.Tokenizer.from_preset("hf://${model.id}")
backbone = keras_nlp.models.Backbone.from_preset("hf://${model.id}")
```

We might want to do more fancy stuff in the future to parse the underlying model architecture server-side but in the meantime this is a valid solution.