### PR TITLE
Add CXR Foundation and Derm Foundation model libraries (Google Health AI)

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -182,7 +182,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	},
 	"derm-foundation": {
 		prettyLabel: "Derm Foundation",
-		repoName: "Derm-Foundation",
+		repoName: "derm-foundation",
 		repoUrl: "https://github.com/google-health/derm-foundation",
 		filter: false,
 		countDownloads: `path:"scin_dataset_precomputed_embeddings.npz" OR path:"saved_model.pb"`,

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -152,7 +152,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	},
 	"cxr-foundation": {
 		prettyLabel: "CXR Foundation",
-		repoName: "CXR-Foundation",
+		repoName: "cxr-foundation",
 		repoUrl: "https://github.com/google-health/cxr-foundation",
 		filter: false,
 		countDownloads: `path:"precomputed_embeddings/embeddings.npz" OR path:"pax-elixr-b-text/saved_model.pb"`,

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -150,6 +150,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"adapter_config.json"`,
 	},
+	"cxr-foundation": {
+		prettyLabel: "CXR Foundation",
+		repoName: "CXR-Foundation",
+		repoUrl: "https://github.com/google-health/cxr-foundation",
+		filter: false,
+		countDownloads: `path:"precomputed_embeddings/embeddings.npz" OR path:"pax-elixr-b-text/saved_model.pb"`,
+	},
 	deepforest: {
 		prettyLabel: "DeepForest",
 		repoName: "deepforest",
@@ -172,6 +179,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path_extension:"pt"`,
 		snippets: snippets.depth_pro,
 		filter: false,
+	},
+	"derm-foundation": {
+		prettyLabel: "Derm Foundation",
+		repoName: "Derm-Foundation",
+		repoUrl: "https://github.com/google-health/derm-foundation",
+		filter: false,
+		countDownloads: `path:"scin_dataset_precomputed_embeddings.npz" OR path:"saved_model.pb"`,
 	},
 	diffree: {
 		prettyLabel: "Diffree",


### PR DESCRIPTION
For two Google Health AI models, a primary usage pattern (with supporting documentation and notebooks) is downloading only the precomputed .npz embeddings. As such, I'm submitting for two new model libraries which are essentially an extension of the TF Keras model library, but they cleanly handle the non-`saved_model.pb` usage pattern in the `countDownload` override. This PR was designed to conform with https://huggingface.co/docs/hub/en/models-download-stats and https://huggingface.co/docs/hub/en/models-adding-libraries#register-your-library.

Public models https://huggingface.co/google/cxr-foundation and https://huggingface.co/google/derm-foundation will be switched over once this PR is merged.