### PR TITLE
Add IMS Toucan to model-libraries.ts

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -305,7 +305,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "IMS Toucan",
 		repoName: "IMS-Toucan",
 		repoUrl: "https://github.com/DigitalPhonetics/IMS-Toucan",
-		countDownloads: `path_extension:"pt"`,
+		countDownloads: `path:"embedding_gan.pt" OR path:"Vocoder.pt", OR path:"ToucanTTS.pt"`,
 	},
 	keras: {
 		prettyLabel: "Keras",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -305,7 +305,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "IMS Toucan",
 		repoName: "IMS-Toucan",
 		repoUrl: "https://github.com/DigitalPhonetics/IMS-Toucan",
-		countDownloads: `path:"embedding_gan.pt" OR path:"Vocoder.pt", OR path:"ToucanTTS.pt"`,
+		countDownloads: `path:"embedding_gan.pt" OR path:"Vocoder.pt" OR path:"ToucanTTS.pt"`,
 	},
 	keras: {
 		prettyLabel: "Keras",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -301,6 +301,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/Tencent/HunyuanDiT",
 		countDownloads: `path:"pytorch_model_ema.pt" OR path:"pytorch_model_distill.pt"`,
 	},
+	imstoucan: {
+		prettyLabel: IMS Toucan",
+		repoName: "IMS-Toucan",
+		repoUrl: "https://github.com/DigitalPhonetics/IMS-Toucan",
+		countDownloads: `path_extension:"pt"`,
+	},
 	keras: {
 		prettyLabel: "Keras",
 		repoName: "Keras",
@@ -660,12 +666,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.timm,
 		filter: true,
 		countDownloads: `path:"pytorch_model.bin" OR path:"model.safetensors"`,
-	},
-	imstoucan: {
-		prettyLabel: IMS-Toucan",
-		repoName: "IMS-Toucan",
-		repoUrl: "https://github.com/DigitalPhonetics/IMS-Toucan",
-		countDownloads: `path_extension:"pt"`,
 	},
 	transformers: {
 		prettyLabel: "Transformers",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -302,7 +302,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path:"pytorch_model_ema.pt" OR path:"pytorch_model_distill.pt"`,
 	},
 	imstoucan: {
-		prettyLabel: IMS Toucan",
+		prettyLabel: "IMS Toucan",
 		repoName: "IMS-Toucan",
 		repoUrl: "https://github.com/DigitalPhonetics/IMS-Toucan",
 		countDownloads: `path_extension:"pt"`,

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -661,6 +661,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: true,
 		countDownloads: `path:"pytorch_model.bin" OR path:"model.safetensors"`,
 	},
+	imstoucan: {
+		prettyLabel: IMS-Toucan",
+		repoName: "IMS-Toucan",
+		repoUrl: "https://github.com/DigitalPhonetics/IMS-Toucan",
+		countDownloads: `path_extension:"pt"`,
+	},
 	transformers: {
 		prettyLabel: "Transformers",
 		repoName: "🤗/transformers",


### PR DESCRIPTION
We have moved the models needed to run our TTS toolkit to the hub. We would like to track the downloads, therefore this PR adds IMS Toucan and specifies countDownloads to track our .pt files.