### PR TITLE
[Tasks] fix typos in `text-to-video` inputs docstrings

### DIFF
--- a/packages/tasks/src/tasks/text-to-video/inference.ts
+++ b/packages/tasks/src/tasks/text-to-video/inference.ts
@@ -22,12 +22,12 @@ export interface TextToVideoInput {
  */
 export interface TextToVideoParameters {
 	/**
-	 * A higher guidance scale value encourages the model to generate images closely linked to
+	 * A higher guidance scale value encourages the model to generate videos closely linked to
 	 * the text prompt, but values too high may cause saturation and other artifacts.
 	 */
 	guidance_scale?: number;
 	/**
-	 * One or several prompt to guide what NOT to include in image generation.
+	 * One or several prompt to guide what NOT to include in video generation.
 	 */
 	negative_prompt?: string[];
 	/**
@@ -36,7 +36,7 @@ export interface TextToVideoParameters {
 	num_frames?: number;
 	/**
 	 * The number of denoising steps. More denoising steps usually lead to a higher quality
-	 * image at the expense of slower inference.
+	 * video at the expense of slower inference.
 	 */
 	num_inference_steps?: number;
 	/**

--- a/packages/tasks/src/tasks/text-to-video/spec/input.json
+++ b/packages/tasks/src/tasks/text-to-video/spec/input.json
@@ -25,18 +25,18 @@
 				},
 				"guidance_scale": {
 					"type": "number",
-					"description": "A higher guidance scale value encourages the model to generate images closely linked to the text prompt, but values too high may cause saturation and other artifacts."
+					"description": "A higher guidance scale value encourages the model to generate videos closely linked to the text prompt, but values too high may cause saturation and other artifacts."
 				},
 				"negative_prompt": {
 					"type": "array",
 					"items": {
 						"type": "string"
 					},
-					"description": "One or several prompt to guide what NOT to include in image generation."
+					"description": "One or several prompt to guide what NOT to include in video generation."
 				},
 				"num_inference_steps": {
 					"type": "integer",
-					"description": "The number of denoising steps. More denoising steps usually lead to a higher quality image at the expense of slower inference."
+					"description": "The number of denoising steps. More denoising steps usually lead to a higher quality video at the expense of slower inference."
 				},
 				"seed": {
 					"type": "integer",


### PR DESCRIPTION
fixing small nits in `text-to-video` parameters docstrings. 