### PR TITLE
add SAELens as a library ⚡

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -429,6 +429,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"tokenizer.model"`,
 	},
+	saelens: {
+		prettyLabel: "SAELens",
+		repoName: "SAELens",
+		repoUrl: "https://github.com/jbloomAus/SAELens",
+		filter: false,
+	},
 	"sample-factory": {
 		prettyLabel: "sample-factory",
 		repoName: "sample-factory",


### PR DESCRIPTION
Couple of quick comments:

1. The way that snippets work are a bit different in the library as they work via this yaml file and load it directly via a snapshot download: https://github.com/jbloomAus/SAELens/blob/fe987f1d1b06a5f0116e390efc87a69f59e04473/sae_lens/toolkit/pretrained_saes.py#L20
Hence, the snippet doesn't really use the repo name directly, ref: https://jbloomaus.github.io/SAELens/

2. Checking how to make the download counts work right now.