### PR TITLE
Add debug script to check inference snippets + update Python text-to-image snippets

### DIFF
--- a/.github/workflows/inference-check-snippets.yml
+++ b/.github/workflows/inference-check-snippets.yml
@@ -21,7 +21,7 @@ jobs:
           cache-dependency-path: "**/pnpm-lock.yaml"
       - run: |
           cd packages/tasks
-          pnpm install --frozen-lockfile .
+          pnpm install
 
       # TODO: Find a way to run on all pipeline tags
       # TODO: print snippet only if it has changed since the last commit on main (?)

--- a/.github/workflows/inference-check-snippets.yml
+++ b/.github/workflows/inference-check-snippets.yml
@@ -1,0 +1,49 @@
+name: Inference check snippets
+on:
+  pull_request:
+    paths:
+      - "packages/tasks/src/snippets/**"
+      - ".github/workflows/inference-check-snippets.yml"
+
+jobs:
+  check-snippets:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: corepack enable
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: "**/pnpm-lock.yaml"
+      - run: |
+          cd packages/tasks
+          pnpm install --frozen-lockfile --filter .
+          pnpm install --frozen-lockfile --filter ...[${{ steps.since.outputs.SINCE }}]...
+          pnpm --filter ...[${{ steps.since.outputs.SINCE }}]... build
+
+      # TODO: Find a way to run on all pipeline tags
+      # TODO: print snippet only if it has changed since the last commit on main (?)
+      # TODO: (even better: automated message on the PR with diff)
+      - name: Print text-to-image snippets
+        run: |
+          cd packages/tasks
+          pnpm run check-snippets --pipeline-tag="text-to-image"
+
+      - name: Print simple text-generation snippets
+        run: |
+          cd packages/tasks
+          pnpm run check-snippets --pipeline-tag="text-generation"
+
+      - name: Print conversational text-generation snippets
+        run: |
+          cd packages/tasks
+          pnpm run check-snippets --pipeline-tag="text-generation" --tags="conversational"
+
+      - name: Print conversational image-text-to-text snippets
+        run: |
+          cd packages/tasks
+          pnpm run check-snippets --pipeline-tag="image-text-to-text" --tags="conversational"

--- a/.github/workflows/inference-check-snippets.yml
+++ b/.github/workflows/inference-check-snippets.yml
@@ -21,9 +21,7 @@ jobs:
           cache-dependency-path: "**/pnpm-lock.yaml"
       - run: |
           cd packages/tasks
-          pnpm install --frozen-lockfile --filter .
-          pnpm install --frozen-lockfile --filter ...[${{ steps.since.outputs.SINCE }}]...
-          pnpm --filter ...[${{ steps.since.outputs.SINCE }}]... build
+          pnpm install --frozen-lockfile .
 
       # TODO: Find a way to run on all pipeline tags
       # TODO: print snippet only if it has changed since the last commit on main (?)

--- a/.github/workflows/inference-check-snippets.yml
+++ b/.github/workflows/inference-check-snippets.yml
@@ -40,8 +40,3 @@ jobs:
         run: |
           cd packages/tasks
           pnpm run check-snippets --pipeline-tag="text-generation" --tags="conversational"
-
-      - name: Print conversational image-text-to-text snippets
-        run: |
-          cd packages/tasks
-          pnpm run check-snippets --pipeline-tag="image-text-to-text" --tags="conversational"

--- a/packages/tasks/package.json
+++ b/packages/tasks/package.json
@@ -32,7 +32,8 @@
 		"check": "tsc",
 		"inference-codegen": "tsx scripts/inference-codegen.ts && prettier --write src/tasks/*/inference.ts",
 		"inference-tgi-import": "tsx scripts/inference-tgi-import.ts && prettier --write src/tasks/text-generation/spec/*.json && prettier --write src/tasks/chat-completion/spec/*.json",
-		"inference-tei-import": "tsx scripts/inference-tei-import.ts && prettier --write src/tasks/feature-extraction/spec/*.json"
+		"inference-tei-import": "tsx scripts/inference-tei-import.ts && prettier --write src/tasks/feature-extraction/spec/*.json",
+		"check-snippets": "tsx scripts/check-snippets.ts"
 	},
 	"type": "module",
 	"files": [
@@ -48,7 +49,9 @@
 	"author": "Hugging Face",
 	"license": "MIT",
 	"devDependencies": {
+		"@types/minimist": "^1.2.5",
 		"@types/node": "^20.11.5",
+		"minimist": "^1.2.8",
 		"quicktype-core": "https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz",
 		"type-fest": "^3.13.1"
 	},

--- a/packages/tasks/package.json
+++ b/packages/tasks/package.json
@@ -49,9 +49,7 @@
 	"author": "Hugging Face",
 	"license": "MIT",
 	"devDependencies": {
-		"@types/minimist": "^1.2.5",
 		"@types/node": "^20.11.5",
-		"minimist": "^1.2.8",
 		"quicktype-core": "https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz",
 		"type-fest": "^3.13.1"
 	},

--- a/packages/tasks/pnpm-lock.yaml
+++ b/packages/tasks/pnpm-lock.yaml
@@ -1,90 +1,102 @@
-lockfileVersion: '9.0'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-importers:
+dependencies:
+  '@huggingface/gguf':
+    specifier: workspace:^
+    version: link:../gguf
 
-  .:
-    dependencies:
-      '@huggingface/gguf':
-        specifier: workspace:^
-        version: link:../gguf
-    devDependencies:
-      '@types/minimist':
-        specifier: ^1.2.5
-        version: 1.2.5
-      '@types/node':
-        specifier: ^20.11.5
-        version: 20.11.5
-      minimist:
-        specifier: ^1.2.8
-        version: 1.2.8
-      quicktype-core:
-        specifier: https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz
-        version: https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz
-      type-fest:
-        specifier: ^3.13.1
-        version: 3.13.1
+devDependencies:
+  '@types/node':
+    specifier: ^20.11.5
+    version: 20.11.5
+  quicktype-core:
+    specifier: https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz
+    version: '@github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz'
+  type-fest:
+    specifier: ^3.13.1
+    version: 3.13.1
 
 packages:
 
-  '@glideapps/ts-necessities@2.1.3':
+  /@glideapps/ts-necessities@2.1.3:
     resolution: {integrity: sha512-q9U8v/n9qbkd2zDYjuX3qtlbl+OIyI9zF+zQhZjfYOE9VMDH7tfcUSJ9p0lXoY3lxmGFne09yi4iiNeQUwV7AA==}
+    dev: true
 
-  '@types/minimist@1.2.5':
-    resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
-
-  '@types/node@20.11.5':
+  /@types/node@20.11.5:
     resolution: {integrity: sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
 
-  '@types/urijs@1.19.25':
+  /@types/urijs@1.19.25:
     resolution: {integrity: sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg==}
+    dev: true
 
-  abort-controller@3.0.0:
+  /abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
+    dependencies:
+      event-target-shim: 5.0.1
+    dev: true
 
-  base64-js@1.5.1:
+  /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: true
 
-  browser-or-node@2.1.1:
+  /browser-or-node@2.1.1:
     resolution: {integrity: sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==}
+    dev: true
 
-  buffer@6.0.3:
+  /buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: true
 
-  collection-utils@1.0.1:
+  /collection-utils@1.0.1:
     resolution: {integrity: sha512-LA2YTIlR7biSpXkKYwwuzGjwL5rjWEZVOSnvdUc7gObvWe4WkjxOpfrdhoP7Hs09YWDVfg0Mal9BpAqLfVEzQg==}
+    dev: true
 
-  cross-fetch@4.0.0:
+  /cross-fetch@4.0.0:
     resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+    dev: true
 
-  event-target-shim@5.0.1:
+  /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+    dev: true
 
-  events@3.3.0:
+  /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+    dev: true
 
-  ieee754@1.2.1:
+  /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    dev: true
 
-  is-url@1.2.4:
+  /is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
+    dev: true
 
-  js-base64@3.7.6:
+  /js-base64@3.7.6:
     resolution: {integrity: sha512-NPrWuHFxFUknr1KqJRDgUQPexQF0uIJWjeT+2KjEePhitQxQEx5EJBG1lVn5/hc8aLycTpXrDOgPQ6Zq+EDiTA==}
+    dev: true
 
-  lodash@4.17.21:
+  /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
 
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  node-fetch@2.7.0:
+  /node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
@@ -92,130 +104,108 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
-
-  pako@0.2.9:
-    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
-
-  pako@1.0.11:
-    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
-
-  pluralize@8.0.0:
-    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
-    engines: {node: '>=4'}
-
-  process@0.11.10:
-    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
-    engines: {node: '>= 0.6.0'}
-
-  quicktype-core@https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz:
-    resolution: {tarball: https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz}
-    version: 18.0.17
-
-  readable-stream@4.4.2:
-    resolution: {integrity: sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
-  tiny-inflate@1.0.3:
-    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
-
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
-  type-fest@3.13.1:
-    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
-    engines: {node: '>=14.16'}
-
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
-  unicode-properties@1.4.1:
-    resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
-
-  unicode-trie@2.0.0:
-    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
-
-  urijs@1.19.11:
-    resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
-  wordwrap@1.0.0:
-    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-
-  yaml@2.3.4:
-    resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
-    engines: {node: '>= 14'}
-
-snapshots:
-
-  '@glideapps/ts-necessities@2.1.3': {}
-
-  '@types/minimist@1.2.5': {}
-
-  '@types/node@20.11.5':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/urijs@1.19.25': {}
-
-  abort-controller@3.0.0:
-    dependencies:
-      event-target-shim: 5.0.1
-
-  base64-js@1.5.1: {}
-
-  browser-or-node@2.1.1: {}
-
-  buffer@6.0.3:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
-  collection-utils@1.0.1: {}
-
-  cross-fetch@4.0.0:
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-
-  event-target-shim@5.0.1: {}
-
-  events@3.3.0: {}
-
-  ieee754@1.2.1: {}
-
-  is-url@1.2.4: {}
-
-  js-base64@3.7.6: {}
-
-  lodash@4.17.21: {}
-
-  minimist@1.2.8: {}
-
-  node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+    dev: true
 
-  pako@0.2.9: {}
+  /pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+    dev: true
 
-  pako@1.0.11: {}
+  /pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+    dev: true
 
-  pluralize@8.0.0: {}
+  /pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+    dev: true
 
-  process@0.11.10: {}
+  /process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+    dev: true
 
-  quicktype-core@https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz:
+  /readable-stream@4.4.2:
+    resolution: {integrity: sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+    dev: true
+
+  /safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: true
+
+  /string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
+  /tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+    dev: true
+
+  /tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: true
+
+  /type-fest@3.13.1:
+    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
+    engines: {node: '>=14.16'}
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
+
+  /unicode-properties@1.4.1:
+    resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
+    dependencies:
+      base64-js: 1.5.1
+      unicode-trie: 2.0.0
+    dev: true
+
+  /unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
+    dev: true
+
+  /urijs@1.19.11:
+    resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
+    dev: true
+
+  /webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: true
+
+  /whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: true
+
+  /wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+    dev: true
+
+  /yaml@2.3.4:
+    resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
+    engines: {node: '>= 14'}
+    dev: true
+
+  '@github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz':
+    resolution: {tarball: https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz}
+    name: quicktype-core
+    version: 18.0.17
     dependencies:
       '@glideapps/ts-necessities': 2.1.3
       '@types/urijs': 1.19.25
@@ -234,48 +224,4 @@ snapshots:
       yaml: 2.3.4
     transitivePeerDependencies:
       - encoding
-
-  readable-stream@4.4.2:
-    dependencies:
-      abort-controller: 3.0.0
-      buffer: 6.0.3
-      events: 3.3.0
-      process: 0.11.10
-      string_decoder: 1.3.0
-
-  safe-buffer@5.2.1: {}
-
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  tiny-inflate@1.0.3: {}
-
-  tr46@0.0.3: {}
-
-  type-fest@3.13.1: {}
-
-  undici-types@5.26.5: {}
-
-  unicode-properties@1.4.1:
-    dependencies:
-      base64-js: 1.5.1
-      unicode-trie: 2.0.0
-
-  unicode-trie@2.0.0:
-    dependencies:
-      pako: 0.2.9
-      tiny-inflate: 1.0.3
-
-  urijs@1.19.11: {}
-
-  webidl-conversions@3.0.1: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
-
-  wordwrap@1.0.0: {}
-
-  yaml@2.3.4: {}
+    dev: true

--- a/packages/tasks/pnpm-lock.yaml
+++ b/packages/tasks/pnpm-lock.yaml
@@ -1,102 +1,90 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  '@huggingface/gguf':
-    specifier: workspace:^
-    version: link:../gguf
+importers:
 
-devDependencies:
-  '@types/node':
-    specifier: ^20.11.5
-    version: 20.11.5
-  quicktype-core:
-    specifier: https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz
-    version: '@github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz'
-  type-fest:
-    specifier: ^3.13.1
-    version: 3.13.1
+  .:
+    dependencies:
+      '@huggingface/gguf':
+        specifier: workspace:^
+        version: link:../gguf
+    devDependencies:
+      '@types/minimist':
+        specifier: ^1.2.5
+        version: 1.2.5
+      '@types/node':
+        specifier: ^20.11.5
+        version: 20.11.5
+      minimist:
+        specifier: ^1.2.8
+        version: 1.2.8
+      quicktype-core:
+        specifier: https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz
+        version: https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz
+      type-fest:
+        specifier: ^3.13.1
+        version: 3.13.1
 
 packages:
 
-  /@glideapps/ts-necessities@2.1.3:
+  '@glideapps/ts-necessities@2.1.3':
     resolution: {integrity: sha512-q9U8v/n9qbkd2zDYjuX3qtlbl+OIyI9zF+zQhZjfYOE9VMDH7tfcUSJ9p0lXoY3lxmGFne09yi4iiNeQUwV7AA==}
-    dev: true
 
-  /@types/node@20.11.5:
+  '@types/minimist@1.2.5':
+    resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
+
+  '@types/node@20.11.5':
     resolution: {integrity: sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==}
-    dependencies:
-      undici-types: 5.26.5
-    dev: true
 
-  /@types/urijs@1.19.25:
+  '@types/urijs@1.19.25':
     resolution: {integrity: sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg==}
-    dev: true
 
-  /abort-controller@3.0.0:
+  abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
-    dependencies:
-      event-target-shim: 5.0.1
-    dev: true
 
-  /base64-js@1.5.1:
+  base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-    dev: true
 
-  /browser-or-node@2.1.1:
+  browser-or-node@2.1.1:
     resolution: {integrity: sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==}
-    dev: true
 
-  /buffer@6.0.3:
+  buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-    dev: true
 
-  /collection-utils@1.0.1:
+  collection-utils@1.0.1:
     resolution: {integrity: sha512-LA2YTIlR7biSpXkKYwwuzGjwL5rjWEZVOSnvdUc7gObvWe4WkjxOpfrdhoP7Hs09YWDVfg0Mal9BpAqLfVEzQg==}
-    dev: true
 
-  /cross-fetch@4.0.0:
+  cross-fetch@4.0.0:
     resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-    dev: true
 
-  /event-target-shim@5.0.1:
+  event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
-    dev: true
 
-  /events@3.3.0:
+  events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
-    dev: true
 
-  /ieee754@1.2.1:
+  ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-    dev: true
 
-  /is-url@1.2.4:
+  is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
-    dev: true
 
-  /js-base64@3.7.6:
+  js-base64@3.7.6:
     resolution: {integrity: sha512-NPrWuHFxFUknr1KqJRDgUQPexQF0uIJWjeT+2KjEePhitQxQEx5EJBG1lVn5/hc8aLycTpXrDOgPQ6Zq+EDiTA==}
-    dev: true
 
-  /lodash@4.17.21:
+  lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: true
 
-  /node-fetch@2.7.0:
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
@@ -104,108 +92,130 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
-    dependencies:
-      whatwg-url: 5.0.0
-    dev: true
 
-  /pako@0.2.9:
+  pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
-    dev: true
 
-  /pako@1.0.11:
+  pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
-    dev: true
 
-  /pluralize@8.0.0:
+  pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
-    dev: true
 
-  /process@0.11.10:
+  process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
-    dev: true
 
-  /readable-stream@4.4.2:
+  quicktype-core@https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz:
+    resolution: {tarball: https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz}
+    version: 18.0.17
+
+  readable-stream@4.4.2:
     resolution: {integrity: sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      abort-controller: 3.0.0
-      buffer: 6.0.3
-      events: 3.3.0
-      process: 0.11.10
-      string_decoder: 1.3.0
-    dev: true
 
-  /safe-buffer@5.2.1:
+  safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: true
 
-  /string_decoder@1.3.0:
+  string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: true
 
-  /tiny-inflate@1.0.3:
+  tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
-    dev: true
 
-  /tr46@0.0.3:
+  tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: true
 
-  /type-fest@3.13.1:
+  type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
-    dev: true
 
-  /undici-types@5.26.5:
+  undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: true
 
-  /unicode-properties@1.4.1:
+  unicode-properties@1.4.1:
     resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
-    dependencies:
-      base64-js: 1.5.1
-      unicode-trie: 2.0.0
-    dev: true
 
-  /unicode-trie@2.0.0:
+  unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
-    dependencies:
-      pako: 0.2.9
-      tiny-inflate: 1.0.3
-    dev: true
 
-  /urijs@1.19.11:
+  urijs@1.19.11:
     resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
-    dev: true
 
-  /webidl-conversions@3.0.1:
+  webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: true
 
-  /whatwg-url@5.0.0:
+  whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
-    dev: true
 
-  /wordwrap@1.0.0:
+  wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-    dev: true
 
-  /yaml@2.3.4:
+  yaml@2.3.4:
     resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
     engines: {node: '>= 14'}
-    dev: true
 
-  '@github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz':
-    resolution: {tarball: https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz}
-    name: quicktype-core
-    version: 18.0.17
+snapshots:
+
+  '@glideapps/ts-necessities@2.1.3': {}
+
+  '@types/minimist@1.2.5': {}
+
+  '@types/node@20.11.5':
+    dependencies:
+      undici-types: 5.26.5
+
+  '@types/urijs@1.19.25': {}
+
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
+  base64-js@1.5.1: {}
+
+  browser-or-node@2.1.1: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  collection-utils@1.0.1: {}
+
+  cross-fetch@4.0.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  event-target-shim@5.0.1: {}
+
+  events@3.3.0: {}
+
+  ieee754@1.2.1: {}
+
+  is-url@1.2.4: {}
+
+  js-base64@3.7.6: {}
+
+  lodash@4.17.21: {}
+
+  minimist@1.2.8: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  pako@0.2.9: {}
+
+  pako@1.0.11: {}
+
+  pluralize@8.0.0: {}
+
+  process@0.11.10: {}
+
+  quicktype-core@https://github.com/huggingface/quicktype/raw/pack-18.0.17/packages/quicktype-core/quicktype-core-18.0.17.tgz:
     dependencies:
       '@glideapps/ts-necessities': 2.1.3
       '@types/urijs': 1.19.25
@@ -224,4 +234,48 @@ packages:
       yaml: 2.3.4
     transitivePeerDependencies:
       - encoding
-    dev: true
+
+  readable-stream@4.4.2:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  safe-buffer@5.2.1: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  tiny-inflate@1.0.3: {}
+
+  tr46@0.0.3: {}
+
+  type-fest@3.13.1: {}
+
+  undici-types@5.26.5: {}
+
+  unicode-properties@1.4.1:
+    dependencies:
+      base64-js: 1.5.1
+      unicode-trie: 2.0.0
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
+
+  urijs@1.19.11: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  wordwrap@1.0.0: {}
+
+  yaml@2.3.4: {}

--- a/packages/tasks/scripts/check-snippets.ts
+++ b/packages/tasks/scripts/check-snippets.ts
@@ -25,7 +25,7 @@ const args = process.argv.slice(2).reduce(
 
 const accessToken = "hf_**********";
 const pipelineTag = (args["pipeline-tag"] || "text-generation") as PipelineType;
-const tags = (args["tags"] || "").split(",");
+const tags = (args["tags"] ?? "").split(",");
 
 const modelMinimal: ModelDataMinimal = {
 	id: "llama-6-1720B-Instruct",

--- a/packages/tasks/scripts/check-snippets.ts
+++ b/packages/tasks/scripts/check-snippets.ts
@@ -38,7 +38,7 @@ const printSnippets = (snippets: InferenceSnippet | InferenceSnippet[], language
 	const snippetArray = Array.isArray(snippets) ? snippets : [snippets];
 	snippetArray.forEach((snippet) => {
 		console.log(`\n\x1b[33m${language} ${snippet.client}\x1b[0m`);
-		console.log(`\n\`\`\`${language.toLowerCase()}\n${snippet.content}\n\`\`\`\n`);
+		console.log(`\n\`\`\`${language}\n${snippet.content}\n\`\`\`\n`);
 	});
 };
 
@@ -50,6 +50,6 @@ const generateAndPrintSnippets = (
 	printSnippets(snippets, language);
 };
 
-generateAndPrintSnippets(curl.getCurlInferenceSnippet, "Curl");
-generateAndPrintSnippets(python.getPythonInferenceSnippet, "Python");
-generateAndPrintSnippets(js.getJsInferenceSnippet, "JS");
+generateAndPrintSnippets(curl.getCurlInferenceSnippet, "curl");
+generateAndPrintSnippets(python.getPythonInferenceSnippet, "python");
+generateAndPrintSnippets(js.getJsInferenceSnippet, "js");

--- a/packages/tasks/scripts/check-snippets.ts
+++ b/packages/tasks/scripts/check-snippets.ts
@@ -17,7 +17,7 @@ import minimist from "minimist";
 const args = minimist(process.argv.slice(2));
 
 const accessToken = "hf_**********";
-const pipelineTag = args["pipeline-type"] || "text-generation";
+const pipelineTag = args["pipeline-tag"] || "text-generation";
 const tags = (args["tags"] || "").split(",");
 
 const modelMinimal: ModelDataMinimal = {

--- a/packages/tasks/scripts/check-snippets.ts
+++ b/packages/tasks/scripts/check-snippets.ts
@@ -9,15 +9,22 @@
  *
  * This script is meant only for debug purposes.
  */
-
 import { python, curl, js } from "../src/snippets/index";
 import type { InferenceSnippet, ModelDataMinimal } from "../src/snippets/types";
-import minimist from "minimist";
+import type { PipelineType } from "../src/pipelines";
 
-const args = minimist(process.argv.slice(2));
+// Parse command-line arguments
+const args = process.argv.slice(2).reduce(
+	(acc, arg) => {
+		const [key, value] = arg.split("=");
+		acc[key.replace("--", "")] = value;
+		return acc;
+	},
+	{} as { [key: string]: string }
+);
 
 const accessToken = "hf_**********";
-const pipelineTag = args["pipeline-tag"] || "text-generation";
+const pipelineTag = (args["pipeline-tag"] || "text-generation") as PipelineType;
 const tags = (args["tags"] || "").split(",");
 
 const modelMinimal: ModelDataMinimal = {

--- a/packages/tasks/scripts/check-snippets.ts
+++ b/packages/tasks/scripts/check-snippets.ts
@@ -38,7 +38,7 @@ const printSnippets = (snippets: InferenceSnippet | InferenceSnippet[], language
 	const snippetArray = Array.isArray(snippets) ? snippets : [snippets];
 	snippetArray.forEach((snippet) => {
 		console.log(`\n\x1b[33m${language} ${snippet.client}\x1b[0m`);
-		console.log(`\n\`\`\`${language === "JS" ? "js" : language.toLowerCase()}\n${snippet.content}\n\`\`\`\n`);
+		console.log(`\n\`\`\`${language.toLowerCase()}\n${snippet.content}\n\`\`\`\n`);
 	});
 };
 

--- a/packages/tasks/scripts/check-snippets.ts
+++ b/packages/tasks/scripts/check-snippets.ts
@@ -1,0 +1,48 @@
+/*
+ * Generates inference snippets as they would be shown on the Hub for Curl, JS and Python.
+ * Snippets will only be printed to the terminal to make it easier to debug when making changes to the snippets.
+ *
+ * Usage:
+ *   pnpm run check-snippets --pipeline-tag="text-generation" --tags="conversational"
+ *   pnpm run check-snippets --pipeline-tag="image-text-to-text" --tags="conversational"
+ *   pnpm run check-snippets --pipeline-tag="text-to-image"
+ *
+ * This script is meant only for debug purposes.
+ */
+
+import { python, curl, js } from "../src/snippets/index";
+import type { InferenceSnippet, ModelDataMinimal } from "../src/snippets/types";
+import minimist from "minimist";
+
+const args = minimist(process.argv.slice(2));
+
+const accessToken = "hf_**********";
+const pipelineTag = args["pipeline-type"] || "text-generation";
+const tags = (args["tags"] || "").split(",");
+
+const modelMinimal: ModelDataMinimal = {
+	id: "llama-6-1720B-Instruct",
+	pipeline_tag: pipelineTag,
+	tags: tags,
+	inference: "****",
+};
+
+const printSnippets = (snippets: InferenceSnippet | InferenceSnippet[], language: string) => {
+	const snippetArray = Array.isArray(snippets) ? snippets : [snippets];
+	snippetArray.forEach((snippet) => {
+		console.log(`\n\x1b[33m${language} ${snippet.client}\x1b[0m`);
+		console.log(`\n\`\`\`${language === "JS" ? "js" : language.toLowerCase()}\n${snippet.content}\n\`\`\`\n`);
+	});
+};
+
+const generateAndPrintSnippets = (
+	generator: (model: ModelDataMinimal, token: string) => InferenceSnippet | InferenceSnippet[],
+	language: string
+) => {
+	const snippets = generator(modelMinimal, accessToken);
+	printSnippets(snippets, language);
+};
+
+generateAndPrintSnippets(curl.getCurlInferenceSnippet, "Curl");
+generateAndPrintSnippets(python.getPythonInferenceSnippet, "Python");
+generateAndPrintSnippets(js.getJsInferenceSnippet, "JS");


### PR DESCRIPTION
Reviewing PRs that updates the inference snippets is a bit painful / error-prone given that we can't easily check the diff.
This PR tries to solve this a bit with a new command that prints the inference snippets to the terminal. I also (tried) to add an automated check in the CI to avoid figuring it out manually. Let's see if it proves useful. 

I also started to update the Python inference snippets, starting with the `text-to-image` one to return both `requests` and `huggingface_hub` versions.

~**Note:** the update of `packages/tasks/pnpm-lock.yaml` is far too much. I'll check if I can't minimize it (I only needed to add a dev dependency).~ => removed the dependency in https://github.com/huggingface/huggingface.js/pull/994/commits/b3deb60d9272ddc8bf5e02c6bba243c4c563dd0e (no real need for it)

Snippets can be checked in https://github.com/huggingface/huggingface.js/actions/runs/11579670253/job/32236421855?pr=994.