### PR TITLE
Add image-feature-extraction task to transformers and timm lib->task mapping

### DIFF
--- a/packages/tasks/src/library-to-tasks.ts
+++ b/packages/tasks/src/library-to-tasks.ts
@@ -43,7 +43,7 @@ export const LIBRARY_TASK_MAPPING: Partial<Record<ModelLibraryKey, PipelineType[
 		"text2text-generation",
 	],
 	stanza: ["token-classification"],
-	timm: ["image-classification"],
+	timm: ["image-classification", "image-feature-extraction"],
 	transformers: [
 		"audio-classification",
 		"automatic-speech-recognition",
@@ -52,6 +52,7 @@ export const LIBRARY_TASK_MAPPING: Partial<Record<ModelLibraryKey, PipelineType[
 		"feature-extraction",
 		"fill-mask",
 		"image-classification",
+		"image-feature-extraction",
 		"image-segmentation",
 		"image-to-image",
 		"image-to-text",


### PR DESCRIPTION
There's no pipeline snippet for models w/ the image-feature-extraction task, probably because this mapping is missing?

cc @pcuenca re slack comment