### PR TITLE
[Python snippets] map `snippetConversationalWithImage`

### DIFF
--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -155,6 +155,7 @@ export const pythonSnippets: Partial<Record<PipelineType, (model: ModelDataMinim
 	"feature-extraction": snippetBasic,
 	"text-generation": snippetBasic,
 	"text2text-generation": snippetBasic,
+	"image-text-to-text": snippetConversationalWithImage,
 	"fill-mask": snippetBasic,
 	"sentence-similarity": snippetBasic,
 	"automatic-speech-recognition": snippetFile,


### PR DESCRIPTION
Follow up to #927

python equavalent of https://github.com/huggingface/huggingface.js/blob/1bb5b31131c6990547087d91aebda2361e91dfad/packages/tasks/src/snippets/js.ts#L188


Because of this missing line, user does not see `python` amongst the options in the[ inference snippet](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct?inference_api=true) 
<img width="995" alt="image" src="https://github.com/user-attachments/assets/2237ca48-0b90-4c68-8beb-60ecdbbb0b86">
