### PR TITLE
[Tasks] Add `Llama-3.2-11B-Vision-Instruct` as the first recommended model for `image-text-to-text`

### DIFF
--- a/packages/tasks/src/tasks/image-text-to-text/data.ts
+++ b/packages/tasks/src/tasks/image-text-to-text/data.ts
@@ -47,10 +47,6 @@ const taskData: TaskDataCustom = {
 			id: "meta-llama/Llama-3.2-11B-Vision-Instruct",
 		},
 		{
-			description: "Cutting-edge vision language model that can take multiple image inputs.",
-			id: "facebook/chameleon-7b",
-		},
-		{
 			description: "Cutting-edge conversational vision language model that can take multiple image inputs.",
 			id: "HuggingFaceM4/idefics2-8b-chatty",
 		},

--- a/packages/tasks/src/tasks/image-text-to-text/data.ts
+++ b/packages/tasks/src/tasks/image-text-to-text/data.ts
@@ -43,6 +43,10 @@ const taskData: TaskDataCustom = {
 	metrics: [],
 	models: [
 		{
+			description: "Powerful vision language model with great visual understanding and reasoning capabilities.",
+			id: "meta-llama/Llama-3.2-11B-Vision-Instruct",
+		},
+		{
 			description: "Cutting-edge vision language model that can take multiple image inputs.",
 			id: "facebook/chameleon-7b",
 		},


### PR DESCRIPTION
This PR is a proposition to add `meta-llama/Llama-3.2-11B-Vision-Instruct` as the first recommended model for [`image-text-to-text`](https://huggingface.co/tasks/image-text-to-text) task. 
This would be nice to have, as we also want to show in the [Inference API documentation](https://huggingface.co/docs/api-inference/index) how to perform inference with this model, since it's both supported by TGI and it's a popular conversational VLM.

Feel free to suggest a better description or another ranking for this model.

cc @merveenoyan @osanseviero 