### PR TITLE
Fix file upload button

### DIFF
--- a/packages/widgets/src/lib/components/InferenceWidget/shared/WidgetFileInput/WidgetFileInput.svelte
+++ b/packages/widgets/src/lib/components/InferenceWidget/shared/WidgetFileInput/WidgetFileInput.svelte
@@ -33,6 +33,7 @@
 	<LogInPopover bind:open={popOverOpen}>
 		<button
 			class={classNames}
+			type="button"
 			on:click={(e) => {
 				if (!$isLoggedIn) {
 					popOverOpen = true;


### PR DESCRIPTION
Fixes https://github.com/huggingface/huggingface.js/issues/612

### Description

Fixes the file upload button.

The problem is caused by `<button>` element that wraps file upload input having no `type` attribute. When used inside a form it defaults to `type="submit"` ([REF](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button)) which causes the page to reload (or submitting the form to the same url) at the same time as opening the upload dialog. The upload dialog itself does nothing in this case because it is mounted to the old page (before reload).

<img width="975" alt="Bildschirmfoto 2024-07-28 um 19 48 31" src="https://github.com/user-attachments/assets/d0b27bd4-bd7b-4793-ac07-c4b6c0011c9f">

