### PR TITLE
fix: make `fileDownloadInfo` use the repo `etag` and not the CDN one

### DIFF
--- a/packages/hub/src/lib/file-download-info.spec.ts
+++ b/packages/hub/src/lib/file-download-info.spec.ts
@@ -13,7 +13,8 @@ describe("fileDownloadInfo", () => {
 		});
 
 		assert.strictEqual(info?.size, 536063208);
-		assert.strictEqual(info?.etag, '"41a0e56472bad33498744818c8b1ef2c-64"');
+		assert.strictEqual(info?.etag, '"a7a17d6d844b5de815ccab5f42cad6d24496db3850a2a43d8258221018ce87d2"');
+		assert.strictEqual(info?.commitHash, 'dd4bc8b21efa05ec961e3efc4ee5e3832a3679c7');
 		assert(info?.downloadLink);
 	});
 
@@ -30,6 +31,7 @@ describe("fileDownloadInfo", () => {
 
 		assert.strictEqual(info?.size, 134);
 		assert.strictEqual(info?.etag, '"9eb98c817f04b051b3bcca591bcd4e03cec88018"');
+		assert.strictEqual(info?.commitHash, 'dd4bc8b21efa05ec961e3efc4ee5e3832a3679c7');
 		assert(!info?.downloadLink);
 	});
 
@@ -45,5 +47,22 @@ describe("fileDownloadInfo", () => {
 
 		assert.strictEqual(info?.size, 28);
 		assert.strictEqual(info?.etag, '"a661b1a138dac6dc5590367402d100765010ffd6"');
+		assert.strictEqual(info?.commitHash, '1a7dd4986e3dab699c24ca19b2afd0f5e1a80f37');
+	});
+
+	it("should fetch LFS file info without redirect", async () => {
+		const info = await fileDownloadInfo({
+			repo: {
+				name: "google-bert/bert-base-uncased", // full name no redirect needed
+				type: "model",
+			},
+			path: "tf_model.h5",
+			revision: "dd4bc8b21efa05ec961e3efc4ee5e3832a3679c7",
+		});
+
+		assert.strictEqual(info?.size, 536063208);
+		assert.strictEqual(info?.etag, '"a7a17d6d844b5de815ccab5f42cad6d24496db3850a2a43d8258221018ce87d2"');
+		assert.strictEqual(info?.commitHash, 'dd4bc8b21efa05ec961e3efc4ee5e3832a3679c7');
+		assert(info?.downloadLink);
 	});
 });


### PR DESCRIPTION
Full explanation on https://github.com/huggingface/huggingface.js/issues/1023

> I opened the pull request, because I had some time to look at it, but I would understand that the `fileDownloadInfo` do not have the same result expectation than `get_hf_file_metadata`. Maybe we are expecting to have the CDN etag when using `fileDownloadInfo`, but then should a dedicated method `getFileMetadata` be created ?

## Related issues

Fixes https://github.com/huggingface/huggingface.js/issues/1023

## Testing

- [x] unit tests has been added

**Manually**

You can try to use the `fileDownloadInfo` for a specific file (LFS), and compare it with the blobs created by the python cli tool.