### PR TITLE
Add support for EDS-NLP library

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -100,7 +100,7 @@ export const diffusers = (model: ModelData): string[] => {
 export const edsnlp = (model: ModelData): string[] => {
 	const packageName = nameWithoutNamespace(model.id).replaceAll("-", "_");
 	return [
-		`# Load it from the huggingface hub directly
+		`# Load it from the Hub directly
 import edsnlp
 nlp = edsnlp.load("${model.id}")
 `,

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -97,6 +97,24 @@ export const diffusers = (model: ModelData): string[] => {
 	}
 };
 
+export const edsnlp = (model: ModelData): string[] => {
+	const packageName = nameWithoutNamespace(model.id).replaceAll("-", "_");
+	return [
+		`# Load it from the huggingface hub directly
+import edsnlp
+nlp = edsnlp.load("${model.id}")
+`,
+		`# Or install it as a package
+!pip install git+https://huggingface.co/${model.id}
+
+# and import it as a module
+import ${packageName}
+
+nlp = ${packageName}.load()  # or edsnlp.load("${packageName}")
+`,
+	];
+};
+
 export const espnetTTS = (model: ModelData): string[] => [
 	`from espnet2.bin.tts_inference import Text2Speech
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -133,6 +133,16 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "doctr",
 		repoUrl: "https://github.com/mindee/doctr",
 	},
+	edsnlp: {
+		prettyLabel: "EDS-NLP",
+		repoName: "edsnlp",
+		repoUrl: "https://github.com/aphp/edsnlp",
+		filter: false,
+		snippets: snippets.edsnlp,
+		countDownloads: {
+			wildcard: { path: "*/config.cfg" },
+		},
+	},
 	elm: {
 		prettyLabel: "ELM",
 		repoName: "elm",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -137,6 +137,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "EDS-NLP",
 		repoName: "edsnlp",
 		repoUrl: "https://github.com/aphp/edsnlp",
+		docsUrl: "https://aphp.github.io/edsnlp/latest/",
 		filter: false,
 		snippets: snippets.edsnlp,
 		countDownloads: {


### PR DESCRIPTION
Hi,

This PR adds support for the edsnlp library (related to https://github.com/huggingface/api-inference-community/pull/424), an NLP library developed at the Greater Paris University Hospitals (AP-HP) with a specific focus on hybrid models (rule-based + ML) and multi-tasking, widely used in the structuring of clinical language at scale (NER, entity linking, document classification, event extraction, ...).
I saw that the file https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/library-to-tasks.ts was automatically generated from a GitHub CI as mentioned on the docs, but didn't see how the action would edit it so I took the liberty of modifying it myself.
Let me know if you need more information or if I need to change anything about this PR, thanks !
