### PR TITLE
[Fix Replicate] Send `Prefer:wait` header

### DIFF
--- a/packages/inference/src/providers/replicate.ts
+++ b/packages/inference/src/providers/replicate.ts
@@ -26,7 +26,7 @@ const makeBody = (params: BodyParams): Record<string, unknown> => {
 };
 
 const makeHeaders = (params: HeaderParams): Record<string, string> => {
-	return { Authorization: `Bearer ${params.accessToken}` };
+	return { Authorization: `Bearer ${params.accessToken}`, Prefer: "wait" };
 };
 
 const makeUrl = (params: UrlParams): string => {


### PR DESCRIPTION
Fixing a bug introduced in https://github.com/huggingface/huggingface.js/pull/1208 and more precisely [here](https://github.com/huggingface/huggingface.js/pull/1208/files#diff-ba5cb4afef57c85afde67b883b333c80972fc4ac5d3083d929447105ebfbe55fL107).

For Replicate provider, we must send `Prefer: wait` header as this is the only path we support for now. 

---

Tested locally and it fixes the textToVideo issue we have on https://huggingface.co/Wan-AI/Wan2.1-T2V-14B

```ts
import { HfInference } from "@huggingface/inference";
import fs from "fs/promises";

async function generateTextToVideo() {
	const hf = new HfInference("xxx");
	const res = await hf.textToVideo({
		inputs: "a cat swimming in an ocean of bananas",
		provider: "replicate",
		model: "Wan-AI/Wan2.1-T2V-14B",
	});

	const arrayBuffer = await res.arrayBuffer();
	const buffer = Buffer.from(arrayBuffer);
	await fs.writeFile("output.mp4", buffer);
}

generateTextToVideo();
```


https://github.com/user-attachments/assets/4234c65e-ab11-45e0-9e29-825f88b2be49



cc @SBrandeis @kefranabg @zeke 