### PR TITLE
No extra newline in inference code snippets

### DIFF
--- a/packages/tasks/src/snippets/curl.ts
+++ b/packages/tasks/src/snippets/curl.ts
@@ -7,8 +7,7 @@ export const snippetBasic = (model: ModelDataMinimal, accessToken: string): stri
 	-X POST \\
 	-d '{"inputs": ${getModelInputSnippet(model, true)}}' \\
 	-H 'Content-Type: application/json' \\
-	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"
-`;
+	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"`;
 
 export const snippetTextGeneration = (model: ModelDataMinimal, accessToken: string): string => {
 	if (model.config?.tokenizer_config?.chat_template) {
@@ -33,15 +32,13 @@ export const snippetZeroShotClassification = (model: ModelDataMinimal, accessTok
 	-X POST \\
 	-d '{"inputs": ${getModelInputSnippet(model, true)}, "parameters": {"candidate_labels": ["refund", "legal", "faq"]}}' \\
 	-H 'Content-Type: application/json' \\
-	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"
-`;
+	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"`;
 
 export const snippetFile = (model: ModelDataMinimal, accessToken: string): string =>
 	`curl https://api-inference.huggingface.co/models/${model.id} \\
 	-X POST \\
 	--data-binary '@${getModelInputSnippet(model, true, true)}' \\
-	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"
-`;
+	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"`;
 
 export const curlSnippets: Partial<Record<PipelineType, (model: ModelDataMinimal, accessToken: string) => string>> = {
 	// Same order as in js/src/lib/interfaces/Types.ts

--- a/packages/tasks/src/snippets/js.ts
+++ b/packages/tasks/src/snippets/js.ts
@@ -36,8 +36,7 @@ for await (const chunk of inference.chatCompletionStream({
 	max_tokens: 500,
 })) {
 	process.stdout.write(chunk.choices[0]?.delta?.content || "");
-}
-`;
+}`;
 	} else {
 		return snippetBasic(model, accessToken);
 	}

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -15,8 +15,7 @@ for message in client.chat_completion(
 	max_tokens=500,
 	stream=True,
 ):
-    print(message.choices[0].delta.content, end="")
-`;
+    print(message.choices[0].delta.content, end="")`;
 
 export const snippetZeroShotClassification = (model: ModelDataMinimal): string =>
 	`def query(payload):


### PR DESCRIPTION
from @osanseviero suggestion in https://github.com/huggingface/hub-docs/pull/1398#discussion_r1735265611 

Let's remove the extra newlines at the end of code snippets (if not already the case)