### PR TITLE
Remove words from DQA output

### DIFF
--- a/packages/tasks/src/tasks/document-question-answering/inference.ts
+++ b/packages/tasks/src/tasks/document-question-answering/inference.ts
@@ -102,9 +102,5 @@ export interface DocumentQuestionAnsweringOutputElement {
 	 * boxes).
 	 */
 	start: number;
-	/**
-	 * The index of each word/box pair that is in the answer
-	 */
-	words: number[];
 	[property: string]: unknown;
 }

--- a/packages/tasks/src/tasks/document-question-answering/spec/output.json
+++ b/packages/tasks/src/tasks/document-question-answering/spec/output.json
@@ -22,15 +22,8 @@
 			"end": {
 				"type": "integer",
 				"description": "The end word index of the answer (in the OCR\u2019d version of the input or provided word boxes)."
-			},
-			"words": {
-				"type": "array",
-				"items": {
-					"type": "integer"
-				},
-				"description": "The index of each word/box pair that is in the answer"
 			}
 		},
-		"required": ["answer", "score", "start", "end", "words"]
+		"required": ["answer", "score", "start", "end"]
 	}
 }


### PR DESCRIPTION
Related to (unfortunately) private slack convo ([here](https://huggingface.slack.com/archives/C07SF7NFK16/p1731942920738749)). 

_originally from @Rocketknight1 :_

> Hey, for document-question-answering, the JS spec has "words", which is:
The index of each word/box pair that is in the answer
In transformers we don't output this at all. I'm not really sure how it's generated/used in the spec, since transformers already had start, end, answer, etc. 

and then 

> Update: I think the `words` output never exists because of a pipeline bug. The pipeline has two code paths in several functions, one for `VisionEncoderDecoder` models and one for everything else.
In `preprocess()`, the `VisionEncoderDecoder` path always sets [words to None](https://github.com/huggingface/transformers/blob/1c471fc3070a9179f32d147df40b760804f2ef4e/src/transformers/pipelines/document_question_answering.py#L348) which means it cannot be passed through to the output.
In `postprocess()` , the non-`VisionEncoderDecoder` path [calls](https://github.com/huggingface/transformers/blob/1c471fc3070a9179f32d147df40b760804f2ef4e/src/transformers/pipelines/document_question_answering.py#L452) `postprocess_extractive_qa`. However, this function [rewrites](https://github.com/huggingface/transformers/blob/1c471fc3070a9179f32d147df40b760804f2ef4e/src/transformers/pipelines/document_question_answering.py#L497) the `answers` dict without a `words` key
In other words, the `preprocess()` method deletes words for `VisionEncoderDecoder` models and the `postprocess()` method deletes it for everything else, so it always gets deleted! The right solution is just to remove it from the docstring and the JS spec.

---

Also to mention: DQA is only served from `transformers` in the Inference API. 