### PR TITLE
Add docstring to `revision` param for `downloadFile`

### DIFF
--- a/packages/hub/src/lib/download-file.ts
+++ b/packages/hub/src/lib/download-file.ts
@@ -16,6 +16,9 @@ export async function downloadFile(params: {
 	 * For example, when calling on a file stored with Git LFS, the pointer file will be downloaded instead.
 	 */
 	raw?: boolean;
+	/**
+ 	* An optional Git revision id which can be a branch name, a tag, or a commit hash.
+  	*/
 	revision?: string;
 	/**
 	 * Fetch only a specific part of the file

--- a/packages/hub/src/lib/download-file.ts
+++ b/packages/hub/src/lib/download-file.ts
@@ -17,8 +17,8 @@ export async function downloadFile(params: {
 	 */
 	raw?: boolean;
 	/**
- 	* An optional Git revision id which can be a branch name, a tag, or a commit hash.
-  	*/
+ 	 * An optional Git revision id which can be a branch name, a tag, or a commit hash.
+  	 */
 	revision?: string;
 	/**
 	 * Fetch only a specific part of the file

--- a/packages/hub/src/lib/download-file.ts
+++ b/packages/hub/src/lib/download-file.ts
@@ -17,8 +17,8 @@ export async function downloadFile(params: {
 	 */
 	raw?: boolean;
 	/**
- 	 * An optional Git revision id which can be a branch name, a tag, or a commit hash.
-  	 */
+	 * An optional Git revision id which can be a branch name, a tag, or a commit hash.
+	 */
 	revision?: string;
 	/**
 	 * Fetch only a specific part of the file

--- a/packages/hub/src/lib/download-file.ts
+++ b/packages/hub/src/lib/download-file.ts
@@ -18,6 +18,8 @@ export async function downloadFile(params: {
 	raw?: boolean;
 	/**
 	 * An optional Git revision id which can be a branch name, a tag, or a commit hash.
+	 *
+	 * @default "main"
 	 */
 	revision?: string;
 	/**


### PR DESCRIPTION
Copies the docstring in the [Python counterpart](https://huggingface.co/docs/huggingface_hub/v0.23.1/en/package_reference/hf_api#huggingface_hub.HfApi.hf_hub_download)