### PR TITLE
[`integration`] Add Model2Vec as a library on the Hub

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -955,7 +955,7 @@ export const model2vec = (model: ModelData): string[] => [
 	`from model2vec import StaticModel
 
 model = StaticModel.from_pretrained("${model.id}")`,
-]
+];
 
 export const nemo = (model: ModelData): string[] => {
 	let command: string[] | undefined = undefined;

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -951,6 +951,12 @@ export const mlxim = (model: ModelData): string[] => [
 model = create_model(${model.id})`,
 ];
 
+export const model2vec = (model: ModelData): string[] => [
+	`from model2vec import StaticModel
+
+model = StaticModel.from_pretrained("${model.id}")`,
+]
+
 export const nemo = (model: ModelData): string[] => {
 	let command: string[] | undefined = undefined;
 	// Resolve the tag to a nemo domain/sub-domain

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -412,7 +412,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/MinishLab/model2vec",
 		snippets: snippets.model2vec,
 		filter: false,
-		countDownloads: `path_extension:"safetensors"`,
 	},
 	moshi: {
 		prettyLabel: "Moshi",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -406,6 +406,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"mlc-chat-config.json"`,
 	},
+	model2vec: {
+		prettyLabel: "Model2Vec",
+		repoName: "model2vec",
+		repoUrl: "https://github.com/MinishLab/model2vec",
+		snippets: snippets.model2vec,
+		filter: false,
+		countDownloads: `path_extension:"safetensors"`,
+	},
 	moshi: {
 		prettyLabel: "Moshi",
 		repoName: "Moshi",


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add Model2Vec as a library on the Hub
  * Including snippet

## Links
* Repository: https://github.com/MinishLab/model2vec
* Models: https://huggingface.co/models?library=model2vec

## Details
A Sentence Transformers integration is planned. Once released, I'll add a second snippet on how to load the model with Sentence Transformers. 

- Tom Aarsen