### PR TITLE
Add missing import for text-ranking in TASKS_DATA

### DIFF
--- a/packages/tasks/src/tasks/index.ts
+++ b/packages/tasks/src/tasks/index.ts
@@ -30,6 +30,7 @@ import tokenClassification from "./token-classification/data.js";
 import translation from "./translation/data.js";
 import textClassification from "./text-classification/data.js";
 import textGeneration from "./text-generation/data.js";
+import textRanking from "./text-ranking/data.js";
 import textToVideo from "./text-to-video/data.js";
 import unconditionalImageGeneration from "./unconditional-image-generation/data.js";
 import videoClassification from "./video-classification/data.js";
@@ -233,7 +234,7 @@ export const TASKS_DATA: Record<PipelineType, TaskData | undefined> = {
 	"tabular-to-text": undefined,
 	"text-classification": getData("text-classification", textClassification),
 	"text-generation": getData("text-generation", textGeneration),
-	"text-ranking": getData("text-ranking", placeholder),
+	"text-ranking": getData("text-ranking", textRanking),
 	"text-retrieval": undefined,
 	"text-to-image": getData("text-to-image", textToImage),
 	"text-to-speech": getData("text-to-speech", textToSpeech),


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add missing import for text-ranking in TASKS_DATA

## Details
I was missing an import to connect the `text-ranking` task to the `data.ts` that I prepared. This meant that the task in hf.co/tasks was considered a placeholder in https://github.com/huggingface-internal/moon-landing/pull/12877 instead:
![image](https://github.com/user-attachments/assets/82cca1fa-c82d-48dd-b22b-b12f74831ffe)
![image](https://github.com/user-attachments/assets/b726c376-3bb5-4e65-95bb-41097abb4713)


- Tom Aarsen