### PR TITLE
[InferenceClient] Support `billTo` header

### DIFF
--- a/packages/inference/src/config.ts
+++ b/packages/inference/src/config.ts
@@ -1,2 +1,3 @@
 export const HF_HUB_URL = "https://huggingface.co";
 export const HF_ROUTER_URL = "https://router.huggingface.co";
+export const HF_HEADER_X_BILL_TO = "X-HF-Bill-To";

--- a/packages/inference/src/lib/makeRequestOptions.ts
+++ b/packages/inference/src/lib/makeRequestOptions.ts
@@ -1,4 +1,4 @@
-import { HF_HUB_URL, HF_ROUTER_URL } from "../config";
+import { HF_HUB_URL, HF_ROUTER_URL, HF_HEADER_X_BILL_TO } from "../config";
 import { BLACK_FOREST_LABS_CONFIG } from "../providers/black-forest-labs";
 import { CEREBRAS_CONFIG } from "../providers/cerebras";
 import { COHERE_CONFIG } from "../providers/cohere";
@@ -116,7 +116,7 @@ export function makeRequestOptionsFromResolvedModel(
 	const provider = maybeProvider ?? "hf-inference";
 	const providerConfig = providerConfigs[provider];
 
-	const { includeCredentials, task, chatCompletion, signal } = options ?? {};
+	const { includeCredentials, task, chatCompletion, signal, billTo } = options ?? {};
 
 	const authMethod = (() => {
 		if (providerConfig.clientSideRoutingOnly) {
@@ -157,6 +157,9 @@ export function makeRequestOptionsFromResolvedModel(
 		accessToken,
 		authMethod,
 	});
+	if (billTo) {
+		headers[HF_HEADER_X_BILL_TO] = billTo;
+	}
 
 	// Add content-type to headers
 	if (!binary) {

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -29,7 +29,7 @@ export interface Options {
 	 * The billing account to use for the requests.
 	 *
 	 * By default the requests are billed on the user's account.
-	 * Requests can only be billed to an organization the user is a member of, and the billing should be enabled for that organization.
+	 * Requests can only be billed to an organization the user is a member of, and billing should be enabled for that organization.
 	 */
 	billTo?: string;
 }

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -24,6 +24,14 @@ export interface Options {
 	 * (Default: "same-origin"). String | Boolean. Credentials to use for the request. If this is a string, it will be passed straight on. If it's a boolean, true will be "include" and false will not send credentials at all.
 	 */
 	includeCredentials?: string | boolean;
+
+	/**
+	 * The billing account to use for the requests.
+	 *
+	 * By default the requests are billed on the user's account.
+	 * Requests can be billed to any organization the user is a member of as long as billing is enabled for that organization.
+	 */
+	billTo?: string;
 }
 
 export type InferenceTask = Exclude<PipelineType, "other">;

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -29,7 +29,7 @@ export interface Options {
 	 * The billing account to use for the requests.
 	 *
 	 * By default the requests are billed on the user's account.
-	 * Requests can be billed to any organization the user is a member of as long as billing is enabled for that organization.
+	 * Requests can only be billed to an organization the user is a member of, and the billing should be enabled for that organization.
 	 */
 	billTo?: string;
 }

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -29,7 +29,7 @@ export interface Options {
 	 * The billing account to use for the requests.
 	 *
 	 * By default the requests are billed on the user's account.
-	 * Requests can only be billed to an organization the user is a member of, and billing should be enabled for that organization.
+	 * Requests can only be billed to an organization the user is a member of, and which has subscribed to Enterprise Hub.
 	 */
 	billTo?: string;
 }


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/pull/2940. Discussed in [DMs](https://huggingface.slack.com/archives/C07KX53FZTK/p1741882879007139) (private link)

Basically adds a parameter allowing a user to be charge all their requests on their organization account instead of personal account.

PR to merge only once `"X-HF-Bill-To"` header is supported server side cc @SBrandeis 

```ts
import { InferenceClient } from "@huggingface/inference";

const client = new InferenceClient("hf_token", { billTo: "huggingface" });

const image = await client.textToImage({
	model: "black-forest-labs/FLUX.1-schnell",
	inputs: "A majestic lion in a fantasy forest",
	provider: "fal-ai",
});
/// Use the generated image (it's a Blob)

```