### PR TITLE
Add VideoCrafter as a library

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -732,14 +732,6 @@ wavs = chat.infer(texts, )
 torchaudio.save("output1.wav", torch.from_numpy(wavs[0]), 24000)`,
 ];
 
-export const videocrafter = (): string[] => [
-	`Install from https://github.com/AILab-CVC/VideoCrafter
-
-# Download pretrained T2V models via Hugging Face,
-# and put the model.ckpt in checkpoints/base_512_v2/model.ckpt
-sh scripts/run_text2video.sh`,
-];
-
 export const mlx = (model: ModelData): string[] => [
 	`pip install huggingface_hub hf_transfer
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -732,6 +732,14 @@ wavs = chat.infer(texts, )
 torchaudio.save("output1.wav", torch.from_numpy(wavs[0]), 24000)`,
 ];
 
+export const videocrafter = (): string[] => [
+	`Install from https://github.com/AILab-CVC/VideoCrafter
+
+# Download pretrained T2V models via Hugging Face,
+# and put the model.ckpt in checkpoints/base_512_v2/model.ckpt
+sh scripts/run_text2video.sh`,
+];
+
 export const mlx = (model: ModelData): string[] => [
 	`pip install huggingface_hub hf_transfer
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -553,11 +553,10 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: true,
 		countDownloads: `path_extension:"sentis"`,
 	},
-	"videocrafter": {
+	videocrafter: {
 		prettyLabel: "VideoCrafter",
 		repoName: "VideoCrafter",
 		repoUrl: "https://github.com/AILab-CVC/VideoCrafter",
-		snippets: snippets.videocrafter,
 		countDownloads: `path_extension:"ckpt"`,
 	},
 	voicecraft: {

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -553,6 +553,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: true,
 		countDownloads: `path_extension:"sentis"`,
 	},
+	"videocrafter": {
+		prettyLabel: "VideoCrafter",
+		repoName: "VideoCrafter",
+		repoUrl: "https://github.com/AILab-CVC/VideoCrafter",
+		snippets: snippets.videocrafter,
+		filter: true,
+		countDownloads: `path_extension:"ckpt"`,
+	},
 	voicecraft: {
 		prettyLabel: "VoiceCraft",
 		repoName: "VoiceCraft",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -558,7 +558,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "VideoCrafter",
 		repoUrl: "https://github.com/AILab-CVC/VideoCrafter",
 		snippets: snippets.videocrafter,
-		filter: true,
 		countDownloads: `path_extension:"ckpt"`,
 	},
 	voicecraft: {


### PR DESCRIPTION
This PR adds https://github.com/AILab-CVC/VideoCrafter as a library.

Models are already on the hub, each in a separate repo: https://huggingface.co/VideoCrafter

To do: ensure the following PRs are merged

- [ ] https://huggingface.co/VideoCrafter/VideoCrafter2/discussions/4
- [ ] https://huggingface.co/VideoCrafter/Text2Video-256/discussions/1
- [ ] https://huggingface.co/VideoCrafter/Text2Video-1024/discussions/10
- [ ] https://huggingface.co/VideoCrafter/Text2Video-512/discussions/6
- [ ] https://huggingface.co/VideoCrafter/Image2Video-512/discussions/4
- [ ] https://huggingface.co/VideoCrafter/t2v-version-1-1/discussions/2