### PR TITLE
Use Wan-AI/Wan2.1-T2V-14B as default model for text to video showcase 

### DIFF
--- a/packages/tasks/src/tasks/text-to-video/data.ts
+++ b/packages/tasks/src/tasks/text-to-video/data.ts
@@ -99,7 +99,7 @@ const taskData: TaskDataCustom = {
 	],
 	summary:
 		"Text-to-video models can be used in any application that requires generating consistent sequence of images from text. ",
-	widgetModels: ["tencent/HunyuanVideo"],
+	widgetModels: [],
 	youtubeId: undefined,
 };
 

--- a/packages/tasks/src/tasks/text-to-video/data.ts
+++ b/packages/tasks/src/tasks/text-to-video/data.ts
@@ -99,7 +99,7 @@ const taskData: TaskDataCustom = {
 	],
 	summary:
 		"Text-to-video models can be used in any application that requires generating consistent sequence of images from text. ",
-	widgetModels: [],
+	widgetModels: ["Wan-AI/Wan2.1-T2V-14B"],
 	youtubeId: undefined,
 };
 


### PR DESCRIPTION
Remove text-to-video HunyuanVideo showcase for now since it can rarely generate video in less than 2mins. We'll probably replace with Wan 2.1 when active in prod

EDIT: actually Wan2.1 just got enabled, so we can use it 👍 