### PR TITLE
Tweak `inference-tei-import` inputs

### DIFF
--- a/packages/tasks-gen/scripts/inference-tei-import.ts
+++ b/packages/tasks-gen/scripts/inference-tei-import.ts
@@ -63,8 +63,9 @@ async function _extractAndAdapt(task: string, mainComponentName: string, type: "
 					// but not Union[List[Union[List[int], int, str]], str]
 					// data.delete(key);
 					delete data[key];
-					data["type"] = "string";
-					data["description"] = "The text to embed.";
+					data["title"] = "FeatureExtractionInputs";
+					data["description"] = "The text or list of texts to embed.";
+					data["oneOf"] = [{ type: "string" }, { type: "array", items: { type: "string" } }];
 				} else if (key === "$ref" && typeof data[key] === "string") {
 					// Verify reference exists
 					const ref = (data[key] as string).split("/").pop() ?? "";

--- a/packages/tasks/src/tasks/feature-extraction/spec/input.json
+++ b/packages/tasks/src/tasks/feature-extraction/spec/input.json
@@ -8,11 +8,18 @@
 	"properties": {
 		"inputs": {
 			"title": "FeatureExtractionInputs",
+			"description": "The text or list of texts to embed.",
 			"oneOf": [
-				{ "type": "string" },
-				{ "type": "array", "items": { "type": "string" } }
-			],
-			"description": "The text or list of texts to embed."
+				{
+					"type": "string"
+				},
+				{
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			]
 		},
 		"normalize": {
 			"type": "boolean",


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface.js/pull/1166 (and see https://github.com/huggingface/huggingface.js/pull/1178?notification_referrer_id=NT_kwDOALQU-bQxNDYyOTk2OTEyMDoxMTgwMTg0OQ#issuecomment-2636509323).

In https://github.com/huggingface/huggingface.js/pull/1166, I've made possible to pass either a `string` or `string[]` as `feature-extraction` input. But since this schema is based on TEI via the `inference-tei-import` script, we also need to update it which this PR does.

**Expectation:** exact same specs but this time we won't have a PR like https://github.com/huggingface/huggingface.js/pull/1178/files opened. 