### PR TITLE
Use default counting rule for TabPFN library (i.e. count config.json downloads)

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -772,8 +772,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	tabpfn: {
 		prettyLabel: "TabPFN",
 		repoName: "TabPFN",
-		repoUrl: "https://github.com/PriorLabs/TabPFN",
-		countDownloads: `path_extension:"ckpt" or path:"config.json"`,
+		repoUrl: "https://github.com/PriorLabs/TabPFN"
 	},
 	"tic-clip": {
 		prettyLabel: "TiC-CLIP",


### PR DESCRIPTION
See https://github.com/huggingface/huggingface.js/pull/1094#discussion_r1913357090.

Better to count only `config.json` downloads to avoid double-counting.

Also, it seems that it should be easy to create a "use this model" snippet for TabPFN models. As mentioned by @merveenoyan in https://github.com/huggingface/huggingface.js/pull/1094#issuecomment-2582492700, documenting it in TabPFN repos + on the Hub will make it easier to load the models for end users. This is orthogonal to this PR though. cc @noahho

