### PR TITLE
Local apps links 

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -99,10 +99,11 @@ export const LOCAL_APPS = {
 		docsUrl: "https://drawthings.ai",
 		mainTask: "text-to-image",
 		macOSOnly: true,
+		comingSoon: true,
 		/**
 		 * random function, will need to refine the actual conditions:
 		 */
-		displayOnModelPage: (model) => model.tags.includes("textual_inversion"),
+		displayOnModelPage: (model) => model.library_name === "diffusers" && model.pipeline_tag === "text-to-image",
 		deeplink: (model) => new URL(`drawthings://open_from_hf?model=${model.id}`),
 	},
 	diffusionbee: {

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -35,6 +35,12 @@ export type LocalApp = {
 			deeplink: (model: ModelData) => URL;
 	  }
 	| {
+					/**
+			 * If the app supports opening through their website
+			 */
+					weblink?: (mode: ModelData) => URL;
+	} 
+	| {
 			/**
 			 * And if not (mostly llama.cpp), snippet to copy/paste in your terminal
 			 */
@@ -84,15 +90,15 @@ export const LOCAL_APPS = {
 		docsUrl: "https://jan.ai",
 		mainTask: "text-generation",
 		displayOnModelPage: isGgufModel,
-		deeplink: (model) => new URL(`jan://open_from_hf?model=${model.id}`),
+		deeplink: (model) => new URL(`jan://models/huggingface/${model.id}`),
 	},
-	faraday: {
-		prettyLabel: "Faraday",
-		docsUrl: "https://faraday.dev",
+	backyard: {
+		prettyLabel: "Backyard",
+		docsUrl: "https://backyard.ai",
 		mainTask: "text-generation",
 		macOSOnly: true,
 		displayOnModelPage: isGgufModel,
-		deeplink: (model) => new URL(`faraday://open_from_hf?model=${model.id}`),
+		weblink: (model) => new URL(`https://backyard.ai/hf/model/${model.id}`),
 	},
 	drawthings: {
 		prettyLabel: "Draw Things",

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -39,7 +39,7 @@ export type LocalApp = {
 			 * If the app supports opening through their website
 			 */
 			weblink?: (mode: ModelData) => URL;
-	} 
+	  }
 	| {
 			/**
 			 * And if not (mostly llama.cpp), snippet to copy/paste in your terminal

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -36,12 +36,6 @@ export type LocalApp = {
 	  }
 	| {
 			/**
-			 * If the app supports opening through their website
-			 */
-			weblink?: (mode: ModelData) => URL;
-	  }
-	| {
-			/**
 			 * And if not (mostly llama.cpp), snippet to copy/paste in your terminal
 			 */
 			snippet: (model: ModelData) => string;
@@ -98,7 +92,7 @@ export const LOCAL_APPS = {
 		mainTask: "text-generation",
 		macOSOnly: true,
 		displayOnModelPage: isGgufModel,
-		weblink: (model) => new URL(`https://backyard.ai/hf/model/${model.id}`),
+		deeplink: (model) => new URL(`https://backyard.ai/hf/model/${model.id}`),
 	},
 	drawthings: {
 		prettyLabel: "Draw Things",

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -35,10 +35,10 @@ export type LocalApp = {
 			deeplink: (model: ModelData) => URL;
 	  }
 	| {
-					/**
+			/**
 			 * If the app supports opening through their website
 			 */
-					weblink?: (mode: ModelData) => URL;
+			weblink?: (mode: ModelData) => URL;
 	} 
 	| {
 			/**


### PR DESCRIPTION
 Deeplinks (and Faraday rebranding)

 - [x] LM Studio: deeplink works well with 0.2.23
 - [x] Jan: deeplink works well with the nightly
 - [ ] Faraday/Backyard: the weblink doesn't work (yet) 
 - [ ] Draw things: coming soon
 - [ ] Diffusionbee: coming soon