### PR TITLE
[vLLM Snippet] Fix escaping

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -145,8 +145,8 @@ const snippetLocalAI = (model: ModelData, filepath?: string): LocalAppSnippet[] 
 const snippetVllm = (model: ModelData): LocalAppSnippet[] => {
 	const runCommand = [
 		"# Call the server using curl:",
-		`curl -X POST "http://localhost:8000/v1/chat/completions" \\ `,
-		`	-H "Content-Type: application/json" \\ `,
+		`curl -X POST "http://localhost:8000/v1/chat/completions" \\`,
+		`	-H "Content-Type: application/json" \\`,
 		`	--data '{`,
 		`		"model": "${model.id}",`,
 		`		"messages": [`,


### PR DESCRIPTION
Follow up to https://github.com/huggingface/huggingface.js/issues/693

There was trailing space in vlmm snippet which made the snippet unusable. When you try the snippet, vllm server would respond with error:
```
mishig@machine:~$ # Call the server using curl:
curl -X POST "http://localhost:8000/v1/chat/completions" \ 
        -H "Content-Type: application/json" \ 
        --data '{
                "model": "meta-llama/Llama-3.2-3B-Instruct",
                "messages": [
                        {"role": "user", "content": "Hello!"}
                ]
        }'

{"object":"error","message":"[{'type': 'missing', 'loc': ('body',), 'msg': 'Field required', 'input': None}]","type":"BadRequestError","param":null,"code":400}curl: (3) URL using bad/illegal format or missing URL
-H: command not found
--data: command not found
mishig@machine:~$ 
```

Explanation:  trailing space was breaking the escaping
