### PR TITLE
Tasks: reorder tasks in main page

### DIFF
--- a/packages/tasks/src/pipelines.ts
+++ b/packages/tasks/src/pipelines.ts
@@ -1,4 +1,4 @@
-export const MODALITIES = ["multimodal", "nlp", "cv", "nlp", "audio", "tabular", "rl", "other"] as const;
+export const MODALITIES = ["multimodal", "nlp", "cv", "audio", "tabular", "rl", "other"] as const;
 
 export type Modality = (typeof MODALITIES)[number];
 

--- a/packages/tasks/src/pipelines.ts
+++ b/packages/tasks/src/pipelines.ts
@@ -1,4 +1,4 @@
-export const MODALITIES = ["cv", "nlp", "audio", "tabular", "multimodal", "rl", "other"] as const;
+export const MODALITIES = ["multimodal", "nlp", "cv", "nlp", "audio", "tabular", "rl", "other"] as const;
 
 export type Modality = (typeof MODALITIES)[number];
 


### PR DESCRIPTION
Move multimodal and nlp up 🔝 @julien-c 

thought it would be enough to change the order here seeing this [LoC](https://github.com/huggingface-internal/moon-landing/blob/9ab039334aed765cf07c0cad002c08ccb670b3e4/server/views/pages/TasksPage/TasksPage.svelte#L36) LMK in case I'm missing something