### PR TITLE
Update NeMo's countDownloads

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -518,7 +518,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/NVIDIA/NeMo",
 		snippets: snippets.nemo,
 		filter: true,
-		countDownloads: `path_extension:"nemo" OR path:"model_config.yaml OR path:"config.json`,
+		countDownloads: `path_extension:"nemo" OR path:"model_config.yaml" OR path:"config.json"`,
 	},
 	"open-oasis": {
 		prettyLabel: "open-oasis",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -518,7 +518,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/NVIDIA/NeMo",
 		snippets: snippets.nemo,
 		filter: true,
-		countDownloads: `path_extension:"nemo" OR path:"model_config.yaml"`,
+		countDownloads: `path_extension:"nemo" OR path:"model_config.yaml OR path:"config.json`,
 	},
 	"open-oasis": {
 		prettyLabel: "open-oasis",


### PR DESCRIPTION
Many model repos that are tagged with "library_name: nemo" actually also have weights under the format of HuggingFace `transformers`, such as https://huggingface.co/nvidia/Minitron-4B-Base and https://huggingface.co/nvidia/Llama-3.1-Minitron-4B-Width-Base

It's inaccurate to only track downloads of ".nemo" and "model_config.yaml" files for them. This PR adds `config.json` to track the downloads of their `transformers` version of weights. 
