### PR TITLE
[draft] Support providerModelId in inference snippets

### DIFF
--- a/packages/tasks-gen/scripts/generate-snippets-fixtures.ts
+++ b/packages/tasks-gen/scripts/generate-snippets-fixtures.ts
@@ -133,7 +133,8 @@ function generateInferenceSnippet(
 	provider: SnippetInferenceProvider,
 	opts?: Record<string, unknown>
 ): InferenceSnippet[] {
-	return GET_SNIPPET_FN[language](model, "api_token", provider, opts);
+	const providerModelId = provider === "hf-inference" ? model.id : `<${provider} alias for ${model.id}>`;
+	return GET_SNIPPET_FN[language](model, "api_token", provider, providerModelId, opts);
 }
 
 async function getExpectedInferenceSnippet(

--- a/packages/tasks-gen/scripts/generate-snippets-fixtures.ts
+++ b/packages/tasks-gen/scripts/generate-snippets-fixtures.ts
@@ -52,7 +52,7 @@ const TEST_CASES: {
 			inference: "",
 		},
 		languages: ["sh", "js", "py"],
-		providers: ["hf-inference"],
+		providers: ["hf-inference", "together"],
 		opts: { streaming: true },
 	},
 	{
@@ -64,7 +64,7 @@ const TEST_CASES: {
 			inference: "",
 		},
 		languages: ["sh", "js", "py"],
-		providers: ["hf-inference"],
+		providers: ["hf-inference", "fireworks-ai"],
 		opts: { streaming: false },
 	},
 	{
@@ -76,7 +76,7 @@ const TEST_CASES: {
 			inference: "",
 		},
 		languages: ["sh", "js", "py"],
-		providers: ["hf-inference"],
+		providers: ["hf-inference", "fireworks-ai"],
 		opts: { streaming: true },
 	},
 	{
@@ -87,7 +87,7 @@ const TEST_CASES: {
 			tags: [],
 			inference: "",
 		},
-		providers: ["hf-inference"],
+		providers: ["hf-inference", "fal-ai"],
 		languages: ["sh", "js", "py"],
 	},
 	{

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/0.curl.together.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/0.curl.together.sh
@@ -2,7 +2,7 @@ curl 'https://router.huggingface.co/together/v1/chat/completions' \
 -H 'Authorization: Bearer api_token' \
 -H 'Content-Type: application/json' \
 --data '{
-    "model": "meta-llama/Llama-3.1-8B-Instruct",
+    "model": "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
     "messages": [
 		{
 			"role": "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/1.openai.together.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/1.openai.together.js
@@ -6,7 +6,7 @@ const client = new OpenAI({
 });
 
 const chatCompletion = await client.chat.completions.create({
-	model: "meta-llama/Llama-3.1-8B-Instruct",
+	model: "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
 	messages: [
 		{
 			role: "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/1.openai.together.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/1.openai.together.py
@@ -13,7 +13,7 @@ messages = [
 ]
 
 completion = client.chat.completions.create(
-	model="meta-llama/Llama-3.1-8B-Instruct", 
+	model="<together alias for meta-llama/Llama-3.1-8B-Instruct>", 
 	messages=messages, 
 	max_tokens=500,
 )

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/0.curl.together.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/0.curl.together.sh
@@ -1,0 +1,14 @@
+curl 'https://router.huggingface.co/together/v1/chat/completions' \
+-H 'Authorization: Bearer api_token' \
+-H 'Content-Type: application/json' \
+--data '{
+    "model": "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
+    "messages": [
+		{
+			"role": "user",
+			"content": "What is the capital of France?"
+		}
+	],
+    "max_tokens": 500,
+    "stream": true
+}'

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/0.huggingface.js.together.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/0.huggingface.js.together.js
@@ -1,0 +1,25 @@
+import { HfInference } from "@huggingface/inference";
+
+const client = new HfInference("api_token");
+
+let out = "";
+
+const stream = client.chatCompletionStream({
+	model: "meta-llama/Llama-3.1-8B-Instruct",
+	messages: [
+		{
+			role: "user",
+			content: "What is the capital of France?"
+		}
+	],
+	provider: "together",
+	max_tokens: 500,
+});
+
+for await (const chunk of stream) {
+	if (chunk.choices && chunk.choices.length > 0) {
+		const newContent = chunk.choices[0].delta.content;
+		out += newContent;
+		console.log(newContent);
+	}  
+}

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/0.huggingface_hub.together.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/0.huggingface_hub.together.py
@@ -1,0 +1,23 @@
+from huggingface_hub import InferenceClient
+
+client = InferenceClient(
+	provider="together",
+	api_key="api_token"
+)
+
+messages = [
+	{
+		"role": "user",
+		"content": "What is the capital of France?"
+	}
+]
+
+stream = client.chat.completions.create(
+	model="meta-llama/Llama-3.1-8B-Instruct", 
+	messages=messages, 
+	max_tokens=500,
+	stream=True
+)
+
+for chunk in stream:
+    print(chunk.choices[0].delta.content, end="")

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/1.openai.together.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/1.openai.together.js
@@ -1,0 +1,28 @@
+import { OpenAI } from "openai";
+
+const client = new OpenAI({
+	baseURL: "https://router.huggingface.co/together",
+	apiKey: "api_token"
+});
+
+let out = "";
+
+const stream = await client.chat.completions.create({
+	model: "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
+	messages: [
+		{
+			role: "user",
+			content: "What is the capital of France?"
+		}
+	],
+	max_tokens: 500,
+	stream: true,
+});
+
+for await (const chunk of stream) {
+	if (chunk.choices && chunk.choices.length > 0) {
+		const newContent = chunk.choices[0].delta.content;
+		out += newContent;
+		console.log(newContent);
+	}  
+}

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/1.openai.together.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/1.openai.together.py
@@ -1,0 +1,23 @@
+from openai import OpenAI
+
+client = OpenAI(
+	base_url="https://router.huggingface.co/together",
+	api_key="api_token"
+)
+
+messages = [
+	{
+		"role": "user",
+		"content": "What is the capital of France?"
+	}
+]
+
+stream = client.chat.completions.create(
+    model="<together alias for meta-llama/Llama-3.1-8B-Instruct>", 
+	messages=messages, 
+	max_tokens=500,
+	stream=True
+)
+
+for chunk in stream:
+	print(chunk.choices[0].delta.content, end="")

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/0.curl.fireworks-ai.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/0.curl.fireworks-ai.sh
@@ -1,0 +1,25 @@
+curl 'https://router.huggingface.co/fireworks-ai/v1/chat/completions' \
+-H 'Authorization: Bearer api_token' \
+-H 'Content-Type: application/json' \
+--data '{
+    "model": "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
+    "messages": [
+		{
+			"role": "user",
+			"content": [
+				{
+					"type": "text",
+					"text": "Describe this image in one sentence."
+				},
+				{
+					"type": "image_url",
+					"image_url": {
+						"url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+					}
+				}
+			]
+		}
+	],
+    "max_tokens": 500,
+    "stream": false
+}'

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/0.huggingface.js.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/0.huggingface.js.fireworks-ai.js
@@ -1,0 +1,28 @@
+import { HfInference } from "@huggingface/inference";
+
+const client = new HfInference("api_token");
+
+const chatCompletion = await client.chatCompletion({
+	model: "meta-llama/Llama-3.2-11B-Vision-Instruct",
+	messages: [
+		{
+			role: "user",
+			content: [
+				{
+					type: "text",
+					text: "Describe this image in one sentence."
+				},
+				{
+					type: "image_url",
+					image_url: {
+						url: "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+					}
+				}
+			]
+		}
+	],
+	provider: "fireworks-ai",
+	max_tokens: 500,
+});
+
+console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/0.huggingface_hub.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/0.huggingface_hub.fireworks-ai.py
@@ -1,0 +1,32 @@
+from huggingface_hub import InferenceClient
+
+client = InferenceClient(
+	provider="fireworks-ai",
+	api_key="api_token"
+)
+
+messages = [
+	{
+		"role": "user",
+		"content": [
+			{
+				"type": "text",
+				"text": "Describe this image in one sentence."
+			},
+			{
+				"type": "image_url",
+				"image_url": {
+					"url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+				}
+			}
+		]
+	}
+]
+
+completion = client.chat.completions.create(
+    model="meta-llama/Llama-3.2-11B-Vision-Instruct", 
+	messages=messages, 
+	max_tokens=500,
+)
+
+print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/1.openai.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/1.openai.fireworks-ai.js
@@ -1,0 +1,30 @@
+import { OpenAI } from "openai";
+
+const client = new OpenAI({
+	baseURL: "https://router.huggingface.co/fireworks-ai",
+	apiKey: "api_token"
+});
+
+const chatCompletion = await client.chat.completions.create({
+	model: "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
+	messages: [
+		{
+			role: "user",
+			content: [
+				{
+					type: "text",
+					text: "Describe this image in one sentence."
+				},
+				{
+					type: "image_url",
+					image_url: {
+						url: "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+					}
+				}
+			]
+		}
+	],
+	max_tokens: 500,
+});
+
+console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/1.openai.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/1.openai.fireworks-ai.py
@@ -1,0 +1,32 @@
+from openai import OpenAI
+
+client = OpenAI(
+	base_url="https://router.huggingface.co/fireworks-ai",
+	api_key="api_token"
+)
+
+messages = [
+	{
+		"role": "user",
+		"content": [
+			{
+				"type": "text",
+				"text": "Describe this image in one sentence."
+			},
+			{
+				"type": "image_url",
+				"image_url": {
+					"url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+				}
+			}
+		]
+	}
+]
+
+completion = client.chat.completions.create(
+	model="<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>", 
+	messages=messages, 
+	max_tokens=500,
+)
+
+print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/0.curl.fireworks-ai.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/0.curl.fireworks-ai.sh
@@ -1,0 +1,25 @@
+curl 'https://router.huggingface.co/fireworks-ai/v1/chat/completions' \
+-H 'Authorization: Bearer api_token' \
+-H 'Content-Type: application/json' \
+--data '{
+    "model": "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
+    "messages": [
+		{
+			"role": "user",
+			"content": [
+				{
+					"type": "text",
+					"text": "Describe this image in one sentence."
+				},
+				{
+					"type": "image_url",
+					"image_url": {
+						"url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+					}
+				}
+			]
+		}
+	],
+    "max_tokens": 500,
+    "stream": true
+}'

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/0.huggingface.js.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/0.huggingface.js.fireworks-ai.js
@@ -1,0 +1,36 @@
+import { HfInference } from "@huggingface/inference";
+
+const client = new HfInference("api_token");
+
+let out = "";
+
+const stream = client.chatCompletionStream({
+	model: "meta-llama/Llama-3.2-11B-Vision-Instruct",
+	messages: [
+		{
+			role: "user",
+			content: [
+				{
+					type: "text",
+					text: "Describe this image in one sentence."
+				},
+				{
+					type: "image_url",
+					image_url: {
+						url: "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+					}
+				}
+			]
+		}
+	],
+	provider: "fireworks-ai",
+	max_tokens: 500,
+});
+
+for await (const chunk of stream) {
+	if (chunk.choices && chunk.choices.length > 0) {
+		const newContent = chunk.choices[0].delta.content;
+		out += newContent;
+		console.log(newContent);
+	}  
+}

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/0.huggingface_hub.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/0.huggingface_hub.fireworks-ai.py
@@ -1,0 +1,34 @@
+from huggingface_hub import InferenceClient
+
+client = InferenceClient(
+	provider="fireworks-ai",
+	api_key="api_token"
+)
+
+messages = [
+	{
+		"role": "user",
+		"content": [
+			{
+				"type": "text",
+				"text": "Describe this image in one sentence."
+			},
+			{
+				"type": "image_url",
+				"image_url": {
+					"url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+				}
+			}
+		]
+	}
+]
+
+stream = client.chat.completions.create(
+	model="meta-llama/Llama-3.2-11B-Vision-Instruct", 
+	messages=messages, 
+	max_tokens=500,
+	stream=True
+)
+
+for chunk in stream:
+    print(chunk.choices[0].delta.content, end="")

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/1.openai.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/1.openai.fireworks-ai.js
@@ -1,0 +1,39 @@
+import { OpenAI } from "openai";
+
+const client = new OpenAI({
+	baseURL: "https://router.huggingface.co/fireworks-ai",
+	apiKey: "api_token"
+});
+
+let out = "";
+
+const stream = await client.chat.completions.create({
+	model: "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
+	messages: [
+		{
+			role: "user",
+			content: [
+				{
+					type: "text",
+					text: "Describe this image in one sentence."
+				},
+				{
+					type: "image_url",
+					image_url: {
+						url: "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+					}
+				}
+			]
+		}
+	],
+	max_tokens: 500,
+	stream: true,
+});
+
+for await (const chunk of stream) {
+	if (chunk.choices && chunk.choices.length > 0) {
+		const newContent = chunk.choices[0].delta.content;
+		out += newContent;
+		console.log(newContent);
+	}  
+}

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/1.openai.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/1.openai.fireworks-ai.py
@@ -1,0 +1,34 @@
+from openai import OpenAI
+
+client = OpenAI(
+	base_url="https://router.huggingface.co/fireworks-ai",
+	api_key="api_token"
+)
+
+messages = [
+	{
+		"role": "user",
+		"content": [
+			{
+				"type": "text",
+				"text": "Describe this image in one sentence."
+			},
+			{
+				"type": "image_url",
+				"image_url": {
+					"url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+				}
+			}
+		]
+	}
+]
+
+stream = client.chat.completions.create(
+    model="<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>", 
+	messages=messages, 
+	max_tokens=500,
+	stream=True
+)
+
+for chunk in stream:
+	print(chunk.choices[0].delta.content, end="")

--- a/packages/tasks-gen/snippets-fixtures/text-to-image/0.huggingface.js.fal-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/text-to-image/0.huggingface.js.fal-ai.js
@@ -1,0 +1,11 @@
+import { HfInference } from "@huggingface/inference";
+
+const client = new HfInference("api_token");
+
+const image = await client.textToImage({
+	model: "black-forest-labs/FLUX.1-schnell",
+	inputs: "Astronaut riding a horse",
+	parameters: { num_inference_steps: 5 },
+	provider: "fal-ai",
+});
+/// Use the generated image (it's a Blob)

--- a/packages/tasks-gen/snippets-fixtures/text-to-image/0.huggingface_hub.fal-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/text-to-image/0.huggingface_hub.fal-ai.py
@@ -1,0 +1,12 @@
+from huggingface_hub import InferenceClient
+
+client = InferenceClient(
+	provider="fal-ai",
+	api_key="api_token"
+)
+
+# output is a PIL.Image object
+image = client.text_to_image(
+	"Astronaut riding a horse",
+	model="black-forest-labs/FLUX.1-schnell"
+)

--- a/packages/tasks-gen/snippets-fixtures/text-to-image/1.fal-client.fal-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/text-to-image/1.fal-client.fal-ai.py
@@ -1,0 +1,10 @@
+import fal_client
+
+result = fal_client.subscribe(
+	# replace with correct id from fal.ai
+	"fal-ai/<fal-ai alias for black-forest-labs/FLUX.1-schnell>",
+	arguments={
+		"prompt": "Astronaut riding a horse",
+	},
+)
+print(result)

--- a/packages/tasks-gen/snippets-fixtures/text-to-image/1.fal-client.fal-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/text-to-image/1.fal-client.fal-ai.py
@@ -2,7 +2,7 @@ import fal_client
 
 result = fal_client.subscribe(
 	# replace with correct id from fal.ai
-	"fal-ai/<fal-ai alias for black-forest-labs/FLUX.1-schnell>",
+	"<fal-ai alias for black-forest-labs/FLUX.1-schnell>",
 	arguments={
 		"prompt": "Astronaut riding a horse",
 	},

--- a/packages/tasks-gen/snippets-fixtures/text-to-image/1.fal-client.fal-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/text-to-image/1.fal-client.fal-ai.py
@@ -1,7 +1,6 @@
 import fal_client
 
 result = fal_client.subscribe(
-	# replace with correct id from fal.ai
 	"<fal-ai alias for black-forest-labs/FLUX.1-schnell>",
 	arguments={
 		"prompt": "Astronaut riding a horse",

--- a/packages/tasks/src/snippets/curl.ts
+++ b/packages/tasks/src/snippets/curl.ts
@@ -30,6 +30,7 @@ export const snippetTextGeneration = (
 	model: ModelDataMinimal,
 	accessToken: string,
 	provider: SnippetInferenceProvider,
+	providerModelId?: string,
 	opts?: {
 		streaming?: boolean;
 		messages?: ChatCompletionInputMessage[];
@@ -43,6 +44,7 @@ export const snippetTextGeneration = (
 			provider === "hf-inference"
 				? `https://router.huggingface.co/hf-inference/models/${model.id}/v1/chat/completions`
 				: HF_HUB_INFERENCE_PROXY_TEMPLATE.replace("{{PROVIDER}}", provider) + "/v1/chat/completions";
+		const modelId = providerModelId ?? model.id;
 
 		// Conversational model detected, so we display a code snippet that features the Messages API
 		const streaming = opts?.streaming ?? true;
@@ -61,17 +63,17 @@ export const snippetTextGeneration = (
 -H 'Authorization: Bearer ${accessToken || `{API_TOKEN}`}' \\
 -H 'Content-Type: application/json' \\
 --data '{
-    "model": "${model.id}",
+    "model": "${modelId}",
     "messages": ${stringifyMessages(messages, {
-					indent: "\t",
-					attributeKeyQuotes: true,
-					customContentEscaper: (str) => str.replace(/'/g, "'\\''"),
-				})},
+			indent: "\t",
+			attributeKeyQuotes: true,
+			customContentEscaper: (str) => str.replace(/'/g, "'\\''"),
+		})},
     ${stringifyGenerationConfig(config, {
-					indent: "\n    ",
-					attributeKeyQuotes: true,
-					attributeValueConnector: ": ",
-				})}
+			indent: "\n    ",
+			attributeKeyQuotes: true,
+			attributeValueConnector: ": ",
+		})}
     "stream": ${!!streaming}
 }'`,
 			},
@@ -127,6 +129,7 @@ export const curlSnippets: Partial<
 			model: ModelDataMinimal,
 			accessToken: string,
 			provider: SnippetInferenceProvider,
+			providerModelId?: string,
 			opts?: Record<string, unknown>
 		) => InferenceSnippet[]
 	>
@@ -161,9 +164,10 @@ export function getCurlInferenceSnippet(
 	model: ModelDataMinimal,
 	accessToken: string,
 	provider: SnippetInferenceProvider,
+	providerModelId?: string,
 	opts?: Record<string, unknown>
 ): InferenceSnippet[] {
 	return model.pipeline_tag && model.pipeline_tag in curlSnippets
-		? curlSnippets[model.pipeline_tag]?.(model, accessToken, provider, opts) ?? []
+		? curlSnippets[model.pipeline_tag]?.(model, accessToken, provider, providerModelId, opts) ?? []
 		: [];
 }

--- a/packages/tasks/src/snippets/js.ts
+++ b/packages/tasks/src/snippets/js.ts
@@ -75,6 +75,7 @@ export const snippetTextGeneration = (
 	model: ModelDataMinimal,
 	accessToken: string,
 	provider: SnippetInferenceProvider,
+	providerModelId?: string,
 	opts?: {
 		streaming?: boolean;
 		messages?: ChatCompletionInputMessage[];
@@ -398,6 +399,7 @@ export const jsSnippets: Partial<
 			model: ModelDataMinimal,
 			accessToken: string,
 			provider: SnippetInferenceProvider,
+			providerModelId?: string,
 			opts?: Record<string, unknown>
 		) => InferenceSnippet[]
 	>
@@ -432,9 +434,10 @@ export function getJsInferenceSnippet(
 	model: ModelDataMinimal,
 	accessToken: string,
 	provider: SnippetInferenceProvider,
+	providerModelId?: string,
 	opts?: Record<string, unknown>
 ): InferenceSnippet[] {
 	return model.pipeline_tag && model.pipeline_tag in jsSnippets
-		? jsSnippets[model.pipeline_tag]?.(model, accessToken, provider, opts) ?? []
+		? jsSnippets[model.pipeline_tag]?.(model, accessToken, provider, providerModelId, opts) ?? []
 		: [];
 }

--- a/packages/tasks/src/snippets/js.ts
+++ b/packages/tasks/src/snippets/js.ts
@@ -27,9 +27,9 @@ export const snippetBasic = (
 	return [
 		...(model.pipeline_tag && model.pipeline_tag in HFJS_METHODS
 			? [
-					{
-						client: "huggingface.js",
-						content: `\
+				{
+					client: "huggingface.js",
+					content: `\
 import { HfInference } from "@huggingface/inference";
 
 const client = new HfInference("${accessToken || `{API_TOKEN}`}");
@@ -42,8 +42,8 @@ const output = await client.${HFJS_METHODS[model.pipeline_tag]}({
 
 console.log(output);
 `,
-					},
-			  ]
+				},
+			]
 			: []),
 		{
 			client: "fetch",
@@ -138,7 +138,7 @@ const client = new OpenAI({
 let out = "";
 
 const stream = await client.chat.completions.create({
-	model: "${model.id}",
+	model: "${providerModelId ?? model.id}",
 	messages: ${messagesStr},
 	${configStr}
 	stream: true,
@@ -181,7 +181,7 @@ const client = new OpenAI({
 });
 
 const chatCompletion = await client.chat.completions.create({
-	model: "${model.id}",
+	model: "${providerModelId ?? model.id}",
 	messages: ${messagesStr},
 	${configStr}
 });
@@ -217,8 +217,8 @@ export const snippetZeroShotClassification = (model: ModelDataMinimal, accessTok
 		}
 		
 		query({"inputs": ${getModelInputSnippet(
-			model
-		)}, "parameters": {"candidate_labels": ["refund", "legal", "faq"]}}).then((response) => {
+				model
+			)}, "parameters": {"candidate_labels": ["refund", "legal", "faq"]}}).then((response) => {
 			console.log(JSON.stringify(response));
 		});`,
 		},
@@ -249,9 +249,9 @@ const image = await client.textToImage({
 		},
 		...(provider === "hf-inference"
 			? [
-					{
-						client: "fetch",
-						content: `async function query(data) {
+				{
+					client: "fetch",
+					content: `async function query(data) {
 	const response = await fetch(
 		"https://router.huggingface.co/hf-inference/models/${model.id}",
 		{
@@ -269,8 +269,8 @@ const image = await client.textToImage({
 query({"inputs": ${getModelInputSnippet(model)}}).then((response) => {
 	// Use image
 });`,
-					},
-			  ]
+				},
+			]
 			: []),
 	];
 };

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -278,8 +278,7 @@ image = client.text_to_image(
 import fal_client
 
 result = fal_client.subscribe(
-	# replace with correct id from fal.ai
-	"fal-ai/${providerModelId ?? model.id}",
+	"${providerModelId ?? model.id}",
 	arguments={
 		"prompt": ${getModelInputSnippet(model)},
 	},

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -52,6 +52,7 @@ export const snippetConversational = (
 	model: ModelDataMinimal,
 	accessToken: string,
 	provider: SnippetInferenceProvider,
+	providerModelId?: string,
 	opts?: {
 		streaming?: boolean;
 		messages?: ChatCompletionInputMessage[];
@@ -394,6 +395,7 @@ export const pythonSnippets: Partial<
 			model: ModelDataMinimal,
 			accessToken: string,
 			provider: SnippetInferenceProvider,
+			providerModelId?: string,
 			opts?: Record<string, unknown>
 		) => InferenceSnippet[]
 	>
@@ -432,15 +434,16 @@ export function getPythonInferenceSnippet(
 	model: ModelDataMinimal,
 	accessToken: string,
 	provider: SnippetInferenceProvider,
+	providerModelId?: string,
 	opts?: Record<string, unknown>
 ): InferenceSnippet[] {
 	if (model.tags.includes("conversational")) {
 		// Conversational model detected, so we display a code snippet that features the Messages API
-		return snippetConversational(model, accessToken, provider, opts);
+		return snippetConversational(model, accessToken, provider, providerModelId, opts);
 	} else {
 		const snippets =
 			model.pipeline_tag && model.pipeline_tag in pythonSnippets
-				? pythonSnippets[model.pipeline_tag]?.(model, accessToken, provider) ?? []
+				? pythonSnippets[model.pipeline_tag]?.(model, accessToken, provider, providerModelId) ?? []
 				: [];
 
 		return snippets.map((snippet) => {

--- a/packages/tasks/src/snippets/python.ts
+++ b/packages/tasks/src/snippets/python.ts
@@ -1,5 +1,4 @@
 import {
-	HF_HUB_INFERENCE_PROXY_TEMPLATE,
 	openAIbaseUrl,
 	type SnippetInferenceProvider,
 } from "../inference-providers.js";
@@ -108,7 +107,7 @@ client = OpenAI(
 messages = ${messagesStr}
 
 stream = client.chat.completions.create(
-    model="${model.id}", 
+    model="${providerModelId ?? model.id}", 
 	messages=messages, 
 	${configStr}
 	stream=True
@@ -148,7 +147,7 @@ client = OpenAI(
 messages = ${messagesStr}
 
 completion = client.chat.completions.create(
-	model="${model.id}", 
+	model="${providerModelId ?? model.id}", 
 	messages=messages, 
 	${configStr}
 )
@@ -207,9 +206,9 @@ export const snippetBasic = (
 	return [
 		...(model.pipeline_tag && model.pipeline_tag in HFH_INFERENCE_CLIENT_METHODS
 			? [
-					{
-						client: "huggingface_hub",
-						content: `\
+				{
+					client: "huggingface_hub",
+					content: `\
 ${snippetImportInferenceClient(accessToken, provider)}
 
 result = client.${HFH_INFERENCE_CLIENT_METHODS[model.pipeline_tag]}(
@@ -220,8 +219,8 @@ result = client.${HFH_INFERENCE_CLIENT_METHODS[model.pipeline_tag]}(
 
 print(result)
 `,
-					},
-			  ]
+				},
+			]
 			: []),
 		{
 			client: "requests",
@@ -256,7 +255,8 @@ output = query(${getModelInputSnippet(model)})`,
 export const snippetTextToImage = (
 	model: ModelDataMinimal,
 	accessToken: string,
-	provider: SnippetInferenceProvider
+	provider: SnippetInferenceProvider,
+	providerModelId?: string,
 ): InferenceSnippet[] => {
 	return [
 		{
@@ -272,28 +272,28 @@ image = client.text_to_image(
 		},
 		...(provider === "fal-ai"
 			? [
-					{
-						client: "fal-client",
-						content: `\
+				{
+					client: "fal-client",
+					content: `\
 import fal_client
 
 result = fal_client.subscribe(
 	# replace with correct id from fal.ai
-	"fal-ai/${model.id}",
+	"fal-ai/${providerModelId ?? model.id}",
 	arguments={
 		"prompt": ${getModelInputSnippet(model)},
 	},
 )
 print(result)
 `,
-					},
-			  ]
+				},
+			]
 			: []),
 		...(provider === "hf-inference"
 			? [
-					{
-						client: "requests",
-						content: `\
+				{
+					client: "requests",
+					content: `\
 def query(payload):
 	response = requests.post(API_URL, headers=headers, json=payload)
 	return response.content
@@ -306,8 +306,8 @@ image_bytes = query({
 import io
 from PIL import Image
 image = Image.open(io.BytesIO(image_bytes))`,
-					},
-			  ]
+				},
+			]
 			: []),
 	];
 };


### PR DESCRIPTION
Goal of this PR is to correctly handle model id mapping when generating inference snippets for a given provider.

For now it's a simple PR to showcase what I had in mind in https://github.com/huggingface-internal/moon-landing/pull/12626#discussion_r1961923510 (private repo). I only implemented it for chat-completion curl snippet but the rest would follow the same pattern.

Note that we should use the mapping "only" for curl, pure Python, pure JS and openai client snippets. For `huggingface.js` and `huggingface_hub` ones, the model id from the Hub should be used. 


---

**Note:** orthogonal to this PR but I realized that some URLs are also incorrect depending on the provider.