### PR TITLE
Add Aphrodite Engine to Local Apps

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -46,6 +46,10 @@ function isGgufModel(model: ModelData) {
 	return model.tags.includes("gguf");
 }
 
+function isTransformersModel(model: ModelData) {
+	return model.tags.includes("transformers");
+}
+
 const snippetLlamacpp = (model: ModelData): string[] => {
 	return [
 		`
@@ -60,6 +64,17 @@ LLAMA_CURL=1 make
 	-m file.gguf \\
 	-p "I believe the meaning of life is" \\
 	-n 128`,
+	];
+};
+
+const snippetAphroditeEngine = (model: ModelData): string[] => {
+	return [
+		`
+  ## Install Aphrodite Engine. It should pull models from HF automatically.
+  pip install aphrodite-engine --extra-index-url https://downloads.pygmalion.chat/whl
+  `,
+		`## Load and run the model
+  aphrodite run "${model.id}"`
 	];
 };
 
@@ -102,6 +117,13 @@ export const LOCAL_APPS = {
 		mainTask: "text-generation",
 		displayOnModelPage: isGgufModel,
 		deeplink: (model) => new URL(`https://backyard.ai/hf/model/${model.id}`),
+	},
+	aphrodite: {
+	        prettyLabel: "Aphrodite Engine",
+		docsUrl: "https://github.com/PygmalionAI/aphrodite-engine/wiki",
+		mainTask: "text-generation",
+		displayOnModelPage: isTransformersModel,
+		snippet: snippetAphroditeEngine,
 	},
 	drawthings: {
 		prettyLabel: "Draw Things",


### PR DESCRIPTION
This PR adds [Aphrodite Engine](https://github.com/PygmalionAI/aphrodite-engine) to the list of local apps.

Aphrodite is a tensor-parallel LLM inference engine based on [vLLM](https://github.com/vllm-project/vllm), with support for almost all transformers models and quantization formats. It currently supports:

- Hugging Face Transformers
- GGUF
- ExLlamaV2
- GPTQ
- AWQ
- Bitsandbytes
- Smoothquant+
- EETQ
- AQLM
- QuIP#

Deeplink support is not planned because it's a CLI-only app. This is my first time writing TypeScript, please let me know if I've made a mistake. Cheers!

Here's the SVG, if needed.
![pygchisel](https://github.com/huggingface/huggingface.js/assets/52078762/806f70dc-4354-4ad9-9427-7c465c5079a9)
