### PR TITLE
[`snippets`] Add `model.encode` and `model.similarity` to Sentence Transformers snippet

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -724,8 +724,8 @@ export const sentenceTransformers = (model: ModelData): string[] => {
 
 model = SentenceTransformer("${model.id}"${remote_code_snippet})
 
-texts = ${JSON.stringify(exampleSentences, null, 4)}
-embeddings = model.encode(texts)
+sentences = ${JSON.stringify(exampleSentences, null, 4)}
+embeddings = model.encode(sentences)
 
 similarities = model.similarity(embeddings, embeddings)
 print(similarities.shape)

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -722,14 +722,11 @@ export const sentenceTransformers = (model: ModelData): string[] => {
 	return [
 		`from sentence_transformers import SentenceTransformer
 
-# Download from the 🤗 Hub
 model = SentenceTransformer("${model.id}"${remote_code_snippet})
 
-# Run inference
 texts = ${JSON.stringify(exampleSentences, null, 4)}
 embeddings = model.encode(texts)
 
-# Get the similarity scores for the texts
 similarities = model.similarity(embeddings, embeddings)
 print(similarities.shape)
 # [${exampleSentences.length}, ${exampleSentences.length}]`,


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add `model.encode` and `model.similarity` to Sentence Transformers snippet

## Details
As suggested internally by @mishig25 [here](https://huggingface.slack.com/archives/C021329G2LT/p1728031682732199) - thanks for the idea!

### Examples
* https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1 (this model has no README widget metadata)

```python
from sentence_transformers import SentenceTransformer

# Download from the 🤗 Hub
model = SentenceTransformer("mixedbread-ai/mxbai-embed-large-v1")

# Run inference
texts = [
    "The weather is lovely today.",
    "It's so sunny outside!",
    "He drove to the stadium."
]
embeddings = model.encode(texts)

# Get the similarity scores for the texts
similarities = model.similarity(embeddings, embeddings)
print(similarities.shape)
# [3, 3]
```

* https://huggingface.co/Kerneld/klue-roberta-base-klue-sts-mrc (this model does have README widget metadata, automatically generated from the Sentence Transformers Trainer based on this user's evaluation dataset)
```python
from sentence_transformers import SentenceTransformer

# Download from the 🤗 Hub
model = SentenceTransformer("Kerneld/klue-roberta-base-klue-sts-mrc")

# Run inference
texts = [
    "LPAT의 시험문제를 출제한 기관은?",
    "센고쿠 시대의 아이즈 지방은 센고쿠 다이묘 아시나씨가 구로카와(黒川)를 본거지로 하여 지배하고 있었다. 1589년, 다테 마사무네가 아시나 가문을 멸망시키고 이 지역을 차지하였으나 1590년에 도요토 미 히데요시에 의해 아이즈 지방 및 주변 지역을 몰수당하였고, 대신 가모 우지사토가 아이즈 42만 석(훗날 92만 석이 됨) 영지를 소유하게 되었다. 우지사토는 구로카와를 와카마쓰(若松)라 개명하였고, 가미가타로부터 상인들을 초빙하여 영지 경영에 공헌하였다. 우지사토의 뒤를 이은 가모 히데유키는 1598년에 우쓰노미야 번 12만 석으로 삭감 전봉되었고, 에치고 국로부터 우에스기 가게카쓰가 고쿠다카 120만  석으로 입번하였다.\n\n그러나 가게카쓰도 세키가하라 전투 때 이시다 미쓰나리의 편에 섰다는 이유로 1601년에 요네자와 번 24만 석으로 삭감 전봉되었고, 당시 도쿠가와 이에야스측에서 싸웠던 가모 히데유 키는 고쿠다카가 60만 석으로 추가되어 아이즈로 돌아올 수 있었다. 히데유키의 뒤를 이은 가모 다다사토가 1627년 급사하자, 후사가 없어 영지가 몰수될 뻔하였으나, 그 어머니가 도쿠가와 이에야스의 딸인  관계로, 동생 가모 다다토모가 가모씨의 당주를 이어받고 이요 마쓰야마 번으로 옮겨가 명맥을 유지하게 되었다. 대신 마쓰야마 번으로부터 가토 요시아키가 아이즈로 들어왔다. 하지만 2대 번주 가토 아키나 리가 아이즈 소동이라는 후계자 분쟁에 휘말리면서 결국 영지를 반납하게 되었다.\n\n가토씨가 아이즈에서 퇴출당한 1643년, 야마가타 번에 있던 호시나 마사유키가 23만 석으로 아이즈 번에 들어왔다. 마사유키는 2대 쇼군 도쿠가와 히데타다의 사생아이자 3대 쇼군 도쿠가와 이에미쓰의 배다른 동생으로, 이에미쓰의 신뢰를 받아 막부 정치에 중요한 역할을 하였으나, 다케다씨의 유신이었던 양부 호시나 마사미쓰와의 의리상 마쓰다이라로 성을 바꾸지는 않았다. 이후 호시나씨는 3대 마사카타 대에 비로소 마쓰다이라로 개성하였고, 도쿠가와 히데타다의 후손으로 인정받아 신판 다이묘가 되었다. 이후 실제 고쿠다카는 40만 석까지 올라갔으며, 미토 번(도쿠가와 고산케 중 하나)보다도 실수입이 많고 군사력도 강대한 번이 되었다.\n\n막말, 마지막 번주 마쓰다이라 가타모리는 1862년에 교토슈고쇼쿠를 맡았고 신센구미를 휘하 에 두어, 존왕양이파 지사들의 관리와 교토 치안유지를 담당했다. 금문의 변 때는 고메이 천황을 탈취하려는 조슈 번 세력으로부터 궁궐을 지켜냈다. 이후 가타모리는 고메이 천황으로부터 아이즈 번에 의지한다는 내용의 서한을 받았다. 고메이 천황 사후, 대정봉환, 왕정복고를 거쳐 보신 전쟁이 발발하자, 가타모리는 구 막부 세력의 중심으로 여겨지면서 신정부군의 주적이 되었고, 고메이 천황의 서한이 있음에도 불구하고 조적(朝敵)으로 간주되었다. 아이즈 번은 오우에쓰 열번동맹의 지원을 받아 쇼나이 번과 함께 동맹을 체결하고 신정부군에 대항하였으나, 아이즈 전쟁에서 패배하고 결국 항복하였다. 아이즈 번 영 지는 이때 몰수되었고, 가타모리는 금고형에 처해져 돗토리 번에 유폐되었다. 1869년, 메이지 정부는 가타모리의 아들 마쓰다이라 가타하루가 가문의 명맥을 잇는 것을 허락하고 도나미 번을 세우게 했지만,  아이즈 지역은 메이지 정부의 직할지가 되었고, 와카마쓰 현이 설치되었다가 1876년에 후쿠시마현에 합병되었다.",
    "영어는 홍콩의 공용어 중 하나이다. 그런데 현지 홍콩 사람들의 약 95%는 중국 사람들이며, 이들은 영어를 학교에서 배우는 제2 언어로서 사용하고 있다. 일상 생활에서는 광둥어가 주로 쓰인다.\n\n1997년 홍콩 주권 이양 이후, 영어는 계속 공식적인 언어로 남아 있지만, 새 정부의 방침에 따라 일부 초등 학교 및 중등 학교만이 공식 교재의 언어로서 영어를 쓰는 데 그치고 있다. 반면 대학 및 기업, 법원 등지에서는 영어가 널리 쓰이고 있다.\n\n싱가포르 사람이나 오스트레일리아 사람들과는 달리, 홍콩 사람들은 자신들이 말하는 홍콩식 영어가 어딘가 조금씩 잘못된 영어라고 생각한다. 교육을 잘 받은 사람들은 보통 영국식 영어를 기본으로 약간의 미국식 영어가 섞인 형태의 영어를 구사한다. 단, 개인 수준 차에 따라 수준은 달라질 수 있다.\n\n영어 원어민이 아닌 지역 영어 교사의 영어 수준은 종종 논란 거리가 된 바 있다. 이에 따라 홍콩 교육부는 영어학과 학사 학위가 없는 교사들에게, 그들의 영어 실력이 일정 수준 이상이 되도록 보장하기 위해, LPAT이라는 시험을 통과한 증명을 제출하도록 요구하였으며, LPAT 을 통과하지 못한 교사들은 퇴출되었다. 정부에 의해 고용된 교사 이외에, 영어 원어민조차도 이 시험에 떨어질 정도였다. 교사들 중 일부는 시험을 피해 은퇴하기도 하였으나, 많은 수의 교사들이 시험을 통 과하지 못하였다.",
    "금오공과대 건축학과를 졸업한 최종섭 씨는 지난해 ‘한·미 대학생 연수취업(WEST)’ 프로그램을 통해 미국에서 인턴으로 근무하던 건축회사 루멘스에 정규직으로 취업했다. 전문대 글로벌 현장학습에 참여했던 정지은 씨(영남이공대 식음료조리계열)도 아랍에미리트(UAE) 두바이의 5성급 호텔인 제벨알리호텔에서 현장실습을 하다 빠른 손놀림과 성실성을 인정받아 현지 취업에 성공했다.해외에서 어학연수나 학점을 이수하며 인턴 체험을 하는 글로벌 현장학습 프로그램을 통해 올해 대학생들이 대거 파견 나간다. 교육부와 한국대학교육협의회, 한국전문대학교육협의회는 3일 ‘2015년 글로벌 현장학습 사업 계획’을 통해 올해 96억9400만원을 들여 학생 1090명을 해외에 파견한다고 발표했다.WEST 프로그램의 경우 올해 390명이 미국에서 어학연수를 받고 정보기술(IT), 금융, 항공, 패션 등 전공과 관련된 분야에서 인턴으로 일한다. 참가자 전원에게 왕복항공료 200만원을 지급하고 어학연수비, 생활비는 소득 수준에 따라 차등적으로 지원한다. 저소득층 학생에게는 최대 2455만원을 지원한다.올해는 기존 18개월과 6개월 외에 12개월 프로그램이 추가됐다. 지원 대상은 4년제대, 전문대 재학생이나 1년 이내 졸업생으로 정부 해외인턴 포털 사이트(www.ggi.go.kr)에서 신청할 수 있다.글로벌 현장학습은 올해 700명이 참가하지만 상반기 선발은 끝났고 7월에 141명을 추가로 뽑는다. 참가 학생은 6개월 동안 외국에서 현장실습을 하며 최대 20학점을 취득할 수 있다. 항공료, 비자 발급비, 보험료 등을 정부로부터 지원받는다.현장학습이지만 본인의 노력에 따라 해외 현지 취업도 가능하다. 김태성(청암대·일본 IT기업 취업), 박원우(인천대·호주 투자운용사) 씨 등이 현장학습을 통해 해외 현지에 취업했다."
]
embeddings = model.encode(texts)

# Get the similarity scores for the texts
similarities = model.similarity(embeddings, embeddings)
print(similarities.shape)
# [4, 4]
```

The snippets on the Hub have scrolling, so long texts is fine.

- Tom Aarsen