### PR TITLE
Add basic SAELens code snippet

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -401,7 +401,7 @@ export const timm = (model: ModelData): string[] => [
 model = timm.create_model("hf_hub:${model.id}", pretrained=True)`,
 ];
 
-export const saelens = (model: ModelData): string[] => [
+export const saelens = (/* model: ModelData */): string[] => [
 	`# pip install sae-lens
 from sae_lens import SAE
 
@@ -409,7 +409,7 @@ sae, cfg_dict, sparsity = SAE.from_pretrained(
     release = "RELEASE_ID", # e.g., "gpt2-small-res-jb". See other options in https://github.com/jbloomAus/SAELens/blob/main/sae_lens/pretrained_saes.yaml
     sae_id = "SAE_ID", # e.g., "blocks.8.hook_resid_pre". Won't always be a hook point
 )`,
-]
+];
 
 const skopsPickle = (model: ModelData, modelFile: string) => {
 	return [
@@ -597,8 +597,8 @@ export const transformers = (model: ModelData): string[] => {
 			info.processor === "AutoTokenizer"
 				? "tokenizer"
 				: info.processor === "AutoFeatureExtractor"
-				  ? "extractor"
-				  : "processor";
+					? "extractor"
+					: "processor";
 		autoSnippet = [
 			"# Load model directly",
 			`from transformers import ${info.processor}, ${info.auto_model}`,

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -401,6 +401,16 @@ export const timm = (model: ModelData): string[] => [
 model = timm.create_model("hf_hub:${model.id}", pretrained=True)`,
 ];
 
+export const saelens = (model: ModelData): string[] => [
+	`# pip install sae-lens
+from sae_lens import SAE
+
+sae, cfg_dict, sparsity = SAE.from_pretrained(
+    release = "RELEASE_ID", # e.g., "gpt2-small-res-jb". See other options in https://github.com/jbloomAus/SAELens/blob/main/sae_lens/pretrained_saes.yaml
+    sae_id = "SAE_ID", # e.g., "blocks.8.hook_resid_pre". Won't always be a hook point
+)`,
+]
+
 const skopsPickle = (model: ModelData, modelFile: string) => {
 	return [
 		`import joblib

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -597,8 +597,8 @@ export const transformers = (model: ModelData): string[] => {
 			info.processor === "AutoTokenizer"
 				? "tokenizer"
 				: info.processor === "AutoFeatureExtractor"
-					? "extractor"
-					: "processor";
+				  ? "extractor"
+				  : "processor";
 		autoSnippet = [
 			"# Load model directly",
 			`from transformers import ${info.processor}, ${info.auto_model}`,

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -433,6 +433,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "SAELens",
 		repoName: "SAELens",
 		repoUrl: "https://github.com/jbloomAus/SAELens",
+		snippets: snippets.saelens,
 		filter: false,
 	},
 	"sample-factory": {


### PR DESCRIPTION
Follow-up to https://github.com/huggingface/huggingface.js/pull/826, and (currently) an intermediate PR before `.from_pretrained` support is added for any model on the HF Hub. See https://github.com/jbloomAus/SAELens/issues/234#issuecomment-2268889182 for additional discussion.