### PR TITLE
 Add download tracking for coreml models on the hub.

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -119,6 +119,15 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: { term: { path: "asset/GPT.pt" } },
 		snippets: snippets.chattts,
 	},
+	coreml: {
+		prettyLabel: "Core ML",
+		repoName: "coreml",
+		repoUrl: "https://github.com/apple/coremltools",
+		filter: true,
+		countDownloads: {
+			wildcard: { path: "*/*.mlmodel" },
+		},
+	},	
 	diffusers: {
 		prettyLabel: "Diffusers",
 		repoName: "🤗/diffusers",


### PR DESCRIPTION
Heya!  I opened this PR to start a discussion about the best way to track model downloads for the `coreml` checkpoints.

Currently `coreml` models on the hub are not tracked wrt their downloads for ex: https://huggingface.co/models?library=coreml&sort=modified 

I looked at both `moon-landing` (internal repo) and `huggingface.js` to find if there was an existing precedence for this but couldn't find anything (except one adding a filter for coreml models)

One caveat here:
`coreml` models are usually nested in some form of folder structure for ex: https://huggingface.co/coreml-projects/FastViT-MA36/tree/main/FastViTMA36F16.mlpackage/Data/com.apple.CoreML (this is not a fixed structure, it could be different, so I wouldn't want to hardcode the folder paths).

Is there a way to do a repo-wide recursive scan to look for `*.mlmodel`?

For the first pass we can assume that one repo will have one coreml model checkpoint and then iterate incase we find other counter examples.

Note: We need this to be merged before Wednesday AM.