### PR TITLE
Add non-mocked test for symlink

### DIFF
--- a/packages/hub/src/lib/download-file-to-cache-dir.spec.ts
+++ b/packages/hub/src/lib/download-file-to-cache-dir.spec.ts
@@ -1,295 +1,293 @@
-// Commented out, let's use non-mocked tests
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import type { RepoDesignation, RepoId } from "../types/public";
+import { dirname, join } from "node:path";
+import { lstat, mkdir, stat, symlink, writeFile, rename } from "node:fs/promises";
+import { pathsInfo } from "./paths-info";
+import type { Stats } from "node:fs";
+import { getHFHubCachePath, getRepoFolderName } from "./cache-management";
+import { toRepoId } from "../utils/toRepoId";
+import { downloadFileToCacheDir } from "./download-file-to-cache-dir";
+import { createSymlink } from "../utils/symlink";
 
-// import { expect, test, describe, vi, beforeEach } from "vitest";
-// import type { RepoDesignation, RepoId } from "../types/public";
-// import { dirname, join } from "node:path";
-// import { lstat, mkdir, stat, symlink, writeFile, rename } from "node:fs/promises";
-// import { pathsInfo } from "./paths-info";
-// import type { Stats } from "node:fs";
-// import { getHFHubCachePath, getRepoFolderName } from "./cache-management";
-// import { toRepoId } from "../utils/toRepoId";
-// import { downloadFileToCacheDir } from "./download-file-to-cache-dir";
-// import { createSymlink } from "../utils/symlink";
+vi.mock("node:fs/promises", () => ({
+	writeFile: vi.fn(),
+	rename: vi.fn(),
+	symlink: vi.fn(),
+	lstat: vi.fn(),
+	mkdir: vi.fn(),
+	stat: vi.fn(),
+}));
 
-// vi.mock("node:fs/promises", () => ({
-// 	writeFile: vi.fn(),
-// 	rename: vi.fn(),
-// 	symlink: vi.fn(),
-// 	lstat: vi.fn(),
-// 	mkdir: vi.fn(),
-// 	stat: vi.fn(),
-// }));
+vi.mock("./paths-info", () => ({
+	pathsInfo: vi.fn(),
+}));
 
-// vi.mock("./paths-info", () => ({
-// 	pathsInfo: vi.fn(),
-// }));
+vi.mock("../utils/symlink", () => ({
+	createSymlink: vi.fn(),
+}));
 
-// vi.mock("../utils/symlink", () => ({
-// 	createSymlink: vi.fn(),
-// }));
+const DUMMY_REPO: RepoId = {
+	name: "hello-world",
+	type: "model",
+};
 
-// const DUMMY_REPO: RepoId = {
-// 	name: "hello-world",
-// 	type: "model",
-// };
+const DUMMY_ETAG = "dummy-etag";
 
-// const DUMMY_ETAG = "dummy-etag";
+// utility test method to get blob file path
+function _getBlobFile(params: {
+	repo: RepoDesignation;
+	etag: string;
+	cacheDir?: string; // default to {@link getHFHubCache}
+}) {
+	return join(params.cacheDir ?? getHFHubCachePath(), getRepoFolderName(toRepoId(params.repo)), "blobs", params.etag);
+}
 
-// // utility test method to get blob file path
-// function _getBlobFile(params: {
-// 	repo: RepoDesignation;
-// 	etag: string;
-// 	cacheDir?: string; // default to {@link getHFHubCache}
-// }) {
-// 	return join(params.cacheDir ?? getHFHubCachePath(), getRepoFolderName(toRepoId(params.repo)), "blobs", params.etag);
-// }
+// utility test method to get snapshot file path
+function _getSnapshotFile(params: {
+	repo: RepoDesignation;
+	path: string;
+	revision: string;
+	cacheDir?: string; // default to {@link getHFHubCache}
+}) {
+	return join(
+		params.cacheDir ?? getHFHubCachePath(),
+		getRepoFolderName(toRepoId(params.repo)),
+		"snapshots",
+		params.revision,
+		params.path
+	);
+}
 
-// // utility test method to get snapshot file path
-// function _getSnapshotFile(params: {
-// 	repo: RepoDesignation;
-// 	path: string;
-// 	revision: string;
-// 	cacheDir?: string; // default to {@link getHFHubCache}
-// }) {
-// 	return join(
-// 		params.cacheDir ?? getHFHubCachePath(),
-// 		getRepoFolderName(toRepoId(params.repo)),
-// 		"snapshots",
-// 		params.revision,
-// 		params.path
-// 	);
-// }
+describe("downloadFileToCacheDir", () => {
+	const fetchMock: typeof fetch = vi.fn();
+	beforeEach(() => {
+		vi.resetAllMocks();
+		// mock 200 request
+		vi.mocked(fetchMock).mockResolvedValue({
+			status: 200,
+			ok: true,
+			body: "dummy-body",
+		} as unknown as Response);
 
-// describe("downloadFileToCacheDir", () => {
-// 	const fetchMock: typeof fetch = vi.fn();
-// 	beforeEach(() => {
-// 		vi.resetAllMocks();
-// 		// mock 200 request
-// 		vi.mocked(fetchMock).mockResolvedValue({
-// 			status: 200,
-// 			ok: true,
-// 			body: "dummy-body",
-// 		} as unknown as Response);
+		// prevent to use caching
+		vi.mocked(stat).mockRejectedValue(new Error("Do not exists"));
+		vi.mocked(lstat).mockRejectedValue(new Error("Do not exists"));
+	});
 
-// 		// prevent to use caching
-// 		vi.mocked(stat).mockRejectedValue(new Error("Do not exists"));
-// 		vi.mocked(lstat).mockRejectedValue(new Error("Do not exists"));
-// 	});
+	test("should throw an error if fileDownloadInfo return nothing", async () => {
+		await expect(async () => {
+			await downloadFileToCacheDir({
+				repo: DUMMY_REPO,
+				path: "/README.md",
+				fetch: fetchMock,
+			});
+		}).rejects.toThrowError("cannot get path info for /README.md");
 
-// 	test("should throw an error if fileDownloadInfo return nothing", async () => {
-// 		await expect(async () => {
-// 			await downloadFileToCacheDir({
-// 				repo: DUMMY_REPO,
-// 				path: "/README.md",
-// 				fetch: fetchMock,
-// 			});
-// 		}).rejects.toThrowError("cannot get path info for /README.md");
+		expect(pathsInfo).toHaveBeenCalledWith(
+			expect.objectContaining({
+				repo: DUMMY_REPO,
+				paths: ["/README.md"],
+				fetch: fetchMock,
+			})
+		);
+	});
 
-// 		expect(pathsInfo).toHaveBeenCalledWith(
-// 			expect.objectContaining({
-// 				repo: DUMMY_REPO,
-// 				paths: ["/README.md"],
-// 				fetch: fetchMock,
-// 			})
-// 		);
-// 	});
+	test("existing symlinked and blob should not re-download it", async () => {
+		// <cache>/<repo>/<revision>/snapshots/README.md
+		const expectPointer = _getSnapshotFile({
+			repo: DUMMY_REPO,
+			path: "/README.md",
+			revision: "dd4bc8b21efa05ec961e3efc4ee5e3832a3679c7",
+		});
+		// stat ensure a symlink and the pointed file exists
+		vi.mocked(stat).mockResolvedValue({} as Stats); // prevent default mocked reject
 
-// 	test("existing symlinked and blob should not re-download it", async () => {
-// 		// <cache>/<repo>/<revision>/snapshots/README.md
-// 		const expectPointer = _getSnapshotFile({
-// 			repo: DUMMY_REPO,
-// 			path: "/README.md",
-// 			revision: "dd4bc8b21efa05ec961e3efc4ee5e3832a3679c7",
-// 		});
-// 		// stat ensure a symlink and the pointed file exists
-// 		vi.mocked(stat).mockResolvedValue({} as Stats); // prevent default mocked reject
+		const output = await downloadFileToCacheDir({
+			repo: DUMMY_REPO,
+			path: "/README.md",
+			fetch: fetchMock,
+			revision: "dd4bc8b21efa05ec961e3efc4ee5e3832a3679c7",
+		});
 
-// 		const output = await downloadFileToCacheDir({
-// 			repo: DUMMY_REPO,
-// 			path: "/README.md",
-// 			fetch: fetchMock,
-// 			revision: "dd4bc8b21efa05ec961e3efc4ee5e3832a3679c7",
-// 		});
+		expect(stat).toHaveBeenCalledOnce();
+		// Get call argument for stat
+		const starArg = vi.mocked(stat).mock.calls[0][0];
 
-// 		expect(stat).toHaveBeenCalledOnce();
-// 		// Get call argument for stat
-// 		const starArg = vi.mocked(stat).mock.calls[0][0];
+		expect(starArg).toBe(expectPointer);
+		expect(fetchMock).not.toHaveBeenCalledWith();
 
-// 		expect(starArg).toBe(expectPointer);
-// 		expect(fetchMock).not.toHaveBeenCalledWith();
+		expect(output).toBe(expectPointer);
+	});
 
-// 		expect(output).toBe(expectPointer);
-// 	});
+	test("existing symlinked and blob with default revision should not re-download it", async () => {
+		// <cache>/<repo>/<revision>/snapshots/README.md
+		const expectPointer = _getSnapshotFile({
+			repo: DUMMY_REPO,
+			path: "/README.md",
+			revision: "main",
+		});
+		// stat ensure a symlink and the pointed file exists
+		vi.mocked(stat).mockResolvedValue({} as Stats); // prevent default mocked reject
+		vi.mocked(lstat).mockResolvedValue({} as Stats);
+		vi.mocked(pathsInfo).mockResolvedValue([
+			{
+				oid: DUMMY_ETAG,
+				size: 55,
+				path: "README.md",
+				type: "file",
+				lastCommit: {
+					date: new Date(),
+					id: "main",
+					title: "Commit msg",
+				},
+			},
+		]);
 
-// 	test("existing symlinked and blob with default revision should not re-download it", async () => {
-// 		// <cache>/<repo>/<revision>/snapshots/README.md
-// 		const expectPointer = _getSnapshotFile({
-// 			repo: DUMMY_REPO,
-// 			path: "/README.md",
-// 			revision: "main",
-// 		});
-// 		// stat ensure a symlink and the pointed file exists
-// 		vi.mocked(stat).mockResolvedValue({} as Stats); // prevent default mocked reject
-// 		vi.mocked(lstat).mockResolvedValue({} as Stats);
-// 		vi.mocked(pathsInfo).mockResolvedValue([
-// 			{
-// 				oid: DUMMY_ETAG,
-// 				size: 55,
-// 				path: "README.md",
-// 				type: "file",
-// 				lastCommit: {
-// 					date: new Date(),
-// 					id: "main",
-// 					title: "Commit msg",
-// 				},
-// 			},
-// 		]);
+		const output = await downloadFileToCacheDir({
+			repo: DUMMY_REPO,
+			path: "/README.md",
+			fetch: fetchMock,
+		});
 
-// 		const output = await downloadFileToCacheDir({
-// 			repo: DUMMY_REPO,
-// 			path: "/README.md",
-// 			fetch: fetchMock,
-// 		});
+		expect(stat).toHaveBeenCalledOnce();
+		expect(symlink).not.toHaveBeenCalledOnce();
+		// Get call argument for stat
+		const starArg = vi.mocked(stat).mock.calls[0][0];
 
-// 		expect(stat).toHaveBeenCalledOnce();
-// 		expect(symlink).not.toHaveBeenCalledOnce();
-// 		// Get call argument for stat
-// 		const starArg = vi.mocked(stat).mock.calls[0][0];
+		expect(starArg).toBe(expectPointer);
+		expect(fetchMock).not.toHaveBeenCalledWith();
 
-// 		expect(starArg).toBe(expectPointer);
-// 		expect(fetchMock).not.toHaveBeenCalledWith();
+		expect(output).toBe(expectPointer);
+	});
 
-// 		expect(output).toBe(expectPointer);
-// 	});
+	test("existing blob should only create the symlink", async () => {
+		// <cache>/<repo>/<revision>/snapshots/README.md
+		const expectPointer = _getSnapshotFile({
+			repo: DUMMY_REPO,
+			path: "/README.md",
+			revision: "dummy-commit-hash",
+		});
+		// <cache>/<repo>/blobs/<etag>
+		const expectedBlob = _getBlobFile({
+			repo: DUMMY_REPO,
+			etag: DUMMY_ETAG,
+		});
 
-// 	test("existing blob should only create the symlink", async () => {
-// 		// <cache>/<repo>/<revision>/snapshots/README.md
-// 		const expectPointer = _getSnapshotFile({
-// 			repo: DUMMY_REPO,
-// 			path: "/README.md",
-// 			revision: "dummy-commit-hash",
-// 		});
-// 		// <cache>/<repo>/blobs/<etag>
-// 		const expectedBlob = _getBlobFile({
-// 			repo: DUMMY_REPO,
-// 			etag: DUMMY_ETAG,
-// 		});
+		// mock existing blob only no symlink
+		vi.mocked(lstat).mockResolvedValue({} as Stats);
+		// mock pathsInfo resolve content
+		vi.mocked(pathsInfo).mockResolvedValue([
+			{
+				oid: DUMMY_ETAG,
+				size: 55,
+				path: "README.md",
+				type: "file",
+				lastCommit: {
+					date: new Date(),
+					id: "dummy-commit-hash",
+					title: "Commit msg",
+				},
+			},
+		]);
 
-// 		// mock existing blob only no symlink
-// 		vi.mocked(lstat).mockResolvedValue({} as Stats);
-// 		// mock pathsInfo resolve content
-// 		vi.mocked(pathsInfo).mockResolvedValue([
-// 			{
-// 				oid: DUMMY_ETAG,
-// 				size: 55,
-// 				path: "README.md",
-// 				type: "file",
-// 				lastCommit: {
-// 					date: new Date(),
-// 					id: "dummy-commit-hash",
-// 					title: "Commit msg",
-// 				},
-// 			},
-// 		]);
+		const output = await downloadFileToCacheDir({
+			repo: DUMMY_REPO,
+			path: "/README.md",
+			fetch: fetchMock,
+		});
 
-// 		const output = await downloadFileToCacheDir({
-// 			repo: DUMMY_REPO,
-// 			path: "/README.md",
-// 			fetch: fetchMock,
-// 		});
+		// should have check for the blob
+		expect(lstat).toHaveBeenCalled();
+		expect(vi.mocked(lstat).mock.calls[0][0]).toBe(expectedBlob);
 
-// 		// should have check for the blob
-// 		expect(lstat).toHaveBeenCalled();
-// 		expect(vi.mocked(lstat).mock.calls[0][0]).toBe(expectedBlob);
+		// symlink should have been created
+		expect(createSymlink).toHaveBeenCalledOnce();
+		// no download done
+		expect(fetchMock).not.toHaveBeenCalled();
 
-// 		// symlink should have been created
-// 		expect(createSymlink).toHaveBeenCalledOnce();
-// 		// no download done
-// 		expect(fetchMock).not.toHaveBeenCalled();
+		expect(output).toBe(expectPointer);
+	});
 
-// 		expect(output).toBe(expectPointer);
-// 	});
+	test("expect resolve value to be the pointer path of downloaded file", async () => {
+		// <cache>/<repo>/<revision>/snapshots/README.md
+		const expectPointer = _getSnapshotFile({
+			repo: DUMMY_REPO,
+			path: "/README.md",
+			revision: "dummy-commit-hash",
+		});
+		// <cache>/<repo>/blobs/<etag>
+		const expectedBlob = _getBlobFile({
+			repo: DUMMY_REPO,
+			etag: DUMMY_ETAG,
+		});
 
-// 	test("expect resolve value to be the pointer path of downloaded file", async () => {
-// 		// <cache>/<repo>/<revision>/snapshots/README.md
-// 		const expectPointer = _getSnapshotFile({
-// 			repo: DUMMY_REPO,
-// 			path: "/README.md",
-// 			revision: "dummy-commit-hash",
-// 		});
-// 		// <cache>/<repo>/blobs/<etag>
-// 		const expectedBlob = _getBlobFile({
-// 			repo: DUMMY_REPO,
-// 			etag: DUMMY_ETAG,
-// 		});
+		vi.mocked(pathsInfo).mockResolvedValue([
+			{
+				oid: DUMMY_ETAG,
+				size: 55,
+				path: "README.md",
+				type: "file",
+				lastCommit: {
+					date: new Date(),
+					id: "dummy-commit-hash",
+					title: "Commit msg",
+				},
+			},
+		]);
 
-// 		vi.mocked(pathsInfo).mockResolvedValue([
-// 			{
-// 				oid: DUMMY_ETAG,
-// 				size: 55,
-// 				path: "README.md",
-// 				type: "file",
-// 				lastCommit: {
-// 					date: new Date(),
-// 					id: "dummy-commit-hash",
-// 					title: "Commit msg",
-// 				},
-// 			},
-// 		]);
+		const output = await downloadFileToCacheDir({
+			repo: DUMMY_REPO,
+			path: "/README.md",
+			fetch: fetchMock,
+		});
 
-// 		const output = await downloadFileToCacheDir({
-// 			repo: DUMMY_REPO,
-// 			path: "/README.md",
-// 			fetch: fetchMock,
-// 		});
+		// expect blobs and snapshots folder to have been mkdir
+		expect(vi.mocked(mkdir).mock.calls[0][0]).toBe(dirname(expectedBlob));
+		expect(vi.mocked(mkdir).mock.calls[1][0]).toBe(dirname(expectPointer));
 
-// 		// expect blobs and snapshots folder to have been mkdir
-// 		expect(vi.mocked(mkdir).mock.calls[0][0]).toBe(dirname(expectedBlob));
-// 		expect(vi.mocked(mkdir).mock.calls[1][0]).toBe(dirname(expectPointer));
+		expect(output).toBe(expectPointer);
+	});
 
-// 		expect(output).toBe(expectPointer);
-// 	});
+	test("should write fetch response to blob", async () => {
+		// <cache>/<repo>/<revision>/snapshots/README.md
+		const expectPointer = _getSnapshotFile({
+			repo: DUMMY_REPO,
+			path: "/README.md",
+			revision: "dummy-commit-hash",
+		});
+		// <cache>/<repo>/blobs/<etag>
+		const expectedBlob = _getBlobFile({
+			repo: DUMMY_REPO,
+			etag: DUMMY_ETAG,
+		});
 
-// 	test("should write fetch response to blob", async () => {
-// 		// <cache>/<repo>/<revision>/snapshots/README.md
-// 		const expectPointer = _getSnapshotFile({
-// 			repo: DUMMY_REPO,
-// 			path: "/README.md",
-// 			revision: "dummy-commit-hash",
-// 		});
-// 		// <cache>/<repo>/blobs/<etag>
-// 		const expectedBlob = _getBlobFile({
-// 			repo: DUMMY_REPO,
-// 			etag: DUMMY_ETAG,
-// 		});
+		// mock pathsInfo resolve content
+		vi.mocked(pathsInfo).mockResolvedValue([
+			{
+				oid: DUMMY_ETAG,
+				size: 55,
+				path: "README.md",
+				type: "file",
+				lastCommit: {
+					date: new Date(),
+					id: "dummy-commit-hash",
+					title: "Commit msg",
+				},
+			},
+		]);
 
-// 		// mock pathsInfo resolve content
-// 		vi.mocked(pathsInfo).mockResolvedValue([
-// 			{
-// 				oid: DUMMY_ETAG,
-// 				size: 55,
-// 				path: "README.md",
-// 				type: "file",
-// 				lastCommit: {
-// 					date: new Date(),
-// 					id: "dummy-commit-hash",
-// 					title: "Commit msg",
-// 				},
-// 			},
-// 		]);
+		await downloadFileToCacheDir({
+			repo: DUMMY_REPO,
+			path: "/README.md",
+			fetch: fetchMock,
+		});
 
-// 		await downloadFileToCacheDir({
-// 			repo: DUMMY_REPO,
-// 			path: "/README.md",
-// 			fetch: fetchMock,
-// 		});
-
-// 		const incomplete = `${expectedBlob}.incomplete`;
-// 		// 1. should write fetch#response#body to incomplete file
-// 		expect(writeFile).toHaveBeenCalledWith(incomplete, "dummy-body");
-// 		// 2. should rename the incomplete to the blob expected name
-// 		expect(rename).toHaveBeenCalledWith(incomplete, expectedBlob);
-// 		// 3. should create symlink pointing to blob
-// 		expect(createSymlink).toHaveBeenCalledWith(expectedBlob, expectPointer);
-// 	});
-// });
+		const incomplete = `${expectedBlob}.incomplete`;
+		// 1. should write fetch#response#body to incomplete file
+		expect(writeFile).toHaveBeenCalledWith(incomplete, "dummy-body");
+		// 2. should rename the incomplete to the blob expected name
+		expect(rename).toHaveBeenCalledWith(incomplete, expectedBlob);
+		// 3. should create symlink pointing to blob
+		expect(createSymlink).toHaveBeenCalledWith({ sourcePath: expectedBlob, finalPath: expectPointer });
+	});
+});

--- a/packages/hub/src/lib/download-file-to-cache-dir.spec.ts
+++ b/packages/hub/src/lib/download-file-to-cache-dir.spec.ts
@@ -1,293 +1,295 @@
-import { expect, test, describe, vi, beforeEach } from "vitest";
-import type { RepoDesignation, RepoId } from "../types/public";
-import { dirname, join } from "node:path";
-import { lstat, mkdir, stat, symlink, writeFile, rename } from "node:fs/promises";
-import { pathsInfo } from "./paths-info";
-import type { Stats } from "node:fs";
-import { getHFHubCachePath, getRepoFolderName } from "./cache-management";
-import { toRepoId } from "../utils/toRepoId";
-import { downloadFileToCacheDir } from "./download-file-to-cache-dir";
-import { createSymlink } from "../utils/symlink";
+// Commented out, let's use non-mocked tests
 
-vi.mock("node:fs/promises", () => ({
-	writeFile: vi.fn(),
-	rename: vi.fn(),
-	symlink: vi.fn(),
-	lstat: vi.fn(),
-	mkdir: vi.fn(),
-	stat: vi.fn(),
-}));
+// import { expect, test, describe, vi, beforeEach } from "vitest";
+// import type { RepoDesignation, RepoId } from "../types/public";
+// import { dirname, join } from "node:path";
+// import { lstat, mkdir, stat, symlink, writeFile, rename } from "node:fs/promises";
+// import { pathsInfo } from "./paths-info";
+// import type { Stats } from "node:fs";
+// import { getHFHubCachePath, getRepoFolderName } from "./cache-management";
+// import { toRepoId } from "../utils/toRepoId";
+// import { downloadFileToCacheDir } from "./download-file-to-cache-dir";
+// import { createSymlink } from "../utils/symlink";
 
-vi.mock("./paths-info", () => ({
-	pathsInfo: vi.fn(),
-}));
+// vi.mock("node:fs/promises", () => ({
+// 	writeFile: vi.fn(),
+// 	rename: vi.fn(),
+// 	symlink: vi.fn(),
+// 	lstat: vi.fn(),
+// 	mkdir: vi.fn(),
+// 	stat: vi.fn(),
+// }));
 
-vi.mock("../utils/symlink", () => ({
-	createSymlink: vi.fn(),
-}));
+// vi.mock("./paths-info", () => ({
+// 	pathsInfo: vi.fn(),
+// }));
 
-const DUMMY_REPO: RepoId = {
-	name: "hello-world",
-	type: "model",
-};
+// vi.mock("../utils/symlink", () => ({
+// 	createSymlink: vi.fn(),
+// }));
 
-const DUMMY_ETAG = "dummy-etag";
+// const DUMMY_REPO: RepoId = {
+// 	name: "hello-world",
+// 	type: "model",
+// };
 
-// utility test method to get blob file path
-function _getBlobFile(params: {
-	repo: RepoDesignation;
-	etag: string;
-	cacheDir?: string; // default to {@link getHFHubCache}
-}) {
-	return join(params.cacheDir ?? getHFHubCachePath(), getRepoFolderName(toRepoId(params.repo)), "blobs", params.etag);
-}
+// const DUMMY_ETAG = "dummy-etag";
 
-// utility test method to get snapshot file path
-function _getSnapshotFile(params: {
-	repo: RepoDesignation;
-	path: string;
-	revision: string;
-	cacheDir?: string; // default to {@link getHFHubCache}
-}) {
-	return join(
-		params.cacheDir ?? getHFHubCachePath(),
-		getRepoFolderName(toRepoId(params.repo)),
-		"snapshots",
-		params.revision,
-		params.path
-	);
-}
+// // utility test method to get blob file path
+// function _getBlobFile(params: {
+// 	repo: RepoDesignation;
+// 	etag: string;
+// 	cacheDir?: string; // default to {@link getHFHubCache}
+// }) {
+// 	return join(params.cacheDir ?? getHFHubCachePath(), getRepoFolderName(toRepoId(params.repo)), "blobs", params.etag);
+// }
 
-describe("downloadFileToCacheDir", () => {
-	const fetchMock: typeof fetch = vi.fn();
-	beforeEach(() => {
-		vi.resetAllMocks();
-		// mock 200 request
-		vi.mocked(fetchMock).mockResolvedValue({
-			status: 200,
-			ok: true,
-			body: "dummy-body",
-		} as unknown as Response);
+// // utility test method to get snapshot file path
+// function _getSnapshotFile(params: {
+// 	repo: RepoDesignation;
+// 	path: string;
+// 	revision: string;
+// 	cacheDir?: string; // default to {@link getHFHubCache}
+// }) {
+// 	return join(
+// 		params.cacheDir ?? getHFHubCachePath(),
+// 		getRepoFolderName(toRepoId(params.repo)),
+// 		"snapshots",
+// 		params.revision,
+// 		params.path
+// 	);
+// }
 
-		// prevent to use caching
-		vi.mocked(stat).mockRejectedValue(new Error("Do not exists"));
-		vi.mocked(lstat).mockRejectedValue(new Error("Do not exists"));
-	});
+// describe("downloadFileToCacheDir", () => {
+// 	const fetchMock: typeof fetch = vi.fn();
+// 	beforeEach(() => {
+// 		vi.resetAllMocks();
+// 		// mock 200 request
+// 		vi.mocked(fetchMock).mockResolvedValue({
+// 			status: 200,
+// 			ok: true,
+// 			body: "dummy-body",
+// 		} as unknown as Response);
 
-	test("should throw an error if fileDownloadInfo return nothing", async () => {
-		await expect(async () => {
-			await downloadFileToCacheDir({
-				repo: DUMMY_REPO,
-				path: "/README.md",
-				fetch: fetchMock,
-			});
-		}).rejects.toThrowError("cannot get path info for /README.md");
+// 		// prevent to use caching
+// 		vi.mocked(stat).mockRejectedValue(new Error("Do not exists"));
+// 		vi.mocked(lstat).mockRejectedValue(new Error("Do not exists"));
+// 	});
 
-		expect(pathsInfo).toHaveBeenCalledWith(
-			expect.objectContaining({
-				repo: DUMMY_REPO,
-				paths: ["/README.md"],
-				fetch: fetchMock,
-			})
-		);
-	});
+// 	test("should throw an error if fileDownloadInfo return nothing", async () => {
+// 		await expect(async () => {
+// 			await downloadFileToCacheDir({
+// 				repo: DUMMY_REPO,
+// 				path: "/README.md",
+// 				fetch: fetchMock,
+// 			});
+// 		}).rejects.toThrowError("cannot get path info for /README.md");
 
-	test("existing symlinked and blob should not re-download it", async () => {
-		// <cache>/<repo>/<revision>/snapshots/README.md
-		const expectPointer = _getSnapshotFile({
-			repo: DUMMY_REPO,
-			path: "/README.md",
-			revision: "dd4bc8b21efa05ec961e3efc4ee5e3832a3679c7",
-		});
-		// stat ensure a symlink and the pointed file exists
-		vi.mocked(stat).mockResolvedValue({} as Stats); // prevent default mocked reject
+// 		expect(pathsInfo).toHaveBeenCalledWith(
+// 			expect.objectContaining({
+// 				repo: DUMMY_REPO,
+// 				paths: ["/README.md"],
+// 				fetch: fetchMock,
+// 			})
+// 		);
+// 	});
 
-		const output = await downloadFileToCacheDir({
-			repo: DUMMY_REPO,
-			path: "/README.md",
-			fetch: fetchMock,
-			revision: "dd4bc8b21efa05ec961e3efc4ee5e3832a3679c7",
-		});
+// 	test("existing symlinked and blob should not re-download it", async () => {
+// 		// <cache>/<repo>/<revision>/snapshots/README.md
+// 		const expectPointer = _getSnapshotFile({
+// 			repo: DUMMY_REPO,
+// 			path: "/README.md",
+// 			revision: "dd4bc8b21efa05ec961e3efc4ee5e3832a3679c7",
+// 		});
+// 		// stat ensure a symlink and the pointed file exists
+// 		vi.mocked(stat).mockResolvedValue({} as Stats); // prevent default mocked reject
 
-		expect(stat).toHaveBeenCalledOnce();
-		// Get call argument for stat
-		const starArg = vi.mocked(stat).mock.calls[0][0];
+// 		const output = await downloadFileToCacheDir({
+// 			repo: DUMMY_REPO,
+// 			path: "/README.md",
+// 			fetch: fetchMock,
+// 			revision: "dd4bc8b21efa05ec961e3efc4ee5e3832a3679c7",
+// 		});
 
-		expect(starArg).toBe(expectPointer);
-		expect(fetchMock).not.toHaveBeenCalledWith();
+// 		expect(stat).toHaveBeenCalledOnce();
+// 		// Get call argument for stat
+// 		const starArg = vi.mocked(stat).mock.calls[0][0];
 
-		expect(output).toBe(expectPointer);
-	});
+// 		expect(starArg).toBe(expectPointer);
+// 		expect(fetchMock).not.toHaveBeenCalledWith();
 
-	test("existing symlinked and blob with default revision should not re-download it", async () => {
-		// <cache>/<repo>/<revision>/snapshots/README.md
-		const expectPointer = _getSnapshotFile({
-			repo: DUMMY_REPO,
-			path: "/README.md",
-			revision: "main",
-		});
-		// stat ensure a symlink and the pointed file exists
-		vi.mocked(stat).mockResolvedValue({} as Stats); // prevent default mocked reject
-		vi.mocked(lstat).mockResolvedValue({} as Stats);
-		vi.mocked(pathsInfo).mockResolvedValue([
-			{
-				oid: DUMMY_ETAG,
-				size: 55,
-				path: "README.md",
-				type: "file",
-				lastCommit: {
-					date: new Date(),
-					id: "main",
-					title: "Commit msg",
-				},
-			},
-		]);
+// 		expect(output).toBe(expectPointer);
+// 	});
 
-		const output = await downloadFileToCacheDir({
-			repo: DUMMY_REPO,
-			path: "/README.md",
-			fetch: fetchMock,
-		});
+// 	test("existing symlinked and blob with default revision should not re-download it", async () => {
+// 		// <cache>/<repo>/<revision>/snapshots/README.md
+// 		const expectPointer = _getSnapshotFile({
+// 			repo: DUMMY_REPO,
+// 			path: "/README.md",
+// 			revision: "main",
+// 		});
+// 		// stat ensure a symlink and the pointed file exists
+// 		vi.mocked(stat).mockResolvedValue({} as Stats); // prevent default mocked reject
+// 		vi.mocked(lstat).mockResolvedValue({} as Stats);
+// 		vi.mocked(pathsInfo).mockResolvedValue([
+// 			{
+// 				oid: DUMMY_ETAG,
+// 				size: 55,
+// 				path: "README.md",
+// 				type: "file",
+// 				lastCommit: {
+// 					date: new Date(),
+// 					id: "main",
+// 					title: "Commit msg",
+// 				},
+// 			},
+// 		]);
 
-		expect(stat).toHaveBeenCalledOnce();
-		expect(symlink).not.toHaveBeenCalledOnce();
-		// Get call argument for stat
-		const starArg = vi.mocked(stat).mock.calls[0][0];
+// 		const output = await downloadFileToCacheDir({
+// 			repo: DUMMY_REPO,
+// 			path: "/README.md",
+// 			fetch: fetchMock,
+// 		});
 
-		expect(starArg).toBe(expectPointer);
-		expect(fetchMock).not.toHaveBeenCalledWith();
+// 		expect(stat).toHaveBeenCalledOnce();
+// 		expect(symlink).not.toHaveBeenCalledOnce();
+// 		// Get call argument for stat
+// 		const starArg = vi.mocked(stat).mock.calls[0][0];
 
-		expect(output).toBe(expectPointer);
-	});
+// 		expect(starArg).toBe(expectPointer);
+// 		expect(fetchMock).not.toHaveBeenCalledWith();
 
-	test("existing blob should only create the symlink", async () => {
-		// <cache>/<repo>/<revision>/snapshots/README.md
-		const expectPointer = _getSnapshotFile({
-			repo: DUMMY_REPO,
-			path: "/README.md",
-			revision: "dummy-commit-hash",
-		});
-		// <cache>/<repo>/blobs/<etag>
-		const expectedBlob = _getBlobFile({
-			repo: DUMMY_REPO,
-			etag: DUMMY_ETAG,
-		});
+// 		expect(output).toBe(expectPointer);
+// 	});
 
-		// mock existing blob only no symlink
-		vi.mocked(lstat).mockResolvedValue({} as Stats);
-		// mock pathsInfo resolve content
-		vi.mocked(pathsInfo).mockResolvedValue([
-			{
-				oid: DUMMY_ETAG,
-				size: 55,
-				path: "README.md",
-				type: "file",
-				lastCommit: {
-					date: new Date(),
-					id: "dummy-commit-hash",
-					title: "Commit msg",
-				},
-			},
-		]);
+// 	test("existing blob should only create the symlink", async () => {
+// 		// <cache>/<repo>/<revision>/snapshots/README.md
+// 		const expectPointer = _getSnapshotFile({
+// 			repo: DUMMY_REPO,
+// 			path: "/README.md",
+// 			revision: "dummy-commit-hash",
+// 		});
+// 		// <cache>/<repo>/blobs/<etag>
+// 		const expectedBlob = _getBlobFile({
+// 			repo: DUMMY_REPO,
+// 			etag: DUMMY_ETAG,
+// 		});
 
-		const output = await downloadFileToCacheDir({
-			repo: DUMMY_REPO,
-			path: "/README.md",
-			fetch: fetchMock,
-		});
+// 		// mock existing blob only no symlink
+// 		vi.mocked(lstat).mockResolvedValue({} as Stats);
+// 		// mock pathsInfo resolve content
+// 		vi.mocked(pathsInfo).mockResolvedValue([
+// 			{
+// 				oid: DUMMY_ETAG,
+// 				size: 55,
+// 				path: "README.md",
+// 				type: "file",
+// 				lastCommit: {
+// 					date: new Date(),
+// 					id: "dummy-commit-hash",
+// 					title: "Commit msg",
+// 				},
+// 			},
+// 		]);
 
-		// should have check for the blob
-		expect(lstat).toHaveBeenCalled();
-		expect(vi.mocked(lstat).mock.calls[0][0]).toBe(expectedBlob);
+// 		const output = await downloadFileToCacheDir({
+// 			repo: DUMMY_REPO,
+// 			path: "/README.md",
+// 			fetch: fetchMock,
+// 		});
 
-		// symlink should have been created
-		expect(createSymlink).toHaveBeenCalledOnce();
-		// no download done
-		expect(fetchMock).not.toHaveBeenCalled();
+// 		// should have check for the blob
+// 		expect(lstat).toHaveBeenCalled();
+// 		expect(vi.mocked(lstat).mock.calls[0][0]).toBe(expectedBlob);
 
-		expect(output).toBe(expectPointer);
-	});
+// 		// symlink should have been created
+// 		expect(createSymlink).toHaveBeenCalledOnce();
+// 		// no download done
+// 		expect(fetchMock).not.toHaveBeenCalled();
 
-	test("expect resolve value to be the pointer path of downloaded file", async () => {
-		// <cache>/<repo>/<revision>/snapshots/README.md
-		const expectPointer = _getSnapshotFile({
-			repo: DUMMY_REPO,
-			path: "/README.md",
-			revision: "dummy-commit-hash",
-		});
-		// <cache>/<repo>/blobs/<etag>
-		const expectedBlob = _getBlobFile({
-			repo: DUMMY_REPO,
-			etag: DUMMY_ETAG,
-		});
+// 		expect(output).toBe(expectPointer);
+// 	});
 
-		vi.mocked(pathsInfo).mockResolvedValue([
-			{
-				oid: DUMMY_ETAG,
-				size: 55,
-				path: "README.md",
-				type: "file",
-				lastCommit: {
-					date: new Date(),
-					id: "dummy-commit-hash",
-					title: "Commit msg",
-				},
-			},
-		]);
+// 	test("expect resolve value to be the pointer path of downloaded file", async () => {
+// 		// <cache>/<repo>/<revision>/snapshots/README.md
+// 		const expectPointer = _getSnapshotFile({
+// 			repo: DUMMY_REPO,
+// 			path: "/README.md",
+// 			revision: "dummy-commit-hash",
+// 		});
+// 		// <cache>/<repo>/blobs/<etag>
+// 		const expectedBlob = _getBlobFile({
+// 			repo: DUMMY_REPO,
+// 			etag: DUMMY_ETAG,
+// 		});
 
-		const output = await downloadFileToCacheDir({
-			repo: DUMMY_REPO,
-			path: "/README.md",
-			fetch: fetchMock,
-		});
+// 		vi.mocked(pathsInfo).mockResolvedValue([
+// 			{
+// 				oid: DUMMY_ETAG,
+// 				size: 55,
+// 				path: "README.md",
+// 				type: "file",
+// 				lastCommit: {
+// 					date: new Date(),
+// 					id: "dummy-commit-hash",
+// 					title: "Commit msg",
+// 				},
+// 			},
+// 		]);
 
-		// expect blobs and snapshots folder to have been mkdir
-		expect(vi.mocked(mkdir).mock.calls[0][0]).toBe(dirname(expectedBlob));
-		expect(vi.mocked(mkdir).mock.calls[1][0]).toBe(dirname(expectPointer));
+// 		const output = await downloadFileToCacheDir({
+// 			repo: DUMMY_REPO,
+// 			path: "/README.md",
+// 			fetch: fetchMock,
+// 		});
 
-		expect(output).toBe(expectPointer);
-	});
+// 		// expect blobs and snapshots folder to have been mkdir
+// 		expect(vi.mocked(mkdir).mock.calls[0][0]).toBe(dirname(expectedBlob));
+// 		expect(vi.mocked(mkdir).mock.calls[1][0]).toBe(dirname(expectPointer));
 
-	test("should write fetch response to blob", async () => {
-		// <cache>/<repo>/<revision>/snapshots/README.md
-		const expectPointer = _getSnapshotFile({
-			repo: DUMMY_REPO,
-			path: "/README.md",
-			revision: "dummy-commit-hash",
-		});
-		// <cache>/<repo>/blobs/<etag>
-		const expectedBlob = _getBlobFile({
-			repo: DUMMY_REPO,
-			etag: DUMMY_ETAG,
-		});
+// 		expect(output).toBe(expectPointer);
+// 	});
 
-		// mock pathsInfo resolve content
-		vi.mocked(pathsInfo).mockResolvedValue([
-			{
-				oid: DUMMY_ETAG,
-				size: 55,
-				path: "README.md",
-				type: "file",
-				lastCommit: {
-					date: new Date(),
-					id: "dummy-commit-hash",
-					title: "Commit msg",
-				},
-			},
-		]);
+// 	test("should write fetch response to blob", async () => {
+// 		// <cache>/<repo>/<revision>/snapshots/README.md
+// 		const expectPointer = _getSnapshotFile({
+// 			repo: DUMMY_REPO,
+// 			path: "/README.md",
+// 			revision: "dummy-commit-hash",
+// 		});
+// 		// <cache>/<repo>/blobs/<etag>
+// 		const expectedBlob = _getBlobFile({
+// 			repo: DUMMY_REPO,
+// 			etag: DUMMY_ETAG,
+// 		});
 
-		await downloadFileToCacheDir({
-			repo: DUMMY_REPO,
-			path: "/README.md",
-			fetch: fetchMock,
-		});
+// 		// mock pathsInfo resolve content
+// 		vi.mocked(pathsInfo).mockResolvedValue([
+// 			{
+// 				oid: DUMMY_ETAG,
+// 				size: 55,
+// 				path: "README.md",
+// 				type: "file",
+// 				lastCommit: {
+// 					date: new Date(),
+// 					id: "dummy-commit-hash",
+// 					title: "Commit msg",
+// 				},
+// 			},
+// 		]);
 
-		const incomplete = `${expectedBlob}.incomplete`;
-		// 1. should write fetch#response#body to incomplete file
-		expect(writeFile).toHaveBeenCalledWith(incomplete, "dummy-body");
-		// 2. should rename the incomplete to the blob expected name
-		expect(rename).toHaveBeenCalledWith(incomplete, expectedBlob);
-		// 3. should create symlink pointing to blob
-		expect(createSymlink).toHaveBeenCalledWith(expectedBlob, expectPointer);
-	});
-});
+// 		await downloadFileToCacheDir({
+// 			repo: DUMMY_REPO,
+// 			path: "/README.md",
+// 			fetch: fetchMock,
+// 		});
+
+// 		const incomplete = `${expectedBlob}.incomplete`;
+// 		// 1. should write fetch#response#body to incomplete file
+// 		expect(writeFile).toHaveBeenCalledWith(incomplete, "dummy-body");
+// 		// 2. should rename the incomplete to the blob expected name
+// 		expect(rename).toHaveBeenCalledWith(incomplete, expectedBlob);
+// 		// 3. should create symlink pointing to blob
+// 		expect(createSymlink).toHaveBeenCalledWith(expectedBlob, expectPointer);
+// 	});
+// });

--- a/packages/hub/src/lib/download-file-to-cache-dir.ts
+++ b/packages/hub/src/lib/download-file-to-cache-dir.ts
@@ -108,7 +108,7 @@ export async function downloadFileToCacheDir(
 	// shortcut the download if needed
 	if (await exists(blobPath)) {
 		// create symlinks in snapshot folder to blob object
-		await createSymlink(blobPath, pointerPath);
+		await createSymlink({ sourcePath: blobPath, finalPath: pointerPath });
 		return pointerPath;
 	}
 
@@ -128,6 +128,6 @@ export async function downloadFileToCacheDir(
 	// rename .incomplete file to expect blob
 	await rename(incomplete, blobPath);
 	// create symlinks in snapshot folder to blob object
-	await createSymlink(blobPath, pointerPath);
+	await createSymlink({ sourcePath: blobPath, finalPath: pointerPath });
 	return pointerPath;
 }

--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -98,7 +98,7 @@ describe("XetBlob", () => {
 					}
 					return fetch(url, opts);
 				},
-				internalLogging: true,
+				// internalLogging: true,
 			});
 
 			const xetDownload = await blob.slice(0, 200_000).arrayBuffer();
@@ -124,7 +124,7 @@ describe("XetBlob", () => {
 				},
 				hash: "7b3b6d07673a88cf467e67c1f7edef1a8c268cbf66e9dd9b0366322d4ab56d9b",
 				size: 5_234_139_343,
-				internalLogging: true,
+				// internalLogging: true,
 			});
 
 			const xetDownload = await blob.slice(10_000_000, 10_100_000).arrayBuffer();

--- a/packages/hub/src/utils/symlink.spec.ts
+++ b/packages/hub/src/utils/symlink.spec.ts
@@ -4,6 +4,8 @@ import { describe, expect, it, vi } from "vitest";
 import { createSymlink } from "./symlink";
 import { readFileSync, writeFileSync } from "node:fs";
 import { lstat, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 let failSymlink = false;
 vi.mock("node:fs/promises", async (importOriginal) => ({
@@ -21,67 +23,67 @@ vi.mock("node:fs/promises", async (importOriginal) => ({
 
 describe("utils/symlink", () => {
 	it("should create a symlink", async () => {
-		writeFileSync("/tmp/test.txt", "hello world");
+		writeFileSync(join(tmpdir(), "test.txt"), "hello world");
 		await createSymlink({
-			sourcePath: "/tmp/test.txt",
-			finalPath: "/tmp/test-symlink.txt",
+			sourcePath: join(tmpdir(), "test.txt"),
+			finalPath: join(tmpdir(), "test-symlink.txt"),
 		});
 
-		const stats = await lstat("/tmp/test-symlink.txt");
+		const stats = await lstat(join(tmpdir(), "test-symlink.txt"));
 		expect(stats.isSymbolicLink()).toBe(true);
 
 		// Test file content
-		const content = readFileSync("/tmp/test-symlink.txt", "utf8");
+		const content = readFileSync(join(tmpdir(), "test-symlink.txt"), "utf8");
 		expect(content).toBe("hello world");
 
 		// Cleanup
-		await rm("/tmp/test-symlink.txt");
-		await rm("/tmp/test.txt");
+		await rm(join(tmpdir(), "test-symlink.txt"));
+		await rm(join(tmpdir(), "test.txt"));
 	});
 
 	it("should work when symlinking twice", async () => {
-		writeFileSync("/tmp/test.txt", "hello world");
-		writeFileSync("/tmp/test2.txt", "hello world2");
+		writeFileSync(join(tmpdir(), "test.txt"), "hello world");
+		writeFileSync(join(tmpdir(), "test2.txt"), "hello world2");
 		await createSymlink({
-			sourcePath: "/tmp/test.txt",
-			finalPath: "/tmp/test-symlink.txt",
+			sourcePath: join(tmpdir(), "test.txt"),
+			finalPath: join(tmpdir(), "test-symlink.txt"),
 		});
 		await createSymlink({
-			sourcePath: "/tmp/test2.txt",
-			finalPath: "/tmp/test-symlink.txt",
+			sourcePath: join(tmpdir(), "test2.txt"),
+			finalPath: join(tmpdir(), "test-symlink.txt"),
 		});
 
-		const stats = await lstat("/tmp/test-symlink.txt");
+		const stats = await lstat(join(tmpdir(), "test-symlink.txt"));
 		expect(stats.isSymbolicLink()).toBe(true);
 
 		// Test file content
-		const content = readFileSync("/tmp/test-symlink.txt", "utf8");
+		const content = readFileSync(join(tmpdir(), "test-symlink.txt"), "utf8");
 		expect(content).toBe("hello world2");
 
 		// Cleanup
-		await rm("/tmp/test-symlink.txt");
-		await rm("/tmp/test.txt");
-		await rm("/tmp/test2.txt");
+		await rm(join(tmpdir(), "test-symlink.txt"));
+		await rm(join(tmpdir(), "test.txt"));
+		await rm(join(tmpdir(), "test2.txt"));
 	});
 
 	it("should work when symlink doesn't work (windows)", async () => {
-		writeFileSync("/tmp/test.txt", "hello world");
+		writeFileSync(join(tmpdir(), "test.txt"), "hello world");
 
 		failSymlink = true;
 		await createSymlink({
-			sourcePath: "/tmp/test.txt",
-			finalPath: "/tmp/test-symlink.txt",
+			sourcePath: join(tmpdir(), "test.txt"),
+			finalPath: join(tmpdir(), "test-symlink.txt"),
 		});
 
-		const stats = await lstat("/tmp/test-symlink.txt");
+		const stats = await lstat(join(tmpdir(), "test-symlink.txt"));
 		expect(stats.isSymbolicLink()).toBe(false);
 
 		// Test file content
-		const content = readFileSync("/tmp/test-symlink.txt", "utf8");
+		const content = readFileSync(join(tmpdir(), "test-symlink.txt"), "utf8");
 		expect(content).toBe("hello world");
 
 		// Cleanup
-		await rm("/tmp/test-symlink.txt");
-		await rm("/tmp/test.txt");
+		await rm(join(tmpdir(), "test-symlink.txt"));
+		await rm(join(tmpdir(), "test.txt"));
 	});
 });

--- a/packages/hub/src/utils/symlink.spec.ts
+++ b/packages/hub/src/utils/symlink.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createSymlink } from "./symlink";
 import { readFileSync, writeFileSync } from "node:fs";
-import { lstat } from "node:fs/promises";
+import { lstat, rm } from "node:fs/promises";
 
 describe("utils/symlink", () => {
 	it("should create a symlink", async () => {
@@ -17,5 +17,34 @@ describe("utils/symlink", () => {
 		// Test file content
 		const content = readFileSync("/tmp/test-symlink.txt", "utf8");
 		expect(content).toBe("hello world");
+
+		// Cleanup
+		await rm("/tmp/test-symlink.txt");
+		await rm("/tmp/test.txt");
+	});
+
+	it("should work when symlinking twice", async () => {
+		writeFileSync("/tmp/test.txt", "hello world");
+		writeFileSync("/tmp/test2.txt", "hello world2");
+		await createSymlink({
+			sourcePath: "/tmp/test.txt",
+			finalPath: "/tmp/test-symlink.txt",
+		});
+		await createSymlink({
+			sourcePath: "/tmp/test2.txt",
+			finalPath: "/tmp/test-symlink.txt",
+		});
+
+		const stats = await lstat("/tmp/test-symlink.txt");
+		expect(stats.isSymbolicLink()).toBe(true);
+
+		// Test file content
+		const content = readFileSync("/tmp/test-symlink.txt", "utf8");
+		expect(content).toBe("hello world2");
+
+		// Cleanup
+		await rm("/tmp/test-symlink.txt");
+		await rm("/tmp/test.txt");
+		await rm("/tmp/test2.txt");
 	});
 });

--- a/packages/hub/src/utils/symlink.spec.ts
+++ b/packages/hub/src/utils/symlink.spec.ts
@@ -30,7 +30,7 @@ describe("utils/symlink", () => {
 		});
 
 		const stats = await lstat(join(tmpdir(), "test-symlink.txt"));
-		expect(stats.isSymbolicLink()).toBe(true);
+		expect(stats.isSymbolicLink()).toBe(process.platform !== "win32");
 
 		// Test file content
 		const content = readFileSync(join(tmpdir(), "test-symlink.txt"), "utf8");
@@ -54,7 +54,7 @@ describe("utils/symlink", () => {
 		});
 
 		const stats = await lstat(join(tmpdir(), "test-symlink.txt"));
-		expect(stats.isSymbolicLink()).toBe(true);
+		expect(stats.isSymbolicLink()).toBe(process.platform !== "win32");
 
 		// Test file content
 		const content = readFileSync(join(tmpdir(), "test-symlink.txt"), "utf8");

--- a/packages/hub/src/utils/symlink.spec.ts
+++ b/packages/hub/src/utils/symlink.spec.ts
@@ -1,7 +1,23 @@
-import { describe, expect, it } from "vitest";
+/* eslint-disable @typescript-eslint/consistent-type-imports */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, vi } from "vitest";
 import { createSymlink } from "./symlink";
 import { readFileSync, writeFileSync } from "node:fs";
 import { lstat, rm } from "node:fs/promises";
+
+let failSymlink = false;
+vi.mock("node:fs/promises", async (importOriginal) => ({
+	...(await importOriginal<typeof import("node:fs/promises")>()),
+	symlink: async (...args: any[]) => {
+		if (failSymlink) {
+			failSymlink = false;
+			throw new Error("Symlink not supported");
+		}
+
+		// @ts-expect-error - ignore
+		return (await importOriginal<typeof import("node:fs/promises")>()).symlink(...args);
+	},
+}));
 
 describe("utils/symlink", () => {
 	it("should create a symlink", async () => {
@@ -46,5 +62,26 @@ describe("utils/symlink", () => {
 		await rm("/tmp/test-symlink.txt");
 		await rm("/tmp/test.txt");
 		await rm("/tmp/test2.txt");
+	});
+
+	it("should work when symlink doesn't work (windows)", async () => {
+		writeFileSync("/tmp/test.txt", "hello world");
+
+		failSymlink = true;
+		await createSymlink({
+			sourcePath: "/tmp/test.txt",
+			finalPath: "/tmp/test-symlink.txt",
+		});
+
+		const stats = await lstat("/tmp/test-symlink.txt");
+		expect(stats.isSymbolicLink()).toBe(false);
+
+		// Test file content
+		const content = readFileSync("/tmp/test-symlink.txt", "utf8");
+		expect(content).toBe("hello world");
+
+		// Cleanup
+		await rm("/tmp/test-symlink.txt");
+		await rm("/tmp/test.txt");
 	});
 });

--- a/packages/hub/src/utils/symlink.ts
+++ b/packages/hub/src/utils/symlink.ts
@@ -57,7 +57,7 @@ export async function createSymlink(params: {
 	}
 
 	try {
-		await fs.symlink(abs_src, abs_dst);
+		await fs.symlink(path.relative(path.dirname(abs_dst), abs_src), abs_dst);
 	} catch {
 		console.info(`Symlink not supported. Copying file from ${abs_src} to ${abs_dst}`);
 		await fs.copyFile(abs_src, abs_dst);

--- a/packages/hub/vitest.config.mts
+++ b/packages/hub/vitest.config.mts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
-		testTimeout: 30_000,
+		testTimeout: 60_000,
 	},
 });


### PR DESCRIPTION
Alternative to https://github.com/huggingface/huggingface.js/pull/1307

Fix #1306 

I was just too confused by the src/dst params, nodej's official docs could be clearer too.

Now the params are explictly named and there is a real test to check the filesystem contents.

By the way, it's a `copy` operation not a `rename` (because it was already the case, the `new_blob` param was never passed)

Also took the opportunty to use relative symlinks cc @Wauplin for better windows support

cc @jeffmaury @axel7083 