### PR TITLE
feat(@huggingface/hub): adding `scanCacheDir`

### DIFF
--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -122,6 +122,7 @@ const result = await scanCacheDir();
 
 console.log(result);
 ```
+Note that the cache directory is created and used only by the Python and Rust libraries. Downloading files using the `@huggingface/hub` package won't use the cache directory.
 
 ## Performance considerations
 

--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -111,6 +111,18 @@ console.log(oauthResult);
 
 Checkout the demo: https://huggingface.co/spaces/huggingfacejs/client-side-oauth
 
+## Hugging face cache
+
+The `@huggingface/hub` package provide basic capabilities to scan the cache directory. Learn more about [Manage huggingface_hub cache-system](https://huggingface.co/docs/huggingface_hub/en/guides/manage-cache).
+
+```ts
+import { scanCacheDir } from "@huggingface/hub";
+
+const result = await scanCacheDir();
+
+console.log(result);
+```
+
 ## Performance considerations
 
 When uploading large files, you may want to run the `commit` calls inside a worker, to offload the sha256 computations.

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -25,7 +25,7 @@
 		"./dist/index.mjs": "./dist/browser/index.mjs"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=18"
 	},
 	"source": "index.ts",
 	"scripts": {
@@ -57,7 +57,7 @@
 	"author": "Hugging Face",
 	"license": "MIT",
 	"devDependencies": {
-		"@types/node": "^20.12.8"
+		"@types/node": "^20.11.28"
 	},
 	"dependencies": {
 		"@huggingface/tasks": "workspace:^"

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -20,11 +20,12 @@
 	"browser": {
 		"./src/utils/sha256-node.ts": false,
 		"./src/utils/FileBlob.ts": false,
+		"./src/lib/cache-management.ts": false,
 		"./dist/index.js": "./dist/browser/index.js",
 		"./dist/index.mjs": "./dist/browser/index.mjs"
 	},
 	"engines": {
-		"node": ">=18"
+		"node": ">=20"
 	},
 	"source": "index.ts",
 	"scripts": {
@@ -56,7 +57,7 @@
 	"author": "Hugging Face",
 	"license": "MIT",
 	"devDependencies": {
-		"@types/node": "^20.11.28"
+		"@types/node": "^20.12.8"
 	},
 	"dependencies": {
 		"@huggingface/tasks": "workspace:^"

--- a/packages/hub/src/lib/cache-management.spec.ts
+++ b/packages/hub/src/lib/cache-management.spec.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import {
-	scan_cache_dir,
-	scan_cached_repo,
+	scanCacheDir,
+	scanCachedRepo,
 	REPO_TYPE_T,
 	scanSnapshotDir,
 	parseRepoType,
@@ -20,13 +20,13 @@ beforeEach(() => {
 	vi.restoreAllMocks();
 });
 
-describe("scan_cache_dir", () => {
+describe("scanCacheDir", () => {
 	test("should throw an error if cacheDir is not a directory", async () => {
 		vi.mocked(stat).mockResolvedValueOnce({
 			isDirectory: () => false,
 		} as Stats);
 
-		await expect(scan_cache_dir("/fake/dir")).rejects.toThrow("Scan cache expects a directory");
+		await expect(scanCacheDir("/fake/dir")).rejects.toThrow("Scan cache expects a directory");
 	});
 
 	test("empty directory should return an empty set of repository and no warnings", async () => {
@@ -37,21 +37,21 @@ describe("scan_cache_dir", () => {
 		// mock empty cache folder
 		vi.mocked(readdir).mockResolvedValue([]);
 
-		const result = await scan_cache_dir("/fake/dir");
+		const result = await scanCacheDir("/fake/dir");
 
 		// cacheDir must have been read
 		expect(readdir).toHaveBeenCalledWith("/fake/dir");
 
 		expect(result.warnings.length).toBe(0);
 		expect(result.repos.size).toBe(0);
-		expect(result.size_on_disk).toBe(0);
+		expect(result.sizeOnDisk).toBe(0);
 	});
 });
 
-describe("scan_cached_repo", () => {
+describe("scanCachedRepo", () => {
 	test("should throw an error for invalid repo path", async () => {
 		await expect(() => {
-			return scan_cached_repo("/fake/repo_path");
+			return scanCachedRepo("/fake/repo_path");
 		}).rejects.toThrow("Repo path is not a valid HuggingFace cache directory");
 	});
 
@@ -62,7 +62,7 @@ describe("scan_cached_repo", () => {
 		} as Stats);
 
 		await expect(() => {
-			return scan_cached_repo("/fake/cacheDir/models--hello-world--name");
+			return scanCachedRepo("/fake/cacheDir/models--hello-world--name");
 		}).rejects.toThrow("Snapshots dir doesn't exist in cached repo");
 	});
 
@@ -73,12 +73,12 @@ describe("scan_cached_repo", () => {
 			isDirectory: () => true,
 		} as Stats);
 
-		const result = await scan_cached_repo(repoPath);
+		const result = await scanCachedRepo(repoPath);
 		expect(readdir).toHaveBeenCalledWith(join(repoPath, "refs"), {
 			withFileTypes: true,
 		});
 
-		expect(result.repo_id).toBe("hello-world/name");
+		expect(result.repoId).toBe("hello-world/name");
 	});
 });
 

--- a/packages/hub/src/lib/cache-management.spec.ts
+++ b/packages/hub/src/lib/cache-management.spec.ts
@@ -1,116 +1,132 @@
-import { describe, test, expect, vi, beforeEach } from 'vitest';
-import * as cacheManagement from './cache-management';
-import { stat, readdir, realpath, lstat } from 'node:fs/promises';
-import { Stats } from "node:fs";
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import {
+	scan_cache_dir,
+	scan_cached_repo,
+	REPO_TYPE_T,
+	scanSnapshotDir,
+	parseRepoType,
+	getBlobStat,
+	type CachedFileInfo,
+} from "./cache-management";
+import { stat, readdir, realpath, lstat } from "node:fs/promises";
+import type { Dirent, Stats } from "node:fs";
+import { join } from "node:path";
 
 // Mocks
-vi.mock('node:fs/promises');
+vi.mock("node:fs/promises");
 
 beforeEach(() => {
 	vi.resetAllMocks();
 	vi.restoreAllMocks();
 });
 
-describe('scan_cache_dir', () => {
-	test('should throw an error if cacheDir is not a directory', async () => {
+describe("scan_cache_dir", () => {
+	test("should throw an error if cacheDir is not a directory", async () => {
 		vi.mocked(stat).mockResolvedValueOnce({
-			isDirectory: () => false
+			isDirectory: () => false,
 		} as Stats);
 
-		await expect(cacheManagement.scan_cache_dir('/fake/dir')).rejects.toThrow('Scan cache expects a directory');
+		await expect(scan_cache_dir("/fake/dir")).rejects.toThrow("Scan cache expects a directory");
 	});
 
-	test('should scan a valid cache directory', async () => {
+	test("empty directory should return an empty set of repository and no warnings", async () => {
 		vi.mocked(stat).mockResolvedValueOnce({
-			isDirectory: () => true
+			isDirectory: () => true,
 		} as Stats);
 
-		vi.mocked(readdir).mockResolvedValueOnce(['repo1', 'repo2']);
+		// mock empty cache folder
+		vi.mocked(readdir).mockResolvedValue([]);
 
-		vi.mocked(stat).mockResolvedValueOnce({ isDirectory: () => true } as any);
-		vi.mocked(stat).mockResolvedValueOnce({ isDirectory: () => true } as any);
+		const result = await scan_cache_dir("/fake/dir");
 
-		vi.spyOn(cacheManagement, 'scan_cached_repo').mockResolvedValueOnce({ repo_id: 'repo1', size_on_disk: 100 } as any);
-		vi.spyOn(cacheManagement, 'scan_cached_repo').mockResolvedValueOnce({ repo_id: 'repo2', size_on_disk: 200 } as any);
+		// cacheDir must have been read
+		expect(readdir).toHaveBeenCalledWith("/fake/dir");
 
-		const result = await cacheManagement.scan_cache_dir('/fake/dir');
-
-		expect(result.size_on_disk).toBe(300);
-		expect(result.repos.size).toBe(2);
+		expect(result.warnings.length).toBe(0);
+		expect(result.repos.size).toBe(0);
+		expect(result.size_on_disk).toBe(0);
 	});
 });
 
-describe('scan_cached_repo', () => {
-	test('should throw an error for invalid repo path', async () => {
+describe("scan_cached_repo", () => {
+	test("should throw an error for invalid repo path", async () => {
 		await expect(() => {
-			return cacheManagement.scan_cached_repo('/fake/repo_path');
-		}).rejects.toThrow('Repo path is not a valid HuggingFace cache directory');
+			return scan_cached_repo("/fake/repo_path");
+		}).rejects.toThrow("Repo path is not a valid HuggingFace cache directory");
 	});
 
-	test('should return CachedRepoInfo for a valid repo', async () => {
-		const repoPath = '/fake/model--repo1';
+	test("should throw an error if the snapshot folder does not exist", async () => {
+		vi.mocked(readdir).mockResolvedValue([]);
+		vi.mocked(stat).mockResolvedValue({
+			isDirectory: () => false,
+		} as Stats);
 
-		vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as unknown as Stats);
-		vi.mocked(readdir).mockImplementationOnce(async () => {
-				return ['snapshot1', 'snapshot2'] as unknown as ReturnType<typeof readdir>
-			}
-		);
-		vi.spyOn(cacheManagement, 'scanSnapshotDir').mockResolvedValueOnce(undefined);
+		await expect(() => {
+			return scan_cached_repo("/fake/cacheDir/models--hello-world--name");
+		}).rejects.toThrow("Snapshots dir doesn't exist in cached repo");
+	});
 
-		const result = await cacheManagement.scan_cached_repo(repoPath);
+	test("should properly parse the repository name", async () => {
+		const repoPath = "/fake/cacheDir/models--hello-world--name";
+		vi.mocked(readdir).mockResolvedValue([]);
+		vi.mocked(stat).mockResolvedValue({
+			isDirectory: () => true,
+		} as Stats);
 
-		expect(result.repo_id).toBe('repo1');
-		expect(result.repo_type).toBe(cacheManagement.REPO_TYPE_T.MODEL);
+		const result = await scan_cached_repo(repoPath);
+		expect(readdir).toHaveBeenCalledWith(join(repoPath, "refs"), {
+			withFileTypes: true,
+		});
+
+		expect(result.repo_id).toBe("hello-world/name");
 	});
 });
 
+describe("scanSnapshotDir", () => {
+	test("should scan a valid snapshot directory", async () => {
+		const cachedFiles = new Set<CachedFileInfo>();
+		const blobStats = new Map<string, Stats>();
+		vi.mocked(readdir).mockResolvedValueOnce([{ name: "file1", isDirectory: () => false } as Dirent]);
 
+		vi.mocked(realpath).mockResolvedValueOnce("/fake/realpath");
+		vi.mocked(lstat).mockResolvedValueOnce({ size: 1024, atimeMs: Date.now(), mtimeMs: Date.now() } as Stats);
 
-describe('scanSnapshotDir', () => {
-	test('should scan a valid snapshot directory', async () => {
-		const cachedFiles = new Set();
-		const blobStats = new Map();
-		vi.mocked(readdir).mockResolvedValueOnce([{ name: 'file1', isDirectory: () => false }]);
-
-		vi.mocked(realpath).mockResolvedValueOnce('/fake/realpath');
-		vi.mocked(lstat).mockResolvedValueOnce({ size: 1024, atimeMs: Date.now(), mtimeMs: Date.now() } as any);
-
-		await cacheManagement.scanSnapshotDir('/fake/revision', cachedFiles, blobStats);
+		await scanSnapshotDir("/fake/revision", cachedFiles, blobStats);
 
 		expect(cachedFiles.size).toBe(1);
 		expect(blobStats.size).toBe(1);
 	});
 });
 
-describe('getBlobStat', () => {
-	test('should retrieve blob stat if already cached', async () => {
-		const blobStats = new Map([['/fake/blob', { size: 1024 } as any]]);
-		const result = await cacheManagement.getBlobStat('/fake/blob', blobStats);
+describe("getBlobStat", () => {
+	test("should retrieve blob stat if already cached", async () => {
+		const blobStats = new Map<string, Stats>([["/fake/blob", { size: 1024 } as Stats]]);
+		const result = await getBlobStat("/fake/blob", blobStats);
 
 		expect(result.size).toBe(1024);
 	});
 
-	test('should fetch and cache blob stat if not cached', async () => {
+	test("should fetch and cache blob stat if not cached", async () => {
 		const blobStats = new Map();
-		vi.mocked(lstat).mockResolvedValueOnce({ size: 2048 } as any);
+		vi.mocked(lstat).mockResolvedValueOnce({ size: 2048 } as Stats);
 
-		const result = await cacheManagement.getBlobStat('/fake/blob', blobStats);
+		const result = await getBlobStat("/fake/blob", blobStats);
 
 		expect(result.size).toBe(2048);
 		expect(blobStats.size).toBe(1);
 	});
 });
 
-describe('parseRepoType', () => {
-	test('should parse model repo type', () => {
-		expect(cacheManagement.parseRepoType('model')).toBe(cacheManagement.REPO_TYPE_T.MODEL);
+describe("parseRepoType", () => {
+	test("should parse model repo type", () => {
+		expect(parseRepoType("model")).toBe(REPO_TYPE_T.MODEL);
 	});
 
-	test('should parse dataset repo type', () => {
-		expect(cacheManagement.parseRepoType('dataset')).toBe(cacheManagement.REPO_TYPE_T.DATASET);
+	test("should parse dataset repo type", () => {
+		expect(parseRepoType("dataset")).toBe(REPO_TYPE_T.DATASET);
 	});
 
-	test('should throw an error for invalid repo type', () => {
-		expect(() => cacheManagement.parseRepoType('invalid')).toThrow();
+	test("should throw an error for invalid repo type", () => {
+		expect(() => parseRepoType("invalid")).toThrow();
 	});
 });

--- a/packages/hub/src/lib/cache-management.spec.ts
+++ b/packages/hub/src/lib/cache-management.spec.ts
@@ -2,7 +2,6 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 import {
 	scanCacheDir,
 	scanCachedRepo,
-	REPO_TYPE_T,
 	scanSnapshotDir,
 	parseRepoType,
 	getBlobStat,
@@ -43,8 +42,8 @@ describe("scanCacheDir", () => {
 		expect(readdir).toHaveBeenCalledWith("/fake/dir");
 
 		expect(result.warnings.length).toBe(0);
-		expect(result.repos.size).toBe(0);
-		expect(result.sizeOnDisk).toBe(0);
+		expect(result.repos).toHaveLength(0);
+		expect(result.size).toBe(0);
 	});
 });
 
@@ -84,7 +83,7 @@ describe("scanCachedRepo", () => {
 
 describe("scanSnapshotDir", () => {
 	test("should scan a valid snapshot directory", async () => {
-		const cachedFiles = new Set<CachedFileInfo>();
+		const cachedFiles: CachedFileInfo[] = [];
 		const blobStats = new Map<string, Stats>();
 		vi.mocked(readdir).mockResolvedValueOnce([{ name: "file1", isDirectory: () => false } as Dirent]);
 
@@ -93,7 +92,7 @@ describe("scanSnapshotDir", () => {
 
 		await scanSnapshotDir("/fake/revision", cachedFiles, blobStats);
 
-		expect(cachedFiles.size).toBe(1);
+		expect(cachedFiles).toHaveLength(1);
 		expect(blobStats.size).toBe(1);
 	});
 });
@@ -120,18 +119,22 @@ describe("getBlobStat", () => {
 
 describe("parseRepoType", () => {
 	test("should parse models repo type", () => {
-		expect(parseRepoType("models")).toBe(REPO_TYPE_T.MODEL);
+		expect(parseRepoType("models")).toBe("model");
 	});
 
 	test("should parse model repo type", () => {
-		expect(parseRepoType("model")).toBe(REPO_TYPE_T.MODEL);
+		expect(parseRepoType("model")).toBe("model");
 	});
 
 	test("should parse dataset repo type", () => {
-		expect(parseRepoType("dataset")).toBe(REPO_TYPE_T.DATASET);
+		expect(parseRepoType("dataset")).toBe("dataset");
+	});
+
+	test("should parse space repo type", () => {
+		expect(parseRepoType("space")).toBe("space");
 	});
 
 	test("should throw an error for invalid repo type", () => {
-		expect(() => parseRepoType("invalid")).toThrow();
+		expect(() => parseRepoType("invalid")).toThrowError("Invalid repo type: invalid");
 	});
 });

--- a/packages/hub/src/lib/cache-management.spec.ts
+++ b/packages/hub/src/lib/cache-management.spec.ts
@@ -123,16 +123,12 @@ describe("parseRepoType", () => {
 		expect(parseRepoType("models")).toBe("model");
 	});
 
-	test("should parse model repo type", () => {
-		expect(parseRepoType("model")).toBe("model");
-	});
-
 	test("should parse dataset repo type", () => {
-		expect(parseRepoType("dataset")).toBe("dataset");
+		expect(parseRepoType("datasets")).toBe("dataset");
 	});
 
 	test("should parse space repo type", () => {
-		expect(parseRepoType("space")).toBe("space");
+		expect(parseRepoType("spaces")).toBe("space");
 	});
 
 	test("should throw an error for invalid repo type", () => {

--- a/packages/hub/src/lib/cache-management.spec.ts
+++ b/packages/hub/src/lib/cache-management.spec.ts
@@ -77,7 +77,8 @@ describe("scanCachedRepo", () => {
 			withFileTypes: true,
 		});
 
-		expect(result.repoId).toBe("hello-world/name");
+		expect(result.id.name).toBe("hello-world/name");
+		expect(result.id.type).toBe("model");
 	});
 });
 

--- a/packages/hub/src/lib/cache-management.spec.ts
+++ b/packages/hub/src/lib/cache-management.spec.ts
@@ -103,6 +103,7 @@ describe("getBlobStat", () => {
 		const blobStats = new Map<string, Stats>([["/fake/blob", { size: 1024 } as Stats]]);
 		const result = await getBlobStat("/fake/blob", blobStats);
 
+		expect(lstat).not.toHaveBeenCalled();
 		expect(result.size).toBe(1024);
 	});
 
@@ -118,6 +119,10 @@ describe("getBlobStat", () => {
 });
 
 describe("parseRepoType", () => {
+	test("should parse models repo type", () => {
+		expect(parseRepoType("models")).toBe(REPO_TYPE_T.MODEL);
+	});
+
 	test("should parse model repo type", () => {
 		expect(parseRepoType("model")).toBe(REPO_TYPE_T.MODEL);
 	});

--- a/packages/hub/src/lib/cache-management.spec.ts
+++ b/packages/hub/src/lib/cache-management.spec.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import * as cacheManagement from './cache-management';
+import { stat, readdir, realpath, lstat } from 'node:fs/promises';
+import { Stats } from "node:fs";
+
+// Mocks
+vi.mock('node:fs/promises');
+
+beforeEach(() => {
+	vi.resetAllMocks();
+	vi.restoreAllMocks();
+});
+
+describe('scan_cache_dir', () => {
+	test('should throw an error if cacheDir is not a directory', async () => {
+		vi.mocked(stat).mockResolvedValueOnce({
+			isDirectory: () => false
+		} as Stats);
+
+		await expect(cacheManagement.scan_cache_dir('/fake/dir')).rejects.toThrow('Scan cache expects a directory');
+	});
+
+	test('should scan a valid cache directory', async () => {
+		vi.mocked(stat).mockResolvedValueOnce({
+			isDirectory: () => true
+		} as Stats);
+
+		vi.mocked(readdir).mockResolvedValueOnce(['repo1', 'repo2']);
+
+		vi.mocked(stat).mockResolvedValueOnce({ isDirectory: () => true } as any);
+		vi.mocked(stat).mockResolvedValueOnce({ isDirectory: () => true } as any);
+
+		vi.spyOn(cacheManagement, 'scan_cached_repo').mockResolvedValueOnce({ repo_id: 'repo1', size_on_disk: 100 } as any);
+		vi.spyOn(cacheManagement, 'scan_cached_repo').mockResolvedValueOnce({ repo_id: 'repo2', size_on_disk: 200 } as any);
+
+		const result = await cacheManagement.scan_cache_dir('/fake/dir');
+
+		expect(result.size_on_disk).toBe(300);
+		expect(result.repos.size).toBe(2);
+	});
+});
+
+describe('scan_cached_repo', () => {
+	test('should throw an error for invalid repo path', async () => {
+		await expect(() => {
+			return cacheManagement.scan_cached_repo('/fake/repo_path');
+		}).rejects.toThrow('Repo path is not a valid HuggingFace cache directory');
+	});
+
+	test('should return CachedRepoInfo for a valid repo', async () => {
+		const repoPath = '/fake/model--repo1';
+
+		vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as unknown as Stats);
+		vi.mocked(readdir).mockImplementationOnce(async () => {
+				return ['snapshot1', 'snapshot2'] as unknown as ReturnType<typeof readdir>
+			}
+		);
+		vi.spyOn(cacheManagement, 'scanSnapshotDir').mockResolvedValueOnce(undefined);
+
+		const result = await cacheManagement.scan_cached_repo(repoPath);
+
+		expect(result.repo_id).toBe('repo1');
+		expect(result.repo_type).toBe(cacheManagement.REPO_TYPE_T.MODEL);
+	});
+});
+
+
+
+describe('scanSnapshotDir', () => {
+	test('should scan a valid snapshot directory', async () => {
+		const cachedFiles = new Set();
+		const blobStats = new Map();
+		vi.mocked(readdir).mockResolvedValueOnce([{ name: 'file1', isDirectory: () => false }]);
+
+		vi.mocked(realpath).mockResolvedValueOnce('/fake/realpath');
+		vi.mocked(lstat).mockResolvedValueOnce({ size: 1024, atimeMs: Date.now(), mtimeMs: Date.now() } as any);
+
+		await cacheManagement.scanSnapshotDir('/fake/revision', cachedFiles, blobStats);
+
+		expect(cachedFiles.size).toBe(1);
+		expect(blobStats.size).toBe(1);
+	});
+});
+
+describe('getBlobStat', () => {
+	test('should retrieve blob stat if already cached', async () => {
+		const blobStats = new Map([['/fake/blob', { size: 1024 } as any]]);
+		const result = await cacheManagement.getBlobStat('/fake/blob', blobStats);
+
+		expect(result.size).toBe(1024);
+	});
+
+	test('should fetch and cache blob stat if not cached', async () => {
+		const blobStats = new Map();
+		vi.mocked(lstat).mockResolvedValueOnce({ size: 2048 } as any);
+
+		const result = await cacheManagement.getBlobStat('/fake/blob', blobStats);
+
+		expect(result.size).toBe(2048);
+		expect(blobStats.size).toBe(1);
+	});
+});
+
+describe('parseRepoType', () => {
+	test('should parse model repo type', () => {
+		expect(cacheManagement.parseRepoType('model')).toBe(cacheManagement.REPO_TYPE_T.MODEL);
+	});
+
+	test('should parse dataset repo type', () => {
+		expect(cacheManagement.parseRepoType('dataset')).toBe(cacheManagement.REPO_TYPE_T.DATASET);
+	});
+
+	test('should throw an error for invalid repo type', () => {
+		expect(() => cacheManagement.parseRepoType('invalid')).toThrow();
+	});
+});

--- a/packages/hub/src/lib/cache-management.ts
+++ b/packages/hub/src/lib/cache-management.ts
@@ -247,11 +247,10 @@ export async function getBlobStat(blobPath: string, blobStats: Map<string, Stats
 export function parseRepoType(type: string): RepoType {
 	switch (type) {
 		case "models":
-		case "model":
 			return "model";
-		case "dataset":
+		case "datasets":
 			return "dataset";
-		case "space":
+		case "spaces":
 			return "space";
 		default:
 			throw new TypeError(`Invalid repo type: ${type}`);

--- a/packages/hub/src/lib/cache-management.ts
+++ b/packages/hub/src/lib/cache-management.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { join, basename } from "node:path";
 import { stat, readdir, readFile, realpath, lstat } from "node:fs/promises";
 import type { Stats } from "node:fs";
-import type { RepoType } from "../types/public";
+import type { RepoType, RepoId } from "../types/public";
 
 function getDefaultHome(): string {
 	return join(homedir(), ".cache");
@@ -43,8 +43,7 @@ export interface CachedRevisionInfo {
 }
 
 export interface CachedRepoInfo {
-	repoId: string;
-	repoType: RepoType;
+	id: RepoId
 	path: string;
 	size: number;
 	filesCount: number;
@@ -179,8 +178,10 @@ export async function scanCachedRepo(repoPath: string): Promise<CachedRepoInfo> 
 
 	// Return the constructed CachedRepoInfo object
 	return {
-		repoId: repoId,
-		repoType: repoType,
+		id: {
+			name: repoId,
+			type: repoType,
+		},
 		path: repoPath,
 		filesCount: blobStats.size,
 		revisions: cachedRevisions,

--- a/packages/hub/src/lib/cache-management.ts
+++ b/packages/hub/src/lib/cache-management.ts
@@ -1,0 +1,252 @@
+import { homedir } from "node:os";
+import { join, basename } from "node:path";
+import { stat, readdir, readFile, realpath, lstat } from "node:fs/promises";
+import type { Stats } from "node:fs";
+
+const default_home = join(homedir(), ".cache");
+export const HF_HOME: string = process.env["HF_HOME"] ?? (
+	join(process.env["XDG_CACHE_HOME"] ?? default_home, "huggingface")
+);
+
+const default_cache_path = join(HF_HOME, "hub");
+
+// Legacy env variable
+export const HUGGINGFACE_HUB_CACHE = process.env['HUGGINGFACE_HUB_CACHE'] ?? default_cache_path;
+// New env variable
+export const HF_HUB_CACHE = process.env["HF_HUB_CACHE"] ?? HUGGINGFACE_HUB_CACHE;
+
+const FILES_TO_IGNORE: string[] = [".DS_Store"]
+
+export enum REPO_TYPE_T {
+	MODEL = "model",
+	DATASET = "dataset",
+	SPACE = "space",
+}
+
+export interface CachedFileInfo {
+	file_name: string
+	file_path: string
+	blob_path: string
+	size_on_disk: number
+
+	blob_last_accessed: number
+	blob_last_modified: number
+}
+
+export interface CachedRevisionInfo {
+	commit_hash: string
+	snapshot_path: string
+	size_on_disk: number
+	readonly files: Set<CachedFileInfo>
+	readonly refs: Set<string>
+
+	last_modified: number
+}
+
+export interface CachedRepoInfo {
+	repo_id: string
+	repo_type: REPO_TYPE_T
+	repo_path: string
+	size_on_disk: number
+	nb_files: number
+	readonly revisions: Set<CachedRevisionInfo>
+
+	last_accessed: number
+	last_modified: number
+}
+
+export interface HFCacheInfo {
+	size_on_disk: number
+	readonly repos: Set<CachedRepoInfo>
+	warnings: Error[]
+}
+
+export async function scan_cache_dir(cacheDir: string | undefined = undefined): Promise<HFCacheInfo> {
+	if (!cacheDir)
+		cacheDir = HF_HUB_CACHE
+
+	const s = await stat(cacheDir);
+	if(!s.isDirectory()) {
+		throw new Error("Scan cache expects a directory but found a file: {cache_dir}. Please use `cache_dir` argument or set `HF_HUB_CACHE` environment variable.")
+	}
+
+	const repos = new Set<CachedRepoInfo>();
+	const warnings: Error[] = [];
+
+	const directories = await readdir(cacheDir);
+	for (const repo of directories) {
+		// skip .locks folder
+		if(repo === ".locks") continue;
+
+		// get the absolute path of the repo
+		const absolute = join(cacheDir, repo);
+
+		// ignore non-directory element
+		const s = await stat(absolute);
+		if(!s.isDirectory()) {
+			continue;
+		}
+
+		try {
+			const cached = await scan_cached_repo(absolute);
+			repos.add(cached);
+		} catch (err: unknown) {
+			warnings.push(err as Error);
+		}
+	}
+
+	return {
+		repos: repos,
+		size_on_disk: [...repos.values()].reduce((sum, repo) => sum + repo.size_on_disk, 0),
+		warnings: warnings,
+	};
+}
+
+export async function scan_cached_repo(repo_path: string): Promise<CachedRepoInfo> {
+	// get the directory name
+	const name = basename(repo_path);
+	if(!name.includes('--')) {
+		throw new Error(`Repo path is not a valid HuggingFace cache directory: ${name}`);
+	}
+
+	// parse the repoId from directory name
+	const [type, ...remaining] = name.split('--');
+	const repoType = parseRepoType(type);
+	const repoId = remaining.join('/');
+
+	const snapshotsPath = join(repo_path, 'snapshots');
+	const refsPath = join(repo_path, 'refs');
+
+	const snapshotStat = await stat(snapshotsPath);
+	if(!snapshotStat.isDirectory()) {
+		throw new Error(`Snapshots dir doesn't exist in cached repo ${snapshotsPath}`);
+	}
+
+	// Check if the refs directory exists and scan it
+	const refsByHash: Map<string, Set<string>> = new Map();
+	const refsStat = await stat(refsPath);
+	if (refsStat.isDirectory()) {
+		await scanRefsDir(refsPath, refsByHash);
+	}
+
+	// Scan snapshots directory and collect cached revision information
+	const cachedRevisions: Set<CachedRevisionInfo> = new Set();
+	const blobStats: Map<string, Stats> = new Map(); // Store blob stats
+
+	const snapshotDirs = await readdir(snapshotsPath);
+	for (const dir of snapshotDirs) {
+		if (FILES_TO_IGNORE.includes(dir)) continue; // Ignore unwanted files
+
+		const revisionPath = join(snapshotsPath, dir);
+		const revisionStat = await stat(revisionPath);
+		if (!revisionStat.isDirectory()) {
+			throw new Error(`Snapshots folder corrupted. Found a file: ${revisionPath}`);
+		}
+
+		const cachedFiles: Set<CachedFileInfo> = new Set();
+		await scanSnapshotDir(revisionPath, cachedFiles, blobStats);
+
+		const revisionLastModified = cachedFiles.size > 0
+			? Math.max(...[...cachedFiles].map(file => file.blob_last_modified))
+			: revisionStat.mtimeMs;
+
+		cachedRevisions.add({
+			commit_hash: dir,
+			files: cachedFiles,
+			refs: refsByHash.get(dir) || new Set(),
+			size_on_disk: [...cachedFiles].reduce((sum, file) => sum + file.size_on_disk, 0),
+			snapshot_path: revisionPath,
+			last_modified: revisionLastModified
+		});
+
+		refsByHash.delete(dir);
+	}
+
+	// Verify that all refs refer to a valid revision
+	// TODO: not sure what this is ?????
+	if (refsByHash.size > 0) {
+		throw new Error(
+			`Reference(s) refer to missing commit hashes: ${JSON.stringify(Object.fromEntries(refsByHash))} (${repo_path})`
+		);
+	}
+
+	const repoStats = await stat(repo_path);
+	const repoLastAccessed = blobStats.size > 0
+		? Math.max(...[...blobStats.values()].map(stat => stat.atimeMs))
+		: repoStats.atimeMs;
+
+	const repoLastModified = blobStats.size > 0
+		? Math.max(...[...blobStats.values()].map(stat => stat.mtimeMs))
+		: repoStats.mtimeMs;
+
+	// Return the constructed CachedRepoInfo object
+	return {
+		repo_id: repoId,
+		repo_type: repoType,
+		repo_path: repo_path,
+		nb_files: blobStats.size,
+		revisions: cachedRevisions,
+		size_on_disk: [...blobStats.values()].reduce((sum, stat) => sum + stat.size, 0),
+		last_accessed: repoLastAccessed,
+		last_modified: repoLastModified
+	};
+}
+
+export async function scanRefsDir(refsPath: string, refsByHash: Map<string, Set<string>>): Promise<void> {
+	const refFiles = await readdir(refsPath, { withFileTypes: true });
+	for (const refFile of refFiles) {
+		const refFilePath = join(refsPath, refFile.name);
+		if (refFile.isDirectory()) continue; // Skip directories
+
+		const commitHash = await readFile(refFilePath, 'utf-8');
+		const refName = refFile.name;
+		if (!refsByHash.has(commitHash)) {
+			refsByHash.set(commitHash, new Set());
+		}
+		refsByHash.get(commitHash)?.add(refName);
+	}
+}
+
+export async function scanSnapshotDir(revisionPath: string, cachedFiles: Set<CachedFileInfo>, blobStats: Map<string, Stats>): Promise<void> {
+	const files = await readdir(revisionPath, { withFileTypes: true });
+	for (const file of files) {
+		if (file.isDirectory()) continue; // Skip directories
+
+		const filePath = join(revisionPath, file.name);
+		const blobPath = await realpath(filePath);
+		const blobStat = await getBlobStat(blobPath, blobStats);
+
+		cachedFiles.add({
+			file_name: file.name,
+			file_path: filePath,
+			blob_path: blobPath,
+			size_on_disk: blobStat.size,
+			blob_last_accessed: blobStat.atimeMs,
+			blob_last_modified: blobStat.mtimeMs
+		});
+	}
+}
+
+export async function getBlobStat(blobPath: string, blobStats: Map<string, Stats>): Promise<Stats> {
+	const blob = blobStats.get(blobPath);
+	if (!blob) {
+		const statResult = await lstat(blobPath);
+		blobStats.set(blobPath, statResult);
+		return statResult;
+	}
+	return blob;
+}
+
+export function parseRepoType(type: string): REPO_TYPE_T {
+	switch (type) {
+		case 'models':
+		case 'model':
+			return REPO_TYPE_T.MODEL;
+		case REPO_TYPE_T.DATASET:
+			return REPO_TYPE_T.DATASET;
+		case REPO_TYPE_T.SPACE:
+			return REPO_TYPE_T.SPACE;
+		default:
+			throw new Error('')
+	}
+}

--- a/packages/hub/src/lib/cache-management.ts
+++ b/packages/hub/src/lib/cache-management.ts
@@ -4,18 +4,17 @@ import { stat, readdir, readFile, realpath, lstat } from "node:fs/promises";
 import type { Stats } from "node:fs";
 
 const default_home = join(homedir(), ".cache");
-export const HF_HOME: string = process.env["HF_HOME"] ?? (
-	join(process.env["XDG_CACHE_HOME"] ?? default_home, "huggingface")
-);
+export const HF_HOME: string =
+	process.env["HF_HOME"] ?? join(process.env["XDG_CACHE_HOME"] ?? default_home, "huggingface");
 
 const default_cache_path = join(HF_HOME, "hub");
 
 // Legacy env variable
-export const HUGGINGFACE_HUB_CACHE = process.env['HUGGINGFACE_HUB_CACHE'] ?? default_cache_path;
+export const HUGGINGFACE_HUB_CACHE = process.env["HUGGINGFACE_HUB_CACHE"] ?? default_cache_path;
 // New env variable
 export const HF_HUB_CACHE = process.env["HF_HUB_CACHE"] ?? HUGGINGFACE_HUB_CACHE;
 
-const FILES_TO_IGNORE: string[] = [".DS_Store"]
+const FILES_TO_IGNORE: string[] = [".DS_Store"];
 
 export enum REPO_TYPE_T {
 	MODEL = "model",
@@ -24,50 +23,51 @@ export enum REPO_TYPE_T {
 }
 
 export interface CachedFileInfo {
-	file_name: string
-	file_path: string
-	blob_path: string
-	size_on_disk: number
+	file_name: string;
+	file_path: string;
+	blob_path: string;
+	size_on_disk: number;
 
-	blob_last_accessed: number
-	blob_last_modified: number
+	blob_last_accessed: number;
+	blob_last_modified: number;
 }
 
 export interface CachedRevisionInfo {
-	commit_hash: string
-	snapshot_path: string
-	size_on_disk: number
-	readonly files: Set<CachedFileInfo>
-	readonly refs: Set<string>
+	commit_hash: string;
+	snapshot_path: string;
+	size_on_disk: number;
+	readonly files: Set<CachedFileInfo>;
+	readonly refs: Set<string>;
 
-	last_modified: number
+	last_modified: number;
 }
 
 export interface CachedRepoInfo {
-	repo_id: string
-	repo_type: REPO_TYPE_T
-	repo_path: string
-	size_on_disk: number
-	nb_files: number
-	readonly revisions: Set<CachedRevisionInfo>
+	repo_id: string;
+	repo_type: REPO_TYPE_T;
+	repo_path: string;
+	size_on_disk: number;
+	nb_files: number;
+	readonly revisions: Set<CachedRevisionInfo>;
 
-	last_accessed: number
-	last_modified: number
+	last_accessed: number;
+	last_modified: number;
 }
 
 export interface HFCacheInfo {
-	size_on_disk: number
-	readonly repos: Set<CachedRepoInfo>
-	warnings: Error[]
+	size_on_disk: number;
+	readonly repos: Set<CachedRepoInfo>;
+	warnings: Error[];
 }
 
 export async function scan_cache_dir(cacheDir: string | undefined = undefined): Promise<HFCacheInfo> {
-	if (!cacheDir)
-		cacheDir = HF_HUB_CACHE
+	if (!cacheDir) cacheDir = HF_HUB_CACHE;
 
 	const s = await stat(cacheDir);
-	if(!s.isDirectory()) {
-		throw new Error("Scan cache expects a directory but found a file: {cache_dir}. Please use `cache_dir` argument or set `HF_HUB_CACHE` environment variable.")
+	if (!s.isDirectory()) {
+		throw new Error(
+			`Scan cache expects a directory but found a file: ${cacheDir}. Please use \`cacheDir\` argument or set \`HF_HUB_CACHE\` environment variable.`
+		);
 	}
 
 	const repos = new Set<CachedRepoInfo>();
@@ -76,14 +76,14 @@ export async function scan_cache_dir(cacheDir: string | undefined = undefined): 
 	const directories = await readdir(cacheDir);
 	for (const repo of directories) {
 		// skip .locks folder
-		if(repo === ".locks") continue;
+		if (repo === ".locks") continue;
 
 		// get the absolute path of the repo
 		const absolute = join(cacheDir, repo);
 
 		// ignore non-directory element
 		const s = await stat(absolute);
-		if(!s.isDirectory()) {
+		if (!s.isDirectory()) {
 			continue;
 		}
 
@@ -105,20 +105,20 @@ export async function scan_cache_dir(cacheDir: string | undefined = undefined): 
 export async function scan_cached_repo(repo_path: string): Promise<CachedRepoInfo> {
 	// get the directory name
 	const name = basename(repo_path);
-	if(!name.includes('--')) {
+	if (!name.includes("--")) {
 		throw new Error(`Repo path is not a valid HuggingFace cache directory: ${name}`);
 	}
 
 	// parse the repoId from directory name
-	const [type, ...remaining] = name.split('--');
+	const [type, ...remaining] = name.split("--");
 	const repoType = parseRepoType(type);
-	const repoId = remaining.join('/');
+	const repoId = remaining.join("/");
 
-	const snapshotsPath = join(repo_path, 'snapshots');
-	const refsPath = join(repo_path, 'refs');
+	const snapshotsPath = join(repo_path, "snapshots");
+	const refsPath = join(repo_path, "refs");
 
 	const snapshotStat = await stat(snapshotsPath);
-	if(!snapshotStat.isDirectory()) {
+	if (!snapshotStat.isDirectory()) {
 		throw new Error(`Snapshots dir doesn't exist in cached repo ${snapshotsPath}`);
 	}
 
@@ -146,9 +146,10 @@ export async function scan_cached_repo(repo_path: string): Promise<CachedRepoInf
 		const cachedFiles: Set<CachedFileInfo> = new Set();
 		await scanSnapshotDir(revisionPath, cachedFiles, blobStats);
 
-		const revisionLastModified = cachedFiles.size > 0
-			? Math.max(...[...cachedFiles].map(file => file.blob_last_modified))
-			: revisionStat.mtimeMs;
+		const revisionLastModified =
+			cachedFiles.size > 0
+				? Math.max(...[...cachedFiles].map((file) => file.blob_last_modified))
+				: revisionStat.mtimeMs;
 
 		cachedRevisions.add({
 			commit_hash: dir,
@@ -156,14 +157,13 @@ export async function scan_cached_repo(repo_path: string): Promise<CachedRepoInf
 			refs: refsByHash.get(dir) || new Set(),
 			size_on_disk: [...cachedFiles].reduce((sum, file) => sum + file.size_on_disk, 0),
 			snapshot_path: revisionPath,
-			last_modified: revisionLastModified
+			last_modified: revisionLastModified,
 		});
 
 		refsByHash.delete(dir);
 	}
 
 	// Verify that all refs refer to a valid revision
-	// TODO: not sure what this is ?????
 	if (refsByHash.size > 0) {
 		throw new Error(
 			`Reference(s) refer to missing commit hashes: ${JSON.stringify(Object.fromEntries(refsByHash))} (${repo_path})`
@@ -171,13 +171,11 @@ export async function scan_cached_repo(repo_path: string): Promise<CachedRepoInf
 	}
 
 	const repoStats = await stat(repo_path);
-	const repoLastAccessed = blobStats.size > 0
-		? Math.max(...[...blobStats.values()].map(stat => stat.atimeMs))
-		: repoStats.atimeMs;
+	const repoLastAccessed =
+		blobStats.size > 0 ? Math.max(...[...blobStats.values()].map((stat) => stat.atimeMs)) : repoStats.atimeMs;
 
-	const repoLastModified = blobStats.size > 0
-		? Math.max(...[...blobStats.values()].map(stat => stat.mtimeMs))
-		: repoStats.mtimeMs;
+	const repoLastModified =
+		blobStats.size > 0 ? Math.max(...[...blobStats.values()].map((stat) => stat.mtimeMs)) : repoStats.mtimeMs;
 
 	// Return the constructed CachedRepoInfo object
 	return {
@@ -188,7 +186,7 @@ export async function scan_cached_repo(repo_path: string): Promise<CachedRepoInf
 		revisions: cachedRevisions,
 		size_on_disk: [...blobStats.values()].reduce((sum, stat) => sum + stat.size, 0),
 		last_accessed: repoLastAccessed,
-		last_modified: repoLastModified
+		last_modified: repoLastModified,
 	};
 }
 
@@ -198,7 +196,7 @@ export async function scanRefsDir(refsPath: string, refsByHash: Map<string, Set<
 		const refFilePath = join(refsPath, refFile.name);
 		if (refFile.isDirectory()) continue; // Skip directories
 
-		const commitHash = await readFile(refFilePath, 'utf-8');
+		const commitHash = await readFile(refFilePath, "utf-8");
 		const refName = refFile.name;
 		if (!refsByHash.has(commitHash)) {
 			refsByHash.set(commitHash, new Set());
@@ -207,7 +205,11 @@ export async function scanRefsDir(refsPath: string, refsByHash: Map<string, Set<
 	}
 }
 
-export async function scanSnapshotDir(revisionPath: string, cachedFiles: Set<CachedFileInfo>, blobStats: Map<string, Stats>): Promise<void> {
+export async function scanSnapshotDir(
+	revisionPath: string,
+	cachedFiles: Set<CachedFileInfo>,
+	blobStats: Map<string, Stats>
+): Promise<void> {
 	const files = await readdir(revisionPath, { withFileTypes: true });
 	for (const file of files) {
 		if (file.isDirectory()) continue; // Skip directories
@@ -222,7 +224,7 @@ export async function scanSnapshotDir(revisionPath: string, cachedFiles: Set<Cac
 			blob_path: blobPath,
 			size_on_disk: blobStat.size,
 			blob_last_accessed: blobStat.atimeMs,
-			blob_last_modified: blobStat.mtimeMs
+			blob_last_modified: blobStat.mtimeMs,
 		});
 	}
 }
@@ -239,14 +241,14 @@ export async function getBlobStat(blobPath: string, blobStats: Map<string, Stats
 
 export function parseRepoType(type: string): REPO_TYPE_T {
 	switch (type) {
-		case 'models':
-		case 'model':
+		case "models":
+		case "model":
 			return REPO_TYPE_T.MODEL;
 		case REPO_TYPE_T.DATASET:
 			return REPO_TYPE_T.DATASET;
 		case REPO_TYPE_T.SPACE:
 			return REPO_TYPE_T.SPACE;
 		default:
-			throw new Error('')
+			throw new Error("");
 	}
 }

--- a/packages/hub/src/lib/cache-management.ts
+++ b/packages/hub/src/lib/cache-management.ts
@@ -28,8 +28,8 @@ export interface CachedFileInfo {
 	blobPath: string;
 	sizeOnDisk: number;
 
-	blobLastAccessed: number;
-	blobLastModified: number;
+	blobLastAccessedAt: Date;
+	blobLastModifiedAt: Date;
 }
 
 export interface CachedRevisionInfo {
@@ -148,7 +148,7 @@ export async function scanCachedRepo(repoPath: string): Promise<CachedRepoInfo> 
 
 		const revisionLastModified =
 			cachedFiles.length > 0
-				? Math.max(...[...cachedFiles].map((file) => file.blobLastModified))
+				? Math.max(...[...cachedFiles].map((file) => file.blobLastModifiedAt.getTime()))
 				: revisionStat.mtimeMs;
 
 		cachedRevisions.push({
@@ -223,8 +223,8 @@ export async function scanSnapshotDir(
 			filePath: filePath,
 			blobPath: blobPath,
 			sizeOnDisk: blobStat.size,
-			blobLastAccessed: blobStat.atimeMs,
-			blobLastModified: blobStat.mtimeMs,
+			blobLastAccessedAt: new Date(blobStat.atimeMs),
+			blobLastModifiedAt: new Date(blobStat.mtimeMs),
 		});
 	}
 }

--- a/packages/hub/src/lib/cache-management.ts
+++ b/packages/hub/src/lib/cache-management.ts
@@ -3,16 +3,21 @@ import { join, basename } from "node:path";
 import { stat, readdir, readFile, realpath, lstat } from "node:fs/promises";
 import type { Stats } from "node:fs";
 
-const default_home = join(homedir(), ".cache");
-export const HF_HOME: string =
-	process.env["HF_HOME"] ?? join(process.env["XDG_CACHE_HOME"] ?? default_home, "huggingface");
+function getDefaultHome(): string {
+	return join(homedir(), ".cache");
+}
 
-const default_cache_path = join(HF_HOME, "hub");
+function getDefaultCachePath(): string {
+	return process.env["HF_HOME"] ?? join(process.env["XDG_CACHE_HOME"] ?? getDefaultHome(), "huggingface")
+}
 
-// Legacy env variable
-export const HUGGINGFACE_HUB_CACHE = process.env["HUGGINGFACE_HUB_CACHE"] ?? default_cache_path;
-// New env variable
-export const HF_HUB_CACHE = process.env["HF_HUB_CACHE"] ?? HUGGINGFACE_HUB_CACHE;
+function getHuggingFaceHubCache(): string {
+	return  process.env["HUGGINGFACE_HUB_CACHE"] ?? getDefaultCachePath();
+}
+
+function getHFHubCache(): string {
+	return  process.env["HF_HUB_CACHE"] ?? getHuggingFaceHubCache();
+}
 
 const FILES_TO_IGNORE: string[] = [".DS_Store"];
 
@@ -61,7 +66,7 @@ export interface HFCacheInfo {
 }
 
 export async function scanCacheDir(cacheDir: string | undefined = undefined): Promise<HFCacheInfo> {
-	if (!cacheDir) cacheDir = HF_HUB_CACHE;
+	if (!cacheDir) cacheDir = getHFHubCache();
 
 	const s = await stat(cacheDir);
 	if (!s.isDirectory()) {

--- a/packages/hub/src/lib/index.ts
+++ b/packages/hub/src/lib/index.ts
@@ -1,3 +1,4 @@
+export * from "./cache-management";
 export * from "./commit";
 export * from "./count-commits";
 export * from "./create-repo";

--- a/packages/hub/vitest-browser.config.mts
+++ b/packages/hub/vitest-browser.config.mts
@@ -2,6 +2,6 @@ import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
-		exclude: [...configDefaults.exclude, "src/utils/FileBlob.spec.ts"],
+		exclude: [...configDefaults.exclude, "src/utils/FileBlob.spec.ts", "src/lib/cache-management.spec.ts"],
 	},
 });


### PR DESCRIPTION
## Description

Took https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/utils/_cache_manager.py as heavy inspiration for the implementation.

This is a very basic implementation, which do not cover the deletion.

## Related issue

Fixes https://github.com/huggingface/huggingface.js/issues/905

## Usage

```ts
import { scanCacheDir } from "@huggingface/hub";

const result = await scanCacheDir();
console.log(result);
```

