### PR TITLE
Add RecurseChat Local App

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -118,6 +118,14 @@ export const LOCAL_APPS = {
 		displayOnModelPage: isGgufModel,
 		deeplink: (model) => new URL(`sanctum://open_from_hf?model=${model.id}`),
 	},
+	recursechat: {
+		prettyLabel: "RecurseChat",
+		docsUrl: "https://recurse.chat",
+		mainTask: "text-generation",
+		macOSOnly: true,
+		displayOnModelPage: isGgufModel,
+		deeplink: (model) => new URL(`recursechat://new-hf-gguf-model?hf-model-id=${model.id}`),
+	},
 	drawthings: {
 		prettyLabel: "Draw Things",
 		docsUrl: "https://drawthings.ai",


### PR DESCRIPTION
Hi HF team! 

Super cool idea to use local model directly from HuggingFace. I'm hoping to add [RecurseChat](https://recurse.chat/) (a local first AI app) to "Use this model" list in this PR. Still in the process of adding deeplink functionality (mainly trying to automatically figuring out a chat template, and need to release it on the Mac App Store), but want to get some feedback first.

The deep link roughly works like below:

https://github.com/huggingface/huggingface.js/assets/679275/5140e1e4-85e8-4c6e-b2d2-c1296cbaae7c

If you need to test the app, please feel free to shoot an email to xiaoyi@recurse.chat for a TestFlight invite. Thank you for considering the request.
