### PR TITLE
Add seed in text to image specs

### DIFF
--- a/packages/tasks/src/tasks/text-to-image/inference.ts
+++ b/packages/tasks/src/tasks/text-to-image/inference.ts
@@ -27,7 +27,7 @@ export interface TextToImageInput {
 export interface TextToImageParameters {
 	/**
 	 * A higher guidance scale value encourages the model to generate images closely linked to
-	 * the text prompt at the expense of lower image quality.
+	 * the text prompt, but values too high may cause saturation and other artifacts.
 	 */
 	guidance_scale?: number;
 	/**

--- a/packages/tasks/src/tasks/text-to-image/inference.ts
+++ b/packages/tasks/src/tasks/text-to-image/inference.ts
@@ -26,8 +26,8 @@ export interface TextToImageInput {
  */
 export interface TextToImageParameters {
 	/**
-	 * For diffusion models. A higher guidance scale value encourages the model to generate
-	 * images closely linked to the text prompt at the expense of lower image quality.
+	 * A higher guidance scale value encourages the model to generate images closely linked to
+	 * the text prompt at the expense of lower image quality.
 	 */
 	guidance_scale?: number;
 	/**
@@ -35,14 +35,18 @@ export interface TextToImageParameters {
 	 */
 	negative_prompt?: string[];
 	/**
-	 * For diffusion models. The number of denoising steps. More denoising steps usually lead to
-	 * a higher quality image at the expense of slower inference.
+	 * The number of denoising steps. More denoising steps usually lead to a higher quality
+	 * image at the expense of slower inference.
 	 */
 	num_inference_steps?: number;
 	/**
-	 * For diffusion models. Override the scheduler with a compatible one
+	 * Override the scheduler with a compatible one.
 	 */
 	scheduler?: string;
+	/**
+	 * Seed for the random number generator.
+	 */
+	seed?: number;
 	/**
 	 * The size in pixel of the output image
 	 */

--- a/packages/tasks/src/tasks/text-to-image/spec/input.json
+++ b/packages/tasks/src/tasks/text-to-image/spec/input.json
@@ -22,7 +22,7 @@
 			"properties": {
 				"guidance_scale": {
 					"type": "number",
-					"description": "For diffusion models. A higher guidance scale value encourages the model to generate images closely linked to the text prompt at the expense of lower image quality."
+					"description": "A higher guidance scale value encourages the model to generate images closely linked to the text prompt at the expense of lower image quality."
 				},
 				"negative_prompt": {
 					"type": "array",
@@ -33,7 +33,7 @@
 				},
 				"num_inference_steps": {
 					"type": "integer",
-					"description": "For diffusion models. The number of denoising steps. More denoising steps usually lead to a higher quality image at the expense of slower inference."
+					"description": "The number of denoising steps. More denoising steps usually lead to a higher quality image at the expense of slower inference."
 				},
 				"target_size": {
 					"type": "object",
@@ -50,7 +50,11 @@
 				},
 				"scheduler": {
 					"type": "string",
-					"description": "For diffusion models. Override the scheduler with a compatible one"
+					"description": "Override the scheduler with a compatible one."
+				},
+				"seed": {
+					"type": "integer",
+					"description": "Seed for the random number generator."
 				}
 			}
 		}

--- a/packages/tasks/src/tasks/text-to-image/spec/input.json
+++ b/packages/tasks/src/tasks/text-to-image/spec/input.json
@@ -22,7 +22,7 @@
 			"properties": {
 				"guidance_scale": {
 					"type": "number",
-					"description": "A higher guidance scale value encourages the model to generate images closely linked to the text prompt at the expense of lower image quality."
+					"description": "A higher guidance scale value encourages the model to generate images closely linked to the text prompt, but values too high may cause saturation and other artifacts."
 				},
 				"negative_prompt": {
 					"type": "array",


### PR DESCRIPTION
Following @apolinario's PR https://github.com/huggingface/api-inference-community/pull/450. This PR adds a "seed" input parameter in the `text-to-image` specs.