### PR TITLE
Add deep link to local app for AiBrow

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -347,6 +347,14 @@ export const LOCAL_APPS = {
 		displayOnModelPage: isLlamaCppGgufModel,
 		deeplink: (model) => new URL(`sanctum://open_from_hf?model=${model.id}`),
 	},
+	aibrow: {
+		prettyLabel: "AiBrow",
+		docsUrl: "https://aibrow.ai",
+		mainTask: "text-generation",
+		displayOnModelPage: isLlamaCppGgufModel,
+		deeplink: (model, filepath) =>
+			new URL(`https://aibrow.ai/huggingface.html?id=${model.id}` + filepath ? `&file=${filepath}` : ""),
+	},
 	jellybox: {
 		prettyLabel: "Jellybox",
 		docsUrl: "https://jellybox.com",


### PR DESCRIPTION
Hi, I've added AiBrow to the list of local apps. AiBrow is a new open source (https://github.com/axonzeta/aibrow) all-in-one local llm Extension for Chromium based browsers and Firefox. It comes bundled with llama.cpp and works on Mac, Windows, and Linux.

It implements the new Chrome AI Prompt API (https://github.com/explainers-by-googlers/prompt-api) under its own namespace (window.aibrow) and polyfills the window .ai Chrome proposal in other browsers. As well as the Prompt API implementation, AiBrow supports using different models (such as gguf models from HF), embeddings, grammar and more. The installer also includes the Q4_K_M version of SmolLM2 1.7 Instruct as the default model, all ready to go.

We just released a new version today with the support for Hugging Face models and deep linking. If you would like to check it out, please visit: https://aibrow.ai/