### PR TITLE
Add ChatTTS download stats

### DIFF
--- a/packages/gguf/package.json
+++ b/packages/gguf/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@huggingface/gguf",
 	"packageManager": "pnpm@8.10.5",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "a GGUF parser that works on remotely hosted files",
 	"repository": "https://github.com/huggingface/huggingface.js.git",
 	"publishConfig": {

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -555,7 +555,7 @@ model = VoiceCraft.from_pretrained("${model.id}")`,
 
 export const chattts = (model: ModelData): string[] => [
 	`import ChatTTS
-from IPython.display import Audio
+import torchaudio
 
 chat = ChatTTS.Chat()
 chat.load_models(compile=False) # Set to True for better performance
@@ -566,7 +566,6 @@ wavs = chat.infer(texts, )
 
 torchaudio.save("output1.wav", torch.from_numpy(wavs[0]), 24000)`,
 ];
-
 
 export const mlx = (model: ModelData): string[] => [
 	`pip install huggingface_hub hf_transfer

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -553,7 +553,7 @@ export const voicecraft = (model: ModelData): string[] => [
 model = VoiceCraft.from_pretrained("${model.id}")`,
 ];
 
-export const chattts = (model: ModelData): string[] => [
+export const chattts = [
 	`import ChatTTS
 import torchaudio
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -553,7 +553,7 @@ export const voicecraft = (model: ModelData): string[] => [
 model = VoiceCraft.from_pretrained("${model.id}")`,
 ];
 
-export const chattts = [
+export const chattts = (): string[] => [
 	`import ChatTTS
 import torchaudio
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -553,6 +553,21 @@ export const voicecraft = (model: ModelData): string[] => [
 model = VoiceCraft.from_pretrained("${model.id}")`,
 ];
 
+export const chattts = (model: ModelData): string[] => [
+	`import ChatTTS
+from IPython.display import Audio
+
+chat = ChatTTS.Chat()
+chat.load_models(compile=False) # Set to True for better performance
+
+texts = ["PUT YOUR TEXT HERE",]
+
+wavs = chat.infer(texts, )
+
+torchaudio.save("output1.wav", torch.from_numpy(wavs[0]), 24000)`,
+];
+
+
 export const mlx = (model: ModelData): string[] => [
 	`pip install huggingface_hub hf_transfer
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -111,6 +111,15 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 			wildcard: { path: "*.npz" },
 		},
 	},
+	chat_tts: {
+		prettyLabel: "ChatTTS",
+		repoName: "ChatTTS",
+		repoUrl: "https://github.com/2noise/ChatTTS.git",
+		filter: false,
+		countDownloads: {
+			wildcard: { path: "asset/GPT.pt" },
+		},
+	},
 	diffusers: {
 		prettyLabel: "Diffusers",
 		repoName: "🤗/diffusers",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -117,6 +117,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/2noise/ChatTTS.git",
 		filter: false,
 		countDownloads: { term: { path: "asset/GPT.pt" } },
+		snippets: snippets.chattts,
 	},
 	diffusers: {
 		prettyLabel: "Diffusers",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -116,9 +116,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "chat_tts",
 		repoUrl: "https://github.com/2noise/ChatTTS.git",
 		filter: false,
-		countDownloads: {
-			wildcard: { path: "asset/GPT.pt" },
-		},
 	},
 	diffusers: {
 		prettyLabel: "Diffusers",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -113,7 +113,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	},
 	chat_tts: {
 		prettyLabel: "ChatTTS",
-		repoName: "ChatTTS",
+		repoName: "chat_tts",
 		repoUrl: "https://github.com/2noise/ChatTTS.git",
 		filter: false,
 		countDownloads: {

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -116,6 +116,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "chat_tts",
 		repoUrl: "https://github.com/2noise/ChatTTS.git",
 		filter: false,
+		countDownloads: { term: { path: "asset/GPT.pt" } },
 	},
 	diffusers: {
 		prettyLabel: "Diffusers",


### PR DESCRIPTION
This PR ensures download stats are working for https://huggingface.co/2Noise/ChatTTS.

To do:

- [x] I assume the repo must have `library_name: chat_tts` in its metadata for this to work. Made a PR on the repo: https://huggingface.co/2Noise/ChatTTS/discussions/10