### PR TITLE
Remove "words" key from DQA output

### DIFF
--- a/packages/tasks/src/tasks/document-question-answering/inference.ts
+++ b/packages/tasks/src/tasks/document-question-answering/inference.ts
@@ -102,9 +102,5 @@ export interface DocumentQuestionAnsweringOutputElement {
 	 * boxes).
 	 */
 	start: number;
-	/**
-	 * The index of each word/box pair that is in the answer
-	 */
-	words: number[];
 	[property: string]: unknown;
 }

--- a/packages/tasks/src/tasks/document-question-answering/spec/output.json
+++ b/packages/tasks/src/tasks/document-question-answering/spec/output.json
@@ -22,15 +22,8 @@
 			"end": {
 				"type": "integer",
 				"description": "The end word index of the answer (in the OCR\u2019d version of the input or provided word boxes)."
-			},
-			"words": {
-				"type": "array",
-				"items": {
-					"type": "integer"
-				},
-				"description": "The index of each word/box pair that is in the answer"
 			}
 		},
-		"required": ["answer", "score", "start", "end", "words"]
+		"required": ["answer", "score", "start", "end"]
 	}
 }


### PR DESCRIPTION
cc @Wauplin - this matches `transformers` because `transformers` never outputs a `words` key. I'll make another PR to `transformers` to remove the key from the docstrings as well.