### PR TITLE
Update conversational inference API snippets

### DIFF
--- a/packages/tasks/src/snippets/common.ts
+++ b/packages/tasks/src/snippets/common.ts
@@ -56,7 +56,7 @@ export function stringifyGenerationConfig(
 	return (
 		opts.start +
 		Object.entries(config)
-			.map(([key, val]) => `${quote}${key}${quote}${opts.attributeValueConnector}${quote}${val}${quote}`)
+			.map(([key, val]) => `${quote}${key}${quote}${opts.attributeValueConnector}${val}`)
 			.join(opts.sep) +
 		opts.end
 	);

--- a/packages/tasks/src/snippets/common.ts
+++ b/packages/tasks/src/snippets/common.ts
@@ -1,0 +1,63 @@
+import type { ChatCompletionInputMessage, GenerationParameters } from "../tasks";
+
+export interface StringifyMessagesOptions {
+	sep: string;
+	start: string;
+	end: string;
+	attributeKeyQuotes?: boolean;
+	customContentEscaper?: (str: string) => string;
+}
+
+export function stringifyMessages(messages: ChatCompletionInputMessage[], opts: StringifyMessagesOptions): string {
+	const keyRole = opts.attributeKeyQuotes ? `"role"` : "role";
+	const keyContent = opts.attributeKeyQuotes ? `"role"` : "role";
+
+	const messagesStringified = messages.map(({ role, content }) => {
+		if (typeof content === "string") {
+			content = JSON.stringify(content).slice(1, -1);
+			if (opts.customContentEscaper) {
+				content = opts.customContentEscaper(content);
+			}
+			return `{ ${keyRole}: "${role}", ${keyContent}: "${content}" }`;
+		} else {
+			2;
+			content = content.map(({ image_url, text, type }) => ({
+				type,
+				image_url,
+				...(text ? { text: JSON.stringify(text).slice(1, -1) } : undefined),
+			}));
+			content = JSON.stringify(content).slice(1, -1);
+			if (opts.customContentEscaper) {
+				content = opts.customContentEscaper(content);
+			}
+			return `{ ${keyRole}: "${role}", ${keyContent}: ${content} }`;
+		}
+	});
+
+	return opts.start + messagesStringified.join(opts.sep) + opts.end;
+}
+
+type PartialGenerationParameters = Partial<Pick<GenerationParameters, "temperature" | "max_tokens" | "top_p">>;
+
+export interface StringifyGenerationConfigOptions {
+	sep: string;
+	start: string;
+	end: string;
+	attributeValueConnector: string;
+	attributeKeyQuotes?: boolean;
+}
+
+export function stringifyGenerationConfig(
+	config: PartialGenerationParameters,
+	opts: StringifyGenerationConfigOptions
+): string {
+	const quote = opts.attributeKeyQuotes ? `"` : "";
+
+	return (
+		opts.start +
+		Object.entries(config)
+			.map(([key, val]) => `${quote}${key}${quote}${opts.attributeValueConnector}${quote}${val}${quote}`)
+			.join(opts.sep) +
+		opts.end
+	);
+}

--- a/packages/tasks/src/snippets/curl.ts
+++ b/packages/tasks/src/snippets/curl.ts
@@ -74,7 +74,10 @@ export const snippetFile = (model: ModelDataMinimal, accessToken: string): Infer
 });
 
 export const curlSnippets: Partial<
-	Record<PipelineType, (model: ModelDataMinimal, accessToken: string) => InferenceSnippet>
+	Record<
+		PipelineType,
+		(model: ModelDataMinimal, accessToken: string, opts?: Record<string, string | boolean | number>) => InferenceSnippet
+	>
 > = {
 	// Same order as in js/src/lib/interfaces/Types.ts
 	"text-classification": snippetBasic,

--- a/packages/tasks/src/snippets/curl.ts
+++ b/packages/tasks/src/snippets/curl.ts
@@ -42,9 +42,9 @@ export const snippetTextGeneration = (
 --data '{
     "model": "${model.id}",
     "messages": ${stringifyMessages(messages, {
-			sep: ",\n    ",
-			start: `[\n    `,
-			end: `\n]`,
+			sep: ",\n\t\t",
+			start: `[\n\t\t`,
+			end: `\n\t]`,
 			attributeKeyQuotes: true,
 			customContentEscaper: (str) => str.replace(/'/g, "'\\''"),
 		})},

--- a/packages/tasks/src/snippets/curl.ts
+++ b/packages/tasks/src/snippets/curl.ts
@@ -19,11 +19,11 @@ export const snippetBasic = (model: ModelDataMinimal, accessToken: string): Infe
 const formatGenerationMessages: GenerationMessagesFormatter = ({ messages, sep, start, end }) =>
 	start +
 	messages
-		.map(({ role, content }) => {
+		.map(({ role }) => {
 			// escape single quotes since single quotes is used to define http post body inside curl requests
 			// TODO: handle the case below
-			content = content?.replace(/'/g, "'\\''");
-			return `{ "role": "${role}", "content": "${content}" }`;
+			// content = content?.replace(/'/g, "'\\''");
+			return `{ "role": "${role}", "content": "test msg" }`;
 		})
 		.join(sep) +
 	end;

--- a/packages/tasks/src/snippets/curl.ts
+++ b/packages/tasks/src/snippets/curl.ts
@@ -54,9 +54,9 @@ export const snippetTextGeneration = (
 		];
 
 		const config = {
-			temperature: opts?.temperature,
+			...(opts?.temperature ? { temperature: opts.temperature } : undefined),
 			max_tokens: opts?.max_tokens ?? 500,
-			top_p: opts?.top_p,
+			...(opts?.top_p ? { top_p: opts.top_p } : undefined),
 		};
 		return {
 			content: `curl 'https://api-inference.huggingface.co/models/${model.id}/v1/chat/completions' \\

--- a/packages/tasks/src/snippets/js.ts
+++ b/packages/tasks/src/snippets/js.ts
@@ -185,7 +185,10 @@ query(${getModelInputSnippet(model)}).then((response) => {
 });
 
 export const jsSnippets: Partial<
-	Record<PipelineType, (model: ModelDataMinimal, accessToken: string) => InferenceSnippet>
+	Record<
+		PipelineType,
+		(model: ModelDataMinimal, accessToken: string, opts?: Record<string, string | boolean | number>) => InferenceSnippet
+	>
 > = {
 	// Same order as in js/src/lib/interfaces/Types.ts
 	"text-classification": snippetBasic,

--- a/packages/tasks/src/snippets/js.ts
+++ b/packages/tasks/src/snippets/js.ts
@@ -1,9 +1,9 @@
 import type { PipelineType } from "../pipelines.js";
 import { getModelInputSnippet } from "./inputs.js";
-import type { ModelDataMinimal } from "./types.js";
+import type { InferenceSnippet, ModelDataMinimal } from "./types.js";
 
-export const snippetBasic = (model: ModelDataMinimal, accessToken: string): string =>
-	`async function query(data) {
+export const snippetBasic = (model: ModelDataMinimal, accessToken: string): InferenceSnippet => ({
+	content: `async function query(data) {
 	const response = await fetch(
 		"https://api-inference.huggingface.co/models/${model.id}",
 		{
@@ -21,12 +21,14 @@ export const snippetBasic = (model: ModelDataMinimal, accessToken: string): stri
 
 query({"inputs": ${getModelInputSnippet(model)}}).then((response) => {
 	console.log(JSON.stringify(response));
-});`;
+});`,
+});
 
-export const snippetTextGeneration = (model: ModelDataMinimal, accessToken: string): string => {
+export const snippetTextGeneration = (model: ModelDataMinimal, accessToken: string): InferenceSnippet => {
 	if (model.tags.includes("conversational")) {
 		// Conversational model detected, so we display a code snippet that features the Messages API
-		return `import { HfInference } from "@huggingface/inference";
+		return {
+			content: `import { HfInference } from "@huggingface/inference";
 
 const inference = new HfInference("${accessToken || `{API_TOKEN}`}");
 
@@ -36,16 +38,18 @@ for await (const chunk of inference.chatCompletionStream({
 	max_tokens: 500,
 })) {
 	process.stdout.write(chunk.choices[0]?.delta?.content || "");
-}`;
+}`,
+		};
 	} else {
 		return snippetBasic(model, accessToken);
 	}
 };
 
-export const snippetImageTextToTextGeneration = (model: ModelDataMinimal, accessToken: string): string => {
+export const snippetImageTextToTextGeneration = (model: ModelDataMinimal, accessToken: string): InferenceSnippet => {
 	if (model.tags.includes("conversational")) {
 		// Conversational model detected, so we display a code snippet that features the Messages API
-		return `import { HfInference } from "@huggingface/inference";
+		return {
+			content: `import { HfInference } from "@huggingface/inference";
 
 const inference = new HfInference("${accessToken || `{API_TOKEN}`}");
 const imageUrl = "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg";
@@ -64,14 +68,15 @@ for await (const chunk of inference.chatCompletionStream({
 	max_tokens: 500,
 })) {
 	process.stdout.write(chunk.choices[0]?.delta?.content || "");
-}`;
+}`,
+		};
 	} else {
 		return snippetBasic(model, accessToken);
 	}
 };
 
-export const snippetZeroShotClassification = (model: ModelDataMinimal, accessToken: string): string =>
-	`async function query(data) {
+export const snippetZeroShotClassification = (model: ModelDataMinimal, accessToken: string): InferenceSnippet => ({
+	content: `async function query(data) {
 	const response = await fetch(
 		"https://api-inference.huggingface.co/models/${model.id}",
 		{
@@ -91,10 +96,11 @@ query({"inputs": ${getModelInputSnippet(
 		model
 	)}, "parameters": {"candidate_labels": ["refund", "legal", "faq"]}}).then((response) => {
 	console.log(JSON.stringify(response));
-});`;
+});`,
+});
 
-export const snippetTextToImage = (model: ModelDataMinimal, accessToken: string): string =>
-	`async function query(data) {
+export const snippetTextToImage = (model: ModelDataMinimal, accessToken: string): InferenceSnippet => ({
+	content: `async function query(data) {
 	const response = await fetch(
 		"https://api-inference.huggingface.co/models/${model.id}",
 		{
@@ -111,9 +117,10 @@ export const snippetTextToImage = (model: ModelDataMinimal, accessToken: string)
 }
 query({"inputs": ${getModelInputSnippet(model)}}).then((response) => {
 	// Use image
-});`;
+});`,
+});
 
-export const snippetTextToAudio = (model: ModelDataMinimal, accessToken: string): string => {
+export const snippetTextToAudio = (model: ModelDataMinimal, accessToken: string): InferenceSnippet => {
 	const commonSnippet = `async function query(data) {
 		const response = await fetch(
 			"https://api-inference.huggingface.co/models/${model.id}",
@@ -127,33 +134,35 @@ export const snippetTextToAudio = (model: ModelDataMinimal, accessToken: string)
 			}
 		);`;
 	if (model.library_name === "transformers") {
-		return (
-			commonSnippet +
-			`
+		return {
+			content:
+				commonSnippet +
+				`
 			const result = await response.blob();
 			return result;
 		}
 		query({"inputs": ${getModelInputSnippet(model)}}).then((response) => {
 			// Returns a byte object of the Audio wavform. Use it directly!
-		});`
-		);
+		});`,
+		};
 	} else {
-		return (
-			commonSnippet +
-			`
+		return {
+			content:
+				commonSnippet +
+				`
 			const result = await response.json();
 			return result;
 		}
 		
 		query({"inputs": ${getModelInputSnippet(model)}}).then((response) => {
 			console.log(JSON.stringify(response));
-		});`
-		);
+		});`,
+		};
 	}
 };
 
-export const snippetFile = (model: ModelDataMinimal, accessToken: string): string =>
-	`async function query(filename) {
+export const snippetFile = (model: ModelDataMinimal, accessToken: string): InferenceSnippet => ({
+	content: `async function query(filename) {
 	const data = fs.readFileSync(filename);
 	const response = await fetch(
 		"https://api-inference.huggingface.co/models/${model.id}",
@@ -172,9 +181,12 @@ export const snippetFile = (model: ModelDataMinimal, accessToken: string): strin
 
 query(${getModelInputSnippet(model)}).then((response) => {
 	console.log(JSON.stringify(response));
-});`;
+});`,
+});
 
-export const jsSnippets: Partial<Record<PipelineType, (model: ModelDataMinimal, accessToken: string) => string>> = {
+export const jsSnippets: Partial<
+	Record<PipelineType, (model: ModelDataMinimal, accessToken: string) => InferenceSnippet>
+> = {
 	// Same order as in js/src/lib/interfaces/Types.ts
 	"text-classification": snippetBasic,
 	"token-classification": snippetBasic,
@@ -201,10 +213,10 @@ export const jsSnippets: Partial<Record<PipelineType, (model: ModelDataMinimal, 
 	"image-segmentation": snippetFile,
 };
 
-export function getJsInferenceSnippet(model: ModelDataMinimal, accessToken: string): string {
+export function getJsInferenceSnippet(model: ModelDataMinimal, accessToken: string): InferenceSnippet {
 	return model.pipeline_tag && model.pipeline_tag in jsSnippets
-		? jsSnippets[model.pipeline_tag]?.(model, accessToken) ?? ""
-		: "";
+		? jsSnippets[model.pipeline_tag]?.(model, accessToken) ?? { content: "" }
+		: { content: "" };
 }
 
 export function hasJsInferenceSnippet(model: ModelDataMinimal): boolean {

--- a/packages/tasks/src/snippets/js.ts
+++ b/packages/tasks/src/snippets/js.ts
@@ -332,7 +332,10 @@ export const jsSnippets: Partial<
 	"image-segmentation": snippetFile,
 };
 
-export function getJsInferenceSnippet(model: ModelDataMinimal, accessToken: string): InferenceSnippet {
+export function getJsInferenceSnippet(
+	model: ModelDataMinimal,
+	accessToken: string
+): InferenceSnippet | InferenceSnippet[] {
 	return model.pipeline_tag && model.pipeline_tag in jsSnippets
 		? jsSnippets[model.pipeline_tag]?.(model, accessToken) ?? { content: "" }
 		: { content: "" };

--- a/packages/tasks/src/snippets/js.ts
+++ b/packages/tasks/src/snippets/js.ts
@@ -60,9 +60,9 @@ export const snippetTextGeneration = (
 		const messagesStr = formatGenerationMessages({ messages, sep: ",\n\t\t", start: "[\n\t\t", end: "\n\t]" });
 
 		const config = {
-			temperature: opts?.temperature,
+			...(opts?.temperature ? { temperature: opts.temperature } : undefined),
 			max_tokens: opts?.max_tokens ?? 500,
-			top_p: opts?.top_p,
+			...(opts?.top_p ? { top_p: opts.top_p } : undefined),
 		};
 		const configStr = formatGenerationConfig({ config, sep: ",\n\t", start: "", end: "" });
 

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -313,19 +313,24 @@ export function getPythonInferenceSnippet(
 		// Example sending an image to the Message API
 		return snippetConversationalWithImage(model, accessToken);
 	} else {
-		const body =
+		let snippets =
 			model.pipeline_tag && model.pipeline_tag in pythonSnippets
-				? pythonSnippets[model.pipeline_tag]?.(model, accessToken) ?? ""
-				: "";
+				? pythonSnippets[model.pipeline_tag]?.(model, accessToken) ?? { content: "" }
+				: { content: "" };
 
-		return {
-			content: `import requests
+		snippets = Array.isArray(snippets) ? snippets : [snippets];
 
+		return snippets.map((snippet) => {
+			return {
+				...snippet,
+				content: `import requests
+	
 API_URL = "https://api-inference.huggingface.co/models/${model.id}"
 headers = {"Authorization": ${accessToken ? `"Bearer ${accessToken}"` : `f"Bearer {API_TOKEN}"`}}
-
-${body}`,
-		};
+	
+${snippet.content}`,
+			};
+		});
 	}
 }
 

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -36,9 +36,9 @@ export const snippetConversational = (
 	const messagesStr = formatGenerationMessages({ messages, sep: ",\n\t", start: `[\n\t`, end: `\n]` });
 
 	const config = {
-		temperature: opts?.temperature,
+		...(opts?.temperature ? { temperature: opts.temperature } : undefined),
 		max_tokens: opts?.max_tokens ?? 500,
-		top_p: opts?.top_p,
+		...(opts?.top_p ? { top_p: opts.top_p } : undefined),
 	};
 	const configStr = formatGenerationConfig({ config, sep: ",\n\t", start: "", end: "", connector: "=" });
 

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -36,7 +36,6 @@ export const snippetConversational = (
 		start: "",
 		end: "",
 		attributeValueConnector: "=",
-		attributeKeyQuotes: true,
 	});
 
 	if (streaming) {

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -307,7 +307,7 @@ export function getPythonInferenceSnippet(
 	model: ModelDataMinimal,
 	accessToken: string,
 	opts?: Record<string, unknown>
-): InferenceSnippet {
+): InferenceSnippet | InferenceSnippet[] {
 	if (model.pipeline_tag === "text-generation" && model.tags.includes("conversational")) {
 		// Conversational model detected, so we display a code snippet that features the Messages API
 		return snippetConversational(model, accessToken, opts);

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -157,7 +157,10 @@ output = query({
 });
 
 export const pythonSnippets: Partial<
-	Record<PipelineType, (model: ModelDataMinimal, accessToken: string) => InferenceSnippet>
+	Record<
+		PipelineType,
+		(model: ModelDataMinimal, accessToken: string, opts?: Record<string, string | boolean | number>) => InferenceSnippet
+	>
 > = {
 	// Same order as in tasks/src/pipelines.ts
 	"text-classification": snippetBasic,

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -33,12 +33,14 @@ export const snippetConversational = (
 	const messages: ChatCompletionInputMessage[] = opts?.messages ?? [
 		{ role: "user", content: "What is the capital of France?" },
 	];
+	const messagesStr = formatGenerationMessages({ messages, sep: ",\n\t", start: `[\n\t`, end: `\n]` });
 
 	const config = {
 		temperature: opts?.temperature,
 		max_tokens: opts?.max_tokens ?? 500,
 		top_p: opts?.top_p,
 	};
+	const configStr = formatGenerationConfig({ config, sep: ",\n\t", start: "", end: "", connector: "=" });
 
 	if (streaming) {
 		return [
@@ -48,12 +50,12 @@ export const snippetConversational = (
 
 client = InferenceClient(api_key="${accessToken || "{API_TOKEN}"}")
 
-messages = ${formatGenerationMessages({ messages, sep: ",\n\t", start: `[\n\t`, end: `\n]` })}
+messages = ${messagesStr}
 
 stream = client.chat.completions.create(
     model="${model.id}", 
 	messages=messages, 
-	${formatGenerationConfig({ config, sep: ",\n\t", start: "", end: "", connector: "=" })},
+	${configStr},
 	stream=True
 )
 
@@ -69,12 +71,12 @@ client = OpenAI(
 	api_key="${accessToken || "{API_TOKEN}"}"
 )
 
-messages = ${formatGenerationMessages({ messages, sep: ",\n\t", start: `[\n\t`, end: `\n]` })}
+messages = ${messagesStr}
 
 stream = client.chat.completions.create(
     model="${model.id}", 
 	messages=messages, 
-	${formatGenerationConfig({ config, sep: ",\n\t", start: "", end: "", connector: "=" })},
+	${configStr},
 	stream=True
 )
 
@@ -90,12 +92,12 @@ for chunk in stream:
 
 client = InferenceClient(api_key="${accessToken || "{API_TOKEN}"}")
 
-messages = ${formatGenerationMessages({ messages, sep: ",\n\t", start: `[\n\t`, end: `\n]` })}
+messages = ${messagesStr}
 
 completion = client.chat.completions.create(
     model="${model.id}", 
 	messages=messages, 
-	${formatGenerationConfig({ config, sep: ",\n\t", start: "", end: "", connector: "=" })}
+	${configStr}
 )
 
 print(completion.choices[0].message)`,
@@ -109,12 +111,12 @@ client = OpenAI(
 	api_key="${accessToken || "{API_TOKEN}"}"
 )
 
-messages = ${formatGenerationMessages({ messages, sep: ",\n\t", start: `[\n\t`, end: `\n]` })}
+messages = ${messagesStr}
 
 completion = client.chat.completions.create(
     model="${model.id}", 
 	messages=messages, 
-	${formatGenerationConfig({ config, sep: ",\n\t", start: "", end: "", connector: "=" })}
+	${configStr}
 )
 
 print(completion.choices[0].message)`,

--- a/packages/tasks/src/snippets/types.ts
+++ b/packages/tasks/src/snippets/types.ts
@@ -1,4 +1,5 @@
 import type { ModelData } from "../model-data";
+import type { ChatCompletionInputMessage, GenerationParameters } from "../tasks";
 
 /**
  * Minimal model data required for snippets.
@@ -14,3 +15,27 @@ export interface InferenceSnippet {
 	content: string;
 	client?: string; // for instance: `client` could be huggingface_hub or openai client for Python snippets
 }
+
+interface GenerationSnippetDelimiter {
+	sep: string;
+	start: string;
+	end: string;
+	connector?: string;
+}
+
+type PartialGenerationParameters = Partial<Pick<GenerationParameters, "temperature" | "max_tokens" | "top_p">>;
+
+export type GenerationMessagesFormatter = ({
+	messages,
+	sep,
+	start,
+	end,
+}: GenerationSnippetDelimiter & { messages: ChatCompletionInputMessage[] }) => string;
+
+export type GenerationConfigFormatter = ({
+	config,
+	sep,
+	start,
+	end,
+	connector,
+}: GenerationSnippetDelimiter & { config: PartialGenerationParameters }) => string;

--- a/packages/tasks/src/snippets/types.ts
+++ b/packages/tasks/src/snippets/types.ts
@@ -9,3 +9,8 @@ export type ModelDataMinimal = Pick<
 	ModelData,
 	"id" | "pipeline_tag" | "mask_token" | "library_name" | "config" | "tags" | "inference"
 >;
+
+export interface InferenceSnippet {
+	content: string;
+	client?: string; // for instance: `client` could be huggingface_hub or openai client for Python snippets
+}

--- a/packages/tasks/src/snippets/types.ts
+++ b/packages/tasks/src/snippets/types.ts
@@ -1,5 +1,4 @@
 import type { ModelData } from "../model-data";
-import type { ChatCompletionInputMessage, GenerationParameters } from "../tasks";
 
 /**
  * Minimal model data required for snippets.
@@ -15,27 +14,3 @@ export interface InferenceSnippet {
 	content: string;
 	client?: string; // for instance: `client` could be `huggingface_hub` or `openai` client for Python snippets
 }
-
-interface GenerationSnippetDelimiter {
-	sep: string;
-	start: string;
-	end: string;
-	connector?: string;
-}
-
-type PartialGenerationParameters = Partial<Pick<GenerationParameters, "temperature" | "max_tokens" | "top_p">>;
-
-export type GenerationMessagesFormatter = ({
-	messages,
-	sep,
-	start,
-	end,
-}: GenerationSnippetDelimiter & { messages: ChatCompletionInputMessage[] }) => string;
-
-export type GenerationConfigFormatter = ({
-	config,
-	sep,
-	start,
-	end,
-	connector,
-}: GenerationSnippetDelimiter & { config: PartialGenerationParameters }) => string;

--- a/packages/tasks/src/snippets/types.ts
+++ b/packages/tasks/src/snippets/types.ts
@@ -13,7 +13,7 @@ export type ModelDataMinimal = Pick<
 
 export interface InferenceSnippet {
 	content: string;
-	client?: string; // for instance: `client` could be huggingface_hub or openai client for Python snippets
+	client?: string; // for instance: `client` could be `huggingface_hub` or `openai` client for Python snippets
 }
 
 interface GenerationSnippetDelimiter {


### PR DESCRIPTION
### Description

This PR updates inference snippet generating functions signatures. Before, the functions were generating `string`. Now, the function will generate `InferenceSnippet  | InferenceSnippet []`.

https://github.com/huggingface/huggingface.js/blob/5bc694b9e7b845d25743e6db30daef60f85883a7/packages/tasks/src/snippets/types.ts#L14-L17

Why do we need to generate `InferenceSnippet []`, not just `InferenceSnippet`?
Because for a given langauge (let's say), we wanna show multiple clients options (`huggingface_hub`, `openai`). (see the attached video below).

Also, this PR improves the conversational snippet greatly.

### Screen recording

https://github.com/user-attachments/assets/6bc982c5-a855-4879-b9be-ca023d2b59fa

