### PR TITLE
Quote modelId in KerasHub snippets

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -443,7 +443,7 @@ const _keras_hub_causal_lm = (modelId: string): string => `
 import keras_hub
 
 # Load CausalLM model (optional: use half precision for inference)
-causal_lm = keras_hub.models.CausalLM.from_preset(${modelId}, dtype="bfloat16")
+causal_lm = keras_hub.models.CausalLM.from_preset("${modelId}", dtype="bfloat16")
 causal_lm.compile(sampler="greedy")  # (optional) specify a sampler
 
 # Generate text
@@ -454,7 +454,7 @@ const _keras_hub_text_to_image = (modelId: string): string => `
 import keras_hub
 
 # Load TextToImage model (optional: use half precision for inference)
-text_to_image = keras_hub.models.TextToImage.from_preset(${modelId}, dtype="bfloat16")
+text_to_image = keras_hub.models.TextToImage.from_preset("${modelId}", dtype="bfloat16")
 
 # Generate images with a TextToImage model.
 text_to_image.generate("Astronaut in a jungle")
@@ -465,7 +465,7 @@ import keras_hub
 
 # Load TextClassifier model
 text_classifier = keras_hub.models.TextClassifier.from_preset(
-    ${modelId},
+    "${modelId}",
     num_classes=2,
 )
 # Fine-tune
@@ -480,7 +480,7 @@ import keras
 
 # Load ImageClassifier model
 image_classifier = keras_hub.models.ImageClassifier.from_preset(
-    ${modelId},
+    "${modelId}",
     num_classes=2,
 )
 # Fine-tune
@@ -503,14 +503,14 @@ const _keras_hub_task_without_example = (task: string, modelId: string): string 
 import keras_hub
 
 # Create a ${task} model
-task = keras_hub.models.${task}.from_preset(${modelId})
+task = keras_hub.models.${task}.from_preset("${modelId}")
 `;
 
 const _keras_hub_generic_backbone = (modelId: string): string => `
 import keras_hub
 
 # Create a Backbone model unspecialized for any task
-backbone = keras_hub.models.Backbone.from_preset(${modelId})
+backbone = keras_hub.models.Backbone.from_preset("${modelId}")
 `;
 
 export const keras_hub = (model: ModelData): string[] => {


### PR DESCRIPTION
Another oversight in my KerasHub PR: https://github.com/huggingface/huggingface.js/pull/1118

Currently on https://huggingface.co/keras/stable_diffusion_3.5_large?library=keras-hub: 
![image](https://github.com/user-attachments/assets/b258780e-5b67-4ec6-88d3-554483d65b04)
