### PR TITLE
:sparkles: Add `inferenceProvider` filter when listing models

### DIFF
--- a/packages/hub/src/lib/list-models.spec.ts
+++ b/packages/hub/src/lib/list-models.spec.ts
@@ -84,12 +84,32 @@ describe("listModels", () => {
 	it("should search model by inference provider", async () => {
 		let count = 0;
 		for await (const entry of listModels({
-			search: { inferenceProvider: "together" },
+			search: { inferenceProvider: ["together"] },
 			additionalFields: ["inferenceProviderMapping"],
 			limit: 10,
 		})) {
 			count++;
-			expect(Object.keys(entry.inferenceProviderMapping)).includes("together");
+			if (Array.isArray(entry.inferenceProviderMapping)) {
+				expect(entry.inferenceProviderMapping.map(({ provider }) => provider)).to.include("together");
+			}
+		}
+
+		expect(count).to.equal(10);
+	});
+
+	it("should search model by several inference providers", async () => {
+		let count = 0;
+		for await (const entry of listModels({
+			search: { inferenceProvider: ["together", "replicate"] },
+			additionalFields: ["inferenceProviderMapping"],
+			limit: 10,
+		})) {
+			count++;
+			if (Array.isArray(entry.inferenceProviderMapping)) {
+				const providerNames = entry.inferenceProviderMapping.map(({ provider }) => provider);
+				expect(providerNames).to.include("together");
+				expect(providerNames).to.include("replicate");
+			}
 		}
 
 		expect(count).to.equal(10);

--- a/packages/hub/src/lib/list-models.spec.ts
+++ b/packages/hub/src/lib/list-models.spec.ts
@@ -84,7 +84,7 @@ describe("listModels", () => {
 	it("should search model by inference provider", async () => {
 		let count = 0;
 		for await (const entry of listModels({
-			search: { inferenceProvider: ["together"] },
+			search: { inferenceProviders: ["together"] },
 			additionalFields: ["inferenceProviderMapping"],
 			limit: 10,
 		})) {
@@ -99,16 +99,17 @@ describe("listModels", () => {
 
 	it("should search model by several inference providers", async () => {
 		let count = 0;
+		const inferenceProviders = ["together", "replicate"];
 		for await (const entry of listModels({
-			search: { inferenceProvider: ["together", "replicate"] },
+			search: { inferenceProviders },
 			additionalFields: ["inferenceProviderMapping"],
 			limit: 10,
 		})) {
 			count++;
 			if (Array.isArray(entry.inferenceProviderMapping)) {
-				const providerNames = entry.inferenceProviderMapping.map(({ provider }) => provider);
-				expect(providerNames).to.include("together");
-				expect(providerNames).to.include("replicate");
+				expect(
+					entry.inferenceProviderMapping.filter(({ provider }) => inferenceProviders.includes(provider)).length
+				).toBeGreaterThan(0);
 			}
 		}
 

--- a/packages/hub/src/lib/list-models.spec.ts
+++ b/packages/hub/src/lib/list-models.spec.ts
@@ -80,4 +80,18 @@ describe("listModels", () => {
 
 		expect(count).to.equal(10);
 	});
+
+	it("should search model by inference provider", async () => {
+		let count = 0;
+		for await (const entry of listModels({
+			search: { inferenceProvider: "together" },
+			additionalFields: ["inferenceProviderMapping"],
+			limit: 10,
+		})) {
+			count++;
+			expect(Object.keys(entry.inferenceProviderMapping)).includes("together");
+		}
+
+		expect(count).to.equal(10);
+	});
 });

--- a/packages/hub/src/lib/list-models.ts
+++ b/packages/hub/src/lib/list-models.ts
@@ -63,6 +63,7 @@ export async function* listModels<
 			owner?: string;
 			task?: PipelineType;
 			tags?: string[];
+			inferenceProvider?: string;
 		};
 		hubUrl?: string;
 		additionalFields?: T[];
@@ -84,6 +85,7 @@ export async function* listModels<
 			...(params?.search?.owner ? { author: params.search.owner } : undefined),
 			...(params?.search?.task ? { pipeline_tag: params.search.task } : undefined),
 			...(params?.search?.query ? { search: params.search.query } : undefined),
+			...(params?.search?.inferenceProvider ? { inference_provider: params.search.inferenceProvider } : undefined),
 		}),
 		...(params?.search?.tags?.map((tag) => ["filter", tag]) ?? []),
 		...MODEL_EXPAND_KEYS.map((val) => ["expand", val] satisfies [string, string]),

--- a/packages/hub/src/lib/list-models.ts
+++ b/packages/hub/src/lib/list-models.ts
@@ -63,7 +63,10 @@ export async function* listModels<
 			owner?: string;
 			task?: PipelineType;
 			tags?: string[];
-			inferenceProvider?: string[];
+			/**
+			 * Will search for models that have one of the inference providers in the list.
+			 */
+			inferenceProviders?: string[];
 		};
 		hubUrl?: string;
 		additionalFields?: T[];
@@ -85,11 +88,13 @@ export async function* listModels<
 			...(params?.search?.owner ? { author: params.search.owner } : undefined),
 			...(params?.search?.task ? { pipeline_tag: params.search.task } : undefined),
 			...(params?.search?.query ? { search: params.search.query } : undefined),
+			...(params?.search?.inferenceProviders
+				? { inference_provider: params.search.inferenceProviders.join(",") }
+				: undefined),
 		}),
 		...(params?.search?.tags?.map((tag) => ["filter", tag]) ?? []),
 		...MODEL_EXPAND_KEYS.map((val) => ["expand", val] satisfies [string, string]),
 		...(params?.additionalFields?.map((val) => ["expand", val] satisfies [string, string]) ?? []),
-		...(params?.search?.inferenceProvider?.map((val) => ["inference_provider", val]) ?? []),
 	]).toString();
 	let url: string | undefined = `${params?.hubUrl || HUB_URL}/api/models?${search}`;
 

--- a/packages/hub/src/lib/list-models.ts
+++ b/packages/hub/src/lib/list-models.ts
@@ -63,7 +63,7 @@ export async function* listModels<
 			owner?: string;
 			task?: PipelineType;
 			tags?: string[];
-			inferenceProvider?: string;
+			inferenceProvider?: string[];
 		};
 		hubUrl?: string;
 		additionalFields?: T[];
@@ -85,11 +85,11 @@ export async function* listModels<
 			...(params?.search?.owner ? { author: params.search.owner } : undefined),
 			...(params?.search?.task ? { pipeline_tag: params.search.task } : undefined),
 			...(params?.search?.query ? { search: params.search.query } : undefined),
-			...(params?.search?.inferenceProvider ? { inference_provider: params.search.inferenceProvider } : undefined),
 		}),
 		...(params?.search?.tags?.map((tag) => ["filter", tag]) ?? []),
 		...MODEL_EXPAND_KEYS.map((val) => ["expand", val] satisfies [string, string]),
 		...(params?.additionalFields?.map((val) => ["expand", val] satisfies [string, string]) ?? []),
+		...(params?.search?.inferenceProvider?.map((val) => ["inference_provider", val]) ?? []),
 	]).toString();
 	let url: string | undefined = `${params?.hubUrl || HUB_URL}/api/models?${search}`;
 


### PR DESCRIPTION
This PR adds the missing query param `inference_provider` when listing models (`listModels`).