### PR TITLE
Update specification for docs

### DIFF
--- a/packages/tasks/src/tasks/audio-classification/inference.ts
+++ b/packages/tasks/src/tasks/audio-classification/inference.ts
@@ -8,9 +8,10 @@
  */
 export interface AudioClassificationInput {
 	/**
-	 * The input audio data
+	 * The input audio data as a base64-encoded string. If no `parameters` are provided, you can
+	 * also provide the audio data as a raw bytes payload.
 	 */
-	inputs: unknown;
+	inputs: string;
 	/**
 	 * Additional inference parameters
 	 */

--- a/packages/tasks/src/tasks/audio-classification/spec/input.json
+++ b/packages/tasks/src/tasks/audio-classification/spec/input.json
@@ -6,7 +6,8 @@
 	"type": "object",
 	"properties": {
 		"inputs": {
-			"description": "The input audio data"
+			"description": "The input audio data as a base64-encoded string. If no `parameters` are provided, you can also provide the audio data as a raw bytes payload.",
+			"type": "string"
 		},
 		"parameters": {
 			"description": "Additional inference parameters",

--- a/packages/tasks/src/tasks/audio-classification/spec/output.json
+++ b/packages/tasks/src/tasks/audio-classification/spec/output.json
@@ -5,6 +5,7 @@
 	"description": "Outputs for Audio Classification inference",
 	"type": "array",
 	"items": {
+		"type": "object",
 		"$ref": "/inference/schemas/common-definitions.json#/definitions/ClassificationOutput"
 	}
 }

--- a/packages/tasks/src/tasks/automatic-speech-recognition/inference.ts
+++ b/packages/tasks/src/tasks/automatic-speech-recognition/inference.ts
@@ -9,7 +9,8 @@
  */
 export interface AutomaticSpeechRecognitionInput {
 	/**
-	 * The input audio data as a base64-encoded string.
+	 * The input audio data as a base64-encoded string. If no `parameters` are provided, you can
+	 * also provide the audio data as a raw bytes payload.
 	 */
 	inputs: string;
 	/**

--- a/packages/tasks/src/tasks/automatic-speech-recognition/inference.ts
+++ b/packages/tasks/src/tasks/automatic-speech-recognition/inference.ts
@@ -9,9 +9,9 @@
  */
 export interface AutomaticSpeechRecognitionInput {
 	/**
-	 * The input audio data
+	 * The input audio data as a base64-encoded string.
 	 */
-	inputs: unknown;
+	inputs: string;
 	/**
 	 * Additional inference parameters
 	 */

--- a/packages/tasks/src/tasks/automatic-speech-recognition/spec/input.json
+++ b/packages/tasks/src/tasks/automatic-speech-recognition/spec/input.json
@@ -6,7 +6,7 @@
 	"type": "object",
 	"properties": {
 		"inputs": {
-			"description": "The input audio data as a base64-encoded string.",
+			"description": "The input audio data as a base64-encoded string. If no `parameters` are provided, you can also provide the audio data as a raw bytes payload.",
 			"type": "string"
 		},
 		"parameters": {

--- a/packages/tasks/src/tasks/automatic-speech-recognition/spec/input.json
+++ b/packages/tasks/src/tasks/automatic-speech-recognition/spec/input.json
@@ -6,7 +6,8 @@
 	"type": "object",
 	"properties": {
 		"inputs": {
-			"description": "The input audio data"
+			"description": "The input audio data as a base64-encoded string.",
+			"type": "string"
 		},
 		"parameters": {
 			"description": "Additional inference parameters",

--- a/packages/tasks/src/tasks/common-definitions.json
+++ b/packages/tasks/src/tasks/common-definitions.json
@@ -74,16 +74,9 @@
 					"description": "Whether to use sampling instead of greedy decoding when generating new tokens."
 				},
 				"early_stopping": {
+					"type": ["boolean", "string"],
 					"description": "Controls the stopping condition for beam-based methods.",
-					"oneOf": [
-						{
-							"type": "boolean"
-						},
-						{
-							"const": "never",
-							"type": "string"
-						}
-					]
+					"enum": ["never", true, false]
 				},
 				"num_beams": {
 					"type": "integer",

--- a/packages/tasks/src/tasks/common-definitions.json
+++ b/packages/tasks/src/tasks/common-definitions.json
@@ -7,17 +7,7 @@
 			"title": "ClassificationOutputTransform",
 			"type": "string",
 			"description": "The function to apply to the model outputs in order to retrieve the scores.",
-			"oneOf": [
-				{
-					"const": "sigmoid"
-				},
-				{
-					"const": "softmax"
-				},
-				{
-					"const": "none"
-				}
-			]
+			"enum": ["sigmoid", "softmax", "none"]
 		},
 		"ClassificationOutput": {
 			"title": "ClassificationOutput",

--- a/packages/tasks/src/tasks/image-classification/inference.ts
+++ b/packages/tasks/src/tasks/image-classification/inference.ts
@@ -8,9 +8,10 @@
  */
 export interface ImageClassificationInput {
 	/**
-	 * The input image data
+	 * The input image data as a base64-encoded string. If no `parameters` are provided, you can
+	 * also provide the image data as a raw bytes payload.
 	 */
-	inputs: unknown;
+	inputs: string;
 	/**
 	 * Additional inference parameters
 	 */

--- a/packages/tasks/src/tasks/image-classification/spec/input.json
+++ b/packages/tasks/src/tasks/image-classification/spec/input.json
@@ -6,7 +6,8 @@
 	"type": "object",
 	"properties": {
 		"inputs": {
-			"description": "The input image data"
+			"type": "string",
+			"description": "The input image data as a base64-encoded string. If no `parameters` are provided, you can also provide the image data as a raw bytes payload."
 		},
 		"parameters": {
 			"description": "Additional inference parameters",

--- a/packages/tasks/src/tasks/image-classification/spec/output.json
+++ b/packages/tasks/src/tasks/image-classification/spec/output.json
@@ -5,6 +5,7 @@
 	"title": "ImageClassificationOutput",
 	"type": "array",
 	"items": {
+		"type": "object",
 		"$ref": "/inference/schemas/common-definitions.json#/definitions/ClassificationOutput"
 	}
 }

--- a/packages/tasks/src/tasks/image-segmentation/inference.ts
+++ b/packages/tasks/src/tasks/image-segmentation/inference.ts
@@ -8,9 +8,10 @@
  */
 export interface ImageSegmentationInput {
 	/**
-	 * The input image data
+	 * The input image data as a base64-encoded string. If no `parameters` are provided, you can
+	 * also provide the image data as a raw bytes payload.
 	 */
-	inputs: unknown;
+	inputs: string;
 	/**
 	 * Additional inference parameters
 	 */
@@ -41,6 +42,9 @@ export interface ImageSegmentationParameters {
 	threshold?: number;
 	[property: string]: unknown;
 }
+/**
+ * Segmentation task to be performed, depending on model capabilities.
+ */
 export type ImageSegmentationSubtask = "instance" | "panoptic" | "semantic";
 export type ImageSegmentationOutput = ImageSegmentationOutputElement[];
 /**
@@ -50,15 +54,15 @@ export type ImageSegmentationOutput = ImageSegmentationOutputElement[];
  */
 export interface ImageSegmentationOutputElement {
 	/**
-	 * The label of the predicted segment
+	 * The label of the predicted segment.
 	 */
 	label: string;
 	/**
-	 * The corresponding mask as a black-and-white image
+	 * The corresponding mask as a black-and-white image (base64-encoded).
 	 */
-	mask: unknown;
+	mask: string;
 	/**
-	 * The score or confidence degreee the model has
+	 * The score or confidence degree the model has.
 	 */
 	score?: number;
 	[property: string]: unknown;

--- a/packages/tasks/src/tasks/image-segmentation/spec/input.json
+++ b/packages/tasks/src/tasks/image-segmentation/spec/input.json
@@ -6,7 +6,8 @@
 	"type": "object",
 	"properties": {
 		"inputs": {
-			"description": "The input image data"
+			"type": "string",
+			"description": "The input image data as a base64-encoded string. If no `parameters` are provided, you can also provide the image data as a raw bytes payload."
 		},
 		"parameters": {
 			"description": "Additional inference parameters",
@@ -31,17 +32,7 @@
 					"title": "ImageSegmentationSubtask",
 					"type": "string",
 					"description": "Segmentation task to be performed, depending on model capabilities.",
-					"oneOf": [
-						{
-							"const": "instance"
-						},
-						{
-							"const": "panoptic"
-						},
-						{
-							"const": "semantic"
-						}
-					]
+					"enum": ["instance", "panoptic", "semantic"]
 				},
 				"threshold": {
 					"type": "number",

--- a/packages/tasks/src/tasks/image-segmentation/spec/output.json
+++ b/packages/tasks/src/tasks/image-segmentation/spec/output.json
@@ -10,14 +10,15 @@
 		"properties": {
 			"label": {
 				"type": "string",
-				"description": "The label of the predicted segment"
+				"description": "The label of the predicted segment."
 			},
 			"mask": {
-				"description": "The corresponding mask as a black-and-white image"
+				"type": "string",
+				"description": "The corresponding mask as a black-and-white image (base64-encoded)."
 			},
 			"score": {
 				"type": "number",
-				"description": "The score or confidence degreee the model has"
+				"description": "The score or confidence degree the model has."
 			}
 		},
 		"required": ["label", "mask"]

--- a/packages/tasks/src/tasks/image-to-image/inference.ts
+++ b/packages/tasks/src/tasks/image-to-image/inference.ts
@@ -61,7 +61,7 @@ export interface TargetSize {
  */
 export interface ImageToImageOutput {
 	/**
-	 * The output image
+	 * The output image returned as raw bytes in the payload.
 	 */
 	image?: unknown;
 	[property: string]: unknown;

--- a/packages/tasks/src/tasks/image-to-image/inference.ts
+++ b/packages/tasks/src/tasks/image-to-image/inference.ts
@@ -9,9 +9,10 @@
  */
 export interface ImageToImageInput {
 	/**
-	 * The input image data
+	 * The input image data as a base64-encoded string. If no `parameters` are provided, you can
+	 * also provide the image data as a raw bytes payload.
 	 */
-	inputs: unknown;
+	inputs: string;
 	/**
 	 * Additional inference parameters
 	 */
@@ -40,14 +41,14 @@ export interface ImageToImageParameters {
 	 */
 	num_inference_steps?: number;
 	/**
-	 * The size in pixel of the output image
+	 * The size in pixel of the output image.
 	 */
 	target_size?: TargetSize;
 	[property: string]: unknown;
 }
 
 /**
- * The size in pixel of the output image
+ * The size in pixel of the output image.
  */
 export interface TargetSize {
 	height: number;

--- a/packages/tasks/src/tasks/image-to-image/spec/input.json
+++ b/packages/tasks/src/tasks/image-to-image/spec/input.json
@@ -6,7 +6,8 @@
 	"type": "object",
 	"properties": {
 		"inputs": {
-			"description": "The input image data"
+			"type": "string",
+			"description": "The input image data as a base64-encoded string. If no `parameters` are provided, you can also provide the image data as a raw bytes payload."
 		},
 		"parameters": {
 			"description": "Additional inference parameters",
@@ -36,7 +37,7 @@
 				},
 				"target_size": {
 					"type": "object",
-					"description": "The size in pixel of the output image",
+					"description": "The size in pixel of the output image.",
 					"properties": {
 						"width": {
 							"type": "integer"

--- a/packages/tasks/src/tasks/image-to-image/spec/output.json
+++ b/packages/tasks/src/tasks/image-to-image/spec/output.json
@@ -6,7 +6,7 @@
 	"type": "object",
 	"properties": {
 		"image": {
-			"description": "The output image"
+			"description": "The output image returned as raw bytes in the payload."
 		}
 	}
 }

--- a/packages/tasks/src/tasks/index.ts
+++ b/packages/tasks/src/tasks/index.ts
@@ -73,12 +73,7 @@ export type * from "./table-question-answering/inference";
 export type { TextToImageInput, TextToImageOutput, TextToImageParameters } from "./text-to-image/inference";
 export type { TextToAudioParameters, TextToSpeechInput, TextToSpeechOutput } from "./text-to-speech/inference";
 export type * from "./token-classification/inference";
-export type {
-	Text2TextGenerationParameters,
-	Text2TextGenerationTruncationStrategy,
-	TranslationInput,
-	TranslationOutput,
-} from "./translation/inference";
+export type { TranslationInput, TranslationOutput } from "./translation/inference";
 export type {
 	ClassificationOutputTransform,
 	TextClassificationInput,

--- a/packages/tasks/src/tasks/object-detection/inference.ts
+++ b/packages/tasks/src/tasks/object-detection/inference.ts
@@ -8,9 +8,10 @@
  */
 export interface ObjectDetectionInput {
 	/**
-	 * The input image data
+	 * The input image data as a base64-encoded string. If no `parameters` are provided, you can
+	 * also provide the image data as a raw bytes payload.
 	 */
-	inputs: unknown;
+	inputs: string;
 	/**
 	 * Additional inference parameters
 	 */
@@ -34,9 +35,21 @@ export interface ObjectDetectionParameters {
  * image.
  */
 export interface BoundingBox {
+	/**
+	 * The x-coordinate of the bottom-right corner of the bounding box.
+	 */
 	xmax: number;
+	/**
+	 * The x-coordinate of the top-left corner of the bounding box.
+	 */
 	xmin: number;
+	/**
+	 * The y-coordinate of the bottom-right corner of the bounding box.
+	 */
 	ymax: number;
+	/**
+	 * The y-coordinate of the top-left corner of the bounding box.
+	 */
 	ymin: number;
 	[property: string]: unknown;
 }
@@ -51,11 +64,11 @@ export interface ObjectDetectionOutputElement {
 	 */
 	box: BoundingBox;
 	/**
-	 * The predicted label for the bounding box
+	 * The predicted label for the bounding box.
 	 */
 	label: string;
 	/**
-	 * The associated score / probability
+	 * The associated score / probability.
 	 */
 	score: number;
 	[property: string]: unknown;

--- a/packages/tasks/src/tasks/object-detection/spec/input.json
+++ b/packages/tasks/src/tasks/object-detection/spec/input.json
@@ -6,7 +6,8 @@
 	"type": "object",
 	"properties": {
 		"inputs": {
-			"description": "The input image data"
+			"type": "string",
+			"description": "The input image data as a base64-encoded string. If no `parameters` are provided, you can also provide the image data as a raw bytes payload."
 		},
 		"parameters": {
 			"description": "Additional inference parameters",

--- a/packages/tasks/src/tasks/object-detection/spec/output.json
+++ b/packages/tasks/src/tasks/object-detection/spec/output.json
@@ -9,11 +9,11 @@
 		"properties": {
 			"label": {
 				"type": "string",
-				"description": "The predicted label for the bounding box"
+				"description": "The predicted label for the bounding box."
 			},
 			"score": {
 				"type": "number",
-				"description": "The associated score / probability"
+				"description": "The associated score / probability."
 			},
 			"box": {
 				"$ref": "#/$defs/BoundingBox",
@@ -28,16 +28,20 @@
 			"title": "BoundingBox",
 			"properties": {
 				"xmin": {
-					"type": "integer"
+					"type": "integer",
+					"description": "The x-coordinate of the top-left corner of the bounding box."
 				},
 				"xmax": {
-					"type": "integer"
+					"type": "integer",
+					"description": "The x-coordinate of the bottom-right corner of the bounding box."
 				},
 				"ymin": {
-					"type": "integer"
+					"type": "integer",
+					"description": "The y-coordinate of the top-left corner of the bounding box."
 				},
 				"ymax": {
-					"type": "integer"
+					"type": "integer",
+					"description": "The y-coordinate of the bottom-right corner of the bounding box."
 				}
 			},
 			"required": ["xmin", "xmax", "ymin", "ymax"]

--- a/packages/tasks/src/tasks/summarization/inference.ts
+++ b/packages/tasks/src/tasks/summarization/inference.ts
@@ -7,15 +7,43 @@
 /**
  * Inputs for Summarization inference
  */
-export type SummarizationInput = unknown[] | boolean | number | number | null | SummarizationInputObject | string;
-
-export interface SummarizationInputObject {
+export interface SummarizationInput {
 	/**
-	 * The text to summarize.
+	 * The input text to summarize.
 	 */
 	inputs: string;
+	/**
+	 * Additional inference parameters.
+	 */
+	parameters?: SummarizationParameters;
 	[property: string]: unknown;
 }
+
+/**
+ * Additional inference parameters.
+ *
+ * Additional inference parameters for summarization.
+ */
+export interface SummarizationParameters {
+	/**
+	 * Whether to clean up the potential extra spaces in the text output.
+	 */
+	clean_up_tokenization_spaces?: boolean;
+	/**
+	 * Additional parametrization of the text generation algorithm.
+	 */
+	generate_parameters?: { [key: string]: unknown };
+	/**
+	 * The truncation strategy to use.
+	 */
+	truncation?: SummarizationTruncationStrategy;
+	[property: string]: unknown;
+}
+
+/**
+ * The truncation strategy to use.
+ */
+export type SummarizationTruncationStrategy = "do_not_truncate" | "longest_first" | "only_first" | "only_second";
 
 /**
  * Outputs of inference for the Summarization task

--- a/packages/tasks/src/tasks/summarization/inference.ts
+++ b/packages/tasks/src/tasks/summarization/inference.ts
@@ -6,43 +6,16 @@
 
 /**
  * Inputs for Summarization inference
- *
- * Inputs for Text2text Generation inference
  */
-export interface SummarizationInput {
+export type SummarizationInput = unknown[] | boolean | number | number | null | SummarizationInputObject | string;
+
+export interface SummarizationInputObject {
 	/**
-	 * The input text data
+	 * The text to summarize.
 	 */
 	inputs: string;
-	/**
-	 * Additional inference parameters
-	 */
-	parameters?: Text2TextGenerationParameters;
 	[property: string]: unknown;
 }
-
-/**
- * Additional inference parameters
- *
- * Additional inference parameters for Text2text Generation
- */
-export interface Text2TextGenerationParameters {
-	/**
-	 * Whether to clean up the potential extra spaces in the text output.
-	 */
-	clean_up_tokenization_spaces?: boolean;
-	/**
-	 * Additional parametrization of the text generation algorithm
-	 */
-	generate_parameters?: { [key: string]: unknown };
-	/**
-	 * The truncation strategy to use
-	 */
-	truncation?: Text2TextGenerationTruncationStrategy;
-	[property: string]: unknown;
-}
-
-export type Text2TextGenerationTruncationStrategy = "do_not_truncate" | "longest_first" | "only_first" | "only_second";
 
 /**
  * Outputs of inference for the Summarization task

--- a/packages/tasks/src/tasks/summarization/spec/input.json
+++ b/packages/tasks/src/tasks/summarization/spec/input.json
@@ -3,5 +3,12 @@
 	"$id": "/inference/schemas/summarization/input.json",
 	"$schema": "http://json-schema.org/draft-06/schema#",
 	"title": "SummarizationInput",
-	"description": "Inputs for Summarization inference"
+	"description": "Inputs for Summarization inference",
+	"properties": {
+		"inputs": {
+			"description": "The text to summarize.",
+			"type": "string"
+		}
+	},
+	"required": ["inputs"]
 }

--- a/packages/tasks/src/tasks/summarization/spec/input.json
+++ b/packages/tasks/src/tasks/summarization/spec/input.json
@@ -1,13 +1,41 @@
 {
-	"$ref": "/inference/schemas/summarization/input.json",
 	"$id": "/inference/schemas/summarization/input.json",
 	"$schema": "http://json-schema.org/draft-06/schema#",
-	"title": "SummarizationInput",
 	"description": "Inputs for Summarization inference",
+	"title": "SummarizationInput",
+	"type": "object",
 	"properties": {
 		"inputs": {
-			"description": "The text to summarize.",
+			"description": "The input text to summarize.",
 			"type": "string"
+		},
+		"parameters": {
+			"description": "Additional inference parameters.",
+			"$ref": "#/$defs/SummarizationParameters"
+		}
+	},
+	"$defs": {
+		"SummarizationParameters": {
+			"title": "SummarizationParameters",
+			"description": "Additional inference parameters for summarization.",
+			"type": "object",
+			"properties": {
+				"clean_up_tokenization_spaces": {
+					"type": "boolean",
+					"description": "Whether to clean up the potential extra spaces in the text output."
+				},
+				"truncation": {
+					"title": "SummarizationTruncationStrategy",
+					"type": "string",
+					"description": "The truncation strategy to use.",
+					"enum": ["do_not_truncate", "longest_first", "only_first", "only_second"]
+				},
+				"generate_parameters": {
+					"title": "generateParameters",
+					"type": "object",
+					"description": "Additional parametrization of the text generation algorithm."
+				}
+			}
 		}
 	},
 	"required": ["inputs"]

--- a/packages/tasks/src/tasks/summarization/spec/input.json
+++ b/packages/tasks/src/tasks/summarization/spec/input.json
@@ -1,5 +1,5 @@
 {
-	"$ref": "/inference/schemas/text2text-generation/input.json",
+	"$ref": "/inference/schemas/summarization/input.json",
 	"$id": "/inference/schemas/summarization/input.json",
 	"$schema": "http://json-schema.org/draft-06/schema#",
 	"title": "SummarizationInput",

--- a/packages/tasks/src/tasks/text-classification/spec/output.json
+++ b/packages/tasks/src/tasks/text-classification/spec/output.json
@@ -5,6 +5,7 @@
 	"title": "TextClassificationOutput",
 	"type": "array",
 	"items": {
+		"type": "object",
 		"$ref": "/inference/schemas/common-definitions.json#/definitions/ClassificationOutput"
 	}
 }

--- a/packages/tasks/src/tasks/text-to-image/inference.ts
+++ b/packages/tasks/src/tasks/text-to-image/inference.ts
@@ -9,7 +9,7 @@
  */
 export interface TextToImageInput {
 	/**
-	 * The input text data (sometimes called "prompt"
+	 * The input text data (sometimes called "prompt")
 	 */
 	inputs: string;
 	/**

--- a/packages/tasks/src/tasks/text-to-image/inference.ts
+++ b/packages/tasks/src/tasks/text-to-image/inference.ts
@@ -64,7 +64,7 @@ export interface TargetSize {
  */
 export interface TextToImageOutput {
 	/**
-	 * The generated image
+	 * The generated image returned as raw bytes in the payload.
 	 */
 	image: unknown;
 	[property: string]: unknown;

--- a/packages/tasks/src/tasks/text-to-image/spec/input.json
+++ b/packages/tasks/src/tasks/text-to-image/spec/input.json
@@ -6,7 +6,7 @@
 	"type": "object",
 	"properties": {
 		"inputs": {
-			"description": "The input text data (sometimes called \"prompt\"",
+			"description": "The input text data (sometimes called \"prompt\")",
 			"type": "string"
 		},
 		"parameters": {

--- a/packages/tasks/src/tasks/text-to-image/spec/output.json
+++ b/packages/tasks/src/tasks/text-to-image/spec/output.json
@@ -6,7 +6,7 @@
 	"type": "object",
 	"properties": {
 		"image": {
-			"description": "The generated image"
+			"description": "The generated image returned as raw bytes in the payload."
 		}
 	},
 	"required": ["image"]

--- a/packages/tasks/src/tasks/translation/inference.ts
+++ b/packages/tasks/src/tasks/translation/inference.ts
@@ -7,9 +7,7 @@
 /**
  * Inputs for Translation inference
  */
-export type TranslationInput = unknown[] | boolean | number | number | null | TranslationInputObject | string;
-
-export interface TranslationInputObject {
+export interface TranslationInput {
 	/**
 	 * The text to translate.
 	 */

--- a/packages/tasks/src/tasks/translation/inference.ts
+++ b/packages/tasks/src/tasks/translation/inference.ts
@@ -28,6 +28,14 @@ export interface TranslationInputObject {
  */
 export interface TranslationParameters {
 	/**
+	 * Whether to clean up the potential extra spaces in the text output.
+	 */
+	clean_up_tokenization_spaces?: boolean;
+	/**
+	 * Additional parametrization of the text generation algorithm.
+	 */
+	generate_parameters?: { [key: string]: unknown };
+	/**
 	 * The source language of the text. Required for models that can translate from multiple
 	 * languages.
 	 */
@@ -37,8 +45,17 @@ export interface TranslationParameters {
 	 * languages.
 	 */
 	tgt_lang?: string;
+	/**
+	 * The truncation strategy to use.
+	 */
+	truncation?: TranslationTruncationStrategy;
 	[property: string]: unknown;
 }
+
+/**
+ * The truncation strategy to use.
+ */
+export type TranslationTruncationStrategy = "do_not_truncate" | "longest_first" | "only_first" | "only_second";
 
 /**
  * Outputs of inference for the Translation task

--- a/packages/tasks/src/tasks/translation/inference.ts
+++ b/packages/tasks/src/tasks/translation/inference.ts
@@ -6,43 +6,39 @@
 
 /**
  * Inputs for Translation inference
- *
- * Inputs for Text2text Generation inference
  */
-export interface TranslationInput {
+export type TranslationInput = unknown[] | boolean | number | number | null | TranslationInputObject | string;
+
+export interface TranslationInputObject {
 	/**
-	 * The input text data
+	 * The text to translate.
 	 */
 	inputs: string;
 	/**
 	 * Additional inference parameters
 	 */
-	parameters?: Text2TextGenerationParameters;
+	parameters?: TranslationParameters;
 	[property: string]: unknown;
 }
 
 /**
  * Additional inference parameters
  *
- * Additional inference parameters for Text2text Generation
+ * Additional inference parameters for Translation
  */
-export interface Text2TextGenerationParameters {
+export interface TranslationParameters {
 	/**
-	 * Whether to clean up the potential extra spaces in the text output.
+	 * The source language of the text. Required for models that can translate from multiple
+	 * languages.
 	 */
-	clean_up_tokenization_spaces?: boolean;
+	src_lang?: string;
 	/**
-	 * Additional parametrization of the text generation algorithm
+	 * Target language to translate to. Required for models that can translate to multiple
+	 * languages.
 	 */
-	generate_parameters?: { [key: string]: unknown };
-	/**
-	 * The truncation strategy to use
-	 */
-	truncation?: Text2TextGenerationTruncationStrategy;
+	tgt_lang?: string;
 	[property: string]: unknown;
 }
-
-export type Text2TextGenerationTruncationStrategy = "do_not_truncate" | "longest_first" | "only_first" | "only_second";
 
 /**
  * Outputs of inference for the Translation task

--- a/packages/tasks/src/tasks/translation/spec/input.json
+++ b/packages/tasks/src/tasks/translation/spec/input.json
@@ -1,9 +1,8 @@
 {
-	"$ref": "/inference/schemas/translation/input.json",
 	"$id": "/inference/schemas/translation/input.json",
 	"$schema": "http://json-schema.org/draft-06/schema#",
-	"title": "TranslationInput",
 	"description": "Inputs for Translation inference",
+	"title": "TranslationInput",
 	"properties": {
 		"inputs": {
 			"description": "The text to translate.",
@@ -27,6 +26,21 @@
 				"tgt_lang": {
 					"type": "string",
 					"description": "Target language to translate to. Required for models that can translate to multiple languages."
+				},
+				"clean_up_tokenization_spaces": {
+					"type": "boolean",
+					"description": "Whether to clean up the potential extra spaces in the text output."
+				},
+				"truncation": {
+					"title": "TranslationTruncationStrategy",
+					"type": "string",
+					"description": "The truncation strategy to use.",
+					"enum": ["do_not_truncate", "longest_first", "only_first", "only_second"]
+				},
+				"generate_parameters": {
+					"title": "generateParameters",
+					"type": "object",
+					"description": "Additional parametrization of the text generation algorithm."
 				}
 			}
 		}

--- a/packages/tasks/src/tasks/translation/spec/input.json
+++ b/packages/tasks/src/tasks/translation/spec/input.json
@@ -3,6 +3,7 @@
 	"$schema": "http://json-schema.org/draft-06/schema#",
 	"description": "Inputs for Translation inference",
 	"title": "TranslationInput",
+	"type": "object",
 	"properties": {
 		"inputs": {
 			"description": "The text to translate.",

--- a/packages/tasks/src/tasks/translation/spec/input.json
+++ b/packages/tasks/src/tasks/translation/spec/input.json
@@ -15,7 +15,7 @@
 		}
 	},
 	"$defs": {
-		"FillMaskParameters": {
+		"TranslationParameters": {
 			"title": "TranslationParameters",
 			"description": "Additional inference parameters for Translation",
 			"type": "object",

--- a/packages/tasks/src/tasks/translation/spec/input.json
+++ b/packages/tasks/src/tasks/translation/spec/input.json
@@ -3,5 +3,33 @@
 	"$id": "/inference/schemas/translation/input.json",
 	"$schema": "http://json-schema.org/draft-06/schema#",
 	"title": "TranslationInput",
-	"description": "Inputs for Translation inference"
+	"description": "Inputs for Translation inference",
+	"properties": {
+		"inputs": {
+			"description": "The text to translate.",
+			"type": "string"
+		},
+		"parameters": {
+			"description": "Additional inference parameters",
+			"$ref": "#/$defs/TranslationParameters"
+		}
+	},
+	"$defs": {
+		"FillMaskParameters": {
+			"title": "TranslationParameters",
+			"description": "Additional inference parameters for Translation",
+			"type": "object",
+			"properties": {
+				"src_lang": {
+					"type": "string",
+					"description": "The source language of the text. Required for models that can translate from multiple languages."
+				},
+				"tgt_lang": {
+					"type": "string",
+					"description": "Target language to translate to. Required for models that can translate to multiple languages."
+				}
+			}
+		}
+	},
+	"required": ["inputs"]
 }

--- a/packages/tasks/src/tasks/translation/spec/input.json
+++ b/packages/tasks/src/tasks/translation/spec/input.json
@@ -1,5 +1,5 @@
 {
-	"$ref": "/inference/schemas/text2text-generation/input.json",
+	"$ref": "/inference/schemas/translation/input.json",
 	"$id": "/inference/schemas/translation/input.json",
 	"$schema": "http://json-schema.org/draft-06/schema#",
 	"title": "TranslationInput",

--- a/packages/tasks/src/tasks/zero-shot-classification/spec/output.json
+++ b/packages/tasks/src/tasks/zero-shot-classification/spec/output.json
@@ -5,6 +5,7 @@
 	"title": "ZeroShotClassificationOutput",
 	"type": "array",
 	"items": {
+		"type": "object",
 		"$ref": "/inference/schemas/common-definitions.json#/definitions/ClassificationOutput"
 	}
 }


### PR DESCRIPTION
This PR should prove useful for the ongoing work of generating documentation pages based on the input/output specs (see https://github.com/huggingface/hub-docs/pull/1379).

In particular, I've made changes when adding new pages to the docs (PRs  https://github.com/huggingface/hub-docs/pull/1398 and https://github.com/huggingface/hub-docs/pull/1399). 

This PR is now ready for review.

**Changes:**
- use enums instead of `oneOf` + list of `const`
- do not rely on `"$ref": "/inference/schemas/text2text-generation/input.json",` for Summarization / Translation. Makes things clearer + it's not possible to extend the parameters which was not possible before.
- typo in `text-to-image`
- add `src_lang` and `tgt_lang` in translation params 
- use enum for `early_stopping` parameter (in common defs)
- for `audio-classification`, `automatic speech recognition`, `image classification`, `image to image`, `object detection`:
   - mention `base64-encoded string` as input
   - mention raw data can be sent if no parameters in the JSON payload
- more descriptions in `object detection` 
- more descriptions in `image segmentation` 
- mention bytes output in `text-to-image` and `image-to-image`