### PR TITLE
[`widgets`] Fix copy-paste error resulting in Sentence Similarity widget failure

### DIFF
--- a/packages/widgets/src/lib/components/InferenceWidget/shared/inputValidation.ts
+++ b/packages/widgets/src/lib/components/InferenceWidget/shared/inputValidation.ts
@@ -77,7 +77,7 @@ export function isSentenceSimilarityInput<TOutput>(
 	return (
 		isObject(sample) &&
 		"source_sentence" in sample &&
-		typeof sample.candidate_labels === "string" &&
+		typeof sample.source_sentence === "string" &&
 		"sentences" in sample &&
 		isStrArray(sample.sentences)
 	);


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix copy-paste error resulting in Sentence Similarity widget failure

## Bug Details
Currently, the Sentence Similarity widget is not filled with any content: 
![image](https://github.com/huggingface/huggingface.js/assets/37621491/a19620bd-f2f7-4ec5-9f2e-d6bb4cc7f5ec)
E.g. for https://huggingface.co/tomaarsen/mpnet-base-all-nli-triplet

This occurs regardless of whether the widget values are overridden by the README.md metadata ([like this](https://huggingface.co/tomaarsen/mpnet-base-all-nli-triplet/raw/main/README.md)) or not.

## After this PR
I've narrowed this down to the fix applied in this PR. After applying it, I was able to see the specified widget data:
![image](https://github.com/huggingface/huggingface.js/assets/37621491/3d71fbd5-731b-4cec-82e1-c3bbde4a340e)

And when I didn't override the default options:
![image](https://github.com/huggingface/huggingface.js/assets/37621491/6cb1153d-1e6f-40ec-bd0d-580b9856ef73)

cc @osanseviero 

- Tom Aarsen