### PR TITLE
Add Sanctum local app to "Use this model" list

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -103,6 +103,13 @@ export const LOCAL_APPS = {
 		displayOnModelPage: isGgufModel,
 		deeplink: (model) => new URL(`https://backyard.ai/hf/model/${model.id}`),
 	},
+	sanctum: {
+		prettyLabel: "Sanctum",
+		docsUrl: "https://sanctum.ai",
+		mainTask: "text-generation",
+		displayOnModelPage: isGgufModel,
+		deeplink: (model) => new URL(`sanctum://open_from_hf?model=${model.id}`),
+	},
 	drawthings: {
 		prettyLabel: "Draw Things",
 		docsUrl: "https://drawthings.ai",


### PR DESCRIPTION
Hi HuggingFace team!

Sanctum is a local encrypted application for running open-source LLMs in just a few clicks. It has a direct integration with HuggingFace GGUF models, so it'd be great to have it under the list of "Use this model" local apps. Sanctum is free and available for download on MacOS & Windows here: [https://sanctum.ai](https://sanctum.ai)

We've also implemented support for deep links, here's a quick video on how it works on MacOS (Windows is also supported). Feel free to use this link to try it out: `sanctum://open_from_hf?model=SanctumAI/Meta-Llama-3-8B-Instruct-GGUF`

https://github.com/huggingface/huggingface.js/assets/32494918/9f9acc09-0396-48b7-ba8b-9945c6dd547c

Also is there anything we could do for Sanctum to be available in the "Use this model" app list by default?

Thanks in advance!