### PR TITLE
➖ Remove node-fetch from tasks

### DIFF
--- a/packages/tasks/package.json
+++ b/packages/tasks/package.json
@@ -47,8 +47,5 @@
 		"@types/node": "^20.11.5",
 		"quicktype-core": "https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz",
 		"type-fest": "^3.13.1"
-	},
-	"dependencies": {
-		"node-fetch": "^3.3.2"
 	}
 }

--- a/packages/tasks/scripts/inference-tgi-import.ts
+++ b/packages/tasks/scripts/inference-tgi-import.ts
@@ -4,7 +4,6 @@
  * See https://huggingface.github.io/text-generation-inference/
  */
 import fs from "fs/promises";
-import fetch from "node-fetch";
 import * as path from "node:path/posix";
 import { existsSync as pathExists } from "node:fs";
 import type { JsonObject, JsonValue } from "type-fest";


### PR DESCRIPTION
It's not necessary, recent versions of node have `fetch` builtin

(even if we wanted to use it, it would have been more appropriate in dev dependencies)