### PR TITLE
👾Fix chunk count not incrementing when parsing additional chunks in a local file

### DIFF
--- a/packages/gguf/src/gguf.ts
+++ b/packages/gguf/src/gguf.ts
@@ -143,6 +143,7 @@ class RangeViewLocalFile extends RangeView {
 		const range = [this.chunk * HTTP_CHUNK_SIZE, (this.chunk + 1) * HTTP_CHUNK_SIZE - 1];
 		const buffer = await blob.slice(range[0], range[1]).arrayBuffer();
 		this.appendBuffer(new Uint8Array(buffer));
+		this.chunk += 1;
 	}
 }
 


### PR DESCRIPTION
When parsing a local GGUF and the metadata section does not fit in the same chunk, the parser would try to load more chunks. However, in the local file implementation range view, the chunk count is not incremented, resulting it not actually loading in more data.