### PR TITLE
More python inference snippets

### DIFF
--- a/packages/tasks/src/snippets/inputs.ts
+++ b/packages/tasks/src/snippets/inputs.ts
@@ -27,9 +27,9 @@ const inputsTableQuestionAnswering = () =>
 
 const inputsVisualQuestionAnswering = () =>
 	`{
-	"image": "cat.png",
-	"question": "What is in this image?"
-}`;
+		"image": "cat.png",
+		"question": "What is in this image?"
+	}`;
 
 const inputsQuestionAnswering = () =>
 	`{

--- a/packages/tasks/src/snippets/inputs.ts
+++ b/packages/tasks/src/snippets/inputs.ts
@@ -86,6 +86,11 @@ const inputsImageClassification = () => `"cats.jpg"`;
 
 const inputsImageToText = () => `"cats.jpg"`;
 
+const inputsImageToImage = () => `{
+	"image": "cat.png",
+	"prompt": "Turn the cat into a tiger."
+}`;
+
 const inputsImageSegmentation = () => `"cats.jpg"`;
 
 const inputsObjectDetection = () => `"cats.jpg"`;
@@ -118,6 +123,7 @@ const modelInputSnippets: {
 	"fill-mask": inputsFillMask,
 	"image-classification": inputsImageClassification,
 	"image-to-text": inputsImageToText,
+	"image-to-image": inputsImageToImage,
 	"image-segmentation": inputsImageSegmentation,
 	"object-detection": inputsObjectDetection,
 	"question-answering": inputsQuestionAnswering,

--- a/packages/tasks/src/snippets/python.spec.ts
+++ b/packages/tasks/src/snippets/python.spec.ts
@@ -3,6 +3,38 @@ import { describe, expect, it } from "vitest";
 import { getPythonInferenceSnippet } from "./python";
 
 describe("inference API snippets", () => {
+	it("automatic-speech-recognition", async () => {
+		const model: ModelDataMinimal = {
+			id: "openai/whisper-large-v3-turbo",
+			pipeline_tag: "automatic-speech-recognition",
+			tags: [],
+			inference: "",
+		};
+		const snippets = getPythonInferenceSnippet(model, "api_token") as InferenceSnippet[];
+
+		expect(snippets.length).toEqual(2);
+
+		expect(snippets[0].client).toEqual("huggingface_hub");
+		expect(snippets[0].content).toEqual(`from huggingface_hub import InferenceClient
+client = InferenceClient("openai/whisper-large-v3-turbo", token="api_token")
+
+output = client.automatic_speech_recognition("sample1.flac")`);
+
+		expect(snippets[1].client).toEqual("requests");
+		expect(snippets[1].content).toEqual(`import requests
+
+API_URL = "https://api-inference.huggingface.co/models/openai/whisper-large-v3-turbo"
+headers = {"Authorization": "Bearer api_token"}
+
+def query(filename):
+    with open(filename, "rb") as f:
+        data = f.read()
+    response = requests.post(API_URL, headers=headers, data=data)
+    return response.json()
+
+output = query("sample1.flac")`);
+	});
+
 	it("conversational llm", async () => {
 		const model: ModelDataMinimal = {
 			id: "meta-llama/Llama-3.1-8B-Instruct",

--- a/packages/tasks/src/snippets/python.spec.ts
+++ b/packages/tasks/src/snippets/python.spec.ts
@@ -155,7 +155,8 @@ client = InferenceClient("impira/layoutlm-invoices", token="api_token")
 output = client.document_question_answering(cat.png, question=What is in this image?)`);
 
 		expect(snippets[1].client).toEqual("requests");
-		expect(snippets[1].content).toEqual(`import requests
+		expect(snippets[1].content).toEqual(`import base64
+import requests
 
 API_URL = "https://api-inference.huggingface.co/models/impira/layoutlm-invoices"
 headers = {"Authorization": "Bearer api_token"}
@@ -194,7 +195,8 @@ client = InferenceClient("stabilityai/stable-diffusion-xl-refiner-1.0", token="a
 image = client.image_to_image("cat.png", prompt="Turn the cat into a tiger.")`);
 
 		expect(snippets[1].client).toEqual("requests");
-		expect(snippets[1].content).toEqual(`import requests
+		expect(snippets[1].content).toEqual(`import base64
+import requests
 
 API_URL = "https://api-inference.huggingface.co/models/stabilityai/stable-diffusion-xl-refiner-1.0"
 headers = {"Authorization": "Bearer api_token"}

--- a/packages/tasks/src/snippets/python.spec.ts
+++ b/packages/tasks/src/snippets/python.spec.ts
@@ -105,6 +105,44 @@ for chunk in stream:
     print(chunk.choices[0].delta.content, end="")`);
 	});
 
+	it("document-question-answering", async () => {
+		const model: ModelDataMinimal = {
+			id: "impira/layoutlm-invoices",
+			pipeline_tag: "document-question-answering",
+			tags: [],
+			inference: "",
+		};
+		const snippets = getPythonInferenceSnippet(model, "api_token") as InferenceSnippet[];
+
+		expect(snippets.length).toEqual(2);
+
+		expect(snippets[0].client).toEqual("huggingface_hub");
+		expect(snippets[0].content).toEqual(`from huggingface_hub import InferenceClient
+client = InferenceClient("impira/layoutlm-invoices", token="api_token")
+
+output = client.document_question_answering(cat.png, question=What is in this image?)`);
+
+		expect(snippets[1].client).toEqual("requests");
+		expect(snippets[1].content).toEqual(`import requests
+
+API_URL = "https://api-inference.huggingface.co/models/impira/layoutlm-invoices"
+headers = {"Authorization": "Bearer api_token"}
+
+def query(payload):
+	with open(payload["image"], "rb") as f:
+		img = f.read()
+		payload["image"] = base64.b64encode(img).decode("utf-8")
+	response = requests.post(API_URL, headers=headers, json=payload)
+	return response.json()
+
+output = query({
+    "inputs": {
+		"image": "cat.png",
+		"question": "What is in this image?"
+	},
+})`);
+	});
+
 	it("text-to-image", async () => {
 		const model: ModelDataMinimal = {
 			id: "black-forest-labs/FLUX.1-schnell",

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -33,6 +33,20 @@ output = query(${getModelInputSnippet(model)})`,
 
 // Specific snippets
 
+const snippetAutomaticSpeechRecognition = (model: ModelDataMinimal, accessToken: string): InferenceSnippet[] => {
+	return [
+		{
+			client: "huggingface_hub",
+			content: `${snippetImportInferenceClient(model, accessToken)}
+output = client.automatic_speech_recognition(${getModelInputSnippet(model)})`,
+		},
+		{
+			client: "requests",
+			content: snippetFile(model).content,
+		},
+	];
+};
+
 const snippetConversational = (
 	model: ModelDataMinimal,
 	accessToken: string,
@@ -285,7 +299,7 @@ const pythonSnippets: Partial<
 	"image-text-to-text": snippetConversational,
 	"fill-mask": snippetBasic,
 	"sentence-similarity": snippetBasic,
-	"automatic-speech-recognition": snippetFile,
+	"automatic-speech-recognition": snippetAutomaticSpeechRecognition,
 	"text-to-image": snippetTextToImage,
 	"text-to-speech": snippetTextToAudio,
 	"text-to-audio": snippetTextToAudio,

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -9,7 +9,7 @@ const snippetImportInferenceClient = (model: ModelDataMinimal, accessToken: stri
 client = InferenceClient("${model.id}", token="${accessToken || "{API_TOKEN}"}")
 `;
 
-export const snippetConversational = (
+const snippetConversational = (
 	model: ModelDataMinimal,
 	accessToken: string,
 	opts?: {
@@ -118,7 +118,7 @@ print(completion.choices[0].message)`,
 	}
 };
 
-export const snippetZeroShotClassification = (model: ModelDataMinimal): InferenceSnippet => ({
+const snippetZeroShotClassification = (model: ModelDataMinimal): InferenceSnippet => ({
 	content: `def query(payload):
 	response = requests.post(API_URL, headers=headers, json=payload)
 	return response.json()
@@ -129,7 +129,7 @@ output = query({
 })`,
 });
 
-export const snippetZeroShotImageClassification = (model: ModelDataMinimal): InferenceSnippet => ({
+const snippetZeroShotImageClassification = (model: ModelDataMinimal): InferenceSnippet => ({
 	content: `def query(data):
 	with open(data["image_path"], "rb") as f:
 		img = f.read()
@@ -146,7 +146,7 @@ output = query({
 })`,
 });
 
-export const snippetBasic = (model: ModelDataMinimal): InferenceSnippet => ({
+const snippetBasic = (model: ModelDataMinimal): InferenceSnippet => ({
 	content: `def query(payload):
 	response = requests.post(API_URL, headers=headers, json=payload)
 	return response.json()
@@ -156,7 +156,7 @@ output = query({
 })`,
 });
 
-export const snippetFile = (model: ModelDataMinimal): InferenceSnippet => ({
+const snippetFile = (model: ModelDataMinimal): InferenceSnippet => ({
 	content: `def query(filename):
     with open(filename, "rb") as f:
         data = f.read()
@@ -166,7 +166,7 @@ export const snippetFile = (model: ModelDataMinimal): InferenceSnippet => ({
 output = query(${getModelInputSnippet(model)})`,
 });
 
-export const snippetTextToImage = (model: ModelDataMinimal, accessToken: string): InferenceSnippet[] => [
+const snippetTextToImage = (model: ModelDataMinimal, accessToken: string): InferenceSnippet[] => [
 	{
 		client: "huggingface_hub",
 		content: `${snippetImportInferenceClient(model, accessToken)}
@@ -189,7 +189,7 @@ image = Image.open(io.BytesIO(image_bytes))`,
 	},
 ];
 
-export const snippetTabular = (model: ModelDataMinimal): InferenceSnippet => ({
+const snippetTabular = (model: ModelDataMinimal): InferenceSnippet => ({
 	content: `def query(payload):
 	response = requests.post(API_URL, headers=headers, json=payload)
 	return response.content
@@ -198,7 +198,7 @@ response = query({
 })`,
 });
 
-export const snippetTextToAudio = (model: ModelDataMinimal): InferenceSnippet => {
+const snippetTextToAudio = (model: ModelDataMinimal): InferenceSnippet => {
 	// Transformers TTS pipeline and api-inference-community (AIC) pipeline outputs are diverged
 	// with the latest update to inference-api (IA).
 	// Transformers IA returns a byte object (wav file), whereas AIC returns wav and sampling_rate.
@@ -231,7 +231,7 @@ Audio(audio, rate=sampling_rate)`,
 	}
 };
 
-export const snippetDocumentQuestionAnswering = (model: ModelDataMinimal): InferenceSnippet => ({
+const snippetDocumentQuestionAnswering = (model: ModelDataMinimal): InferenceSnippet => ({
 	content: `def query(payload):
  	with open(payload["image"], "rb") as f:
   		img = f.read()
@@ -244,7 +244,7 @@ output = query({
 })`,
 });
 
-export const pythonSnippets: Partial<
+const pythonSnippets: Partial<
 	Record<
 		PipelineType,
 		(

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -231,18 +231,31 @@ Audio(audio, rate=sampling_rate)`,
 	}
 };
 
-const snippetDocumentQuestionAnswering = (model: ModelDataMinimal): InferenceSnippet => ({
-	content: `def query(payload):
- 	with open(payload["image"], "rb") as f:
-  		img = f.read()
-		payload["image"] = base64.b64encode(img).decode("utf-8")  
+const snippetDocumentQuestionAnswering = (model: ModelDataMinimal, accessToken: string): InferenceSnippet[] => {
+	const inputsAsStr = getModelInputSnippet(model) as string;
+	const inputsAsObj = JSON.parse(inputsAsStr);
+
+	return [
+		{
+			client: "huggingface_hub",
+			content: `${snippetImportInferenceClient(model, accessToken)}
+output = client.document_question_answering(${inputsAsObj.image}, question=${inputsAsObj.question})`,
+		},
+		{
+			client: "requests",
+			content: `def query(payload):
+	with open(payload["image"], "rb") as f:
+		img = f.read()
+		payload["image"] = base64.b64encode(img).decode("utf-8")
 	response = requests.post(API_URL, headers=headers, json=payload)
 	return response.json()
 
 output = query({
-    "inputs": ${getModelInputSnippet(model)},
+    "inputs": ${inputsAsStr},
 })`,
-});
+		},
+	];
+};
 
 const pythonSnippets: Partial<
 	Record<


### PR DESCRIPTION
Given the size of the PR and the internal changes, I think it's best to review the changes commit per commit.

This PR:
-  improves snippets for document-question-answering (https://github.com/huggingface/huggingface.js/commit/0288149bbd86dae9d7a836ca3bafa0daef999b65)
- improves snippets for automated-speech-recognition (https://github.com/huggingface/huggingface.js/commit/060cd21206523d3db27f249b67e4378db967997e)
- adds snippets for image-to-image (https://github.com/huggingface/huggingface.js/commit/6234469c9f70d81bee077c7abae440787b127765)
- fixes some base64 imports (https://github.com/huggingface/huggingface.js/commit/0907d8fa7ecdd352f70f0f9b6652431626e00d9f)

I added tests for all the above.
I did not add `InferenceClient` snippets for all tasks as it's time-consuming. I only added tasks based on the trending models listed on [huggingface.co/models](https://huggingface.co/models). We might add more tasks in the future but that's less a priority.

Also includes some cleaning:
- remove useless `"export ..."` from python snippets module (https://github.com/huggingface/huggingface.js/commit/6d299913c1a05a2a50462d5aa09cb12f913c4598)
- order snippet definitions alphabetically for easier retrieval (https://github.com/huggingface/huggingface.js/commit/0900c99c9b85e86c043b8c7ca51e37664c2a1317) 

