### PR TITLE
Fix webBlob test (use LFS file as example instead of Xet file)

### DIFF
--- a/packages/hub/src/utils/WebBlob.spec.ts
+++ b/packages/hub/src/utils/WebBlob.spec.ts
@@ -48,17 +48,21 @@ describe("WebBlob", () => {
 		expect(streamText).toBe(fullText);
 	});
 
-	it("should lazy load a LFS file hosted on Hugging Face", async () => {
-		const stableDiffusionUrl =
-			"https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/unet/diffusion_pytorch_model.fp16.safetensors";
-		const url = new URL(stableDiffusionUrl);
-		const webBlob = await WebBlob.create(url);
+	it(
+		"should lazy load a LFS file hosted on Hugging Face",
+		async () => {
+			const stableDiffusionUrl =
+				"https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/unet/diffusion_pytorch_model.fp16.safetensors";
+			const url = new URL(stableDiffusionUrl);
+			const webBlob = await WebBlob.create(url);
 
-		expect(webBlob.size).toBe(5_135_149_760);
-		expect(webBlob).toBeInstanceOf(WebBlob);
-		expect(webBlob).toMatchObject({ url });
-		expect(await webBlob.slice(10, 22).text()).toBe("__metadata__");
-	});
+			expect(webBlob.size).toBe(5_135_149_760);
+			expect(webBlob).toBeInstanceOf(WebBlob);
+			expect(webBlob).toMatchObject({ url });
+			expect(await webBlob.slice(10, 22).text()).toBe("__metadata__");
+		},
+		{ timeout: 30_000 }
+	);
 
 	it("should create a slice on the file", async () => {
 		const expectedText = fullText.slice(10, 20);

--- a/packages/hub/src/utils/WebBlob.spec.ts
+++ b/packages/hub/src/utils/WebBlob.spec.ts
@@ -48,21 +48,17 @@ describe("WebBlob", () => {
 		expect(streamText).toBe(fullText);
 	});
 
-	it(
-		"should lazy load a LFS file hosted on Hugging Face",
-		async () => {
-			const stableDiffusionUrl =
-				"https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/unet/diffusion_pytorch_model.fp16.safetensors";
-			const url = new URL(stableDiffusionUrl);
-			const webBlob = await WebBlob.create(url);
+	it("should lazy load a LFS file hosted on Hugging Face", async () => {
+		const stableDiffusionUrl =
+			"https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/unet/diffusion_pytorch_model.fp16.safetensors";
+		const url = new URL(stableDiffusionUrl);
+		const webBlob = await WebBlob.create(url);
 
-			expect(webBlob.size).toBe(5_135_149_760);
-			expect(webBlob).toBeInstanceOf(WebBlob);
-			expect(webBlob).toMatchObject({ url });
-			expect(await webBlob.slice(10, 22).text()).toBe("__metadata__");
-		},
-		{ timeout: 30_000 }
-	);
+		expect(webBlob.size).toBe(5_135_149_760);
+		expect(webBlob).toBeInstanceOf(WebBlob);
+		expect(webBlob).toMatchObject({ url });
+		expect(await webBlob.slice(10, 22).text()).toBe("__metadata__");
+	});
 
 	it("should create a slice on the file", async () => {
 		const expectedText = fullText.slice(10, 20);

--- a/packages/hub/src/utils/WebBlob.spec.ts
+++ b/packages/hub/src/utils/WebBlob.spec.ts
@@ -49,12 +49,12 @@ describe("WebBlob", () => {
 	});
 
 	it("should lazy load a LFS file hosted on Hugging Face", async () => {
-		const stableDiffusionUrl =
-			"https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/unet/diffusion_pytorch_model.fp16.safetensors";
-		const url = new URL(stableDiffusionUrl);
+		const zephyrUrl =
+			"https://huggingface.co/HuggingFaceH4/zephyr-7b-alpha/resolve/main/model-00001-of-00008.safetensors";
+		const url = new URL(zephyrUrl);
 		const webBlob = await WebBlob.create(url);
 
-		expect(webBlob.size).toBe(5_135_149_760);
+		expect(webBlob.size).toBe(1_889_587_040);
 		expect(webBlob).toBeInstanceOf(WebBlob);
 		expect(webBlob).toMatchObject({ url });
 		expect(await webBlob.slice(10, 22).text()).toBe("__metadata__");

--- a/packages/hub/src/utils/WebBlob.ts
+++ b/packages/hub/src/utils/WebBlob.ts
@@ -21,7 +21,7 @@ export class WebBlob extends Blob {
 		const customFetch = opts?.fetch ?? fetch;
 		const response = await customFetch(url, { method: "HEAD" });
 
-		const size = Number(response.headers.get("x-linked-size") ?? response.headers.get("content-length"));
+		const size = Number(response.headers.get("content-length"));
 		const contentType = response.headers.get("content-type") || "";
 		const supportRange = response.headers.get("accept-ranges") === "bytes";
 

--- a/packages/hub/src/utils/WebBlob.ts
+++ b/packages/hub/src/utils/WebBlob.ts
@@ -21,7 +21,7 @@ export class WebBlob extends Blob {
 		const customFetch = opts?.fetch ?? fetch;
 		const response = await customFetch(url, { method: "HEAD" });
 
-		const size = Number(response.headers.get("content-length"));
+		const size = Number(response.headers.get("x-linked-size") ?? response.headers.get("content-length"));
 		const contentType = response.headers.get("content-type") || "";
 		const supportRange = response.headers.get("accept-ranges") === "bytes";
 


### PR DESCRIPTION
CI currently fails with:

```
packages/hub test:browser: ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
packages/hub test:browser:  FAIL  src/utils/WebBlob.spec.ts > WebBlob > should lazy load a LFS file hosted on Hugging Face
packages/hub test:browser: Error: Test timed out in 5000ms.
packages/hub test:browser: If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
packages/hub test:browser: ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
```

PR expectation: CI is green.

See https://github.com/huggingface/huggingface.js/pull/1230#issuecomment-2685601898 and https://github.com/huggingface/huggingface.js/pull/1230#issuecomment-2685619852 for explanation.