### PR TITLE
add yolov8 as a library

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1028,6 +1028,15 @@ wavs = chat.infer(texts, )
 torchaudio.save("output1.wav", torch.from_numpy(wavs[0]), 24000)`,
 ];
 
+export const yolov8 = (model: ModelData): string[] => [
+	`from ultralytics import YOLOv8
+
+model = YOLOv8.from_pretrained("${model.id}")
+source = 'http://images.cocodataset.org/val2017/000000039769.jpg'
+model.predict(source=source, save=True)
+`,
+];
+
 export const yolov10 = (model: ModelData): string[] => [
 	`from ultralytics import YOLOv10
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -843,6 +843,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		docsUrl: "https://github.com/jasonppy/VoiceCraft",
 		snippets: snippets.voicecraft,
 	},
+	yolov8: {
+		prettyLabel: "YOLOv8",
+		repoName: "yolov8",
+		repoUrl: "https://github.com/ultralytics/ultralytics",
+		docsUrl: "https://github.com/ultralytics/ultralytics",
+		filter: false,
+		snippets: snippets.yolov8,
+	},
 	yolov10: {
 		prettyLabel: "YOLOv10",
 		repoName: "yolov10",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -849,6 +849,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/ultralytics/ultralytics",
 		docsUrl: "https://github.com/ultralytics/ultralytics",
 		filter: false,
+		countDownloads: `path_extension:"pt"`,
 		snippets: snippets.yolov8,
 	},
 	yolov10: {
@@ -856,6 +857,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "yolov10",
 		repoUrl: "https://github.com/THU-MIG/yolov10",
 		docsUrl: "https://github.com/THU-MIG/yolov10",
+		countDownloads: `path_extension:"pt"`,
 		snippets: snippets.yolov10,
 	},
 	whisperkit: {


### PR DESCRIPTION
ping @NielsRogge also @pcuenca for review
I feel like it makes sense to add this as a separate library rather than "yolo" since other orgs can come up with new yolo models, which would have a separate link (like yolov10)