### PR TITLE
[Tasks] remove duplicate description in task parameter objects

### DIFF
--- a/packages/tasks/src/tasks/audio-classification/inference.ts
+++ b/packages/tasks/src/tasks/audio-classification/inference.ts
@@ -13,14 +13,12 @@ export interface AudioClassificationInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Audio Classification
 	 */
 	parameters?: AudioClassificationParameters;
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Audio Classification
  */
 export interface AudioClassificationParameters {

--- a/packages/tasks/src/tasks/audio-classification/spec/input.json
+++ b/packages/tasks/src/tasks/audio-classification/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Audio Classification",
 			"$ref": "#/$defs/AudioClassificationParameters"
 		}
 	},
 	"$defs": {
 		"AudioClassificationParameters": {
 			"title": "AudioClassificationParameters",
-			"description": "Additional inference parameters for Audio Classification",
 			"type": "object",
 			"properties": {
 				"function_to_apply": {

--- a/packages/tasks/src/tasks/automatic-speech-recognition/inference.ts
+++ b/packages/tasks/src/tasks/automatic-speech-recognition/inference.ts
@@ -14,15 +14,13 @@ export interface AutomaticSpeechRecognitionInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Automatic Speech Recognition
 	 */
 	parameters?: AutomaticSpeechRecognitionParameters;
 	[property: string]: unknown;
 }
 
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Automatic Speech Recognition
  */
 export interface AutomaticSpeechRecognitionParameters {

--- a/packages/tasks/src/tasks/automatic-speech-recognition/inference.ts
+++ b/packages/tasks/src/tasks/automatic-speech-recognition/inference.ts
@@ -37,8 +37,6 @@ export interface AutomaticSpeechRecognitionParameters {
 
 /**
  * Parametrization of the text generation process
- *
- * Ad-hoc parametrization of the text generation process
  */
 export interface GenerationParameters {
 	/**

--- a/packages/tasks/src/tasks/automatic-speech-recognition/spec/input.json
+++ b/packages/tasks/src/tasks/automatic-speech-recognition/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Automatic Speech Recognition",
 			"$ref": "#/$defs/AutomaticSpeechRecognitionParameters"
 		}
 	},
 	"$defs": {
 		"AutomaticSpeechRecognitionParameters": {
 			"title": "AutomaticSpeechRecognitionParameters",
-			"description": "Additional inference parameters for Automatic Speech Recognition",
 			"type": "object",
 			"properties": {
 				"return_timestamps": {

--- a/packages/tasks/src/tasks/common-definitions.json
+++ b/packages/tasks/src/tasks/common-definitions.json
@@ -26,7 +26,6 @@
 		},
 		"GenerationParameters": {
 			"title": "GenerationParameters",
-			"description": "Ad-hoc parametrization of the text generation process",
 			"type": "object",
 			"properties": {
 				"temperature": {

--- a/packages/tasks/src/tasks/depth-estimation/inference.ts
+++ b/packages/tasks/src/tasks/depth-estimation/inference.ts
@@ -13,7 +13,7 @@ export interface DepthEstimationInput {
 	 */
 	inputs: unknown;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Depth Estimation
 	 */
 	parameters?: { [key: string]: unknown };
 	[property: string]: unknown;

--- a/packages/tasks/src/tasks/depth-estimation/spec/input.json
+++ b/packages/tasks/src/tasks/depth-estimation/spec/input.json
@@ -9,14 +9,13 @@
 			"description": "The input image data"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Depth Estimation",
 			"$ref": "#/$defs/DepthEstimationParameters"
 		}
 	},
 	"$defs": {
 		"DepthEstimationParameters": {
 			"title": "DepthEstimationParameters",
-			"description": "Additional inference parameters for Depth Estimation",
 			"type": "object",
 			"properties": {}
 		}

--- a/packages/tasks/src/tasks/document-question-answering/inference.ts
+++ b/packages/tasks/src/tasks/document-question-answering/inference.ts
@@ -12,7 +12,7 @@ export interface DocumentQuestionAnsweringInput {
 	 */
 	inputs: DocumentQuestionAnsweringInputData;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Document Question Answering
 	 */
 	parameters?: DocumentQuestionAnsweringParameters;
 	[property: string]: unknown;
@@ -32,8 +32,6 @@ export interface DocumentQuestionAnsweringInputData {
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Document Question Answering
  */
 export interface DocumentQuestionAnsweringParameters {

--- a/packages/tasks/src/tasks/document-question-answering/spec/input.json
+++ b/packages/tasks/src/tasks/document-question-answering/spec/input.json
@@ -21,14 +21,13 @@
 			"required": ["image", "question"]
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Document Question Answering",
 			"$ref": "#/$defs/DocumentQuestionAnsweringParameters"
 		}
 	},
 	"$defs": {
 		"DocumentQuestionAnsweringParameters": {
 			"title": "DocumentQuestionAnsweringParameters",
-			"description": "Additional inference parameters for Document Question Answering",
 			"type": "object",
 			"properties": {
 				"doc_stride": {

--- a/packages/tasks/src/tasks/fill-mask/inference.ts
+++ b/packages/tasks/src/tasks/fill-mask/inference.ts
@@ -12,14 +12,12 @@ export interface FillMaskInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Fill Mask
 	 */
 	parameters?: FillMaskParameters;
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Fill Mask
  */
 export interface FillMaskParameters {

--- a/packages/tasks/src/tasks/fill-mask/spec/input.json
+++ b/packages/tasks/src/tasks/fill-mask/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Fill Mask",
 			"$ref": "#/$defs/FillMaskParameters"
 		}
 	},
 	"$defs": {
 		"FillMaskParameters": {
 			"title": "FillMaskParameters",
-			"description": "Additional inference parameters for Fill Mask",
 			"type": "object",
 			"properties": {
 				"top_k": {

--- a/packages/tasks/src/tasks/image-classification/inference.ts
+++ b/packages/tasks/src/tasks/image-classification/inference.ts
@@ -13,14 +13,12 @@ export interface ImageClassificationInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Image Classification
 	 */
 	parameters?: ImageClassificationParameters;
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Image Classification
  */
 export interface ImageClassificationParameters {

--- a/packages/tasks/src/tasks/image-classification/spec/input.json
+++ b/packages/tasks/src/tasks/image-classification/spec/input.json
@@ -10,14 +10,13 @@
 			"description": "The input image data as a base64-encoded string. If no `parameters` are provided, you can also provide the image data as a raw bytes payload."
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Image Classification",
 			"$ref": "#/$defs/ImageClassificationParameters"
 		}
 	},
 	"$defs": {
 		"ImageClassificationParameters": {
 			"title": "ImageClassificationParameters",
-			"description": "Additional inference parameters for Image Classification",
 			"type": "object",
 			"properties": {
 				"function_to_apply": {

--- a/packages/tasks/src/tasks/image-segmentation/inference.ts
+++ b/packages/tasks/src/tasks/image-segmentation/inference.ts
@@ -13,14 +13,12 @@ export interface ImageSegmentationInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Image Segmentation
 	 */
 	parameters?: ImageSegmentationParameters;
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Image Segmentation
  */
 export interface ImageSegmentationParameters {

--- a/packages/tasks/src/tasks/image-segmentation/spec/input.json
+++ b/packages/tasks/src/tasks/image-segmentation/spec/input.json
@@ -10,14 +10,13 @@
 			"description": "The input image data as a base64-encoded string. If no `parameters` are provided, you can also provide the image data as a raw bytes payload."
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Image Segmentation",
 			"$ref": "#/$defs/ImageSegmentationParameters"
 		}
 	},
 	"$defs": {
 		"ImageSegmentationParameters": {
 			"title": "ImageSegmentationParameters",
-			"description": "Additional inference parameters for Image Segmentation",
 			"type": "object",
 			"properties": {
 				"mask_threshold": {

--- a/packages/tasks/src/tasks/image-to-image/inference.ts
+++ b/packages/tasks/src/tasks/image-to-image/inference.ts
@@ -14,15 +14,13 @@ export interface ImageToImageInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Image To Image
 	 */
 	parameters?: ImageToImageParameters;
 	[property: string]: unknown;
 }
 
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Image To Image
  */
 export interface ImageToImageParameters {

--- a/packages/tasks/src/tasks/image-to-image/spec/input.json
+++ b/packages/tasks/src/tasks/image-to-image/spec/input.json
@@ -10,14 +10,13 @@
 			"description": "The input image data as a base64-encoded string. If no `parameters` are provided, you can also provide the image data as a raw bytes payload."
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Image To Image",
 			"$ref": "#/$defs/ImageToImageParameters"
 		}
 	},
 	"$defs": {
 		"ImageToImageParameters": {
 			"title": "ImageToImageParameters",
-			"description": "Additional inference parameters for Image To Image",
 			"type": "object",
 			"properties": {
 				"guidance_scale": {

--- a/packages/tasks/src/tasks/image-to-text/inference.ts
+++ b/packages/tasks/src/tasks/image-to-text/inference.ts
@@ -13,15 +13,13 @@ export interface ImageToTextInput {
 	 */
 	inputs: unknown;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Image To Text
 	 */
 	parameters?: ImageToTextParameters;
 	[property: string]: unknown;
 }
 
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Image To Text
  */
 export interface ImageToTextParameters {

--- a/packages/tasks/src/tasks/image-to-text/inference.ts
+++ b/packages/tasks/src/tasks/image-to-text/inference.ts
@@ -36,8 +36,6 @@ export interface ImageToTextParameters {
 
 /**
  * Parametrization of the text generation process
- *
- * Ad-hoc parametrization of the text generation process
  */
 export interface GenerationParameters {
 	/**

--- a/packages/tasks/src/tasks/image-to-text/spec/input.json
+++ b/packages/tasks/src/tasks/image-to-text/spec/input.json
@@ -9,14 +9,13 @@
 			"description": "The input image data"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Image To Text",
 			"$ref": "#/$defs/ImageToTextParameters"
 		}
 	},
 	"$defs": {
 		"ImageToTextParameters": {
 			"title": "ImageToTextParameters",
-			"description": "Additional inference parameters for Image To Text",
 			"type": "object",
 			"properties": {
 				"max_new_tokens": {

--- a/packages/tasks/src/tasks/object-detection/inference.ts
+++ b/packages/tasks/src/tasks/object-detection/inference.ts
@@ -13,14 +13,12 @@ export interface ObjectDetectionInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Object Detection
 	 */
 	parameters?: ObjectDetectionParameters;
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Object Detection
  */
 export interface ObjectDetectionParameters {

--- a/packages/tasks/src/tasks/object-detection/spec/input.json
+++ b/packages/tasks/src/tasks/object-detection/spec/input.json
@@ -10,14 +10,13 @@
 			"description": "The input image data as a base64-encoded string. If no `parameters` are provided, you can also provide the image data as a raw bytes payload."
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Object Detection",
 			"$ref": "#/$defs/ObjectDetectionParameters"
 		}
 	},
 	"$defs": {
 		"ObjectDetectionParameters": {
 			"title": "ObjectDetectionParameters",
-			"description": "Additional inference parameters for Object Detection",
 			"type": "object",
 			"properties": {
 				"threshold": {

--- a/packages/tasks/src/tasks/placeholder/spec/input.json
+++ b/packages/tasks/src/tasks/placeholder/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "TODO: describe additional parameters here.",
 			"$ref": "#/$defs/<TASK_ID>Parameters"
 		}
 	},
 	"$defs": {
 		"<TASK_ID>Parameters": {
 			"title": "<TASK_ID>Parameters",
-			"description": "TODO: describe additional parameters here.",
 			"type": "object",
 			"properties": {
 				"dummy_parameter_name": {

--- a/packages/tasks/src/tasks/question-answering/inference.ts
+++ b/packages/tasks/src/tasks/question-answering/inference.ts
@@ -12,7 +12,7 @@ export interface QuestionAnsweringInput {
 	 */
 	inputs: QuestionAnsweringInputData;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Question Answering
 	 */
 	parameters?: QuestionAnsweringParameters;
 	[property: string]: unknown;
@@ -32,8 +32,6 @@ export interface QuestionAnsweringInputData {
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Question Answering
  */
 export interface QuestionAnsweringParameters {

--- a/packages/tasks/src/tasks/question-answering/spec/input.json
+++ b/packages/tasks/src/tasks/question-answering/spec/input.json
@@ -22,14 +22,13 @@
 			"required": ["question", "context"]
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Question Answering",
 			"$ref": "#/$defs/QuestionAnsweringParameters"
 		}
 	},
 	"$defs": {
 		"QuestionAnsweringParameters": {
 			"title": "QuestionAnsweringParameters",
-			"description": "Additional inference parameters for Question Answering",
 			"type": "object",
 			"properties": {
 				"top_k": {

--- a/packages/tasks/src/tasks/sentence-similarity/inference.ts
+++ b/packages/tasks/src/tasks/sentence-similarity/inference.ts
@@ -12,7 +12,7 @@ export type SentenceSimilarityOutput = number[];
 export interface SentenceSimilarityInput {
 	inputs: SentenceSimilarityInputData;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Sentence Similarity
 	 */
 	parameters?: { [key: string]: unknown };
 	[property: string]: unknown;

--- a/packages/tasks/src/tasks/sentence-similarity/spec/input.json
+++ b/packages/tasks/src/tasks/sentence-similarity/spec/input.json
@@ -24,14 +24,13 @@
 			"required": ["sourceSentence", "sentences"]
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Sentence Similarity",
 			"$ref": "#/$defs/SentenceSimilarityParameters"
 		}
 	},
 	"$defs": {
 		"SentenceSimilarityParameters": {
 			"title": "SentenceSimilarityParameters",
-			"description": "Additional inference parameters for Sentence Similarity",
 			"type": "object",
 			"properties": {}
 		}

--- a/packages/tasks/src/tasks/summarization/inference.ts
+++ b/packages/tasks/src/tasks/summarization/inference.ts
@@ -13,15 +13,13 @@ export interface SummarizationInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters.
+	 * Additional inference parameters for summarization.
 	 */
 	parameters?: SummarizationParameters;
 	[property: string]: unknown;
 }
 
 /**
- * Additional inference parameters.
- *
  * Additional inference parameters for summarization.
  */
 export interface SummarizationParameters {

--- a/packages/tasks/src/tasks/summarization/spec/input.json
+++ b/packages/tasks/src/tasks/summarization/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters.",
+			"description": "Additional inference parameters for summarization.",
 			"$ref": "#/$defs/SummarizationParameters"
 		}
 	},
 	"$defs": {
 		"SummarizationParameters": {
 			"title": "SummarizationParameters",
-			"description": "Additional inference parameters for summarization.",
 			"type": "object",
 			"properties": {
 				"clean_up_tokenization_spaces": {

--- a/packages/tasks/src/tasks/table-question-answering/inference.ts
+++ b/packages/tasks/src/tasks/table-question-answering/inference.ts
@@ -12,7 +12,7 @@ export interface TableQuestionAnsweringInput {
 	 */
 	inputs: TableQuestionAnsweringInputData;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Table Question Answering
 	 */
 	parameters?: {
 		[key: string]: unknown;

--- a/packages/tasks/src/tasks/table-question-answering/spec/input.json
+++ b/packages/tasks/src/tasks/table-question-answering/spec/input.json
@@ -28,14 +28,13 @@
 			"required": ["table", "question"]
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Table Question Answering",
 			"$ref": "#/$defs/TableQuestionAnsweringParameters"
 		}
 	},
 	"$defs": {
 		"TableQuestionAnsweringParameters": {
 			"title": "TableQuestionAnsweringParameters",
-			"description": "Additional inference parameters for Table Question Answering",
 			"type": "object",
 			"properties": {}
 		}

--- a/packages/tasks/src/tasks/text-classification/inference.ts
+++ b/packages/tasks/src/tasks/text-classification/inference.ts
@@ -12,14 +12,12 @@ export interface TextClassificationInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Text Classification
 	 */
 	parameters?: TextClassificationParameters;
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Text Classification
  */
 export interface TextClassificationParameters {

--- a/packages/tasks/src/tasks/text-classification/spec/input.json
+++ b/packages/tasks/src/tasks/text-classification/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Text Classification",
 			"$ref": "#/$defs/TextClassificationParameters"
 		}
 	},
 	"$defs": {
 		"TextClassificationParameters": {
 			"title": "TextClassificationParameters",
-			"description": "Additional inference parameters for Text Classification",
 			"type": "object",
 			"properties": {
 				"function_to_apply": {

--- a/packages/tasks/src/tasks/text-to-audio/inference.ts
+++ b/packages/tasks/src/tasks/text-to-audio/inference.ts
@@ -13,15 +13,13 @@ export interface TextToAudioInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Text To Audio
 	 */
 	parameters?: TextToAudioParameters;
 	[property: string]: unknown;
 }
 
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Text To Audio
  */
 export interface TextToAudioParameters {

--- a/packages/tasks/src/tasks/text-to-audio/inference.ts
+++ b/packages/tasks/src/tasks/text-to-audio/inference.ts
@@ -32,8 +32,6 @@ export interface TextToAudioParameters {
 
 /**
  * Parametrization of the text generation process
- *
- * Ad-hoc parametrization of the text generation process
  */
 export interface GenerationParameters {
 	/**

--- a/packages/tasks/src/tasks/text-to-audio/spec/input.json
+++ b/packages/tasks/src/tasks/text-to-audio/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Text To Audio",
 			"$ref": "#/$defs/TextToAudioParameters"
 		}
 	},
 	"$defs": {
 		"TextToAudioParameters": {
 			"title": "TextToAudioParameters",
-			"description": "Additional inference parameters for Text To Audio",
 			"type": "object",
 			"properties": {
 				"generation_parameters": {

--- a/packages/tasks/src/tasks/text-to-image/inference.ts
+++ b/packages/tasks/src/tasks/text-to-image/inference.ts
@@ -13,15 +13,13 @@ export interface TextToImageInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Text To Image
 	 */
 	parameters?: TextToImageParameters;
 	[property: string]: unknown;
 }
 
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Text To Image
  */
 export interface TextToImageParameters {

--- a/packages/tasks/src/tasks/text-to-image/spec/input.json
+++ b/packages/tasks/src/tasks/text-to-image/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Text To Image",
 			"$ref": "#/$defs/TextToImageParameters"
 		}
 	},
 	"$defs": {
 		"TextToImageParameters": {
 			"title": "TextToImageParameters",
-			"description": "Additional inference parameters for Text To Image",
 			"type": "object",
 			"properties": {
 				"guidance_scale": {

--- a/packages/tasks/src/tasks/text-to-speech/inference.ts
+++ b/packages/tasks/src/tasks/text-to-speech/inference.ts
@@ -13,15 +13,13 @@ export interface TextToSpeechInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Text To Speech
 	 */
 	parameters?: TextToSpeechParameters;
 	[property: string]: unknown;
 }
 
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Text To Speech
  */
 export interface TextToSpeechParameters {

--- a/packages/tasks/src/tasks/text-to-speech/inference.ts
+++ b/packages/tasks/src/tasks/text-to-speech/inference.ts
@@ -32,8 +32,6 @@ export interface TextToSpeechParameters {
 
 /**
  * Parametrization of the text generation process
- *
- * Ad-hoc parametrization of the text generation process
  */
 export interface GenerationParameters {
 	/**

--- a/packages/tasks/src/tasks/text-to-speech/spec/input.json
+++ b/packages/tasks/src/tasks/text-to-speech/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Text To Speech",
 			"$ref": "#/$defs/TextToSpeechParameters"
 		}
 	},
 	"$defs": {
 		"TextToSpeechParameters": {
 			"title": "TextToSpeechParameters",
-			"description": "Additional inference parameters for Text To Speech",
 			"type": "object",
 			"properties": {
 				"generation_parameters": {

--- a/packages/tasks/src/tasks/text2text-generation/inference.ts
+++ b/packages/tasks/src/tasks/text2text-generation/inference.ts
@@ -13,15 +13,13 @@ export interface Text2TextGenerationInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Text2text Generation
 	 */
 	parameters?: Text2TextGenerationParameters;
 	[property: string]: unknown;
 }
 
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Text2text Generation
  */
 export interface Text2TextGenerationParameters {

--- a/packages/tasks/src/tasks/text2text-generation/spec/input.json
+++ b/packages/tasks/src/tasks/text2text-generation/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Text2text Generation",
 			"$ref": "#/$defs/Text2textGenerationParameters"
 		}
 	},
 	"$defs": {
 		"Text2textGenerationParameters": {
 			"title": "Text2textGenerationParameters",
-			"description": "Additional inference parameters for Text2text Generation",
 			"type": "object",
 			"properties": {
 				"clean_up_tokenization_spaces": {

--- a/packages/tasks/src/tasks/token-classification/inference.ts
+++ b/packages/tasks/src/tasks/token-classification/inference.ts
@@ -12,14 +12,12 @@ export interface TokenClassificationInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Token Classification
 	 */
 	parameters?: TokenClassificationParameters;
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Token Classification
  */
 export interface TokenClassificationParameters {

--- a/packages/tasks/src/tasks/token-classification/spec/input.json
+++ b/packages/tasks/src/tasks/token-classification/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Token Classification",
 			"$ref": "#/$defs/TokenClassificationParameters"
 		}
 	},
 	"$defs": {
 		"TokenClassificationParameters": {
 			"title": "TokenClassificationParameters",
-			"description": "Additional inference parameters for Token Classification",
 			"type": "object",
 			"properties": {
 				"ignore_labels": {

--- a/packages/tasks/src/tasks/translation/inference.ts
+++ b/packages/tasks/src/tasks/translation/inference.ts
@@ -13,15 +13,13 @@ export interface TranslationInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Translation
 	 */
 	parameters?: TranslationParameters;
 	[property: string]: unknown;
 }
 
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Translation
  */
 export interface TranslationParameters {

--- a/packages/tasks/src/tasks/translation/spec/input.json
+++ b/packages/tasks/src/tasks/translation/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Translation",
 			"$ref": "#/$defs/TranslationParameters"
 		}
 	},
 	"$defs": {
 		"TranslationParameters": {
 			"title": "TranslationParameters",
-			"description": "Additional inference parameters for Translation",
 			"type": "object",
 			"properties": {
 				"src_lang": {

--- a/packages/tasks/src/tasks/video-classification/inference.ts
+++ b/packages/tasks/src/tasks/video-classification/inference.ts
@@ -12,14 +12,12 @@ export interface VideoClassificationInput {
 	 */
 	inputs: unknown;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Video Classification
 	 */
 	parameters?: VideoClassificationParameters;
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Video Classification
  */
 export interface VideoClassificationParameters {

--- a/packages/tasks/src/tasks/video-classification/spec/input.json
+++ b/packages/tasks/src/tasks/video-classification/spec/input.json
@@ -9,14 +9,13 @@
 			"description": "The input video data"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Video Classification",
 			"$ref": "#/$defs/VideoClassificationParameters"
 		}
 	},
 	"$defs": {
 		"VideoClassificationParameters": {
 			"title": "VideoClassificationParameters",
-			"description": "Additional inference parameters for Video Classification",
 			"type": "object",
 			"properties": {
 				"function_to_apply": {

--- a/packages/tasks/src/tasks/visual-question-answering/inference.ts
+++ b/packages/tasks/src/tasks/visual-question-answering/inference.ts
@@ -12,7 +12,7 @@ export interface VisualQuestionAnsweringInput {
 	 */
 	inputs: VisualQuestionAnsweringInputData;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Visual Question Answering
 	 */
 	parameters?: VisualQuestionAnsweringParameters;
 	[property: string]: unknown;
@@ -32,8 +32,6 @@ export interface VisualQuestionAnsweringInputData {
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Visual Question Answering
  */
 export interface VisualQuestionAnsweringParameters {

--- a/packages/tasks/src/tasks/visual-question-answering/spec/input.json
+++ b/packages/tasks/src/tasks/visual-question-answering/spec/input.json
@@ -20,14 +20,13 @@
 			"required": ["question", "image"]
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Visual Question Answering",
 			"$ref": "#/$defs/VisualQuestionAnsweringParameters"
 		}
 	},
 	"$defs": {
 		"VisualQuestionAnsweringParameters": {
 			"title": "VisualQuestionAnsweringParameters",
-			"description": "Additional inference parameters for Visual Question Answering",
 			"type": "object",
 			"properties": {
 				"top_k": {

--- a/packages/tasks/src/tasks/zero-shot-classification/inference.ts
+++ b/packages/tasks/src/tasks/zero-shot-classification/inference.ts
@@ -12,14 +12,12 @@ export interface ZeroShotClassificationInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Zero Shot Classification
 	 */
 	parameters: ZeroShotClassificationParameters;
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Zero Shot Classification
  */
 export interface ZeroShotClassificationParameters {

--- a/packages/tasks/src/tasks/zero-shot-classification/spec/input.json
+++ b/packages/tasks/src/tasks/zero-shot-classification/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Zero Shot Classification",
 			"$ref": "#/$defs/ZeroShotClassificationParameters"
 		}
 	},
 	"$defs": {
 		"ZeroShotClassificationParameters": {
 			"title": "ZeroShotClassificationParameters",
-			"description": "Additional inference parameters for Zero Shot Classification",
 			"type": "object",
 			"properties": {
 				"candidate_labels": {

--- a/packages/tasks/src/tasks/zero-shot-image-classification/inference.ts
+++ b/packages/tasks/src/tasks/zero-shot-image-classification/inference.ts
@@ -12,14 +12,12 @@ export interface ZeroShotImageClassificationInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Zero Shot Image Classification
 	 */
 	parameters: ZeroShotImageClassificationParameters;
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Zero Shot Image Classification
  */
 export interface ZeroShotImageClassificationParameters {

--- a/packages/tasks/src/tasks/zero-shot-image-classification/spec/input.json
+++ b/packages/tasks/src/tasks/zero-shot-image-classification/spec/input.json
@@ -10,14 +10,13 @@
 			"description": "The input image data to classify as a base64-encoded string."
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Zero Shot Image Classification",
 			"$ref": "#/$defs/ZeroShotImageClassificationParameters"
 		}
 	},
 	"$defs": {
 		"ZeroShotImageClassificationParameters": {
 			"title": "ZeroShotImageClassificationParameters",
-			"description": "Additional inference parameters for Zero Shot Image Classification",
 			"type": "object",
 			"properties": {
 				"candidate_labels": {

--- a/packages/tasks/src/tasks/zero-shot-object-detection/inference.ts
+++ b/packages/tasks/src/tasks/zero-shot-object-detection/inference.ts
@@ -12,14 +12,12 @@ export interface ZeroShotObjectDetectionInput {
 	 */
 	inputs: string;
 	/**
-	 * Additional inference parameters
+	 * Additional inference parameters for Zero Shot Object Detection
 	 */
 	parameters: ZeroShotObjectDetectionParameters;
 	[property: string]: unknown;
 }
 /**
- * Additional inference parameters
- *
  * Additional inference parameters for Zero Shot Object Detection
  */
 export interface ZeroShotObjectDetectionParameters {

--- a/packages/tasks/src/tasks/zero-shot-object-detection/spec/input.json
+++ b/packages/tasks/src/tasks/zero-shot-object-detection/spec/input.json
@@ -10,14 +10,13 @@
 			"type": "string"
 		},
 		"parameters": {
-			"description": "Additional inference parameters",
+			"description": "Additional inference parameters for Zero Shot Object Detection",
 			"$ref": "#/$defs/ZeroShotObjectDetectionParameters"
 		}
 	},
 	"$defs": {
 		"ZeroShotObjectDetectionParameters": {
 			"title": "ZeroShotObjectDetectionParameters",
-			"description": "Additional inference parameters for Zero Shot Object Detection",
 			"type": "object",
 			"properties": {
 				"candidate_labels": {


### PR DESCRIPTION
this PR removes redundant description in task parameter classes definition while keeping it in the parameters field reference. this avoids duplicate documentation, see: [huggingface/huggingface_hub/pull/2664#discussion](https://github.com/huggingface/huggingface_hub/pull/2664#discussion_r1851713362) for more context.

Note : `packages/tasks/src/tasks/{task_name/inference.ts` files are auto-generated.