### PR TITLE
Add 'prompt' input to image-to-image specs

### DIFF
--- a/packages/tasks/src/tasks/image-to-image/inference.ts
+++ b/packages/tasks/src/tasks/image-to-image/inference.ts
@@ -37,6 +37,10 @@ export interface ImageToImageParameters {
 	 */
 	num_inference_steps?: number;
 	/**
+	 * The text prompt to guide the image generation.
+	 */
+	prompt?: string;
+	/**
 	 * The size in pixel of the output image.
 	 */
 	target_size?: TargetSize;

--- a/packages/tasks/src/tasks/image-to-image/spec/input.json
+++ b/packages/tasks/src/tasks/image-to-image/spec/input.json
@@ -20,6 +20,10 @@
 			"title": "ImageToImageParameters",
 			"type": "object",
 			"properties": {
+				"prompt": {
+					"type": "string",
+					"description": "The text prompt to guide the image generation."
+				},
 				"guidance_scale": {
 					"type": "number",
 					"description": "For diffusion models. A higher guidance scale value encourages the model to generate images closely linked to the text prompt at the expense of lower image quality."


### PR DESCRIPTION
Seems like we've forgotten the most important parameter :smile: 

Already used in https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-1.0 widget even though we've not documented it properly in the specs.