### PR TITLE
Add new text-to-image LocalApp  JoyFusion(macOS)

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -133,7 +133,9 @@ export const LOCAL_APPS = {
 		mainTask: "text-to-image",
 		macOSOnly: true,
 		comingSoon: true,
-		displayOnModelPage: (model) => (model.tags.includes("coreml") || model.tags.includes("core-ml") ) && model.pipeline_tag === "text-to-image",
+		displayOnModelPage: (model) => {
+			return (model.tags.includes("coreml") || model.tags.includes("core-ml")) && model.pipeline_tag === "text-to-image"
+		},
 		deeplink: (model) => new URL(`https://joyfusion.app/import_from_hf?repo_id=${model.id}`),
 	},
 } satisfies Record<string, LocalApp>;

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -127,6 +127,15 @@ export const LOCAL_APPS = {
 		displayOnModelPage: (model) => model.library_name === "diffusers" && model.pipeline_tag === "text-to-image",
 		deeplink: (model) => new URL(`diffusionbee://open_from_hf?model=${model.id}`),
 	},
+	joyfusion: {
+		prettyLabel: "JoyFusion",
+		docsUrl: "https://joyfusion.app",
+		mainTask: "text-to-image",
+		macOSOnly: true,
+		comingSoon: true,
+		displayOnModelPage: (model) => (model.tags.includes("coreml") || model.tags.includes("core-ml") ) && model.pipeline_tag === "text-to-image",
+		deeplink: (model) => new URL(`https://joyfusion.app/import_from_hf?repo_id=${model.id}`),
+	},
 } satisfies Record<string, LocalApp>;
 
 export type LocalAppKey = keyof typeof LOCAL_APPS;

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -133,9 +133,7 @@ export const LOCAL_APPS = {
 		mainTask: "text-to-image",
 		macOSOnly: true,
 		comingSoon: true,
-		displayOnModelPage: (model) => {
-			return (model.tags.includes("coreml") || model.tags.includes("core-ml")) && model.pipeline_tag === "text-to-image"
-		},
+		displayOnModelPage: (model) => model.tags.includes("coreml") && model.pipeline_tag === "text-to-image",
 		deeplink: (model) => new URL(`https://joyfusion.app/import_from_hf?repo_id=${model.id}`),
 	},
 } satisfies Record<string, LocalApp>;


### PR DESCRIPTION
JoyFusion is a native application for macOS , built upon Stable Diffusion and CoreML technologies. It can locally  run CoreML-based text-to-image models.

👇Here is Icon SVG


![joyfusion-icon](https://github.com/huggingface/huggingface.js/assets/21988177/4da48c3d-c27c-47c3-9065-a1c293751181)




