### PR TITLE
Added CoTracker for download stats

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -715,6 +715,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path:"model_vae_fp16.pt"`,
 		snippets: snippets.threedtopia_xl,
 	},
+	cotracker: {
+		prettyLabel: "cotracker",
+		repoName: "cotracker",
+		repoUrl: "https://github.com/facebookresearch/co-tracker",
+		filter: false,
+		countDownloads: `path_extension:"pt"`,
+	},
 } satisfies Record<string, LibraryUiElement>;
 
 export type ModelLibraryKey = keyof typeof MODEL_LIBRARIES_UI_ELEMENTS;

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -204,6 +204,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/cartesia-ai/cartesia_mlx",
 		snippets: snippets.cartesia_mlx,
 	},
+	cotracker: {
+		prettyLabel: "CoTracker",
+		repoName: "CoTracker",
+		repoUrl: "https://github.com/facebookresearch/co-tracker",
+		filter: false,
+		countDownloads: `path_extension:"pth"`,
+	},
 	edsnlp: {
 		prettyLabel: "EDS-NLP",
 		repoName: "edsnlp",
@@ -714,13 +721,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"model_vae_fp16.pt"`,
 		snippets: snippets.threedtopia_xl,
-	},
-	cotracker: {
-		prettyLabel: "CoTracker",
-		repoName: "CoTracker",
-		repoUrl: "https://github.com/facebookresearch/co-tracker",
-		filter: false,
-		countDownloads: `path_extension:"pt"`,
 	},
 } satisfies Record<string, LibraryUiElement>;
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -716,8 +716,8 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.threedtopia_xl,
 	},
 	cotracker: {
-		prettyLabel: "cotracker",
-		repoName: "cotracker",
+		prettyLabel: "CoTracker",
+		repoName: "CoTracker",
 		repoUrl: "https://github.com/facebookresearch/co-tracker",
 		filter: false,
 		countDownloads: `path_extension:"pt"`,


### PR DESCRIPTION
Hey! 

Thanks for the amazing library :) 

We are hosting CoTracker model checkpoint [here](https://huggingface.co/facebook/cotracker/tree/main) and would like to see the download count. This PR follows [this one](https://github.com/huggingface/huggingface.js/pull/561/files) to enable it. 

Hope it's correct way to do it, let me know if any changes are needed or there is a better way to do so. 

