### PR TITLE
Update Cantonese and Southern Min language names

### DIFF
--- a/packages/languages/src/languages_iso_639_3.ts
+++ b/packages/languages/src/languages_iso_639_3.ts
@@ -17884,7 +17884,7 @@ export const LANGUAGES_ISO_639_3 = {
 	},
 	nan: {
 		code: "nan",
-		name: "Min Nan Chinese",
+		name: "Southern Min (Min Nan Chinese)",
 	},
 	nao: {
 		code: "nao",
@@ -30790,7 +30790,7 @@ export const LANGUAGES_ISO_639_3 = {
 	},
 	yue: {
 		code: "yue",
-		name: "Yue Chinese",
+		name: "Cantonese (Yue Chinese)",
 	},
 	yuf: {
 		code: "yuf",


### PR DESCRIPTION
Name is based on wikipedia: 

- https://en.wikipedia.org/wiki/Cantonese
- https://en.wikipedia.org/wiki/Southern_Min

Although "Yue Chinese" and "Min Nan Chinese" are linguistically correct, they are academic names and are not used by the general public. So I put them inside brackets.