### PR TITLE
Account for the fact that there non-llama.cpp gguf files now

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -58,6 +58,7 @@ export type LocalApp = {
 	  }
 );
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function isGgufModel(model: ModelData) {
 	return model.tags.includes("gguf");
 }

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -62,6 +62,10 @@ function isGgufModel(model: ModelData) {
 	return model.tags.includes("gguf");
 }
 
+function isLlamaCppGgufModel(model: ModelData) {
+	return !!model.gguf?.context_length;
+}
+
 const snippetLlamacpp = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 	const command = (binary: string) =>
 		[
@@ -138,14 +142,14 @@ export const LOCAL_APPS = {
 		prettyLabel: "llama.cpp",
 		docsUrl: "https://github.com/ggerganov/llama.cpp",
 		mainTask: "text-generation",
-		displayOnModelPage: isGgufModel,
+		displayOnModelPage: isLlamaCppGgufModel,
 		snippet: snippetLlamacpp,
 	},
 	lmstudio: {
 		prettyLabel: "LM Studio",
 		docsUrl: "https://lmstudio.ai",
 		mainTask: "text-generation",
-		displayOnModelPage: isGgufModel,
+		displayOnModelPage: isLlamaCppGgufModel,
 		deeplink: (model, filepath) =>
 			new URL(`lmstudio://open_from_hf?model=${model.id}${filepath ? `&file=${filepath}` : ""}`),
 	},
@@ -153,28 +157,28 @@ export const LOCAL_APPS = {
 		prettyLabel: "LocalAI",
 		docsUrl: "https://github.com/mudler/LocalAI",
 		mainTask: "text-generation",
-		displayOnModelPage: isGgufModel,
+		displayOnModelPage: isLlamaCppGgufModel,
 		snippet: snippetLocalAI,
 	},
 	jan: {
 		prettyLabel: "Jan",
 		docsUrl: "https://jan.ai",
 		mainTask: "text-generation",
-		displayOnModelPage: isGgufModel,
+		displayOnModelPage: isLlamaCppGgufModel,
 		deeplink: (model) => new URL(`jan://models/huggingface/${model.id}`),
 	},
 	backyard: {
 		prettyLabel: "Backyard AI",
 		docsUrl: "https://backyard.ai",
 		mainTask: "text-generation",
-		displayOnModelPage: isGgufModel,
+		displayOnModelPage: isLlamaCppGgufModel,
 		deeplink: (model) => new URL(`https://backyard.ai/hf/model/${model.id}`),
 	},
 	sanctum: {
 		prettyLabel: "Sanctum",
 		docsUrl: "https://sanctum.ai",
 		mainTask: "text-generation",
-		displayOnModelPage: isGgufModel,
+		displayOnModelPage: isLlamaCppGgufModel,
 		deeplink: (model) => new URL(`sanctum://open_from_hf?model=${model.id}`),
 	},
 	jellybox: {
@@ -182,12 +186,12 @@ export const LOCAL_APPS = {
 		docsUrl: "https://jellybox.com",
 		mainTask: "text-generation",
 		displayOnModelPage: (model) =>
-			isGgufModel(model) ||
+			isLlamaCppGgufModel(model) ||
 			(model.library_name === "diffusers" &&
 				model.tags.includes("safetensors") &&
 				(model.pipeline_tag === "text-to-image" || model.tags.includes("lora"))),
 		deeplink: (model) => {
-			if (isGgufModel(model)) {
+			if (isLlamaCppGgufModel(model)) {
 				return new URL(`jellybox://llm/models/huggingface/LLM/${model.id}`);
 			} else if (model.tags.includes("lora")) {
 				return new URL(`jellybox://image/models/huggingface/ImageLora/${model.id}`);
@@ -200,7 +204,7 @@ export const LOCAL_APPS = {
 		prettyLabel: "Msty",
 		docsUrl: "https://msty.app",
 		mainTask: "text-generation",
-		displayOnModelPage: isGgufModel,
+		displayOnModelPage: isLlamaCppGgufModel,
 		deeplink: (model) => new URL(`msty://models/search/hf/${model.id}`),
 	},
 	recursechat: {
@@ -208,7 +212,7 @@ export const LOCAL_APPS = {
 		docsUrl: "https://recurse.chat",
 		mainTask: "text-generation",
 		macOSOnly: true,
-		displayOnModelPage: isGgufModel,
+		displayOnModelPage: isLlamaCppGgufModel,
 		deeplink: (model) => new URL(`recursechat://new-hf-gguf-model?hf-model-id=${model.id}`),
 	},
 	drawthings: {

--- a/packages/tasks/src/model-data.ts
+++ b/packages/tasks/src/model-data.ts
@@ -109,6 +109,16 @@ export interface ModelData {
 	 * Example: transformers, SpeechBrain, Stanza, etc.
 	 */
 	library_name?: string;
+	safetensors?: {
+		parameters: Record<string, number>;
+		total:      number;
+		sharded:    boolean;
+	};
+	gguf?: {
+		total:           number;
+		architecture?:   string;
+		context_length?: number;
+	};
 }
 
 /**

--- a/packages/tasks/src/model-data.ts
+++ b/packages/tasks/src/model-data.ts
@@ -111,12 +111,12 @@ export interface ModelData {
 	library_name?: string;
 	safetensors?: {
 		parameters: Record<string, number>;
-		total:      number;
-		sharded:    boolean;
+		total: number;
+		sharded: boolean;
 	};
 	gguf?: {
-		total:           number;
-		architecture?:   string;
+		total: number;
+		architecture?: string;
 		context_length?: number;
 	};
 }


### PR DESCRIPTION
[companion internal PR](https://github.com/huggingface-internal/moon-landing/pull/10946)

**TL;DR:** we want the ability to discriminate non-llama.cpp gguf repos

I've picked `${architecture}.context_length` as a property that, if it's in the gguf file, we assume it's compatible with llama.cpp

Another option was to check whether `architecture` is inside the list in `@huggingface/gguf` (and keep this list up to date with upstream, maybe through some CI)

Both options are possible, so let me know what you think is best