### PR TITLE
[llama.cpp snippet] Present both options

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -51,7 +51,7 @@ const snippetLlamacpp = (model: ModelData): string[] => {
 		`# Option 1: use llama.cpp with brew
 brew install llama.cpp
 
-# Build llama.cpp then load and run the model
+# Load and run the model
 llama \\
 	--hf-repo "${model.id}" \\
 	--hf-file file.gguf \\

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -51,7 +51,7 @@ const snippetLlamacpp = (model: ModelData): string[] => {
 		`# Option 1: use llama.cpp with brew
 brew install llama.cpp
 
-# Load and run the model
+# Build llama.cpp then load and run the model
 llama \\
 	--hf-repo "${model.id}" \\
 	--hf-file file.gguf \\

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -48,19 +48,24 @@ function isGgufModel(model: ModelData) {
 
 const snippetLlamacpp = (model: ModelData): string[] => {
 	return [
-		`## Install llama.cpp via brew
+		`# Option 1: use llama.cpp with brew
 brew install llama.cpp
 
-## or from source with curl support
-## see llama.cpp README for compilation flags to optimize for your hardware
-git clone https://github.com/ggerganov/llama.cpp
-cd llama.cpp
-LLAMA_CURL=1 make
-`,
-		`## Load and run the model
+# Load and run the model
 llama \\
 	--hf-repo "${model.id}" \\
 	--hf-file file.gguf \\
+	-p "I believe the meaning of life is" \\
+	-n 128`,
+		`# Option 2: build llama.cpp from source with curl support
+git clone https://github.com/ggerganov/llama.cpp.git 
+cd llama.cpp
+LLAMA_CURL=1 make
+
+# Load and run the model
+./main \\
+	--hf-repo "${model.id}" \\
+	-m file.gguf \\
 	-p "I believe the meaning of life is" \\
 	-n 128`,
 	];


### PR DESCRIPTION
follow up to https://github.com/huggingface/huggingface.js/pull/720

just like we show two snippets for transformers (pipeline & automodel) (example [here](https://huggingface.co/mistralai/Codestral-22B-v0.1?library=transformers))

![Screenshot 2024-06-05 at 14 51 22](https://github.com/huggingface/huggingface.js/assets/11827707/04cc26ce-18c4-497d-8a2e-c0983bd07085)

we should show the two options for llama.cpp clearly as well. The two options are: installing from brew and installing from source

![Screenshot 2024-06-05 at 15 37 22](https://github.com/huggingface/huggingface.js/assets/11827707/4cfd87f0-62d7-471c-bbb0-05d8b8c82ef7)

