### PR TITLE
[Inference] Better types for HfInference

### DIFF
--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -55,8 +55,7 @@
 		"@huggingface/tasks": "workspace:^"
 	},
 	"devDependencies": {
-		"@types/node": "18.13.0",
-		"type-fest": "^3.13.1"
+		"@types/node": "18.13.0"
 	},
 	"resolutions": {}
 }

--- a/packages/inference/pnpm-lock.yaml
+++ b/packages/inference/pnpm-lock.yaml
@@ -13,17 +13,9 @@ devDependencies:
   '@types/node':
     specifier: 18.13.0
     version: 18.13.0
-  type-fest:
-    specifier: ^3.13.1
-    version: 3.13.1
 
 packages:
 
   /@types/node@18.13.0:
     resolution: {integrity: sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==}
-    dev: true
-
-  /type-fest@3.13.1:
-    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
-    engines: {node: '>=14.16'}
     dev: true

--- a/packages/inference/src/utils/typedEntries.ts
+++ b/packages/inference/src/utils/typedEntries.ts
@@ -1,5 +1,0 @@
-import type { Entries } from "type-fest";
-
-export function typedEntries<T extends { [s: string]: T[keyof T] } | ArrayLike<T[keyof T]>>(obj: T): Entries<T> {
-	return Object.entries(obj) as Entries<T>;
-}


### PR DESCRIPTION
(unfinished, but I would love some inputs)

cc @coyotte508 

Before this PR, Typescript was unable to determine actual types for the inputs of methods on the `HfInference` client 

`HfInference.textToImage` would lack typings for `parameters` for example

This PR ensures that all tasks that are exported in `src/tasks/index` are re-exported by the client `HfInference`, and introduces a helper function that keeps every task's types along the way