### PR TITLE
Add MITIE as library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -471,6 +471,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path:"MeshAnything_350m.pth"`,
 		snippets: snippets.mesh_anything,
 	},
+	mitie:{
+		prettyLabel: "MITIE",
+		repoName: "MITIE",
+		repoUrl: "https://github.com/mit-nlp/MITIE",
+		countDownloads: `path:total_word_feature_extractor.dat`,
+	},
 	"ml-agents": {
 		prettyLabel: "ml-agents",
 		repoName: "ml-agents",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -471,7 +471,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path:"MeshAnything_350m.pth"`,
 		snippets: snippets.mesh_anything,
 	},
-	mitie:{
+	mitie: {
 		prettyLabel: "MITIE",
 		repoName: "MITIE",
 		repoUrl: "https://github.com/mit-nlp/MITIE",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -475,7 +475,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "MITIE",
 		repoName: "MITIE",
 		repoUrl: "https://github.com/mit-nlp/MITIE",
-		countDownloads: `path:total_word_feature_extractor.dat`,
+		countDownloads: `path_filename:"total_word_feature_extractor"`,
 	},
 	"ml-agents": {
 		prettyLabel: "ml-agents",


### PR DESCRIPTION
This PR ensures download stats work for the [MITIE](https://github.com/mit-nlp/MITIE) models. 

I would much appreciate it if you would consider the following change!