### PR TITLE
Add LiteRT tracking rule for tflite files

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -360,6 +360,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "k2",
 		repoUrl: "https://github.com/k2-fsa/k2",
 	},
+	litert: {
+		prettyLabel: "LiteRT",
+		repoName: "LiteRT",
+		repoUrl: "https://github.com/google-ai-edge/LiteRT",
+		docsUrl: "https://ai.google.dev/edge/litert",
+		filter: true,
+		countDownloads: `path_extension:"tflite"`,
+	},
 	liveportrait: {
 		prettyLabel: "LivePortrait",
 		repoName: "LivePortrait",


### PR DESCRIPTION
This PR adds a tracking rule for `.tflite` model files. There doesn't appear at first glance to be a `.tflite` download tracking rule, although [many repos](https://huggingface.co/models?library=tflite&sort=trending) currently include `.tflite` files, and have "TF Lite" mentioned in their tags as a library, so if there is some automated tagging logic somewhere for this that may need an update as well. 

Tensorflow Lite recently changed its name to LiteRT (Lite Runtime) announced in this [blog post](https://developers.googleblog.com/en/tensorflow-lite-is-now-litert/) so it would make sense to wrap those changes with this as well.

Future work would be to add this as a formal library with an SVG logo (which I was unable to locate via public searches besides [this](https://storage.googleapis.com/gweb-developer-goog-blog-assets/images/LiteRT_BlogGraphics_4209x1253px_1.original.jpg)) **Update:** Was able to locate a webp that could be usable [here](https://aihub.qualcomm.com/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Flitert-logo.bf5e4716.webp&w=1200&q=75): 

There also appears to be some internal discussion in https://github.com/huggingface/huggingface.js/pull/747 this PR that may be relevant. https://github.com/huggingface/huggingface.js/pull/747

Also worth mentioning this repo is still in an early state https://github.com/google-ai-edge/LiteRT and they are currently pointing toward the main tensorflow repo for LiteRT development, to be separated at a later date (according to the README.md).