### PR TITLE
Update pipelines.ts to add Optical Music Recognition as subtask

### DIFF
--- a/packages/tasks/src/pipelines.ts
+++ b/packages/tasks/src/pipelines.ts
@@ -426,6 +426,10 @@ export const PIPELINE_DATA = {
 				type: "image-captioning",
 				name: "Image Captioning",
 			},
+			{
+				type: "optical-music-recognition",
+				name: "Optical Music Recognition",
+			},
 		],
 		modality: "cv",
 		color: "red",


### PR DESCRIPTION
As I plan to publish a dataset specific for Optical Music Recognition, I would like to have this subtask to tag properly the dataset.