### PR TITLE
[Inference providers] Root-only base URLs

### DIFF
--- a/packages/inference/src/providers/black-forest-labs.ts
+++ b/packages/inference/src/providers/black-forest-labs.ts
@@ -16,7 +16,7 @@
  */
 import type { ProviderConfig, UrlParams, HeaderParams, BodyParams } from "../types";
 
-const BLACK_FOREST_LABS_AI_API_BASE_URL = "https://api.us1.bfl.ai/v1";
+const BLACK_FOREST_LABS_AI_API_BASE_URL = "https://api.us1.bfl.ai";
 
 const makeBody = (params: BodyParams): Record<string, unknown> => {
 	return params.args;
@@ -31,7 +31,7 @@ const makeHeaders = (params: HeaderParams): Record<string, string> => {
 };
 
 const makeUrl = (params: UrlParams): string => {
-	return `${params.baseUrl}/${params.model}`;
+	return `${params.baseUrl}/v1/${params.model}`;
 };
 
 export const BLACK_FOREST_LABS_CONFIG: ProviderConfig = {

--- a/packages/inference/src/providers/fireworks-ai.ts
+++ b/packages/inference/src/providers/fireworks-ai.ts
@@ -16,7 +16,7 @@
  */
 import type { ProviderConfig, UrlParams, HeaderParams, BodyParams } from "../types";
 
-const FIREWORKS_AI_API_BASE_URL = "https://api.fireworks.ai/inference";
+const FIREWORKS_AI_API_BASE_URL = "https://api.fireworks.ai";
 
 const makeBody = (params: BodyParams): Record<string, unknown> => {
 	return {
@@ -31,9 +31,9 @@ const makeHeaders = (params: HeaderParams): Record<string, string> => {
 
 const makeUrl = (params: UrlParams): string => {
 	if (params.task === "text-generation" && params.chatCompletion) {
-		return `${params.baseUrl}/v1/chat/completions`;
+		return `${params.baseUrl}/inference/v1/chat/completions`;
 	}
-	return params.baseUrl;
+	return `${params.baseUrl}/inference`;
 };
 
 export const FIREWORKS_AI_CONFIG: ProviderConfig = {


### PR DESCRIPTION
Related to https://github.com/huggingface-internal/moon-landing/pull/12849 and https://github.com/huggingface-internal/moon-landing/pull/12855 (private repo). Similar PR for Python client https://github.com/huggingface/huggingface_hub/pull/2918.

It is best if all base URLs for inference providers are "root-domain-only" i.e. without subpaths. This PR updates Black Forest Labs and Fireworks AI providers. Novita is taken care of in https://github.com/huggingface/huggingface.js/pull/1263.

Note that this change requires a server-side update to make things backward compatible (i.e. legacy clients using a subpath are still working). This fix is already handled server-side.