### PR TITLE
:adhesive_bandage: local-apps : remove extra space from llama.cpp snippet

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -50,7 +50,7 @@ const snippetLlamacpp = (model: ModelData): string => {
 	return `./main \\
 	--hf-repo "${model.id}" \\
 	-m file.gguf \\
-	-p "I believe the meaning of life is " \\
+	-p "I believe the meaning of life is" \\
 	-n 128`;
 };
 


### PR DESCRIPTION
The extra space at the end of the `--prompt` input can mess up the tokenization, so it is better to remove it.

To illustrate, here is how `"I believe the meaning of life is "` tokenizes:

```
main: prompt: 'I believe the meaning of life is '
main: number of tokens in prompt = 9
     2 -> '<bos>'
   590 -> ' I'
  4564 -> ' believe'
   573 -> ' the'
  6996 -> ' meaning'
   576 -> ' of'
  1913 -> ' life'
   603 -> ' is'
235248 -> ' '
```

There is an extra whitespace token 235248 at the end due to the extra space.