### PR TITLE
Do not make any extra API call when endpoint URL is directly specified

### DIFF
--- a/packages/inference/src/lib/makeRequestOptions.ts
+++ b/packages/inference/src/lib/makeRequestOptions.ts
@@ -35,6 +35,12 @@ export async function makeRequestOptions(
 	if (maybeModel && isUrl(maybeModel)) {
 		throw new Error(`Model URLs are no longer supported. Use endpointUrl instead.`);
 	}
+
+	if (args.endpointUrl) {
+		// No need to have maybeModel, or to load default model for a task
+		return makeRequestOptionsFromResolvedModel(args.endpointUrl, args, options);
+	}
+
 	if (!maybeModel && !task) {
 		throw new Error("No model provided, and no task has been specified.");
 	}

--- a/packages/inference/src/lib/makeRequestOptions.ts
+++ b/packages/inference/src/lib/makeRequestOptions.ts
@@ -38,7 +38,7 @@ export async function makeRequestOptions(
 
 	if (args.endpointUrl) {
 		// No need to have maybeModel, or to load default model for a task
-		return makeRequestOptionsFromResolvedModel(args.endpointUrl, args, options);
+		return makeRequestOptionsFromResolvedModel(maybeModel ?? args.endpointUrl, args, options);
 	}
 
 	if (!maybeModel && !task) {


### PR DESCRIPTION
Fix #1321 (cc @Kakulukian for viz)

The fix is not perfect, a greater refactoring would need to take place (eg to remove all concept of `providerConfig` when `endpointUrl` is provided, use a separate default provider config maybe not relying on `model` being defined)