### PR TITLE
Add countDownloads for Oasis

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -474,7 +474,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "open-oasis",
 		repoUrl: "https://github.com/etched-ai/open-oasis",
 		filter: true,
-		countDownloads: `path_extension:"pt"`,
+		countDownloads: `path:"oasis500m.pt"`,
 	},
 	open_clip: {
 		prettyLabel: "OpenCLIP",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -469,7 +469,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: true,
 		countDownloads: `path_extension:"nemo" OR path:"model_config.yaml"`,
 	},
-	open_oasis: {
+	open-oasis: {
 		prettyLabel: "open-oasis",
 		repoName: "open-oasis",
 		repoUrl: "https://github.com/etched-ai/open-oasis",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -473,7 +473,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "open-oasis",
 		repoName: "open-oasis",
 		repoUrl: "https://github.com/etched-ai/open-oasis",
-		filter: true,
 		countDownloads: `path:"oasis500m.pt"`,
 	},
 	open_clip: {

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -469,6 +469,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: true,
 		countDownloads: `path_extension:"nemo" OR path:"model_config.yaml"`,
 	},
+	open_oasis: {
+		prettyLabel: "open-oasis",
+		repoName: "open-oasis",
+		repoUrl: "https://github.com/etched-ai/open-oasis",
+		filter: true,
+		countDownloads: `path_extension:"pt"`,
+	},
 	open_clip: {
 		prettyLabel: "OpenCLIP",
 		repoName: "OpenCLIP",


### PR DESCRIPTION
This PR is intended to add download counting support for https://huggingface.co/Etched/oasis-500m. It matches `.pt` files in order to match both the autoencoder and the diffusion model.
The relevant github repository (used for inferencing the model) is https://github.com/etched-ai/open-oasis.