### PR TITLE
Add Jellybox Local App

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -110,15 +110,17 @@ export const LOCAL_APPS = {
 		displayOnModelPage: isGgufModel,
 		deeplink: (model) => new URL(`sanctum://open_from_hf?model=${model.id}`),
 	},
-	jellybox : {
+	jellybox: {
 		prettyLabel: "Jellybox",
 		docsUrl: "https://jellybox.com",
 		mainTask: "text-generation",
 		displayOnModelPage: (model) =>
 			isGgufModel(model) ||
-			model.library_name === "diffusers" && model.tags.includes("safetensors") && (model.pipeline_tag === "text-to-image" || model.tags.includes("lora")),
+			(model.library_name === "diffusers" &&
+				model.tags.includes("safetensors") &&
+				(model.pipeline_tag === "text-to-image" || model.tags.includes("lora"))),
 		deeplink: (model) => {
-			if(isGgufModel(model)) {
+			if (isGgufModel(model)) {
 				return new URL(`jellybox://llm/models/huggingface/LLM/${model.id}`);
 			} else if (model.tags.includes("lora")) {
 				return new URL(`jellybox://image/models/huggingface/ImageLora/${model.id}`);

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -110,6 +110,23 @@ export const LOCAL_APPS = {
 		displayOnModelPage: isGgufModel,
 		deeplink: (model) => new URL(`sanctum://open_from_hf?model=${model.id}`),
 	},
+	jellybox : {
+		prettyLabel: "Jellybox",
+		docsUrl: "https://jellybox.com",
+		mainTask: "text-generation",
+		displayOnModelPage: (model) =>
+			isGgufModel(model) ||
+			model.library_name === "diffusers" && model.tags.includes("safetensors") && (model.pipeline_tag === "text-to-image" || model.tags.includes("lora")),
+		deeplink: (model) => {
+			if(isGgufModel(model)) {
+				return new URL(`jellybox://llm/models/huggingface/LLM/${model.id}`);
+			} else if (model.tags.includes("lora")) {
+				return new URL(`jellybox://image/models/huggingface/ImageLora/${model.id}`);
+			} else {
+				return new URL(`jellybox://image/models/huggingface/Image/${model.id}`);
+			}
+		},
+	},
 	drawthings: {
 		prettyLabel: "Draw Things",
 		docsUrl: "https://drawthings.ai",


### PR DESCRIPTION
Hi Huggingface team!

[Jellybox](https://jellybox.com) is a local first app for running both language models, and image generation.
Here is a current features list:

1. Download models from Huggingface
2. In depth configuration for creating templates for chatting with language models
3. Allow language models to execute code in a container sandbox (prompted with unprompted coming soon)
4. Windows (Nvidia (CUDA) & AMD (ROCm)) and macOS support
5. Image generation templates, with per template image galleries
6. Deep link support

