### PR TITLE
Update FastText countDownloads

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -164,7 +164,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.fasttext,
 		filter: true,
 		countDownloads: {
-			term: { path: "model.bin" },
+			wildcard: { path: "*.bin" },
 		},
 	},
 	flair: {

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -164,8 +164,8 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.fasttext,
 		filter: true,
 		countDownloads: {
-            wildcard: { path: "*.bin" },
-        },
+			term: { path: "model.bin" },
+		},
 	},
 	flair: {
 		prettyLabel: "Flair",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -163,6 +163,9 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://fasttext.cc/",
 		snippets: snippets.fasttext,
 		filter: true,
+		countDownloads: {
+            wildcard: { path: "*.bin" },
+        },
 	},
 	flair: {
 		prettyLabel: "Flair",


### PR DESCRIPTION
Add query file for FastText library according to [here](https://huggingface.co/docs/hub/en/models-download-stats).  
Most FastText model is in format of [bin](https://fasttext.cc/docs/en/python-module.html) so a wildcard of "*.bin" is added.