### PR TITLE
add GTX 1660 hardware

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -184,6 +184,10 @@ export const SKUS = {
 				tflops: 32.62,
 				memory: [24],
 			},
+			"GTX 1660": {
+				tflops: 10.05,
+				memory: [6],
+			},
 			"GTX 1650 Mobile": {
 				tflops: 6.39,
 				memory: [4],


### PR DESCRIPTION
this will add GTX 1660 hardware.
Data has been curated from https://www.techpowerup.com/gpu-specs/geforce-gtx-1660.c3365 .