### PR TITLE
add new type hasZipFilePaths

### DIFF
--- a/packages/tasks/src/model-data.ts
+++ b/packages/tasks/src/model-data.ts
@@ -109,6 +109,10 @@ export interface ModelData {
 	 * Example: transformers, SpeechBrain, Stanza, etc.
 	 */
 	library_name?: string;
+	/**
+	 * If the model has a zip file that needs to be downloaded
+	 */
+	hasZipFilePaths?: boolean;
 }
 
 /**


### PR DESCRIPTION
Added into HF Hub a new `hasZipFilePaths` field to know if there is at least 1 zip file in the model repository, could be use into hf.js tasks too, especially for local-apps which are using .zip files only (like https://github.com/huggingface/huggingface.js/pull/740)

`hasZipFilePaths` is a boolean