### PR TITLE
📝 Fix documentation CI?

### DIFF
--- a/.github/workflows/agents-publish.yml
+++ b/.github/workflows/agents-publish.yml
@@ -69,3 +69,4 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         with:
           event-type: doc-build
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}

--- a/.github/workflows/hub-publish.yml
+++ b/.github/workflows/hub-publish.yml
@@ -107,3 +107,4 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         with:
           event-type: doc-build
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}

--- a/.github/workflows/space-header-publish.yml
+++ b/.github/workflows/space-header-publish.yml
@@ -66,3 +66,4 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         with:
           event-type: doc-build
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}

--- a/.github/workflows/tasks-publish.yml
+++ b/.github/workflows/tasks-publish.yml
@@ -66,3 +66,4 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         with:
           event-type: doc-build
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}


### PR DESCRIPTION
We update docs on publish

But this job fails:

```
      - name: "Update Doc"
        uses: peter-evans/repository-dispatch@v2
        with:
          event-type: doc-build
```

Probably due to a policy change in the org cc @glegendre01  (https://huggingface.slack.com/archives/C02SPHC1KD1/p1722448474979249?thread_ts=1722339176.798599&cid=C02SPHC1KD1)

With the error message: `Error: Resource not accessible by integration`

eg https://github.com/huggingface/huggingface.js/actions/runs/10736074066/job/29774687075 cc @merveenoyan :)

It doesn't stop publishing thank god, but it'd be nice to avoid errors

cc @Wauplin too
