### PR TITLE
:sparkle: FEAT(local-apps): add ComfyUI LocalApp

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -545,6 +545,15 @@ export const LOCAL_APPS = {
 		displayOnModelPage: (model) => isLlamaCppGgufModel(model) || isAmdRyzenModel(model),
 		snippet: snippetLemonade,
 	},
+	comfyui: {
+		prettyLabel: "ComfyUI",
+		docsUrl: "https://docs.comfy.org/get_started/introduction",
+		mainTask: "text-to-image",
+		displayOnModelPage: (model: ModelData) =>
+			(isGgufModel(model) || (isTransformersModel(model) && model.tags.includes("safetensors"))) &&
+			model.tags.includes("text-to-image"),
+		deeplink: (model) => new URL(`https://huggingface.co/${model.id}`),
+	},
 } satisfies Record<string, LocalApp>;
 
 export type LocalAppKey = keyof typeof LOCAL_APPS;


### PR DESCRIPTION
Closes #855

RE: the discussion in :arrow_up: - to the best of of my knowledge there's no way to ask vanilla Comfy[1] to d/l a model for you; it's completely manual

Related to above: `deeplink` is almost certainly incorrect, but 1) the local type checker was very pissed about it **not** being present 2) I don't know the HF API well enough to know what to put there.

Apologies for no local verification/testing; I'm not a TS person, and it would take me longer to figure out/set up than it took me to write the code :grin: 

[1] There are probably 3rd-party nodes to do so, but it's more likely that such a thing would build a list of its own in some way 