### PR TITLE
gguf: test local file with big metadata

### DIFF
--- a/packages/gguf/src/gguf.spec.ts
+++ b/packages/gguf/src/gguf.spec.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
-import { GGMLQuantizationType, GGUFParseOutput, gguf, ggufAllShards, parseGgufShardFilename } from "./gguf";
+import type { GGUFParseOutput} from "./gguf";
+import { GGMLQuantizationType, gguf, ggufAllShards, parseGgufShardFilename } from "./gguf";
 import fs from "node:fs";
 
 const URL_LLAMA = "https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/191239b/llama-2-7b-chat.Q2_K.gguf";

--- a/packages/gguf/src/gguf.spec.ts
+++ b/packages/gguf/src/gguf.spec.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
-import type { GGUFParseOutput} from "./gguf";
+import type { GGUFParseOutput } from "./gguf";
 import { GGMLQuantizationType, gguf, ggufAllShards, parseGgufShardFilename } from "./gguf";
 import fs from "node:fs";
 


### PR DESCRIPTION
Ref comment: https://github.com/huggingface/huggingface.js/pull/767#issuecomment-2181173686

This file have 32MB of just metadata (no tensor), can be useful for testing or benchmarking.

Due to its large size, running the download process inside the test case may cause timeout (so I moved it to `beforeAll`)