### PR TITLE
[vLLM] metadata script

### DIFF
--- a/.github/workflows/vllm-metadata.yml
+++ b/.github/workflows/vllm-metadata.yml
@@ -1,0 +1,89 @@
+# Step1: scrape https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/registry.py
+# Step2: upload to https://huggingface.co/datasets/huggingface/vllm-metadata
+name: Daily vLLM Metadata Scraper
+
+on:
+  schedule:
+    # Runs at 00:00 UTC every day
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  run-python-script:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests huggingface-hub
+
+      - name: Execute Python script
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          python -c '
+          import os
+          import ast
+          import json
+          import requests
+          from huggingface_hub import HfApi
+
+          def extract_models_sub_dict(parsed_code, sub_dict_name):
+              class MODELS_SUB_LIST_VISITOR(ast.NodeVisitor):
+                  def __init__(self):
+                      self.key = sub_dict_name
+                      self.value = None
+                  
+                  def visit_Assign(self, node):
+                      for target in node.targets:
+                          if isinstance(target, ast.Name) and target.id == self.key:
+                              self.value = ast.literal_eval(node.value)  
+              
+              visitor = MODELS_SUB_LIST_VISITOR()
+              visitor.visit(parsed_code)
+              return visitor.value
+
+          def extract_models_dict(source_code):
+              parsed_code = ast.parse(source_code)
+              class MODELS_LIST_VISITOR(ast.NodeVisitor):
+                  def __init__(self):
+                      self.key = "_MODELS"
+                      self.value = {}
+                  def visit_Assign(self, node):
+                      for target in node.targets:
+                          if not isinstance(target, ast.Name):
+                              return
+                          if target.id == self.key:
+                              for value in node.value.values:
+                                  dict = extract_models_sub_dict(parsed_code, value.id)
+                                  self.value.update(dict)
+              visitor = MODELS_LIST_VISITOR()
+              visitor.visit(parsed_code)
+              return visitor.value
+
+          url = "https://raw.githubusercontent.com/vllm-project/vllm/refs/heads/main/vllm/model_executor/models/registry.py"
+          response = requests.get(url)
+          response.raise_for_status()  # Raise an exception for bad status codes
+          source_code = response.text
+
+          models_dict = extract_models_dict(source_code)
+          architectures = [item for tup in models_dict.values() for item in tup]
+          architectures_json_str = json.dumps(architectures, indent=4)
+          json_bytes = architectures_json_str.encode("utf-8")
+
+          api = HfApi(token=os.environ["HF_VLLM_METADATA_PUSH"])
+          api.upload_file(
+              path_or_fileobj=json_bytes,
+              path_in_repo="architectures.json",
+              repo_id="huggingface/vllm-metadata",
+              repo_type="dataset",
+          )'

--- a/.github/workflows/vllm-metadata.yml
+++ b/.github/workflows/vllm-metadata.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Execute Python script
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_VLLM_METADATA_PUSH: ${{ secrets.HF_VLLM_METADATA_PUSH }}
         run: |
           python -c '
           import os


### PR DESCRIPTION
Follow up to https://github.com/huggingface/huggingface.js/pull/957. To precisely show [vLLM snippet](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct?local-app=vllm) on [HF models](https://huggingface.co/models), we need to have record on which models are supported by vLLM. vLLM provides supported models list: [doc page](https://docs.vllm.ai/en/latest/models/supported_models.html), [python src](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/registry.py#L20).

<img width="400" alt="image" src="https://github.com/user-attachments/assets/dd3ee7bb-c51c-44f3-be21-f5f127a4f965">

This PR creates a github cron job (runs once a day) script that:
1. parses [python src](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/registry.py#L20) through AST to extract supported architectures list (both for transformers & ggml/llama.cpp styles)
2. uploads the result to [huggingface/vllm-metadata](https://huggingface.co/datasets/huggingface/vllm-metadata). You can see working example [here](https://huggingface.co/datasets/mishig/test-vllm/blob/main/archtiectures.json). 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/7d00fc8a-d2ed-46ac-92cc-3b7351fe50fd">

3. [HF models](https://huggingface.co/models) will use this list to whether show or not show vLLM snippet.

Find the python script here: [get_vlmm_metadata.py.zip](https://github.com/user-attachments/files/17293079/get_vlmm_metadata.py.zip) _(you can locally test run if you want)_.
