### PR TITLE
[BUGFIX] `EEXIST`: file already exists, symlink when file already downloaded

### DIFF
--- a/packages/hub/src/lib/download-file-to-cache-dir.ts
+++ b/packages/hub/src/lib/download-file-to-cache-dir.ts
@@ -100,6 +100,9 @@ export async function downloadFileToCacheDir(
 	await mkdir(dirname(blobPath), { recursive: true });
 	await mkdir(dirname(pointerPath), { recursive: true });
 
+	// if we have the pointer file, we can shortcut the download
+	if (await exists(pointerPath, true)) return pointerPath;
+
 	// We might already have the blob but not the pointer
 	// shortcut the download if needed
 	if (await exists(blobPath)) {

--- a/packages/hub/src/lib/download-file-to-cache-dir.ts
+++ b/packages/hub/src/lib/download-file-to-cache-dir.ts
@@ -96,12 +96,12 @@ export async function downloadFileToCacheDir(
 	const pointerPath = getFilePointer(storageFolder, commitHash ?? pathsInformation[0].lastCommit.id, params.path);
 	const blobPath = join(storageFolder, "blobs", etag);
 
+	// if we have the pointer file, we can shortcut the download
+	if (await exists(pointerPath, true)) return pointerPath;
+
 	// mkdir blob and pointer path parent directory
 	await mkdir(dirname(blobPath), { recursive: true });
 	await mkdir(dirname(pointerPath), { recursive: true });
-
-	// if we have the pointer file, we can shortcut the download
-	if (await exists(pointerPath, true)) return pointerPath;
 
 	// We might already have the blob but not the pointer
 	// shortcut the download if needed


### PR DESCRIPTION
Using the library in Linux environments, I have the following errors when using cached files:

```bash
Error: EEXIST: file already exists, symlink '/home/node/.cache/huggingface/hub/datasets--facebook--natural_reasoning/blobs/704a73a635633c697507c74576e30798d42a3455967ef4d5bd0865b5242ee7fe' -> '/home/node/.cache/huggingface/hub/datasets--facebook--natural_reasoning/snapshots/bf8da7626caecdea87df7b5a8d97bf9650d909a3/full.jsonl'
```
This happens when trying to recreate the symbolic link.  This PR checks if the symlink already exists and returns the pointer file.