### PR TITLE
Amend spec for token classification

### DIFF
--- a/packages/tasks/src/tasks/token-classification/inference.ts
+++ b/packages/tasks/src/tasks/token-classification/inference.ts
@@ -60,12 +60,15 @@ export interface TokenClassificationOutputElement {
 	/**
 	 * The character position in the input where this group ends.
 	 */
-	end?: number;
+	end: number;
 	/**
 	 * The predicted label for that group of tokens
 	 */
 	entity_group?: string;
-	label: unknown;
+	/**
+	 * The predicted label for a single token
+	 */
+	entity?: string;
 	/**
 	 * The associated score / probability
 	 */
@@ -73,10 +76,10 @@ export interface TokenClassificationOutputElement {
 	/**
 	 * The character position in the input where this group begins.
 	 */
-	start?: number;
+	start: number;
 	/**
 	 * The corresponding text
 	 */
-	word?: string;
+	word: string;
 	[property: string]: unknown;
 }

--- a/packages/tasks/src/tasks/token-classification/inference.ts
+++ b/packages/tasks/src/tasks/token-classification/inference.ts
@@ -62,13 +62,13 @@ export interface TokenClassificationOutputElement {
 	 */
 	end: number;
 	/**
-	 * The predicted label for that group of tokens
-	 */
-	entity_group?: string;
-	/**
 	 * The predicted label for a single token
 	 */
 	entity?: string;
+	/**
+	 * The predicted label for a group of one or more tokens
+	 */
+	entity_group?: string;
 	/**
 	 * The associated score / probability
 	 */

--- a/packages/tasks/src/tasks/token-classification/spec/output.json
+++ b/packages/tasks/src/tasks/token-classification/spec/output.json
@@ -9,7 +9,11 @@
 		"properties": {
 			"entity_group": {
 				"type": "string",
-				"description": "The predicted label for that group of tokens"
+				"description": "The predicted label for a group of one or more tokens"
+			},
+			"entity": {
+				"type": "string",
+				"description": "The predicted label for a single token"
 			},
 			"score": {
 				"type": "number",
@@ -28,6 +32,6 @@
 				"description": "The character position in the input where this group ends."
 			}
 		},
-		"required": ["label", "score"]
+		"required": ["score", "word", "start", "end"]
 	}
 }


### PR DESCRIPTION
This PR makes a few changes to the spec for `token-classification` output:

1) We allow either `entity` or `entity_group`. In `transformers`, `entity` is used for standard token classification or NER when we don't aggregate tokens, and `entity_group` is used when a single label is applied to an aggregated group of tokens.
2) We remove `label` from the `required` list. `label` was not actually one of the output keys in the spec, or in `transformers`!
3) We add `start`, `end` and `word` to the required list.
