### PR TITLE
Add TRL to model filters

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -670,6 +670,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.transformersJS,
 		filter: true,
 	},
+	trl: {
+		prettyLabel: "TRL",
+		repoName: "trl",
+		repoUrl: "https://github.com/huggingface/trl",
+		docsUrl: "https://huggingface.co/docs/trl",
+		filter: true,
+	},
 	"unity-sentis": {
 		prettyLabel: "unity-sentis",
 		repoName: "unity-sentis",


### PR DESCRIPTION
This should add TRL to the model filters on the Hub:

![Screenshot 2024-09-23 at 10 37 23](https://github.com/user-attachments/assets/73bb88e6-9245-4a8e-86ad-51fc7d5d841c)
