### PR TITLE
Add SoloAudio as lib for download stats 

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -590,8 +590,8 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "SoloAudio",
 		repoName: "SoloAudio",
 		repoUrl: "https://github.com/WangHelin1997/SoloAudio",
-		docsUrl: "https://github.com/WangHelin1997/SoloAudio",
-		snippets: snippets.soloaudio,
+		filter: false,
+		countDownloads: `path:"soloaudio_v2.pt"`,
 	},
 	"stable-baselines3": {
 		prettyLabel: "stable-baselines3",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -586,6 +586,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path:"cvlm_llama2_tokenizer/tokenizer.model"`,
 		snippets: snippets.seed_story,
 	},
+	soloaudio: {
+		prettyLabel: "SoloAudio",
+		repoName: "SoloAudio",
+		repoUrl: "https://github.com/WangHelin1997/SoloAudio",
+		docsUrl: "https://github.com/WangHelin1997/SoloAudio",
+		snippets: snippets.soloaudio,
+	},
 	"stable-baselines3": {
 		prettyLabel: "stable-baselines3",
 		repoName: "stable-baselines3",


### PR DESCRIPTION
Hi, I want to add the model [SoloAudio](https://github.com/WangHelin1997/SoloAudio) as a library for download stats. Thanks!
The huggingface repo is [https://huggingface.co/westbrook/SoloAudio](https://huggingface.co/westbrook/SoloAudio)