### PR TITLE
Ignore unsupported pipelines for transformers

### DIFF
--- a/packages/tasks/src/library-to-tasks.ts
+++ b/packages/tasks/src/library-to-tasks.ts
@@ -70,6 +70,7 @@ export const LIBRARY_TASK_MAPPING: Partial<Record<ModelLibraryKey, PipelineType[
 		"visual-question-answering",
 		"zero-shot-classification",
 		"zero-shot-image-classification",
+		"zero-shot-object-detection",
 	],
 	mindspore: ["image-classification"],
 };

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1,4 +1,5 @@
 import type { ModelData } from "./model-data";
+import { LIBRARY_TASK_MAPPING } from "./library-to-tasks";
 
 const TAG_CUSTOM_CODE = "custom_code";
 
@@ -438,7 +439,7 @@ export const transformers = (model: ModelData): string[] => {
 		].join("\n");
 	}
 
-	if (model.pipeline_tag) {
+	if (model.pipeline_tag && LIBRARY_TASK_MAPPING.transformers?.includes(model.pipeline_tag)) {
 		const pipelineSnippet = [
 			"# Use a pipeline as a high-level helper",
 			"from transformers import pipeline",


### PR DESCRIPTION
If a model has a type without a corresponding pipeline in transformers, we don't show the `pipeline` snippet but we still show the `AutoModel` one. This is useful for example for `sentence-similarity` models

![Screenshot from 2024-05-22 18-35-06](https://github.com/huggingface/huggingface.js/assets/7246357/77373f2b-477a-4dc4-84af-12b4baa31dd5)
![Screenshot from 2024-05-22 18-34-43](https://github.com/huggingface/huggingface.js/assets/7246357/64006386-6e61-49b3-8a5c-1795f23f6c4d)

https://huggingface.slack.com/archives/C02EMARJ65P/p1716294199591799