### PR TITLE
docs: improve llama.cpp install instructions.

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -48,16 +48,14 @@ function isGgufModel(model: ModelData) {
 
 const snippetLlamacpp = (model: ModelData): string[] => {
 	return [
-		`
-## Install and build llama.cpp with curl support
-git clone https://github.com/ggerganov/llama.cpp.git 
-cd llama.cpp
-LLAMA_CURL=1 make
+		`## Install llama.cpp via brew or from source https://github.com/ggerganov/llama.cpp?tab=readme-ov-file#build
+
+brew install llama.cpp
 `,
 		`## Load and run the model
-./main \\
+llama \\
 	--hf-repo "${model.id}" \\
-	-m file.gguf \\
+	--hf-file file.gguf \\
 	-p "I believe the meaning of life is" \\
 	-n 128`,
 	];


### PR DESCRIPTION
Does two things:

1. Makes homebrew install the default and points users to build instructions for other platforms (note: our previous instructions were also only for Mac - this PRs makes the wording more generalised)
2. moves from `-m` to `--hf-file` this would make sure that the models are cached