### PR TITLE
Add NVIDIA RTX 2070 to hardware.ts list

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -161,7 +161,7 @@ export const SKUS = {
 				memory: [12, 8],
 			},
 			"RTX 2070": {
-				tflops: 7.465,
+				tflops: 14.93,
 				memory: [8],
 			}, 
 			"RTX 3050 Mobile": {

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -159,7 +159,7 @@ export const SKUS = {
 			"RTX 3060": {
 				tflops: 12.74,
 				memory: [12, 8],
-			}, 
+			},
 			"RTX 2070": {
 				tflops: 7.465,
 				memory: [8],

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -163,7 +163,7 @@ export const SKUS = {
 			"RTX 2070": {
 				tflops: 14.93,
 				memory: [8],
-			}, 
+			},
 			"RTX 3050 Mobile": {
 				tflops: 7.639,
 				memory: [6],

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -159,7 +159,11 @@ export const SKUS = {
 			"RTX 3060": {
 				tflops: 12.74,
 				memory: [12, 8],
-			},
+			}, 
+			"RTX 2070": {
+				tflops: 7.465,
+				memory: [8],
+			}, 
 			"RTX 3050 Mobile": {
 				tflops: 7.639,
 				memory: [6],


### PR DESCRIPTION
Just came across this: https://huggingface.co/settings/local-apps

Noticed it didn't have the NVIDIA RTX 2070 on it so this PR aims to add it. I'm going off of FP32 TFLOPS performance.
![image](https://github.com/huggingface/huggingface.js/assets/28925758/edd0c6fc-2dc3-4c0a-a154-0006ea7bd8cb)
https://www.techpowerup.com/gpu-specs/geforce-rtx-2070.c3252
