### PR TITLE
ollama: fix permission for automatically creating PR

### DIFF
--- a/.github/workflows/ollama-template-update.yml
+++ b/.github/workflows/ollama-template-update.yml
@@ -81,6 +81,7 @@ jobs:
           CURRENT_DATE: ${{ steps.prepare.outputs.CURRENT_DATE }}
           NEW_BRANCH: ${{ steps.changes.outputs.NEW_BRANCH }}
         with:
+          github-token: ${{ secrets.HUGGINGFACE_JS_AUTOMATIC_PR }}
           script: |
             const { repo, owner } = context.repo;
             const currDate = process.env.CURRENT_DATE;


### PR DESCRIPTION
Ref discussion: https://huggingface.slack.com/archives/CTKK32GE8/p1740478906515669

The CI token does not have permission to create PR automatically, therefore we replace it with a PAT provided via `secrets.HUGGINGFACE_JS_AUTOMATIC_PR`

CC @paulinebm for viz