### PR TITLE
[Tasks] Fix undefined `model.tags` check in tasks snippets

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -788,11 +788,11 @@ export const transformers = (model: ModelData): string[] => {
 	if (model.pipeline_tag && LIBRARY_TASK_MAPPING.transformers?.includes(model.pipeline_tag)) {
 		const pipelineSnippet = ["# Use a pipeline as a high-level helper", "from transformers import pipeline", ""];
 
-		if (model.tags.includes("conversational") && model.config?.tokenizer_config?.chat_template) {
+		if (model.tags?.includes("conversational") && model.config?.tokenizer_config?.chat_template) {
 			pipelineSnippet.push("messages = [", '    {"role": "user", "content": "Who are you?"},', "]");
 		}
 		pipelineSnippet.push(`pipe = pipeline("${model.pipeline_tag}", model="${model.id}"` + remote_code_snippet + ")");
-		if (model.tags.includes("conversational") && model.config?.tokenizer_config?.chat_template) {
+		if (model.tags?.includes("conversational") && model.config?.tokenizer_config?.chat_template) {
 			pipelineSnippet.push("pipe(messages)");
 		}
 

--- a/packages/tasks/src/snippets/curl.ts
+++ b/packages/tasks/src/snippets/curl.ts
@@ -10,7 +10,7 @@ export const snippetBasic = (model: ModelDataMinimal, accessToken: string): stri
 	-H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}"`;
 
 export const snippetTextGeneration = (model: ModelDataMinimal, accessToken: string): string => {
-	if (model.tags.includes("conversational")) {
+	if (model.tags?.includes("conversational")) {
 		// Conversational model detected, so we display a code snippet that features the Messages API
 		return `curl 'https://api-inference.huggingface.co/models/${model.id}/v1/chat/completions' \\
 -H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}" \\
@@ -28,7 +28,7 @@ export const snippetTextGeneration = (model: ModelDataMinimal, accessToken: stri
 };
 
 export const snippetImageTextToTextGeneration = (model: ModelDataMinimal, accessToken: string): string => {
-	if (model.tags.includes("conversational")) {
+	if (model.tags?.includes("conversational")) {
 		// Conversational model detected, so we display a code snippet that features the Messages API
 		return `curl 'https://api-inference.huggingface.co/models/${model.id}/v1/chat/completions' \\
 -H "Authorization: Bearer ${accessToken || `{API_TOKEN}`}" \\

--- a/packages/tasks/src/snippets/js.ts
+++ b/packages/tasks/src/snippets/js.ts
@@ -24,7 +24,7 @@ query({"inputs": ${getModelInputSnippet(model)}}).then((response) => {
 });`;
 
 export const snippetTextGeneration = (model: ModelDataMinimal, accessToken: string): string => {
-	if (model.tags.includes("conversational")) {
+	if (model.tags?.includes("conversational")) {
 		// Conversational model detected, so we display a code snippet that features the Messages API
 		return `import { HfInference } from "@huggingface/inference";
 
@@ -43,7 +43,7 @@ for await (const chunk of inference.chatCompletionStream({
 };
 
 export const snippetImageTextToTextGeneration = (model: ModelDataMinimal, accessToken: string): string => {
-	if (model.tags.includes("conversational")) {
+	if (model.tags?.includes("conversational")) {
 		// Conversational model detected, so we display a code snippet that features the Messages API
 		return `import { HfInference } from "@huggingface/inference";
 

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -175,10 +175,10 @@ export const pythonSnippets: Partial<Record<PipelineType, (model: ModelDataMinim
 };
 
 export function getPythonInferenceSnippet(model: ModelDataMinimal, accessToken: string): string {
-	if (model.pipeline_tag === "text-generation" && model.tags.includes("conversational")) {
+	if (model.pipeline_tag === "text-generation" && model.tags?.includes("conversational")) {
 		// Conversational model detected, so we display a code snippet that features the Messages API
 		return snippetConversational(model, accessToken);
-	} else if (model.pipeline_tag === "image-text-to-text" && model.tags.includes("conversational")) {
+	} else if (model.pipeline_tag === "image-text-to-text" && model.tags?.includes("conversational")) {
 		// Example sending an image to the Message API
 		return snippetConversationalWithImage(model, accessToken);
 	} else {


### PR DESCRIPTION
this PR fixes a small bug when getting the task snippets to generate the inference API docs in  [hub-docs/scripts/api-inference/scripts/generate.ts](https://github.com/huggingface/hub-docs/blob/main/scripts/api-inference/scripts/generate.ts). when generating the documentation with the latest version of `huggingface/tasks`, I got the following error:
```
if (model.tags.includes("conversational")) {
                 ^
TypeError: Cannot read properties of undefined (reading 'includes')
```

Changes made:
- added optional chaining operator to the `model.tags` check in the snippets.