### PR TITLE
feat: add Ollama to local-apps.ts

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -91,6 +91,13 @@ export const LOCAL_APPS = {
 		displayOnModelPage: isGgufModel,
 		snippet: snippetLlamacpp,
 	},
+	ollama: {
+		prettyLabel: "Ollama",
+		docsUrl: "https://github.com/ollama/ollama",
+		mainTask: "text-generation",
+		displayOnModelPage: isGgufModel,
+		deeplink: (model) => new URL(`https://ollama.com/search?q=${model.id}`),
+	},
 	lmstudio: {
 		prettyLabel: "LM Studio",
 		docsUrl: "https://lmstudio.ai",


### PR DESCRIPTION
I saw there were a couple of other PRs to add Ollama but they had problems with the deeplinks, however - I think this could possibly be a solution - instead of trying to link to an exact model - this would search for the model on the hub.

Another option might be to do something similar to llama.cpp using Ollama's import command with the GGUF from huggingface - https://github.com/ollama/ollama/blob/main/docs/import.md