### PR TITLE
Add TabPFN as library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -773,7 +773,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "TabPFN",
 		repoName: "TabPFN",
 		repoUrl: "https://github.com/PriorLabs/TabPFN",
-		filter: false,
 		countDownloads: `path_extension:"ckpt"`,
 	},
 	"tic-clip": {

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -769,6 +769,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/TensorSpeech/TensorFlowTTS",
 		snippets: snippets.tensorflowtts,
 	},
+	"tabpfn": {
+		prettyLabel: "TabPFN",
+		repoName: "TabPFN",
+		repoUrl: "https://github.com/PriorLabs/TabPFN",
+		filter: false,
+		countDownloads: `path_extension:"ckpt"`,
+	},
 	"tic-clip": {
 		prettyLabel: "TiC-CLIP",
 		repoName: "TiC-CLIP",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -769,7 +769,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/TensorSpeech/TensorFlowTTS",
 		snippets: snippets.tensorflowtts,
 	},
-	"tabpfn": {
+	tabpfn: {
 		prettyLabel: "TabPFN",
 		repoName: "TabPFN",
 		repoUrl: "https://github.com/PriorLabs/TabPFN",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -773,7 +773,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "TabPFN",
 		repoName: "TabPFN",
 		repoUrl: "https://github.com/PriorLabs/TabPFN",
-		countDownloads: `path_extension:"ckpt"`,
+		countDownloads: `path_extension:"ckpt" or path:"config.json"`,
 	},
 	"tic-clip": {
 		prettyLabel: "TiC-CLIP",


### PR DESCRIPTION
The authors of TabPFN want to track the model (it's being downloaded a lot on GH it seems but not as much on Hub because they track config) @pcuenca 