### PR TITLE
Add SDXL to fal supported models

### DIFF
--- a/packages/inference/src/providers/fal-ai.ts
+++ b/packages/inference/src/providers/fal-ai.ts
@@ -14,6 +14,7 @@ export const FAL_AI_SUPPORTED_MODEL_IDS: ProviderMapping<FalAiId> = {
 		"stabilityai/stable-diffusion-3-medium": "fal-ai/stable-diffusion-v3-medium",
 		"Warlord-K/Sana-1024": "fal-ai/sana",
 		"fal/AuraFlow-v0.2": "fal-ai/aura-flow",
+		"stabilityai/stable-diffusion-xl-base-1.0": "fal-ai/fast-sdxl",
 		"stabilityai/stable-diffusion-3.5-large": "fal-ai/stable-diffusion-v35-large",
 		"stabilityai/stable-diffusion-3.5-large-turbo": "fal-ai/stable-diffusion-v35-large/turbo",
 		"stabilityai/stable-diffusion-3.5-medium": "fal-ai/stable-diffusion-v35-medium",


### PR DESCRIPTION
Gave it a spin with:
```ts
import { HfInference } from "@huggingface/inference";
import fs from "fs";

const hf = new HfInference("hf_xxxx");

async function callFalAiModel() {
	try {
		const result = await hf.textToImage({
			provider: "fal-ai",
			model: "stabilityai/stable-diffusion-xl-base-1.0",
			inputs: "A cat in the shape of a hug smiley",
		});
		console.log(result);

		const blob = new Blob([result], { type: "image/jpeg" });
		const arrayBuffer = await blob.arrayBuffer();
		const buffer = Buffer.from(arrayBuffer);

		fs.writeFileSync("output.jpg", buffer);
		console.log("Image saved to output.jpg");
	} catch (error) {
		console.error("Error calling fal-ai/fast-sdxl model:", error);
	}
}

callFalAiModel();
```

got
![output](https://github.com/user-attachments/assets/1f46f7ec-41b6-481d-9e75-5ac4233720a2)
