### PR TITLE
Track oasis .safetensors instead of .pt

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -480,7 +480,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "open-oasis",
 		repoName: "open-oasis",
 		repoUrl: "https://github.com/etched-ai/open-oasis",
-		countDownloads: `path:"oasis500m.pt"`,
+		countDownloads: `path:"oasis500m.safetensors"`,
 	},
 	open_clip: {
 		prettyLabel: "OpenCLIP",


### PR DESCRIPTION
Hello! We recently updated our model (https://huggingface.co/Etched/oasis-500m/tree/main) to use the safetensors format instead of pickle. We want to make the .safetensors the default and remove the .pt, and so this PR allows download counting on the .safetensors instead.