### PR TITLE
Add support for Relik

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -363,6 +363,12 @@ export const pyannote_audio = (model: ModelData): string[] => {
 	return pyannote_audio_model(model);
 };
 
+const relik = (model: ModelData) => [
+	`from relik import Relik
+ 
+relik = Relik.from_pretrained("${model.id}")`,
+];
+
 const tensorflowttsTextToMel = (model: ModelData): string[] => [
 	`from tensorflow_tts.inference import AutoProcessor, TFAutoModel
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -429,6 +429,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"tokenizer.model"`,
 	},
+	relik: {
+		prettyLabel: "Relik",
+		repoName: "Relik",
+		repoUrl: "https://github.com/SapienzaNLP/relik",
+		snippets: snippets.relik,
+		filter: false,
+	},
 	saelens: {
 		prettyLabel: "SAELens",
 		repoName: "SAELens",


### PR DESCRIPTION
Library: https://github.com/SapienzaNLP/relik
Some model repos (adding `library_name` soon): https://huggingface.co/collections/sapienzanlp/relik-retrieve-read-and-link-665d9e4a5c3ecba98c1bef19

The repos already use `config.yaml` so downloads work out of the box already

cc @Riccorl 