### PR TITLE
Add GPT-NeoX and SAE

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -369,7 +369,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "SAE",
 		repoName: "sae",
 		repoUrl: "https://github.com/EleutherAI/sae",
-		filter: true,
+   	filter: false,
 		countDownloads: `path_extension:"safetensors" OR path_extension:"bin"`,
 	},
 	"sample-factory": {

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -227,7 +227,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "GPT-NeoX",
 		repoUrl: "https://github.com/EleutherAI/gpt-neox",
 		filter: false,
-		countDownloads: `path_extension:"safetensors" OR path_extension:"bin"`,
+		countDownloads: `path:"config.json"`,
 	},
 	grok: {
 		prettyLabel: "Grok",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -222,6 +222,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"checkpoints/byt5_model.pt"`,
 	},
+	"gpt-neox": {
+		prettyLabel: "GPT-NeoX",
+		repoName: "GPT-NeoX",
+		repoUrl: "https://github.com/EleutherAI/gpt-neox",
+		filter: true,
+		countDownloads: `path_extension:"safetensors" OR path_extension:"bin"`,
+	},
 	grok: {
 		prettyLabel: "Grok",
 		repoName: "Grok",
@@ -357,6 +364,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/google-deepmind/recurrentgemma",
 		filter: false,
 		countDownloads: `path:"tokenizer.model"`,
+	},
+	"sae": {
+		prettyLabel: "SAE",
+		repoName: "sae",
+		repoUrl: "https://github.com/EleutherAI/sae",
+		filter: true,
+		countDownloads: `path_extension:"safetensors" OR path_extension:"bin"`,
 	},
 	"sample-factory": {
 		prettyLabel: "sample-factory",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -226,7 +226,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "GPT-NeoX",
 		repoName: "GPT-NeoX",
 		repoUrl: "https://github.com/EleutherAI/gpt-neox",
-		filter: true,
+		filter: false,
 		countDownloads: `path_extension:"safetensors" OR path_extension:"bin"`,
 	},
 	grok: {


### PR DESCRIPTION
Adds two libraries developed by EleutherAI, [GPT-NeoX](https://github.com/EleutherAI/gpt-neox) and [SAE](https://github.com/EleutherAI/sae).