### PR TITLE
Adding Merlin for accurate download count

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -480,7 +480,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	},
 	"merlin": {
 		prettyLabel: "Merlin",
-		repoName: "merlin",
+		repoName: "Merlin",
 		repoUrl: "https://github.com/StanfordMIMI/Merlin",
 		filter: false,
 		countDownloads: `path_filename:"i3_resnet_clinical_longformer_best_clip_04-02-2024_23-21-36_epoch_99.pt"`,

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -478,6 +478,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path:"MeshAnything_350m.pth"`,
 		snippets: snippets.mesh_anything,
 	},
+	"merlin": {
+		prettyLabel: "Merlin",
+		repoName: "merlin",
+		repoUrl: "https://github.com/StanfordMIMI/Merlin",
+		filter: false,
+		countDownloads: `path_filename:"i3_resnet_clinical_longformer_best_clip_04-02-2024_23-21-36_epoch_99.pt"`,
+	},
 	mitie: {
 		prettyLabel: "MITIE",
 		repoName: "MITIE",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -483,7 +483,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "Merlin",
 		repoUrl: "https://github.com/StanfordMIMI/Merlin",
 		filter: false,
-		countDownloads: `path_filename:"i3_resnet_clinical_longformer_best_clip_04-02-2024_23-21-36_epoch_99.pt"`,
+		countDownloads: `path_extension:"pt"`,
 	},
 	mitie: {
 		prettyLabel: "MITIE",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -478,7 +478,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path:"MeshAnything_350m.pth"`,
 		snippets: snippets.mesh_anything,
 	},
-	"merlin": {
+	merlin: {
 		prettyLabel: "Merlin",
 		repoName: "Merlin",
 		repoUrl: "https://github.com/StanfordMIMI/Merlin",


### PR DESCRIPTION
I don't think we are getting an accurate download count for our hugging face repo: https://huggingface.co/stanfordmimi/Merlin, since the downloads page counts the queries to the config.json file and in our case the config.json file is empty. I was looking through the hugging face documentation and it seems like I had to add the file to the hugging face repo to allow it to have an accurate download count? Please let me know if I'm mistaken.