### PR TITLE
✨ Count downloads for audiocraft

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -90,6 +90,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/facebookresearch/audiocraft",
 		snippets: snippets.audiocraft,
 		filter: false,
+		countDownloads: `path:"state_dict.bin" OR path:"config.json"`,
 	},
 	audioseal: {
 		prettyLabel: "AudioSeal",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -90,7 +90,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/facebookresearch/audiocraft",
 		snippets: snippets.audiocraft,
 		filter: false,
-		countDownloads: `path:"state_dict.bin" OR path:"config.json"`,
+		countDownloads: `path:"state_dict.bin"`,
 	},
 	audioseal: {
 		prettyLabel: "AudioSeal",


### PR DESCRIPTION
Hey there, wanted to add download counts for `audiocraft` to see how many folks are downloading [songstarter-v0.2](https://huggingface.co/nateraw/musicgen-songstarter-v0.2). :)

My model doesn't have transformers ckpts in it, so the counts are missed. Existing musicgen models from FB are only being counted if the user is using transformers too I think.

So I updated the logic here to count on `state_dict.bin`, which is `audiocraft` checkpoint, or `config.json`, which captures downloads from `transformers`.