### PR TITLE
[nit] Format \t tabs to '    ' 4 spaces in snippets inputs

### DIFF
--- a/packages/tasks/src/snippets/inputs.ts
+++ b/packages/tasks/src/snippets/inputs.ts
@@ -12,29 +12,29 @@ const inputsSummarization = () =>
 
 const inputsTableQuestionAnswering = () =>
 	`{
-	"query": "How many stars does the transformers repository have?",
-	"table": {
-		"Repository": ["Transformers", "Datasets", "Tokenizers"],
-		"Stars": ["36542", "4512", "3934"],
-		"Contributors": ["651", "77", "34"],
-		"Programming language": [
-			"Python",
-			"Python",
-			"Rust, Python and NodeJS"
-		]
-	}
+    "query": "How many stars does the transformers repository have?",
+    "table": {
+        "Repository": ["Transformers", "Datasets", "Tokenizers"],
+        "Stars": ["36542", "4512", "3934"],
+        "Contributors": ["651", "77", "34"],
+        "Programming language": [
+            "Python",
+            "Python",
+            "Rust, Python and NodeJS"
+        ]
+    }
 }`;
 
 const inputsVisualQuestionAnswering = () =>
 	`{
-		"image": "cat.png",
-		"question": "What is in this image?"
-	}`;
+        "image": "cat.png",
+        "question": "What is in this image?"
+    }`;
 
 const inputsQuestionAnswering = () =>
 	`{
-	"question": "What is my name?",
-	"context": "My name is Clara and I live in Berkeley."
+    "question": "What is my name?",
+    "context": "My name is Clara and I live in Berkeley."
 }`;
 
 const inputsTextClassification = () => `"I like you. I love you"`;
@@ -72,12 +72,12 @@ const inputsFillMask = (model: ModelDataMinimal) => `"The answer to the universe
 
 const inputsSentenceSimilarity = () =>
 	`{
-	"source_sentence": "That is a happy person",
-	"sentences": [
-		"That is a happy dog",
-		"That is a very happy person",
-		"Today is a sunny day"
-	]
+    "source_sentence": "That is a happy person",
+    "sentences": [
+        "That is a happy dog",
+        "That is a very happy person",
+        "Today is a sunny day"
+    ]
 }`;
 
 const inputsFeatureExtraction = () => `"Today is a sunny day and I will get some ice cream."`;
@@ -87,8 +87,8 @@ const inputsImageClassification = () => `"cats.jpg"`;
 const inputsImageToText = () => `"cats.jpg"`;
 
 const inputsImageToImage = () => `{
-	"image": "cat.png",
-	"prompt": "Turn the cat into a tiger."
+    "image": "cat.png",
+    "prompt": "Turn the cat into a tiger."
 }`;
 
 const inputsImageSegmentation = () => `"cats.jpg"`;


### PR DESCRIPTION
Just an alignment with the rest of the snippets (and inputs snippets).

Suggested by @julien-c but at some point would be good to just run ruff/prettier on the generated snippets so that we don't have to handle this manually. 