### PR TITLE
gguf: Fix ArrayBuffer.resize not supported on Firefox

### DIFF
--- a/packages/gguf/src/gguf.ts
+++ b/packages/gguf/src/gguf.ts
@@ -52,7 +52,7 @@ class RangeView {
 	private chunk: number;
 	private buffer: ArrayBuffer;
 	private dataView: DataView;
-	
+
 	get view(): DataView {
 		return this.dataView;
 	}
@@ -91,7 +91,7 @@ class RangeView {
 		this.chunk += 1;
 	}
 	/**
-	 * Append new data into the buffer 
+	 * Append new data into the buffer
 	 */
 	appendBuffer(buf: Uint8Array) {
 		/// TODO(fix typing)


### PR DESCRIPTION
`ArrayBuffer.resize()` is not supported on Firefox. This causes the error while visualizing gguf:

![image](https://github.com/huggingface/huggingface.js/assets/7702203/9b159123-d42f-4380-b217-64ea66204c51)

This PR introduces a small patch that uses a polyfill in case `ArrayBuffer.resize()` cannot be used.

Tested on Firefox and Chrome.