### PR TITLE
[YOLOv10] Add safetensors extension

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -897,7 +897,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "YOLOv10",
 		repoUrl: "https://github.com/THU-MIG/yolov10",
 		docsUrl: "https://github.com/THU-MIG/yolov10",
-		countDownloads: `path_extension:"pt"`,
+		countDownloads: `path_extension:"pt" OR path_extension:"safetensors"`,
 		snippets: snippets.ultralytics,
 	},
 	"3dtopia-xl": {


### PR DESCRIPTION
As pointed out [here](https://github.com/huggingface/huggingface.js/pull/1101#issuecomment-2670799523), download counts for YOLOv10 repos which leverage safetensors aren't tracked. 

This PR fixes that.