### PR TITLE
Add "trust_remote_code" to Sentence Transformer snippets

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -678,11 +678,15 @@ export const sampleFactory = (model: ModelData): string[] => [
 	`python -m sample_factory.huggingface.load_from_hub -r ${model.id} -d ./train_dir`,
 ];
 
-export const sentenceTransformers = (model: ModelData): string[] => [
-	`from sentence_transformers import SentenceTransformer
+export const sentenceTransformers = (model: ModelData): string[] => {
+	const remote_code_snippet = model.tags.includes(TAG_CUSTOM_CODE) ? ", trust_remote_code=True" : "";
 
-model = SentenceTransformer("${model.id}")`,
-];
+	return [
+		`from sentence_transformers import SentenceTransformer
+
+model = SentenceTransformer("${model.id}"${remote_code_snippet})`,
+	];
+};
 
 export const setfit = (model: ModelData): string[] => [
 	`from setfit import SetFitModel


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add "trust_remote_code" to Sentence Transformer snippets

## Details
The `SentenceTransformer` class supports the `trust_remote_code` argument, so let's take advantage of it.
I didn't test it with `moon-landing`, etc.

Some examples where this would be used:
* https://huggingface.co/nomic-ai/nomic-embed-text-v1.5
* https://huggingface.co/jinaai/jina-embeddings-v3

---

- Tom Aarsen