### PR TITLE
feat(hub): adding revision property to modelInfo, datasetInfo, spaceInfo

### DIFF
--- a/packages/hub/src/lib/dataset-info.spec.ts
+++ b/packages/hub/src/lib/dataset-info.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { datasetInfo } from "./dataset-info";
+import type { DatasetEntry } from "./list-datasets";
+import type { ApiDatasetInfo } from "../types/api/api-dataset";
 
 describe("datasetInfo", () => {
 	it("should return the dataset info", async () => {
@@ -14,6 +16,41 @@ describe("datasetInfo", () => {
 			updatedAt: expect.any(Date),
 			likes: expect.any(Number),
 			private: false,
+		});
+	});
+
+	it("should return the dataset info with author", async () => {
+		const info: DatasetEntry & Pick<ApiDatasetInfo, 'author'> = await datasetInfo({
+			name: "nyu-mll/glue",
+			additionalFields: ['author'],
+		});
+		expect(info).toEqual({
+			id: "621ffdd236468d709f181e3f",
+			downloads: expect.any(Number),
+			gated: false,
+			name: "nyu-mll/glue",
+			updatedAt: expect.any(Date),
+			likes: expect.any(Number),
+			private: false,
+			author: 'nyu-mll'
+		});
+	});
+
+	it("should return the dataset info for a specific revision", async () => {
+		const info: DatasetEntry & Pick<ApiDatasetInfo, 'sha'> = await datasetInfo({
+			name: "nyu-mll/glue",
+			revision: "cb2099c76426ff97da7aa591cbd317d91fb5fcb7",
+			additionalFields: ["sha"],
+		});
+		expect(info).toEqual({
+			id: "621ffdd236468d709f181e3f",
+			downloads: expect.any(Number),
+			gated: false,
+			name: "nyu-mll/glue",
+			updatedAt: expect.any(Date),
+			likes: expect.any(Number),
+			private: false,
+			sha: 'cb2099c76426ff97da7aa591cbd317d91fb5fcb7'
 		});
 	});
 });

--- a/packages/hub/src/lib/dataset-info.ts
+++ b/packages/hub/src/lib/dataset-info.ts
@@ -14,6 +14,10 @@ export async function datasetInfo<
 		hubUrl?: string;
 		additionalFields?: T[];
 		/**
+		 * An optional Git revision id which can be a branch name, a tag, or a commit hash.
+		 */
+		revision?: string;
+		/**
 		 * Custom fetch function to use instead of the default one, for example to use a proxy or edit headers.
 		 */
 		fetch?: typeof fetch;
@@ -27,7 +31,7 @@ export async function datasetInfo<
 	]).toString();
 
 	const response = await (params.fetch || fetch)(
-		`${params?.hubUrl || HUB_URL}/api/datasets/${params.name}?${search.toString()}`,
+		`${params?.hubUrl || HUB_URL}/api/datasets/${params.name}${params.revision ? `/revision/${params.revision}` : ''}?${search.toString()}`,
 		{
 			headers: {
 				...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),

--- a/packages/hub/src/lib/dataset-info.ts
+++ b/packages/hub/src/lib/dataset-info.ts
@@ -31,7 +31,7 @@ export async function datasetInfo<
 	]).toString();
 
 	const response = await (params.fetch || fetch)(
-		`${params?.hubUrl || HUB_URL}/api/datasets/${params.name}${params.revision ? `/revision/${params.revision}` : ''}?${search.toString()}`,
+		`${params?.hubUrl || HUB_URL}/api/datasets/${params.name}/revision/${encodeURIComponent(params.revision ?? "HEAD")}?${search.toString()}`,
 		{
 			headers: {
 				...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),

--- a/packages/hub/src/lib/model-info.spec.ts
+++ b/packages/hub/src/lib/model-info.spec.ts
@@ -1,9 +1,27 @@
 import { describe, expect, it } from "vitest";
 import { modelInfo } from "./model-info";
+import type { ModelEntry } from "./list-models";
+import type { ApiModelInfo } from "../types/api/api-model";
 
 describe("modelInfo", () => {
 	it("should return the model info", async () => {
 		const info = await modelInfo({
+			name: "openai-community/gpt2",
+		});
+		expect(info).toEqual({
+			id: "621ffdc036468d709f17434d",
+			downloads: expect.any(Number),
+			gated: false,
+			name: "openai-community/gpt2",
+			updatedAt: expect.any(Date),
+			likes: expect.any(Number),
+			task: "text-generation",
+			private: false,
+		});
+	});
+
+	it("should return the model info with author", async () => {
+		const info: ModelEntry & Pick<ApiModelInfo, 'author'> = await modelInfo({
 			name: "openai-community/gpt2",
 			additionalFields: ["author"],
 		});
@@ -17,6 +35,25 @@ describe("modelInfo", () => {
 			likes: expect.any(Number),
 			task: "text-generation",
 			private: false,
+		});
+	});
+
+	it("should return the model info for a specific revision", async () => {
+		const info: ModelEntry & Pick<ApiModelInfo, 'sha'> = await modelInfo({
+			name: "openai-community/gpt2",
+			additionalFields: ["sha"],
+			revision: 'f27b190eeac4c2302d24068eabf5e9d6044389ae',
+		});
+		expect(info).toEqual({
+			id: "621ffdc036468d709f17434d",
+			downloads: expect.any(Number),
+			gated: false,
+			name: "openai-community/gpt2",
+			updatedAt: expect.any(Date),
+			likes: expect.any(Number),
+			task: "text-generation",
+			private: false,
+			sha: "f27b190eeac4c2302d24068eabf5e9d6044389ae",
 		});
 	});
 });

--- a/packages/hub/src/lib/model-info.ts
+++ b/packages/hub/src/lib/model-info.ts
@@ -31,7 +31,7 @@ export async function modelInfo<
 	]).toString();
 
 	const response = await (params.fetch || fetch)(
-		`${params?.hubUrl || HUB_URL}/api/models/${params.name}${params.revision ? `/revision/${params.revision}` : ''}?${search.toString()}`,
+		`${params?.hubUrl || HUB_URL}/api/models/${params.name}/revision/${encodeURIComponent(params.revision ?? "HEAD")}?${search.toString()}`,
 		{
 			headers: {
 				...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),

--- a/packages/hub/src/lib/model-info.ts
+++ b/packages/hub/src/lib/model-info.ts
@@ -14,6 +14,10 @@ export async function modelInfo<
 		hubUrl?: string;
 		additionalFields?: T[];
 		/**
+		 * An optional Git revision id which can be a branch name, a tag, or a commit hash.
+		 */
+		revision?: string;
+		/**
 		 * Custom fetch function to use instead of the default one, for example to use a proxy or edit headers.
 		 */
 		fetch?: typeof fetch;
@@ -27,7 +31,7 @@ export async function modelInfo<
 	]).toString();
 
 	const response = await (params.fetch || fetch)(
-		`${params?.hubUrl || HUB_URL}/api/models/${params.name}?${search.toString()}`,
+		`${params?.hubUrl || HUB_URL}/api/models/${params.name}${params.revision ? `/revision/${params.revision}` : ''}?${search.toString()}`,
 		{
 			headers: {
 				...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),

--- a/packages/hub/src/lib/space-info.spec.ts
+++ b/packages/hub/src/lib/space-info.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { spaceInfo } from "./space-info";
+import type { SpaceEntry } from "./list-spaces";
+import type { ApiSpaceInfo } from "../types/api/api-space";
 
 describe("spaceInfo", () => {
 	it("should return the space info", async () => {
@@ -13,6 +15,39 @@ describe("spaceInfo", () => {
 			likes: expect.any(Number),
 			private: false,
 			sdk: "static",
+		});
+	});
+
+	it("should return the space info with author", async () => {
+		const info: SpaceEntry & Pick<ApiSpaceInfo, 'author'> = await spaceInfo({
+			name: "huggingfacejs/client-side-oauth",
+			additionalFields: ['author'],
+		});
+		expect(info).toEqual({
+			id: "659835e689010f9c7aed608d",
+			name: "huggingfacejs/client-side-oauth",
+			updatedAt: expect.any(Date),
+			likes: expect.any(Number),
+			private: false,
+			sdk: "static",
+			author: 'huggingfacejs',
+		});
+	});
+
+	it("should return the space info for a given revision", async () => {
+		const info: SpaceEntry & Pick<ApiSpaceInfo, 'sha'> = await spaceInfo({
+			name: "huggingfacejs/client-side-oauth",
+			additionalFields: ['sha'],
+			revision: 'e410a9ff348e6bed393b847711e793282d7c672e'
+		});
+		expect(info).toEqual({
+			id: "659835e689010f9c7aed608d",
+			name: "huggingfacejs/client-side-oauth",
+			updatedAt: expect.any(Date),
+			likes: expect.any(Number),
+			private: false,
+			sdk: "static",
+			sha: 'e410a9ff348e6bed393b847711e793282d7c672e',
 		});
 	});
 });

--- a/packages/hub/src/lib/space-info.ts
+++ b/packages/hub/src/lib/space-info.ts
@@ -32,7 +32,7 @@ export async function spaceInfo<
 	]).toString();
 
 	const response = await (params.fetch || fetch)(
-		`${params?.hubUrl || HUB_URL}/api/spaces/${params.name}${params.revision ? `/revision/${params.revision}` : ''}?${search.toString()}`,
+		`${params?.hubUrl || HUB_URL}/api/spaces/${params.name}/revision/${encodeURIComponent(params.revision ?? "HEAD")}?${search.toString()}`,
 		{
 			headers: {
 				...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),

--- a/packages/hub/src/lib/space-info.ts
+++ b/packages/hub/src/lib/space-info.ts
@@ -15,6 +15,10 @@ export async function spaceInfo<
 		hubUrl?: string;
 		additionalFields?: T[];
 		/**
+		 * An optional Git revision id which can be a branch name, a tag, or a commit hash.
+		 */
+		revision?: string;
+		/**
 		 * Custom fetch function to use instead of the default one, for example to use a proxy or edit headers.
 		 */
 		fetch?: typeof fetch;
@@ -28,7 +32,7 @@ export async function spaceInfo<
 	]).toString();
 
 	const response = await (params.fetch || fetch)(
-		`${params?.hubUrl || HUB_URL}/api/spaces/${params.name}?${search.toString()}`,
+		`${params?.hubUrl || HUB_URL}/api/spaces/${params.name}${params.revision ? `/revision/${params.revision}` : ''}?${search.toString()}`,
 		{
 			headers: {
 				...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),


### PR DESCRIPTION
When getting modelInfo, datasetInfo, spaceInfo, we might need to get the details for a specific revision.

This PR adds an optional `revision` property to those methods