### PR TITLE
[Inference] [3rd party] Support versioned and unversioned Replicate models

### DIFF
--- a/packages/inference/src/lib/makeRequestOptions.ts
+++ b/packages/inference/src/lib/makeRequestOptions.ts
@@ -174,7 +174,7 @@ export async function makeRequestOptions(
 		credentials = "include";
 	}
 
-	/* 
+	/*
 	 * Versioned Replicate models in the format `owner/model:version` expect the version in the body
 	 */
 	if (provider === "replicate" && model.includes(":")) {
@@ -188,10 +188,10 @@ export async function makeRequestOptions(
 		body: binary
 			? args.data
 			: JSON.stringify({
-				...((otherArgs.model && isUrl(otherArgs.model)) || provider === "replicate" || provider === "fal-ai"
-					? omit(otherArgs, "model")
-					: { ...otherArgs, model }),
-			}),
+					...((otherArgs.model && isUrl(otherArgs.model)) || provider === "replicate" || provider === "fal-ai"
+						? omit(otherArgs, "model")
+						: { ...otherArgs, model }),
+			  }),
 		...(credentials ? { credentials } : undefined),
 		signal: options?.signal,
 	};

--- a/packages/inference/src/lib/makeRequestOptions.ts
+++ b/packages/inference/src/lib/makeRequestOptions.ts
@@ -134,7 +134,13 @@ export async function makeRequestOptions(
 					case "fal-ai":
 						return `${FAL_AI_API_BASE_URL}/${model}`;
 					case "replicate":
-						return `${REPLICATE_API_BASE_URL}/v1/models/${model}/predictions`;
+						if (model.includes(":")) {
+							// Versioned models are in the form of `owner/model:version`
+							return `${REPLICATE_API_BASE_URL}/v1/predictions/${model.split(":")[0]}`;
+						} else {
+							// Unversioned models are in the form of `owner/model`
+							return `${REPLICATE_API_BASE_URL}/v1/models/${model}/predictions`;
+						}
 					case "sambanova":
 						return SAMBANOVA_API_BASE_URL;
 					case "together":
@@ -166,6 +172,14 @@ export async function makeRequestOptions(
 		credentials = includeCredentials as RequestCredentials;
 	} else if (includeCredentials === true) {
 		credentials = "include";
+	}
+
+	/* 
+	 * Versioned Replicate models in the format `owner/model:version` expect the version in the body
+	 */
+	if (provider === "replicate" && model.includes(":")) {
+		const version = model.split(":")[1];
+		otherArgs.version = version;
 	}
 
 	const info: RequestInit = {

--- a/packages/inference/src/lib/makeRequestOptions.ts
+++ b/packages/inference/src/lib/makeRequestOptions.ts
@@ -136,7 +136,7 @@ export async function makeRequestOptions(
 					case "replicate":
 						if (model.includes(":")) {
 							// Versioned models are in the form of `owner/model:version`
-							return `${REPLICATE_API_BASE_URL}/v1/predictions/${model.split(":")[0]}`;
+							return `${REPLICATE_API_BASE_URL}/v1/predictions`;
 						} else {
 							// Unversioned models are in the form of `owner/model`
 							return `${REPLICATE_API_BASE_URL}/v1/models/${model}/predictions`;
@@ -179,7 +179,7 @@ export async function makeRequestOptions(
 	 */
 	if (provider === "replicate" && model.includes(":")) {
 		const version = model.split(":")[1];
-		otherArgs.version = version;
+		(otherArgs as typeof otherArgs & { version: string }).version = version;
 	}
 
 	const info: RequestInit = {
@@ -188,10 +188,10 @@ export async function makeRequestOptions(
 		body: binary
 			? args.data
 			: JSON.stringify({
-					...((otherArgs.model && isUrl(otherArgs.model)) || provider === "replicate" || provider === "fal-ai"
-						? omit(otherArgs, "model")
-						: { ...otherArgs, model }),
-			  }),
+				...((otherArgs.model && isUrl(otherArgs.model)) || provider === "replicate" || provider === "fal-ai"
+					? omit(otherArgs, "model")
+					: { ...otherArgs, model }),
+			}),
 		...(credentials ? { credentials } : undefined),
 		signal: options?.signal,
 	};

--- a/packages/inference/src/providers/replicate.ts
+++ b/packages/inference/src/providers/replicate.ts
@@ -17,5 +17,5 @@ type ReplicateId = string;
 export const REPLICATE_MODEL_IDS: Record<ModelId, ReplicateId> = {
 	/** text-to-image */
 	"black-forest-labs/FLUX.1-schnell": "black-forest-labs/flux-schnell",
-	"ByteDance/SDXL-Lightning": "bytedance/sdxl-lightning-4step",
+	"ByteDance/SDXL-Lightning": "bytedance/sdxl-lightning-4step:5599ed30703defd1d160a25a63321b4dec97101d98b4674bcc56e41f62f35637",
 };

--- a/packages/inference/src/providers/replicate.ts
+++ b/packages/inference/src/providers/replicate.ts
@@ -17,5 +17,6 @@ type ReplicateId = string;
 export const REPLICATE_MODEL_IDS: Record<ModelId, ReplicateId> = {
 	/** text-to-image */
 	"black-forest-labs/FLUX.1-schnell": "black-forest-labs/flux-schnell",
-	"ByteDance/SDXL-Lightning": "bytedance/sdxl-lightning-4step:5599ed30703defd1d160a25a63321b4dec97101d98b4674bcc56e41f62f35637",
+	"ByteDance/SDXL-Lightning":
+		"bytedance/sdxl-lightning-4step:5599ed30703defd1d160a25a63321b4dec97101d98b4674bcc56e41f62f35637",
 };

--- a/packages/inference/test/HfInference.spec.ts
+++ b/packages/inference/test/HfInference.spec.ts
@@ -815,7 +815,7 @@ describe.concurrent("HfInference", () => {
 					inputs: "black forest gateau cake spelling out the words FLUX SCHNELL, tasty, food photography, dynamic shot",
 				});
 				expect(res).toBeInstanceOf(Blob);
-			})
+			});
 		},
 		TIMEOUT
 	);

--- a/packages/inference/test/HfInference.spec.ts
+++ b/packages/inference/test/HfInference.spec.ts
@@ -799,7 +799,7 @@ describe.concurrent("HfInference", () => {
 		() => {
 			const client = new HfInference(env.HF_REPLICATE_KEY);
 
-			it("textToImage", async () => {
+			it("textToImage canonical", async () => {
 				const res = await client.textToImage({
 					model: "black-forest-labs/FLUX.1-schnell",
 					provider: "replicate",
@@ -807,6 +807,15 @@ describe.concurrent("HfInference", () => {
 				});
 				expect(res).toBeInstanceOf(Blob);
 			});
+
+			it("textToImage versioned", async () => {
+				const res = await client.textToImage({
+					model: "ByteDance/SDXL-Lightning",
+					provider: "replicate",
+					inputs: "black forest gateau cake spelling out the words FLUX SCHNELL, tasty, food photography, dynamic shot",
+				});
+				expect(res).toBeInstanceOf(Blob);
+			})
 		},
 		TIMEOUT
 	);

--- a/packages/inference/test/tapes.json
+++ b/packages/inference/test/tapes.json
@@ -2525,5 +2525,58 @@
         "content-type": "image/jpeg"
       }
     }
+  },
+  "84b1cb6a9d1039df7c10ffb2c90832009f4399964368f18f9b621da494d6c591": {
+    "url": "https://api.replicate.com/v1/predictions",
+    "init": {
+      "headers": {
+        "Content-Type": "application/json",
+        "Prefer": "wait"
+      },
+      "method": "POST",
+      "body": "{\"input\":{\"prompt\":\"black forest gateau cake spelling out the words FLUX SCHNELL, tasty, food photography, dynamic shot\"},\"version\":\"5599ed30703defd1d160a25a63321b4dec97101d98b4674bcc56e41f62f35637\"}"
+    },
+    "response": {
+      "body": "{\"id\":\"a0fyn914thrj00cmd6e8cd6e14\",\"model\":\"bytedance/sdxl-lightning-4step\",\"version\":\"5599ed30703defd1d160a25a63321b4dec97101d98b4674bcc56e41f62f35637\",\"input\":{\"prompt\":\"black forest gateau cake spelling out the words FLUX SCHNELL, tasty, food photography, dynamic shot\"},\"logs\":\"\",\"output\":[\"https://replicate.delivery/yhqm/f8ALqF3E4myiHqr66Gg765nEhsco4pvr32ABQvZX3fdFaUFUA/out-0.png\"],\"data_removed\":false,\"error\":null,\"status\":\"processing\",\"created_at\":\"2025-01-15T10:57:08.308Z\",\"urls\":{\"cancel\":\"https://api.replicate.com/v1/predictions/a0fyn914thrj00cmd6e8cd6e14/cancel\",\"get\":\"https://api.replicate.com/v1/predictions/a0fyn914thrj00cmd6e8cd6e14\",\"stream\":\"https://stream.replicate.com/v1/files/qoxq-pku5oelao43fx5g5ny4qbdm2qqyf5fqwp5yv26jpxcslw5ufwrtq\"}}",
+      "status": 201,
+      "statusText": "Created",
+      "headers": {
+        "alt-svc": "h3=\":443\"; ma=86400",
+        "cf-cache-status": "DYNAMIC",
+        "cf-ray": "902557da19120198-CDG",
+        "connection": "keep-alive",
+        "content-type": "application/json; charset=UTF-8",
+        "nel": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}",
+        "preference-applied": "wait=60",
+        "ratelimit-remaining": "599",
+        "ratelimit-reset": "1",
+        "report-to": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=dJWB5mgkALTqjarim6D5LybEWWkOtTzyTu4kxPRj%2FzVGVi%2BAmI0GsIe47bjsScWSZIIfuSe0XRTCtS3%2FW00TqVqiOT%2BmtKxvY903AZFVatuU2qx5IfRi1wE41l%2BlKyRMkjqs\"}],\"group\":\"cf-nel\",\"max_age\":604800}",
+        "server": "cloudflare",
+        "server-timing": "cfL4;desc=\"?proto=TCP&rtt=4793&min_rtt=3728&rtt_var=2159&sent=4&recv=5&lost=0&retrans=0&sent_bytes=2847&recv_bytes=1013&delivery_rate=776824&cwnd=251&unsent_bytes=0&cid=c3db321825f7d0a3&ts=1415&x=0\"",
+        "strict-transport-security": "max-age=15552000",
+        "vary": "Accept-Encoding"
+      }
+    }
+  },
+  "a3b664767cd6d4e44d76a7b3870730f789f02f3d05af00a26f4418c59c6b6cbc": {
+    "url": "https://replicate.delivery/yhqm/f8ALqF3E4myiHqr66Gg765nEhsco4pvr32ABQvZX3fdFaUFUA/out-0.png",
+    "init": {},
+    "response": {
+      "body": "",
+      "status": 200,
+      "statusText": "OK",
+      "headers": {
+        "accept-ranges": "bytes",
+        "access-control-allow-origin": "*",
+        "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+        "cache-control": "public,max-age=3600",
+        "cache-id": "PAR-31976c84",
+        "cache-status": "miss",
+        "content-type": "image/png",
+        "etag": "\"0e4e24383e70701c57477916dbc681de\"",
+        "last-modified": "Wed, 15 Jan 2025 10:57:09 GMT",
+        "server": "UploadServer"
+      }
+    }
   }
 }

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -772,7 +772,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	tabpfn: {
 		prettyLabel: "TabPFN",
 		repoName: "TabPFN",
-		repoUrl: "https://github.com/PriorLabs/TabPFN"
+		repoUrl: "https://github.com/PriorLabs/TabPFN",
 	},
 	"tic-clip": {
 		prettyLabel: "TiC-CLIP",


### PR DESCRIPTION
This PR updates the Replicate integration to support running both versioned and unversioned models via API.

### Versioned models

The vast majority of models on Replicate are [versioned](https://replicate.com/docs/topics/models/versions). Each time a model author publishes changes to the model, a new version is created with a new 64-character SHA identifier. You have to specify a model's version by ID when running them with the API. 

Versioned models use the following HTTP API endpoint:

```
POST /v1/predictions
```

☝🏼 This endpoint expects a `version` in the body of the request.

See https://replicate.com/docs/reference/http#predictions.create

### Unversioned models

Some models on Replicate like [black-forest-labs/flux-schnell](https://replicate.com/black-forest-labs/flux-schnell) are _unversioned_. Replicate staff maintains these as evergreen models, improving their performance and fixing bugs while maintaining API compatibility, so users know they're always running the latest and greatest.

Unversioned models have their own HTTP API endpoint:

```
POST /v1/models/{owner}/{model}/predictions
```

See https://replicate.com/docs/reference/http#models.predictions.create