### PR TITLE
:memo: docs: add Msty to the list of local apps

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -113,6 +113,13 @@ export const LOCAL_APPS = {
 		displayOnModelPage: isGgufModel,
 		deeplink: (model) => new URL(`sanctum://open_from_hf?model=${model.id}`),
 	},
+	msty: {
+		prettyLabel: "Msty",
+		docsUrl: "https://msty.app",
+		mainTask: "text-generation",
+		displayOnModelPage: isGgufModel,
+		deeplink: (model) => new URL(`msty://models/search/hf/${model.id}`),
+	},
 	drawthings: {
 		prettyLabel: "Draw Things",
 		docsUrl: "https://drawthings.ai",


### PR DESCRIPTION
Hi, I'm adding Msty to the list of local apps. Msty is a local LLM app for Mac, Windows, and Linux - packed with many features in a simple and clean interface.

We just released a new version today with the support for Hugging Face models and deep linking. If you would like to check it out, please visit: https://msty.app.

Example deep link usage: msty://models/search/hf/TheBloke/Llama-2-7B-32K-Instruct-GGUF

![msty-deeplink-example](https://github.com/huggingface/huggingface.js/assets/47485043/1e53f35e-752d-4be5-bd4e-da17504b2d60)


Cheers,

Nikesh