### PR TITLE
Add NVIDIA Jetson models

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -332,42 +332,42 @@ export const SKUS = {
 				tflops: 10.65,
 				memory: [64],
 			},
-		      	"AGX Orin 32GB": {
+			"AGX Orin 32GB": {
 				tflops: 6.66,
 				memory: [32],
-		      	},
-		      	"Orin NX 16GB": {
+			},
+			"Orin NX 16GB": {
 				tflops: 3.76,
 				memory: [16],
-		      	},
-		      	"Orin NX 8GB": {
+			},
+			"Orin NX 8GB": {
 				tflops: 3.13,
 				memory: [8],
-		      	},
-		      	"Orin Nano 8GB": {
+			},
+			"Orin Nano 8GB": {
 				tflops: 2.56,
 				memory: [8],
-		      	},
-		      	"Orin Nano 4GB": {
+			},
+			"Orin Nano 4GB": {
 				tflops: 1.28,
 				memory: [4],
-		      	},
-		      	"AGX Xavier": {
+			},
+			"AGX Xavier": {
 				tflops: 2.82,
 				memory: [32, 64],
-		      	},
-		      	"Xavier NX": {
+			},
+			"Xavier NX": {
 				tflops: 1.69,
 				memory: [8, 16],
-		      	},
-		      	"TX2": {
+			},
+			TX2: {
 				tflops: 1.33,
 				memory: [4, 8],
-		      	},
-		      	"Nano": {
+			},
+			Nano: {
 				tflops: 0.47,
 				memory: [4],
-		      	},
+			},
 		},
 		AMD: {
 			MI300: {

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -328,43 +328,43 @@ export const SKUS = {
 				tflops: 19.05,
 				memory: [16],
 			},
-			"AGX Orin 64GB": {
+			"Jetson AGX Orin 64GB": {
 				tflops: 10.65,
 				memory: [64],
 			},
-			"AGX Orin 32GB": {
+			"Jetson AGX Orin 32GB": {
 				tflops: 6.66,
 				memory: [32],
 			},
-			"Orin NX 16GB": {
+			"Jetson Orin NX 16GB": {
 				tflops: 3.76,
 				memory: [16],
 			},
-			"Orin NX 8GB": {
+			"Jetson Orin NX 8GB": {
 				tflops: 3.13,
 				memory: [8],
 			},
-			"Orin Nano 8GB": {
+			"Jetson Orin Nano 8GB": {
 				tflops: 2.56,
 				memory: [8],
 			},
-			"Orin Nano 4GB": {
+			"Jetson Orin Nano 4GB": {
 				tflops: 1.28,
 				memory: [4],
 			},
-			"AGX Xavier": {
+			"Jetson AGX Xavier": {
 				tflops: 2.82,
 				memory: [32, 64],
 			},
-			"Xavier NX": {
+			"Jetson Xavier NX": {
 				tflops: 1.69,
 				memory: [8, 16],
 			},
-			TX2: {
+			"Jetson TX2": {
 				tflops: 1.33,
 				memory: [4, 8],
 			},
-			Nano: {
+			"Jetson Nano": {
 				tflops: 0.47,
 				memory: [4],
 			},

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -324,6 +324,46 @@ export const SKUS = {
 				tflops: 19.05,
 				memory: [16],
 			},
+			"AGX Orin 64GB": {
+				tflops: 10.65,
+				memory: [64],
+			},
+		      	"AGX Orin 32GB": {
+				tflops: 6.66,
+				memory: [32],
+		      	},
+		      	"Orin NX 16GB": {
+				tflops: 3.76,
+				memory: [16],
+		      	},
+		      	"Orin NX 8GB": {
+				tflops: 3.13,
+				memory: [8],
+		      	},
+		      	"Orin Nano 8GB": {
+				tflops: 2.56,
+				memory: [8],
+		      	},
+		      	"Orin Nano 4GB": {
+				tflops: 1.28,
+				memory: [4],
+		      	},
+		      	"AGX Xavier": {
+				tflops: 2.82,
+				memory: [32, 64],
+		      	},
+		      	"Xavier NX": {
+				tflops: 1.69,
+				memory: [8, 16],
+		      	},
+		      	"TX2": {
+				tflops: 1.33,
+				memory: [4, 8],
+		      	},
+		      	"Nano": {
+				tflops: 0.47,
+				memory: [4],
+		      	},
 		},
 		AMD: {
 			MI300: {


### PR DESCRIPTION
Added NVIDIA Jetson models based on [techpowerup.com](https://www.techpowerup.com) info.

Official Jetson spec: [https://developer.nvidia.com/embedded/jetson-modules](https://developer.nvidia.com/embedded/jetson-modules)