### PR TITLE
gguf: Add type definitions for `split.*` metadata + sanity check

### DIFF
--- a/packages/gguf/src/types.spec.ts
+++ b/packages/gguf/src/types.spec.ts
@@ -51,5 +51,12 @@ describe("gguf-types", () => {
 			// @ts-expect-error llama does not have ssm.* keys
 			model["mamba.ssm.conv_kernel"] = 0;
 		}
+
+		if (model["split.count"]) {
+			model["split.no"] = 123;
+		} else {
+			// @ts-expect-error not a split (shard) model
+			model["split.no"] = 123;
+		}
 	});
 });

--- a/packages/gguf/src/types.ts
+++ b/packages/gguf/src/types.ts
@@ -92,6 +92,20 @@ interface NoTokenizer {
 	"tokenizer.ggml.model"?: undefined;
 }
 
+/// Splits
+
+interface Splits {
+	// Index of the current split (couting from 0)
+	"split.no": number;
+	// Total number of splits (couting from 1)
+	"split.count": number;
+	// Total number of tensors from all splits
+	"split.tensors.count": number;
+}
+interface NoSplits {
+	"split.count"?: undefined;
+}
+
 /// Models outside of llama.cpp: "rwkv" and "whisper"
 
 export type RWKV = GGUFGeneralInfo<"rwkv"> &
@@ -126,7 +140,7 @@ export type GGUFMetadata<Options extends GGUFMetadataOptions = { strict: true }>
 } & GGUFModelKV &
 	(Options extends { strict: true } ? unknown : Record<string, MetadataValue>);
 
-export type GGUFModelKV = (NoModelMetadata | ModelMetadata) & (NoTokenizer | Tokenizer);
+export type GGUFModelKV = (NoModelMetadata | ModelMetadata) & (NoTokenizer | Tokenizer) & (Splits | NoSplits);
 
 export interface GGUFTensorInfo {
 	name: string;


### PR DESCRIPTION
This PR add correct type definitions for GGUF `split.*`, and use them in `ggufAllShards` for sanity checks.

The sanity checks does not really serves real-life purpose, since it is very unlikely that users mess up with file name. For now, it mostly to demonstrate how to use these metadata keys.

This PR also modify output format of `ggufAllShards`. Because metadata is saved in the first split only, we can simply discard metadata of other splits.

For more details, please have a look on `gguf-split` source code:

https://github.com/ggerganov/llama.cpp/blob/24ecb58168dce81646c2ed425690a106591c8c6d/examples/gguf-split/gguf-split.cpp#L223-L225