### PR TITLE
[widgets] Conv Widget with Model Loading

### DIFF
--- a/packages/widgets/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
+++ b/packages/widgets/src/lib/components/InferenceWidget/widgets/ConversationalWidget/ConversationalWidget.svelte
@@ -45,6 +45,10 @@
 	let isLoading: boolean = false;
 	let outputJson: string;
 	let text = "";
+	let modelLoading = {
+		isLoading: false,
+		estimatedTime: 0,
+	};
 
 	let compiledTemplate: Template;
 	let tokenizerConfig: TokenizerConfig;
@@ -201,7 +205,16 @@
 		} catch (e) {
 			if (!isOnLoadCall) {
 				if (!!e && typeof e === "object" && "message" in e && typeof e.message === "string") {
-					error = e.message;
+					if (e.message.includes("is currently loading")) {
+						modelLoading = {
+							isLoading: true,
+							estimatedTime: 10, // 10 seconds for an estimate
+						};
+						await getOutput({ withModelLoading: true, useCache });
+						modelLoading = { isLoading: false, estimatedTime: 0 };
+					} else {
+						error = e.message;
+					}
 				} else {
 					error = `Something went wrong with the request.`;
 				}
@@ -286,7 +299,7 @@
 		on:cmdEnter={handleNewMessage}
 	/>
 
-	<WidgetInfo {model} {error} />
+	<WidgetInfo {model} {error} {modelLoading} />
 
 	<WidgetFooter {model} {isDisabled} {outputJson} />
 </WidgetWrapper>


### PR DESCRIPTION
### Fix `Model Loading` behaviour in Conversational Widget.

Follow up to https://github.com/huggingface/huggingface.js/pull/486
Due to https://github.com/huggingface/huggingface.js/pull/486, Conversational Widget is different from other widgets in how it calls hf api-inference: Conversational Widget uses `@huggingface/inference client` while other widgets use `regular fetch`.

Equivalent of lines below were missing in Conversational Widget https://github.com/huggingface/huggingface.js/blob/f2e9ce3c11822910d293ae3455e22bad093026a3/packages/widgets/src/lib/components/InferenceWidget/widgets/TextGenerationWidget/TextGenerationWidget.svelte#L144-L149

And this PR add this missing function.

#### Screen cast

https://github.com/huggingface/huggingface.js/assets/11827707/2201c471-964f-4943-8455-8a51800ade12

note: in the demo above `mrfakename/refusal-old` is not supported in TGI, therefore, the output is not streamed
