### PR TITLE
Add Open-Sora as library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -590,6 +590,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 			OR path:"open_clip_pytorch_model.bin"
 			OR path:"pytorch_model.bin"`,
 	},
+	"open-sora": {
+		prettyLabel: "OpenSora",
+		repoName: "OpenSora",
+		repoUrl: "https://github.com/hpcaitech/Open-Sora",
+		filter: false,
+		countDownloads: `path:"model.safetensors"`,
+	},
 	paddlenlp: {
 		prettyLabel: "paddlenlp",
 		repoName: "PaddleNLP",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -591,11 +591,11 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 			OR path:"pytorch_model.bin"`,
 	},
 	"open-sora": {
-		prettyLabel: "OpenSora",
-		repoName: "OpenSora",
+		prettyLabel: "Open-Sora",
+		repoName: "Open-Sora",
 		repoUrl: "https://github.com/hpcaitech/Open-Sora",
 		filter: false,
-		countDownloads: `path:"model.safetensors"`,
+		countDownloads: `path:"Open_Sora_v2.safetensors"`,
 	},
 	paddlenlp: {
 		prettyLabel: "paddlenlp",


### PR DESCRIPTION
We added `library_name: open-sora` here: https://huggingface.co/hpcai-tech/Open-Sora-v2, hence this PR ensures download stats work for them.

cc @zhengzangw let me know whether I also need to add a custom code snippet, which will show up for users as a "Use this model" button at the top right, see https://huggingface.co/jameslahm/yolov10x as an example.