### PR TITLE
text-to-image: replace nested dict by `height` and `width` properties in the input schema

### DIFF
--- a/packages/tasks/src/tasks/text-to-image/inference.ts
+++ b/packages/tasks/src/tasks/text-to-image/inference.ts
@@ -48,9 +48,21 @@ export interface TextToImageParameters {
 	 */
 	seed?: number;
 	/**
+	 * @deprecated use {@link width} and {@link height} instead
+	 */
+	target_size?: TargetSize;
+	/**
 	 * The width in pixels of the output image
 	 */
 	width?: number;
+	[property: string]: unknown;
+}
+/**
+ * @deprecated use {@link width} and {@link height} instead
+ */
+export interface TargetSize {
+	height: number;
+	width: number;
 	[property: string]: unknown;
 }
 /**

--- a/packages/tasks/src/tasks/text-to-image/inference.ts
+++ b/packages/tasks/src/tasks/text-to-image/inference.ts
@@ -27,6 +27,10 @@ export interface TextToImageParameters {
 	 */
 	guidance_scale?: number;
 	/**
+	 * The height in pixels of the output image
+	 */
+	height?: number;
+	/**
 	 * One prompt to guide what NOT to include in image generation.
 	 */
 	negative_prompt?: string;
@@ -44,17 +48,9 @@ export interface TextToImageParameters {
 	 */
 	seed?: number;
 	/**
-	 * The size in pixel of the output image
+	 * The width in pixels of the output image
 	 */
-	target_size?: TargetSize;
-	[property: string]: unknown;
-}
-/**
- * The size in pixel of the output image
- */
-export interface TargetSize {
-	height: number;
-	width: number;
+	width?: number;
 	[property: string]: unknown;
 }
 /**

--- a/packages/tasks/src/tasks/text-to-image/inference.ts
+++ b/packages/tasks/src/tasks/text-to-image/inference.ts
@@ -48,21 +48,9 @@ export interface TextToImageParameters {
 	 */
 	seed?: number;
 	/**
-	 * @deprecated use {@link width} and {@link height} instead
-	 */
-	target_size?: TargetSize;
-	/**
 	 * The width in pixels of the output image
 	 */
 	width?: number;
-	[property: string]: unknown;
-}
-/**
- * @deprecated use {@link width} and {@link height} instead
- */
-export interface TargetSize {
-	height: number;
-	width: number;
 	[property: string]: unknown;
 }
 /**

--- a/packages/tasks/src/tasks/text-to-image/spec/input.json
+++ b/packages/tasks/src/tasks/text-to-image/spec/input.json
@@ -39,20 +39,6 @@
 					"type": "integer",
 					"description": "The height in pixels of the output image"
 				},
-
-				"target_size": {
-					"type": "object",
-					"description": "@deprecated use {@link width} and {@link height} instead",
-					"properties": {
-						"width": {
-							"type": "integer"
-						},
-						"height": {
-							"type": "integer"
-						}
-					},
-					"required": ["width", "height"]
-				},
 				"scheduler": {
 					"type": "string",
 					"description": "Override the scheduler with a compatible one."

--- a/packages/tasks/src/tasks/text-to-image/spec/input.json
+++ b/packages/tasks/src/tasks/text-to-image/spec/input.json
@@ -31,18 +31,13 @@
 					"type": "integer",
 					"description": "The number of denoising steps. More denoising steps usually lead to a higher quality image at the expense of slower inference."
 				},
-				"target_size": {
-					"type": "object",
-					"description": "The size in pixel of the output image",
-					"properties": {
-						"width": {
-							"type": "integer"
-						},
-						"height": {
-							"type": "integer"
-						}
-					},
-					"required": ["width", "height"]
+				"width": {
+					"type": "integer",
+					"description": "The width in pixels of the output image"
+				},
+				"height": {
+					"type": "integer",
+					"description": "The height in pixels of the output image"
 				},
 				"scheduler": {
 					"type": "string",

--- a/packages/tasks/src/tasks/text-to-image/spec/input.json
+++ b/packages/tasks/src/tasks/text-to-image/spec/input.json
@@ -39,6 +39,20 @@
 					"type": "integer",
 					"description": "The height in pixels of the output image"
 				},
+
+				"target_size": {
+					"type": "object",
+					"description": "@deprecated use {@link width} and {@link height} instead",
+					"properties": {
+						"width": {
+							"type": "integer"
+						},
+						"height": {
+							"type": "integer"
+						}
+					},
+					"required": ["width", "height"]
+				},
 				"scheduler": {
 					"type": "string",
 					"description": "Override the scheduler with a compatible one."


### PR DESCRIPTION
Flattening `height` and `width` parameters for `text-to-image`, making the API simpler for users and making provider-specific transformations (dict/enum) easier to handle for us. 

yes, It's a breaking change but I expect the usage of `target_size` to be really minimal so far.