### PR TITLE
add user-agent header to inference requests

### DIFF
--- a/packages/inference/src/lib/makeRequestOptions.ts
+++ b/packages/inference/src/lib/makeRequestOptions.ts
@@ -7,6 +7,7 @@ import { TOGETHER_API_BASE_URL, TOGETHER_SUPPORTED_MODEL_IDS } from "../provider
 import type { InferenceProvider } from "../types";
 import type { InferenceTask, Options, RequestArgs } from "../types";
 import { isUrl } from "./isUrl";
+import { version as packageVersion, name as packageName } from "../../package.json" assert { type: "json" };
 
 const HF_HUB_INFERENCE_PROXY_TEMPLATE = `${HF_HUB_URL}/api/inference-proxy/{{PROVIDER}}`;
 
@@ -88,6 +89,9 @@ export async function makeRequestOptions(
 		headers["Authorization"] =
 			provider === "fal-ai" && authMethod === "provider-key" ? `Key ${accessToken}` : `Bearer ${accessToken}`;
 	}
+
+	// e.g. @huggingface/inference@3.1.3
+	headers["User-Agent"] = `${packageName}@${packageVersion}`;
 
 	const binary = "data" in args && !!args.data;
 


### PR DESCRIPTION
This PR updates the inference client to include a user-agent header in outgoing API requests.

The value is derived from the `name` and `version` of the inference package, e.g. `@huggingface/inference@3.1.3`

This will allow third-party inference providers to identify API requests that originate from HF's new inference integration.

See https://huggingface.co/blog/inference-providers

cc @julien-c @SBrandeis 