### PR TITLE
[Tasks] Rename `generate` property in task specs

### DIFF
--- a/packages/tasks/src/tasks/automatic-speech-recognition/inference.ts
+++ b/packages/tasks/src/tasks/automatic-speech-recognition/inference.ts
@@ -29,7 +29,7 @@ export interface AutomaticSpeechRecognitionParameters {
 	/**
 	 * Parametrization of the text generation process
 	 */
-	generate?: GenerationParameters;
+	generation_parameters?: GenerationParameters;
 	/**
 	 * Whether to output corresponding timestamps with the generated text
 	 */

--- a/packages/tasks/src/tasks/automatic-speech-recognition/spec/input.json
+++ b/packages/tasks/src/tasks/automatic-speech-recognition/spec/input.json
@@ -24,7 +24,7 @@
 					"type": "boolean",
 					"description": "Whether to output corresponding timestamps with the generated text"
 				},
-				"generate": {
+				"generation_parameters": {
 					"description": "Parametrization of the text generation process",
 					"$ref": "/inference/schemas/common-definitions.json#/definitions/GenerationParameters"
 				}

--- a/packages/tasks/src/tasks/image-to-text/inference.ts
+++ b/packages/tasks/src/tasks/image-to-text/inference.ts
@@ -28,7 +28,7 @@ export interface ImageToTextParameters {
 	/**
 	 * Parametrization of the text generation process
 	 */
-	generate?: GenerationParameters;
+	generation_parameters?: GenerationParameters;
 	/**
 	 * The amount of maximum tokens to generate.
 	 */

--- a/packages/tasks/src/tasks/image-to-text/spec/input.json
+++ b/packages/tasks/src/tasks/image-to-text/spec/input.json
@@ -23,7 +23,7 @@
 					"type": "integer",
 					"description": "The amount of maximum tokens to generate."
 				},
-				"generate": {
+				"generation_parameters": {
 					"description": "Parametrization of the text generation process",
 					"$ref": "/inference/schemas/common-definitions.json#/definitions/GenerationParameters"
 				}

--- a/packages/tasks/src/tasks/text-to-audio/inference.ts
+++ b/packages/tasks/src/tasks/text-to-audio/inference.ts
@@ -28,7 +28,7 @@ export interface TextToAudioParameters {
 	/**
 	 * Parametrization of the text generation process
 	 */
-	generate?: GenerationParameters;
+	generation_parameters?: GenerationParameters;
 	[property: string]: unknown;
 }
 

--- a/packages/tasks/src/tasks/text-to-audio/spec/input.json
+++ b/packages/tasks/src/tasks/text-to-audio/spec/input.json
@@ -20,7 +20,7 @@
 			"description": "Additional inference parameters for Text To Audio",
 			"type": "object",
 			"properties": {
-				"generate": {
+				"generation_parameters": {
 					"description": "Parametrization of the text generation process",
 					"$ref": "/inference/schemas/common-definitions.json#/definitions/GenerationParameters"
 				}

--- a/packages/tasks/src/tasks/text-to-speech/inference.ts
+++ b/packages/tasks/src/tasks/text-to-speech/inference.ts
@@ -28,7 +28,7 @@ export interface TextToSpeechParameters {
 	/**
 	 * Parametrization of the text generation process
 	 */
-	generate?: GenerationParameters;
+	generation_parameters?: GenerationParameters;
 	[property: string]: unknown;
 }
 

--- a/packages/tasks/src/tasks/text-to-speech/spec/input.json
+++ b/packages/tasks/src/tasks/text-to-speech/spec/input.json
@@ -20,7 +20,7 @@
 			"description": "Additional inference parameters for Text To Speech",
 			"type": "object",
 			"properties": {
-				"generate": {
+				"generation_parameters": {
 					"description": "Parametrization of the text generation process",
 					"$ref": "/inference/schemas/common-definitions.json#/definitions/GenerationParameters"
 				}


### PR DESCRIPTION
Fixes #923 

This PR updates the task specs to rename the `generate` property to `generation_parameters`. This change aligns with the discussion in the issue.

Key changes: 
- Renamed `generate` to `generation_parameters` in the specs for `automatic-speech-recognition`, `image-to-text`,  `text-to-audio` and `text-to-speech` tasks.