### PR TITLE
Add llama3.3 license to types

### DIFF
--- a/packages/hub/src/types/public.ts
+++ b/packages/hub/src/types/public.ts
@@ -176,6 +176,7 @@ export type License =
 	| "llama3"
 	| "llama3.1"
 	| "llama3.2"
+	| "llama3.3"
 	| "gemma"
 	| "apple-ascl"
 	| "apple-amlr"


### PR DESCRIPTION
Related: https://github.com/huggingface/hub-docs/pull/1619
Also missing from here apparently @SBrandeis 