### PR TITLE
Tasks: add `function_to_apply`'s docstring for classification tasks

### DIFF
--- a/packages/tasks/src/tasks/audio-classification/inference.ts
+++ b/packages/tasks/src/tasks/audio-classification/inference.ts
@@ -24,6 +24,9 @@ export interface AudioClassificationInput {
  * Additional inference parameters for Audio Classification
  */
 export interface AudioClassificationParameters {
+	/**
+	 * The function to apply to the model outputs in order to retrieve the scores.
+	 */
 	function_to_apply?: ClassificationOutputTransform;
 	/**
 	 * When specified, limits the output to the top K most probable classes.

--- a/packages/tasks/src/tasks/audio-classification/spec/input.json
+++ b/packages/tasks/src/tasks/audio-classification/spec/input.json
@@ -22,7 +22,8 @@
 			"properties": {
 				"function_to_apply": {
 					"title": "AudioClassificationOutputTransform",
-					"$ref": "/inference/schemas/common-definitions.json#/definitions/ClassificationOutputTransform"
+					"$ref": "/inference/schemas/common-definitions.json#/definitions/ClassificationOutputTransform",
+					"description": "The function to apply to the model outputs in order to retrieve the scores."
 				},
 				"top_k": {
 					"type": "integer",

--- a/packages/tasks/src/tasks/image-classification/inference.ts
+++ b/packages/tasks/src/tasks/image-classification/inference.ts
@@ -24,6 +24,9 @@ export interface ImageClassificationInput {
  * Additional inference parameters for Image Classification
  */
 export interface ImageClassificationParameters {
+	/**
+	 * The function to apply to the model outputs in order to retrieve the scores.
+	 */
 	function_to_apply?: ClassificationOutputTransform;
 	/**
 	 * When specified, limits the output to the top K most probable classes.

--- a/packages/tasks/src/tasks/image-classification/spec/input.json
+++ b/packages/tasks/src/tasks/image-classification/spec/input.json
@@ -22,7 +22,8 @@
 			"properties": {
 				"function_to_apply": {
 					"title": "ImageClassificationOutputTransform",
-					"$ref": "/inference/schemas/common-definitions.json#/definitions/ClassificationOutputTransform"
+					"$ref": "/inference/schemas/common-definitions.json#/definitions/ClassificationOutputTransform",
+					"description": "The function to apply to the model outputs in order to retrieve the scores."
 				},
 				"top_k": {
 					"type": "integer",

--- a/packages/tasks/src/tasks/text-classification/inference.ts
+++ b/packages/tasks/src/tasks/text-classification/inference.ts
@@ -23,6 +23,9 @@ export interface TextClassificationInput {
  * Additional inference parameters for Text Classification
  */
 export interface TextClassificationParameters {
+	/**
+	 * The function to apply to the model outputs in order to retrieve the scores.
+	 */
 	function_to_apply?: ClassificationOutputTransform;
 	/**
 	 * When specified, limits the output to the top K most probable classes.

--- a/packages/tasks/src/tasks/text-classification/spec/input.json
+++ b/packages/tasks/src/tasks/text-classification/spec/input.json
@@ -22,7 +22,8 @@
 			"properties": {
 				"function_to_apply": {
 					"title": "TextClassificationOutputTransform",
-					"$ref": "/inference/schemas/common-definitions.json#/definitions/ClassificationOutputTransform"
+					"$ref": "/inference/schemas/common-definitions.json#/definitions/ClassificationOutputTransform",
+					"description": "The function to apply to the model outputs in order to retrieve the scores."
 				},
 				"top_k": {
 					"type": "integer",

--- a/packages/tasks/src/tasks/video-classification/inference.ts
+++ b/packages/tasks/src/tasks/video-classification/inference.ts
@@ -27,6 +27,9 @@ export interface VideoClassificationParameters {
 	 * The sampling rate used to select frames from the video.
 	 */
 	frame_sampling_rate?: number;
+	/**
+	 * The function to apply to the model outputs in order to retrieve the scores.
+	 */
 	function_to_apply?: ClassificationOutputTransform;
 	/**
 	 * The number of sampled frames to consider for classification.

--- a/packages/tasks/src/tasks/video-classification/spec/input.json
+++ b/packages/tasks/src/tasks/video-classification/spec/input.json
@@ -21,7 +21,8 @@
 			"properties": {
 				"function_to_apply": {
 					"title": "TextClassificationOutputTransform",
-					"$ref": "/inference/schemas/common-definitions.json#/definitions/ClassificationOutputTransform"
+					"$ref": "/inference/schemas/common-definitions.json#/definitions/ClassificationOutputTransform",
+					"description": "The function to apply to the model outputs in order to retrieve the scores."
 				},
 				"num_frames": {
 					"type": "integer",


### PR DESCRIPTION
This PR adds missing parameter description for `function_to_apply`. this documentation is required since huggingface_hub's `InferenceClient` documentation is automatically generated from the specs defined here (See [huggingface_hub/.github/workflows/update-inference-types.yaml](https://github.com/huggingface/huggingface_hub/blob/main/.github/workflows/update-inference-types.yaml) for more details). 

Note: the description was not technically missing since it's already available in `ClassificationOutputTransform`'s description, but it wasn't being properly inferred for the `function_to_apply` property.