### PR TITLE
[inference] Flipped usage of wait_for_model flag

### DIFF
--- a/packages/inference/src/tasks/custom/request.ts
+++ b/packages/inference/src/tasks/custom/request.ts
@@ -16,7 +16,7 @@ export async function request<T>(
 	const { url, info } = await makeRequestOptions(args, options);
 	const response = await (options?.fetch ?? fetch)(url, info);
 
-	if (options?.retry_on_error !== false && response.status === 503 && !options?.wait_for_model) {
+	if (options?.retry_on_error !== false && response.status === 503 && options?.wait_for_model) {
 		return request(args, {
 			...options,
 			wait_for_model: true,

--- a/packages/inference/src/tasks/custom/streamingRequest.ts
+++ b/packages/inference/src/tasks/custom/streamingRequest.ts
@@ -18,7 +18,7 @@ export async function* streamingRequest<T>(
 	const { url, info } = await makeRequestOptions({ ...args, stream: true }, options);
 	const response = await (options?.fetch ?? fetch)(url, info);
 
-	if (options?.retry_on_error !== false && response.status === 503 && !options?.wait_for_model) {
+	if (options?.retry_on_error !== false && response.status === 503 && options?.wait_for_model) {
 		return yield* streamingRequest(args, {
 			...options,
 			wait_for_model: true,


### PR DESCRIPTION
I think `wait_for_model` usage is flipped incorrectly in https://github.com/huggingface/huggingface.js/pull/148. Check [files tab](https://github.com/huggingface/huggingface.js/pull/649/files)

What prompted this error:
from @gary149 

> 503 but no error appears in the UI?
https://huggingface.co/microsoft/Phi-3-mini-128k-instruct?text=hi

<img src="https://github.com/huggingface/huggingface.js/assets/11827707/c07ce78d-3e00-45e1-b07d-dfa709c2ebe5" width="200px">

Explanation: although widget sends `wait_for_model: false`, inference.js does NOT throw error and tries to load the model and make a call to this model once it is loaded
