### PR TITLE
diffusion bee is available

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -201,7 +201,6 @@ export const LOCAL_APPS = {
 		docsUrl: "https://diffusionbee.com",
 		mainTask: "text-to-image",
 		macOSOnly: true,
-		comingSoon: true,
 		displayOnModelPage: (model) => model.library_name === "diffusers" && model.pipeline_tag === "text-to-image",
 		deeplink: (model) => new URL(`diffusionbee://open_from_hf?model=${model.id}`),
 	},


### PR DESCRIPTION
Remove the coming soon tag on Diffusion Bee local apps (cc @julien-c)
<img width="290" alt="Screenshot 2024-08-07 at 1 34 39 PM" src="https://github.com/user-attachments/assets/fcbd7639-aa33-44e5-a66f-0cd2053e74d2">
