### PR TITLE
Update `voicecraft` snippet

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -532,9 +532,9 @@ IWorker engine = WorkerFactory.CreateWorker(BackendType.GPUCompute, model);
 ];
 
 export const voicecraft = (model: ModelData): string[] => [
-	`from voicecraft import VoiceCraftHF
+	`from voicecraft import VoiceCraft
 
-model = VoiceCraftHF.from_pretrained("${model.id}")`,
+model = VoiceCraft.from_pretrained("${model.id}")`,
 ];
 
 export const mlx = (model: ModelData): string[] => [


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface.js/pull/626. See https://github.com/huggingface/huggingface.js/pull/626#discussion_r1566963199 for more context.

This PR update the voicecraft code snippet to switch from `VoiceCraftHF` class to `VoiceCraft`. PR https://github.com/jasonppy/VoiceCraft/pull/90 must be merged to make this snippet work.