### PR TITLE
Accept string[] as feature-extraction input

### DIFF
--- a/packages/tasks/src/tasks/feature-extraction/inference.ts
+++ b/packages/tasks/src/tasks/feature-extraction/inference.ts
@@ -13,9 +13,9 @@ export type FeatureExtractionOutput = Array<number[]>;
  */
 export interface FeatureExtractionInput {
 	/**
-	 * The text to embed.
+	 * The text or list of texts to embed.
 	 */
-	inputs: string;
+	inputs: FeatureExtractionInputs;
 	normalize?: boolean;
 	/**
 	 * The name of the prompt that should be used by for encoding. If not set, no prompt
@@ -34,4 +34,8 @@ export interface FeatureExtractionInput {
 	truncation_direction?: FeatureExtractionInputTruncationDirection;
 	[property: string]: unknown;
 }
+/**
+ * The text or list of texts to embed.
+ */
+export type FeatureExtractionInputs = string[] | string;
 export type FeatureExtractionInputTruncationDirection = "Left" | "Right";

--- a/packages/tasks/src/tasks/feature-extraction/spec/input.json
+++ b/packages/tasks/src/tasks/feature-extraction/spec/input.json
@@ -7,8 +7,12 @@
 	"required": ["inputs"],
 	"properties": {
 		"inputs": {
-			"type": "string",
-			"description": "The text to embed."
+			"title": "FeatureExtractionInputs",
+			"oneOf": [
+				{ "type": "string" },
+				{ "type": "array", "items": { "type": "string" } }
+			],
+			"description": "The text or list of texts to embed."
 		},
 		"normalize": {
 			"type": "boolean",


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/issues/2824.

This PR makes it possible to send a `string[]` instead of `string` as `feature-extraction` inputs. This is already possible in practice in Inference API but not documented.

In the past, I've pushed back on this change (see https://github.com/huggingface/huggingface_hub/issues/1745 and https://github.com/huggingface/huggingface_hub/pull/1746#issuecomment-1766640525) but I think it's fine to revisit it now. The main reason I mentioned was that `feature-extraction`'s server-side implementation was mostly a for-loop on the text input so acception a `string[]` would not really improve performances. That been said, there has been quite some improvements since then and especially the `text-embedding-inference` framework. 