### PR TITLE
[Inference Providers] Refactor: better typing?

### DIFF
--- a/packages/inference/src/providers/black-forest-labs.ts
+++ b/packages/inference/src/providers/black-forest-labs.ts
@@ -18,7 +18,7 @@ import { InferenceOutputError } from "../lib/InferenceOutputError";
 import type { BodyParams, HeaderParams, UrlParams } from "../types";
 import { delay } from "../utils/delay";
 import { omit } from "../utils/omit";
-import { TaskProviderHelper } from "./providerHelper";
+import { TaskProviderHelper, type TextToImageTaskHelper } from "./providerHelper";
 
 const BLACK_FOREST_LABS_AI_API_BASE_URL = "https://api.us1.bfl.ai";
 interface BlackForestLabsResponse {
@@ -26,7 +26,7 @@ interface BlackForestLabsResponse {
 	polling_url: string;
 }
 
-export class BlackForestLabsTextToImageTask extends TaskProviderHelper {
+export class BlackForestLabsTextToImageTask extends TaskProviderHelper implements TextToImageTaskHelper {
 	constructor() {
 		super("black-forest-labs", BLACK_FOREST_LABS_AI_API_BASE_URL, "text-to-image");
 	}

--- a/packages/inference/src/providers/hf-inference.ts
+++ b/packages/inference/src/providers/hf-inference.ts
@@ -14,6 +14,7 @@ import { HF_ROUTER_URL } from "../config";
 import { InferenceOutputError } from "../lib/InferenceOutputError";
 import type { BodyParams, InferenceTask, UrlParams } from "../types";
 import { toArray } from "../utils/toArray";
+import type { TextToImageTaskHelper } from "./providerHelper";
 import { TaskProviderHelper } from "./providerHelper";
 
 interface Base64ImageGeneration {
@@ -53,7 +54,7 @@ export class HFInferenceTask extends TaskProviderHelper {
 	}
 }
 
-export class HFInferenceTextToImageTask extends HFInferenceTask {
+export class HFInferenceTextToImageTask extends HFInferenceTask implements TextToImageTaskHelper {
 	constructor() {
 		super("text-to-image");
 	}
@@ -63,7 +64,7 @@ export class HFInferenceTextToImageTask extends HFInferenceTask {
 		url?: string,
 		headers?: Record<string, string>,
 		outputType?: "url" | "blob"
-	): Promise<unknown> {
+	): Promise<string | Blob> {
 		if (!response) {
 			throw new InferenceOutputError("response is undefined");
 		}

--- a/packages/inference/src/providers/nebius.ts
+++ b/packages/inference/src/providers/nebius.ts
@@ -17,6 +17,7 @@
 import { InferenceOutputError } from "../lib/InferenceOutputError";
 import type { BodyParams, UrlParams } from "../types";
 import { omit } from "../utils/omit";
+import type { TextToImageTaskHelper } from "./providerHelper";
 import { BaseConversationalTask, BaseTextGenerationTask, TaskProviderHelper } from "./providerHelper";
 
 const NEBIUS_API_BASE_URL = "https://api.studio.nebius.ai";
@@ -39,7 +40,7 @@ export class NebiusTextGenerationTask extends BaseTextGenerationTask {
 	}
 }
 
-export class NebiusTextToImageTask extends TaskProviderHelper {
+export class NebiusTextToImageTask extends TaskProviderHelper implements TextToImageTaskHelper {
 	constructor() {
 		super("nebius", NEBIUS_API_BASE_URL, "text-to-image");
 	}
@@ -59,7 +60,7 @@ export class NebiusTextToImageTask extends TaskProviderHelper {
 		return "v1/images/generations";
 	}
 
-	getResponse(response: NebiusBase64ImageGeneration, outputType?: "url" | "blob"): string | Promise<Blob> {
+	async getResponse(response: NebiusBase64ImageGeneration, outputType?: "url" | "blob"): Promise<string | Blob> {
 		if (
 			typeof response === "object" &&
 			"data" in response &&

--- a/packages/inference/src/providers/together.ts
+++ b/packages/inference/src/providers/together.ts
@@ -18,6 +18,7 @@ import type { ChatCompletionOutput, TextGenerationOutput, TextGenerationOutputFi
 import { InferenceOutputError } from "../lib/InferenceOutputError";
 import type { BodyParams, UrlParams } from "../types";
 import { omit } from "../utils/omit";
+import type { TextToImageTaskHelper } from "./providerHelper";
 import { BaseConversationalTask, BaseTextGenerationTask, TaskProviderHelper } from "./providerHelper";
 
 const TOGETHER_API_BASE_URL = "https://api.together.xyz";
@@ -57,7 +58,7 @@ export class TogetherTextGenerationTask extends BaseTextGenerationTask {
 		};
 	}
 
-	override getResponse(response: TogeteherTextCompletionOutput): TextGenerationOutput {
+	override async getResponse(response: TogeteherTextCompletionOutput): Promise<TextGenerationOutput> {
 		if (
 			typeof response === "object" &&
 			"choices" in response &&
@@ -73,7 +74,7 @@ export class TogetherTextGenerationTask extends BaseTextGenerationTask {
 	}
 }
 
-export class TogetherTextToImageTask extends TaskProviderHelper {
+export class TogetherTextToImageTask extends TaskProviderHelper implements TextToImageTaskHelper {
 	constructor() {
 		super("together", TOGETHER_API_BASE_URL, "text-to-image");
 	}
@@ -93,7 +94,7 @@ export class TogetherTextToImageTask extends TaskProviderHelper {
 		};
 	}
 
-	getResponse(response: TogetherBase64ImageGeneration, outputType?: "url" | "blob"): string | Promise<Blob> {
+	async getResponse(response: TogetherBase64ImageGeneration, outputType?: "url" | "blob"): Promise<string | Blob> {
 		if (
 			typeof response === "object" &&
 			"data" in response &&

--- a/packages/inference/src/tasks/cv/textToImage.ts
+++ b/packages/inference/src/tasks/cv/textToImage.ts
@@ -25,11 +25,10 @@ export async function textToImage(
 export async function textToImage(args: TextToImageArgs, options?: TextToImageOptions): Promise<Blob | string> {
 	const provider = args.provider ?? "hf-inference";
 	const providerHelper = getProviderHelper(provider, "text-to-image");
-	const res = await request<Record<string, unknown>>(args, {
+	const res = await request(args, {
 		...options,
 		task: "text-to-image",
 	});
 	const { url, info } = await makeRequestOptions(args, { ...options, task: "text-to-image" });
-	// @ts-expect-error - Provider-specific implementations accept the outputType parameter
-	return providerHelper.getResponse(res, url, info.headers as Record<string, string>, options?.outputType);
+	return await providerHelper.getResponse(res, url, info.headers, options?.outputType);
 }

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -115,8 +115,8 @@ export interface UrlParams {
 	task?: InferenceTask;
 }
 
-export interface BodyParams {
-	args: Record<string, unknown>;
+export interface BodyParams<T extends Record<string, unknown> = Record<string, unknown>> {
+	args: T;
 	model: string;
 	task?: InferenceTask;
 }

--- a/packages/inference/src/utils/typedIn.ts
+++ b/packages/inference/src/utils/typedIn.ts
@@ -1,0 +1,3 @@
+export function typedIn<T extends object>(obj: T, maybeKey: PropertyKey): maybeKey is keyof T {
+	return maybeKey in obj;
+}

--- a/packages/inference/src/utils/typedKeys.ts
+++ b/packages/inference/src/utils/typedKeys.ts
@@ -1,0 +1,5 @@
+export function typedKeys<T extends object>(obj: T): (keyof T)[] {
+	const keys = Object.keys(obj) as (keyof T)[];
+	return keys;
+}
+


### PR DESCRIPTION
cc @hanouticelina 

For demonstration purpose only - let's not merge

I think we can achieve better typing of the `getProviderHelper` if we reverse the mapping (`provider -> task` to `task -> provider`)

See the textToImage file (no more type casts)

Having to implement and extend 2 types when implementing a helper is quite inconvenient on the other hand - so not sure about this either

