### PR TITLE
Add AMD Ryzen Threadripper 7000 series

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -14,7 +14,7 @@ export const TFLOPS_THRESHOLD_EU_AI_ACT_MODEL_TRAINING_TOTAL = 10 ** 13;
 
 export interface HardwareSpec {
 	/**
-	 * Approximate value, in FP16 whenever possible.
+	 * Approximate value, in FP16 whenever possible of GPUs and FP32 for CPUs.
 	 * This is only approximate/theoretical and shouldn't be taken too seriously.
 	 * Currently the CPU values are from cpu-monkey.com
 	 * while the GPU values are from techpowerup.com
@@ -417,7 +417,7 @@ export const SKUS = {
 				tflops: 0.6,
 			},
 			"Ryzen Zen 4 7000 (Threadripper)": {
-				tflops: ?,
+				tflops: 10.0,
 			},
 			"Ryzen Zen4 7000 (Ryzen 9)": {
 				tflops: 0.56,

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -14,7 +14,7 @@ export const TFLOPS_THRESHOLD_EU_AI_ACT_MODEL_TRAINING_TOTAL = 10 ** 13;
 
 export interface HardwareSpec {
 	/**
-	 * Approximate value, in FP16 whenever possible of GPUs and FP32 for CPUs.
+	 * Approximate value, in FP16 whenever possible for GPUs and FP32 for CPUs.
 	 * This is only approximate/theoretical and shouldn't be taken too seriously.
 	 * Currently the CPU values are from cpu-monkey.com
 	 * while the GPU values are from techpowerup.com

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -416,6 +416,9 @@ export const SKUS = {
 			"EPYC 1st Generation (Naples)": {
 				tflops: 0.6,
 			},
+			"Ryzen Zen 4 7000 (Threadripper)": {
+				tflops: ?,
+			},
 			"Ryzen Zen4 7000 (Ryzen 9)": {
 				tflops: 0.56,
 			},


### PR DESCRIPTION
- Adding AMD Ryzen Threadripper 7000 series to the drop-down selection option.
- Use 10 TFLOPS for this Threadripper generation.
- Update comment to explain we use FP32 results for CPUs

---

And it seems there might be no FP16 or FP32 measurements done yet on either cpu-monkey.com or techpowerup.com regarding the Threadripper 7000 serie CPUs.

And are like 7 or 8 CPUs in this 7000 series, so I would pick a AMD Ryzen Threadripper 7970X or AMD Ryzen Threadripper 7980X as a generic CPU for the whole 7000 serie.  
Then again, I have no clue what the tflops would be.


I personally own an AMD Ryzen Threadripper 7960X. Could I do some benchmark myself? If so, which tool or calculation (stress) test do you advice to give us a good indication?
