### PR TITLE
Add MambaSSM as a library

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -273,8 +273,7 @@ model = from_pretrained_keras("${model.id}")
 export const mamba_ssm = (model: ModelData): string[] => [
 	`from mamba_ssm import MambaLMHeadModel
 
-model = MambaLMHeadModel.from_pretrained("${model.id}")
-`,
+model = MambaLMHeadModel.from_pretrained("${model.id}")`,
 ];
 
 export const mars5_tts = (model: ModelData): string[] => [

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -270,27 +270,12 @@ model = from_pretrained_keras("${model.id}")
 `,
 ];
 
-export const mamba_ssm = (model: ModelData): string[] => {
-	if (model.tags.includes("mamba2")) {
-		return [
-			`from mamba_ssm import Mamba2
+export const mamba_ssm = (model: ModelData): string[] => [
+	`from mamba_ssm import MambaLMHeadModel
 
-model = Mamba2.from_pretrained("${model.id}")`,
-		];
-	} else if (model.tags.includes("mamba2simple")) {
-		return [
-			`from mamba_ssm.modules.mamba2_simple import Mamba2Simple
-
-model = Mamba2Simple.from_pretrained("${model.id}")`,
-		];
-	} else {
-		return [
-			`from mamba_ssm import Mamba
-
-model = Mamba.from_pretrained("${model.id}")`,
-		];
-	}
-};
+model = MambaLMHeadModel.from_pretrained("${model.id}")
+`,
+];
 
 export const mars5_tts = (model: ModelData): string[] => [
 	`# Install from https://github.com/Camb-ai/MARS5-TTS

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -270,6 +270,28 @@ model = from_pretrained_keras("${model.id}")
 `,
 ];
 
+export const mamba_ssm = (model: ModelData): string[] => {
+	if (model.tags.includes("mamba2")) {
+		return [
+			`from mamba_ssm import Mamba2
+
+model = Mamba2.from_pretrained("${model.id}")`,
+		];
+	} else if (model.tags.includes("mamba2simple")) {
+		return [
+			`from mamba_ssm.modules.mamba2_simple import Mamba2Simple
+
+model = Mamba2Simple.from_pretrained("${model.id}")`,
+		];
+	} else {
+		return [
+			`from mamba_ssm import Mamba
+
+model = Mamba.from_pretrained("${model.id}")`,
+		];
+	}
+};
+
 export const mars5_tts = (model: ModelData): string[] => [
 	`# Install from https://github.com/Camb-ai/MARS5-TTS
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -298,6 +298,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "mindspore",
 		repoUrl: "https://github.com/mindspore-ai/mindspore",
 	},
+	mamba_ssm: {
+		prettyLabel: "MambaSSM",
+		repoName: "MambaSSM",
+		repoUrl: "https://github.com/state-spaces/mamba",
+		filter: false,
+		countDownloads: `path:"config.json"`,
+		snippets: snippets.mamba_ssm,
+	},
 	"mars5-tts": {
 		prettyLabel: "MARS5-TTS",
 		repoName: "MARS5-TTS",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -303,7 +303,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "MambaSSM",
 		repoUrl: "https://github.com/state-spaces/mamba",
 		filter: false,
-		countDownloads: `path:"config.json"`,
 		snippets: snippets.mamba_ssm,
 	},
 	"mars5-tts": {

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -298,7 +298,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "mindspore",
 		repoUrl: "https://github.com/mindspore-ai/mindspore",
 	},
-	mamba_ssm: {
+	"mamba-ssm": {
 		prettyLabel: "MambaSSM",
 		repoName: "MambaSSM",
 		repoUrl: "https://github.com/state-spaces/mamba",


### PR DESCRIPTION
This PR adds https://github.com/state-spaces/mamba as an official library on the Hub.
Let's wait for Mamba integration to be merged (coming soon) + having a few first models uploaded on the Hub.

cc @osanseviero @NielsRogge @tridao

Related PR on Mamba side: https://github.com/state-spaces/mamba/pull/471