### PR TITLE
Fix zero-shot tasks specs

### DIFF
--- a/packages/tasks/src/tasks/index.ts
+++ b/packages/tasks/src/tasks/index.ts
@@ -102,7 +102,6 @@ export type * from "./zero-shot-image-classification/inference.js";
 export type {
 	BoundingBox,
 	ZeroShotObjectDetectionInput,
-	ZeroShotObjectDetectionInputData,
 	ZeroShotObjectDetectionOutput,
 	ZeroShotObjectDetectionOutputElement,
 } from "./zero-shot-object-detection/inference.js";

--- a/packages/tasks/src/tasks/zero-shot-classification/inference.ts
+++ b/packages/tasks/src/tasks/zero-shot-classification/inference.ts
@@ -8,27 +8,13 @@
  */
 export interface ZeroShotClassificationInput {
 	/**
-	 * The input text data, with candidate labels
+	 * The text to classify
 	 */
-	inputs: ZeroShotClassificationInputData;
+	inputs: string;
 	/**
 	 * Additional inference parameters
 	 */
-	parameters?: ZeroShotClassificationParameters;
-	[property: string]: unknown;
-}
-/**
- * The input text data, with candidate labels
- */
-export interface ZeroShotClassificationInputData {
-	/**
-	 * The set of possible class labels to classify the text into.
-	 */
-	candidateLabels: string[];
-	/**
-	 * The text to classify
-	 */
-	text: string;
+	parameters: ZeroShotClassificationParameters;
 	[property: string]: unknown;
 }
 /**
@@ -38,8 +24,12 @@ export interface ZeroShotClassificationInputData {
  */
 export interface ZeroShotClassificationParameters {
 	/**
-	 * The sentence used in conjunction with candidateLabels to attempt the text classification
-	 * by replacing the placeholder with the candidate labels.
+	 * The set of possible class labels to classify the text into.
+	 */
+	candidate_labels: string[];
+	/**
+	 * The sentence used in conjunction with `candidate_labels` to attempt the text
+	 * classification by replacing the placeholder with the candidate labels.
 	 */
 	hypothesis_template?: string;
 	/**

--- a/packages/tasks/src/tasks/zero-shot-classification/spec/input.json
+++ b/packages/tasks/src/tasks/zero-shot-classification/spec/input.json
@@ -6,23 +6,8 @@
 	"type": "object",
 	"properties": {
 		"inputs": {
-			"description": "The input text data, with candidate labels",
-			"type": "object",
-			"title": "ZeroShotClassificationInputData",
-			"properties": {
-				"text": {
-					"type": "string",
-					"description": "The text to classify"
-				},
-				"candidateLabels": {
-					"type": "array",
-					"description": "The set of possible class labels to classify the text into.",
-					"items": {
-						"type": "string"
-					}
-				}
-			},
-			"required": ["text", "candidateLabels"]
+			"description": "The text to classify",
+			"type": "string"
 		},
 		"parameters": {
 			"description": "Additional inference parameters",
@@ -35,16 +20,24 @@
 			"description": "Additional inference parameters for Zero Shot Classification",
 			"type": "object",
 			"properties": {
+				"candidate_labels": {
+					"type": "array",
+					"description": "The set of possible class labels to classify the text into.",
+					"items": {
+						"type": "string"
+					}
+				},
 				"hypothesis_template": {
 					"type": "string",
-					"description": "The sentence used in conjunction with candidateLabels to attempt the text classification by replacing the placeholder with the candidate labels."
+					"description": "The sentence used in conjunction with `candidate_labels` to attempt the text classification by replacing the placeholder with the candidate labels."
 				},
 				"multi_label": {
 					"type": "boolean",
 					"description": "Whether multiple candidate labels can be true. If false, the scores are normalized such that the sum of the label likelihoods for each sequence is 1. If true, the labels are considered independent and probabilities are normalized for each candidate."
 				}
-			}
+			},
+			"required": ["candidate_labels"]
 		}
 	},
-	"required": ["inputs"]
+	"required": ["inputs", "parameters"]
 }

--- a/packages/tasks/src/tasks/zero-shot-image-classification/inference.ts
+++ b/packages/tasks/src/tasks/zero-shot-image-classification/inference.ts
@@ -8,27 +8,13 @@
  */
 export interface ZeroShotImageClassificationInput {
 	/**
-	 * The input image data, with candidate labels
+	 * The input image data to classify as a base64-encoded string.
 	 */
-	inputs: ZeroShotImageClassificationInputData;
+	inputs: string;
 	/**
 	 * Additional inference parameters
 	 */
-	parameters?: ZeroShotImageClassificationParameters;
-	[property: string]: unknown;
-}
-/**
- * The input image data, with candidate labels
- */
-export interface ZeroShotImageClassificationInputData {
-	/**
-	 * The candidate labels for this image
-	 */
-	candidateLabels: string[];
-	/**
-	 * The image data to classify
-	 */
-	image: unknown;
+	parameters: ZeroShotImageClassificationParameters;
 	[property: string]: unknown;
 }
 /**
@@ -38,8 +24,12 @@ export interface ZeroShotImageClassificationInputData {
  */
 export interface ZeroShotImageClassificationParameters {
 	/**
-	 * The sentence used in conjunction with candidateLabels to attempt the text classification
-	 * by replacing the placeholder with the candidate labels.
+	 * The candidate labels for this image
+	 */
+	candidate_labels: string[];
+	/**
+	 * The sentence used in conjunction with `candidate_labels` to attempt the image
+	 * classification by replacing the placeholder with the candidate labels.
 	 */
 	hypothesis_template?: string;
 	[property: string]: unknown;

--- a/packages/tasks/src/tasks/zero-shot-image-classification/spec/input.json
+++ b/packages/tasks/src/tasks/zero-shot-image-classification/spec/input.json
@@ -6,22 +6,8 @@
 	"type": "object",
 	"properties": {
 		"inputs": {
-			"description": "The input image data, with candidate labels",
-			"type": "object",
-			"title": "ZeroShotImageClassificationInputData",
-			"properties": {
-				"image": {
-					"description": "The image data to classify"
-				},
-				"candidateLabels": {
-					"description": "The candidate labels for this image",
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			},
-			"required": ["image", "candidateLabels"]
+			"type": "string",
+			"description": "The input image data to classify as a base64-encoded string."
 		},
 		"parameters": {
 			"description": "Additional inference parameters",
@@ -34,12 +20,20 @@
 			"description": "Additional inference parameters for Zero Shot Image Classification",
 			"type": "object",
 			"properties": {
+				"candidate_labels": {
+					"description": "The candidate labels for this image",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
 				"hypothesis_template": {
 					"type": "string",
-					"description": "The sentence used in conjunction with candidateLabels to attempt the text classification by replacing the placeholder with the candidate labels."
+					"description": "The sentence used in conjunction with `candidate_labels` to attempt the image classification by replacing the placeholder with the candidate labels."
 				}
-			}
+			},
+			"required": ["candidate_labels"]
 		}
 	},
-	"required": ["inputs"]
+	"required": ["inputs", "parameters"]
 }

--- a/packages/tasks/src/tasks/zero-shot-object-detection/inference.ts
+++ b/packages/tasks/src/tasks/zero-shot-object-detection/inference.ts
@@ -8,29 +8,25 @@
  */
 export interface ZeroShotObjectDetectionInput {
 	/**
-	 * The input image data, with candidate labels
+	 * The input image data as a base64-encoded string.
 	 */
-	inputs: ZeroShotObjectDetectionInputData;
+	inputs: string;
 	/**
 	 * Additional inference parameters
 	 */
-	parameters?: {
-		[key: string]: unknown;
-	};
+	parameters: ZeroShotObjectDetectionParameters;
 	[property: string]: unknown;
 }
 /**
- * The input image data, with candidate labels
+ * Additional inference parameters
+ *
+ * Additional inference parameters for Zero Shot Object Detection
  */
-export interface ZeroShotObjectDetectionInputData {
+export interface ZeroShotObjectDetectionParameters {
 	/**
 	 * The candidate labels for this image
 	 */
-	candidateLabels: string[];
-	/**
-	 * The image data to generate bounding boxes from
-	 */
-	image: unknown;
+	candidate_labels: string[];
 	[property: string]: unknown;
 }
 /**

--- a/packages/tasks/src/tasks/zero-shot-object-detection/spec/input.json
+++ b/packages/tasks/src/tasks/zero-shot-object-detection/spec/input.json
@@ -6,22 +6,8 @@
 	"type": "object",
 	"properties": {
 		"inputs": {
-			"description": "The input image data, with candidate labels",
-			"type": "object",
-			"title": "ZeroShotObjectDetectionInputData",
-			"properties": {
-				"image": {
-					"description": "The image data to generate bounding boxes from"
-				},
-				"candidateLabels": {
-					"description": "The candidate labels for this image",
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			},
-			"required": ["image", "candidateLabels"]
+			"description": "The input image data as a base64-encoded string.",
+			"type": "string"
 		},
 		"parameters": {
 			"description": "Additional inference parameters",
@@ -33,8 +19,17 @@
 			"title": "ZeroShotObjectDetectionParameters",
 			"description": "Additional inference parameters for Zero Shot Object Detection",
 			"type": "object",
-			"properties": {}
+			"properties": {
+				"candidate_labels": {
+					"description": "The candidate labels for this image",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			},
+			"required": ["candidate_labels"]
 		}
 	},
-	"required": ["inputs"]
+	"required": ["inputs", "parameters"]
 }


### PR DESCRIPTION
Related to [slack thread](https://huggingface.slack.com/archives/C069KSP486B/p1731923978189269) (private).

This PR fixes the specs for `zero-shot-classification`, `zero-shot-image-classification` and `zero-shot-object-detection`. The candidate labels must be sent as parameters, not in `inputs`. The Inference API itself **did not change**, it's just the specs that were not aligned with the existing API.