### PR TITLE
[integration] Add `hezar` to libraries and snippets

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1032,4 +1032,12 @@ export const threedtopia_xl = (model: ModelData): string[] => [
 model = threedtopia_xl.from_pretrained("${model.id}")
 model.generate(cond="path/to/image.png")`,
 ];
+
+export const hezar = (model: ModelData): string[] => [
+	`# !pip install hezar
+from hezar import Model
+
+model = Model.load("${model.id}")
+outputs = model.predict("a valid input based on modality (text, path, array, etc.)")`,
+];
 //#endregion

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1034,10 +1034,8 @@ model.generate(cond="path/to/image.png")`,
 ];
 
 export const hezar = (model: ModelData): string[] => [
-	`# !pip install hezar
-from hezar import Model
+	`from hezar import Model
 
-model = Model.load("${model.id}")
-outputs = model.predict("a valid input based on modality (text, path, array, etc.)")`,
+model = Model.load("${model.id}")`,
 ];
 //#endregion

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -295,6 +295,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/fudan-generative-vision/hallo",
 		countDownloads: `path:"hallo/net.pth"`,
 	},
+	hezar: {
+		prettyLabel: "Hezar",
+		repoName: "Hezar",
+		repoUrl: "https://github.com/hezarai/hezar",
+		docsUrl: "https://hezarai.github.io/hezar",
+		countDownloads: `path:"model.pt" OR path:"model_config.yaml" OR path:"embedding/embedding_config.yaml"`,
+	},
 	"hunyuan-dit": {
 		prettyLabel: "HunyuanDiT",
 		repoName: "HunyuanDiT",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -300,7 +300,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "Hezar",
 		repoUrl: "https://github.com/hezarai/hezar",
 		docsUrl: "https://hezarai.github.io/hezar",
-		countDownloads: `path:"model.pt" OR path:"model_config.yaml" OR path:"embedding/embedding_config.yaml"`,
+		countDownloads: `path:"model_config.yaml" OR path:"embedding/embedding_config.yaml"`,
 	},
 	"hunyuan-dit": {
 		prettyLabel: "HunyuanDiT",


### PR DESCRIPTION
This PR adds integration for `hezar` mainly for download stats and supporting code snippets for the models built with this library. This library currently has 30 models and 10 datasets with 70K installs and counting. This library has been around for a year now and since our users requested this a lot, we decided to add this integration for convenience.

Library repo: https://github.com/hezarai/hezar
Creator: @arxyzan

Let me know if this PR conforms to the necessary guidelines. Thank you guys ;)
