### PR TITLE
[Snippets] Fix text-to-image fetch snippets

### DIFF
--- a/packages/inference/src/snippets/templates/js/fetch/textToImage.jinja
+++ b/packages/inference/src/snippets/templates/js/fetch/textToImage.jinja
@@ -14,16 +14,7 @@ async function query(data) {
 	return result;
 }
 
-query({
-{% set input_items = providerInputs.asObj.items() | list %}
-{% if input_items %}
-{% for key, value in input_items %}
-    {%- if not loop.first %}{{ '\n    ' }}{% else %}{{ '    ' }}{% endif %}
-    {{- key | tojson }}: {{ value | tojson }}
-    {%- if not loop.last %},{% endif %}
-{% endfor %}
-{% if input_items | length > 0 %}{{ '\n' }}{% endif %}
-{% endif %}
-}).then((response) => {
+
+query({ {{ providerInputs.asTsString }} }).then((response) => {
     // Use image
 });

--- a/packages/inference/src/snippets/templates/js/fetch/textToImage.jinja
+++ b/packages/inference/src/snippets/templates/js/fetch/textToImage.jinja
@@ -23,7 +23,7 @@ query({
     {%- if not loop.last %},{% endif %}
 {% endfor %}
 {% if input_items | length > 0 %}{{ '\n' }}{% endif %}
-{% endif %} {# End input_items check #}
+{% endif %}
 }).then((response) => {
     // Use image
 });

--- a/packages/inference/src/snippets/templates/js/fetch/textToImage.jinja
+++ b/packages/inference/src/snippets/templates/js/fetch/textToImage.jinja
@@ -14,6 +14,16 @@ async function query(data) {
 	return result;
 }
 
-query({ inputs: {{ providerInputs.asObj.inputs }} }).then((response) => {
+query({
+{% set input_items = providerInputs.asObj.items() | list %}
+{% if input_items %}
+{% for key, value in input_items %}
+    {%- if not loop.first %}{{ '\n    ' }}{% else %}{{ '    ' }}{% endif %}
+    {{- key | tojson }}: {{ value | tojson }}
+    {%- if not loop.last %},{% endif %}
+{% endfor %}
+{% if input_items | length > 0 %}{{ '\n' }}{% endif %}
+{% endif %} {# End input_items check #}
+}).then((response) => {
     // Use image
 });

--- a/packages/tasks-gen/snippets-fixtures/text-to-image/js/fetch/0.fal-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/text-to-image/js/fetch/0.fal-ai.js
@@ -16,6 +16,6 @@ async function query(data) {
 
 query({
     "inputs": "\"Astronaut riding a horse\""
- }).then((response) => {
+}).then((response) => {
     // Use image
 });

--- a/packages/tasks-gen/snippets-fixtures/text-to-image/js/fetch/0.fal-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/text-to-image/js/fetch/0.fal-ai.js
@@ -14,8 +14,7 @@ async function query(data) {
 	return result;
 }
 
-query({
-    "inputs": "\"Astronaut riding a horse\""
-}).then((response) => {
+
+query({     inputs: "\"Astronaut riding a horse\"", }).then((response) => {
     // Use image
 });

--- a/packages/tasks-gen/snippets-fixtures/text-to-image/js/fetch/0.fal-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/text-to-image/js/fetch/0.fal-ai.js
@@ -14,6 +14,8 @@ async function query(data) {
 	return result;
 }
 
-query({ inputs: "Astronaut riding a horse" }).then((response) => {
+query({
+    "inputs": "\"Astronaut riding a horse\""
+ }).then((response) => {
     // Use image
 });

--- a/packages/tasks-gen/snippets-fixtures/text-to-image/js/fetch/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/text-to-image/js/fetch/0.hf-inference.js
@@ -16,6 +16,6 @@ async function query(data) {
 
 query({
     "inputs": "\"Astronaut riding a horse\""
- }).then((response) => {
+}).then((response) => {
     // Use image
 });

--- a/packages/tasks-gen/snippets-fixtures/text-to-image/js/fetch/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/text-to-image/js/fetch/0.hf-inference.js
@@ -14,8 +14,7 @@ async function query(data) {
 	return result;
 }
 
-query({
-    "inputs": "\"Astronaut riding a horse\""
-}).then((response) => {
+
+query({     inputs: "\"Astronaut riding a horse\"", }).then((response) => {
     // Use image
 });

--- a/packages/tasks-gen/snippets-fixtures/text-to-image/js/fetch/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/text-to-image/js/fetch/0.hf-inference.js
@@ -14,6 +14,8 @@ async function query(data) {
 	return result;
 }
 
-query({ inputs: "Astronaut riding a horse" }).then((response) => {
+query({
+    "inputs": "\"Astronaut riding a horse\""
+ }).then((response) => {
     // Use image
 });


### PR DESCRIPTION
with @Wauplin, we realized that some `text-to-image` js snippets were incorrect, the key use to pass the prompt is different from a provider to another, so it's better to get the inputs from the body instead. 

**EDIT**: this PR does not fix totally the issue, since the input keys are customized per provider in the `textToImage` function. This is fixed in #1315.

**EDIT 2**: in a later PR we will apply a linter on the generated snippets which should make the snippets much nicer!