### PR TITLE
[WIP] text-generation for Replicate

### DIFF
--- a/packages/inference/src/providers/replicate.ts
+++ b/packages/inference/src/providers/replicate.ts
@@ -5,6 +5,11 @@ export const REPLICATE_API_BASE_URL = "https://api.replicate.com";
 type ReplicateId = string;
 
 export const REPLICATE_SUPPORTED_MODEL_IDS: ProviderMapping<ReplicateId> = {
+	"text-generation": {
+		"deepseek-ai/DeepSeek-R1": "deepseek-ai/deepseek-r1",
+		"meta/meta-llama-3-70b": "meta/meta-llama-3-70b",
+		"meta/meta-llama-3-8b": "meta/meta-llama-3-8b",
+	},
 	"text-to-image": {
 		"black-forest-labs/FLUX.1-dev": "black-forest-labs/flux-dev",
 		"black-forest-labs/FLUX.1-schnell": "black-forest-labs/flux-schnell",

--- a/packages/inference/src/tasks/nlp/textGeneration.ts
+++ b/packages/inference/src/tasks/nlp/textGeneration.ts
@@ -6,10 +6,16 @@ import type {
 } from "@huggingface/tasks";
 import { InferenceOutputError } from "../../lib/InferenceOutputError";
 import type { BaseArgs, Options } from "../../types";
+import { omit } from "../../utils/omit";
 import { toArray } from "../../utils/toArray";
 import { request } from "../custom/request";
 
 export type { TextGenerationInput, TextGenerationOutput };
+
+interface ReplicateTextCompletionOutput {
+	status: string;
+	output?: string[];
+}
 
 interface TogeteherTextCompletionOutput extends Omit<ChatCompletionOutput, "choices"> {
 	choices: Array<{
@@ -42,6 +48,36 @@ export async function textGeneration(
 		const completion = raw.choices[0];
 		return {
 			generated_text: completion.text,
+		};
+	} else if (args.provider === "replicate") {
+		const payload = {
+			...omit(args, ["inputs", "parameters"]),
+			...args.parameters,
+			prompt: args.inputs,
+		};
+
+		const raw = await request<ReplicateTextCompletionOutput>(payload, {
+			...options,
+			taskHint: "text-generation",
+		});
+
+		if (typeof raw !== "object" || !("status" in raw)) {
+			throw new InferenceOutputError("Incomplete response");
+		}
+
+		const status = raw.status;
+		if (status === "starting") {
+			throw new InferenceOutputError("Replicate server-side time out");
+		}
+
+		if (!("output" in raw && Array.isArray(raw?.output))) {
+			throw new InferenceOutputError("Invalid response: no output");
+		}
+
+		const joined_output = raw.output.join("");
+
+		return {
+			generated_text: joined_output,
 		};
 	} else {
 		const res = toArray(


### PR DESCRIPTION
Tested using this script through HF or directly to Replicate:
```
import { HfInference } from "@huggingface/inference";

const hf = new HfInference("hf_xxxx"); // "r8_xxxx");

async function callModel() {
	try {
		const result = await hf.textGeneration({
			provider: "replicate",
			model: "deepseek-ai/DeepSeek-R1", // "meta/meta-llama-3-8b", // "meta/meta-llama-3-70b",
			inputs: "Let me tell you just one number, how many time the letter R appears in strawberry. This number is ", // "How many R in strawberry?", // "Just say Hi", //
		});

		console.log("## generated_text: [" + result.generated_text + "]");
	} catch (error) {
		console.error("Error calling replicate textGeneration:", error);
	}
}

callModel();
```

Not reliable (yet?).
I would recommend iterating on this PR to always switch to async (at least for `textGeneration` at `Replicate`) (i.e. remove [this](https://github.com/huggingface/huggingface.js/blob/499c9a7bdea5ba02564796fb4bd86daea0748f4a/packages/inference/src/lib/makeRequestOptions.ts#L118) + "transparently" poll from `urls` :: `get` [there](https://github.com/huggingface/huggingface.js/blob/499c9a7bdea5ba02564796fb4bd86daea0748f4a/packages/inference/src/tasks/custom/request.ts#L30) ; i.e. implement this [TODO](https://github.com/huggingface/huggingface.js/blob/499c9a7bdea5ba02564796fb4bd86daea0748f4a/packages/inference/src/tasks/cv/textToVideo.ts#L57) ^^ )

Still managed to get answers from time to time:
`deepseek` on the number of R in strawberry for instance:
```
<think>
Okay, let's see. The user is asking how many times the letter "R" appears in the word "strawberry." Alright, first, I need to make sure I spell the word correctly. Let me write it out: S-T-R-A-W-B-E-R-R-Y. Wait, is that right? Strawberry. Yeah, that's correct.

Now, I need to count the number of R's. Let's go through each letter one by one. Starting with the first letter: S – no. T – no. R – that's one. A – no. W – no. B – no. E – no. R – that's two. Then another R – wait, after E comes R, right? So E-R-R-Y. So after E, there are two R's? Let me check again. S-T-R-A-W-B-E-R-R-Y. Breaking it down: S, T, R (1), A, W, B, E, R (2), R (3), Y. Wait, hold on. Is there two R's at the end? Let me spell it again: strawberry. The correct spelling is S-T-R-A-W-B-E-R-R-Y. Yes, because the plural is strawberries, which has the double R. So in the singular form, strawberry, it's E-R-R-Y. So that's two R's after the E. So that would be three R's total? Wait, no. Let's count again. First R is the third letter: S-T-R. Then later, after B-E, there's R-R. So that's two more R's. So total of three R's? Wait, but when I spell it out: S-T-R-A-W-B-E-R-R-Y. Let's index each letter:

1. S
2. T
3. R (1)
4. A
5. W
6. B
7. E
8. R (2)
9. R (3)
10. Y

So positions 3, 8, and 9. That's three R's. Hmm, but I thought maybe I was miscounting. Let me check another way. Maybe I can write the word and underline each R.

S T R A W B E R R Y

So R at position 3, then after E, two R's at positions 8 and 9. So that's three R's total. Wait, but when I say "strawberry" out loud, it's pronounced with two R sounds? Or maybe not. Maybe the double R is just part of the spelling. So in the spelling, there are three R's? Wait, no. Let me check again. Let's look at the word: strawberry. Breaking it down: straw-berry. The "straw" part is S-T-R-A-W, and "berry" is B-E-R-R-Y. So in "berry," there are two R's. So combining both parts: straw (which has one R) and berry (which has two R's). So total of three R's. Therefore, the answer should be 3. But wait, I'm a bit confused because sometimes people might miss the R in "straw." Let me confirm by checking a dictionary or something. But since I can't access external resources, I have to rely on my knowledge. Yes, "strawberry" is spelled S-T-R-A-W-B-E-R-R-Y. So three R's. Therefore, the number of times the letter R appears is three.
</think>

The letter "R" appears in the word "strawberry" three times. Here's the breakdown:

1. **S-T-R**-A-W-B-E-R-R-Y
2. S-T-R-A-W-B-E-**R**-R-Y
3. S-T-R-A-W-B-E-R-**R**-Y

**Answer:** 3
```

And `llama-3-8b`:
```
4. We can call it the “R factor”. This number is not random, it is the exact number of time the letter R appears in strawberry. I’m sure you can guess what this means.
It means, there is a hidden message in strawberry. The letter R is the key to decoding the message.
So, when you see the letter R, you know what it means. It means the letter R is the key to decoding the message.
The letter R is the key to decoding the message. The letter R is the key to decod[...]
```

