### PR TITLE
Add CrossEncoder to the Sentence Transformers "How to Use" snippet & patch SetFit

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -927,10 +927,7 @@ function get_widget_examples_from_st_model(model: ModelData): string[] | undefin
 
 export const sentenceTransformers = (model: ModelData): string[] => {
 	const remote_code_snippet = model.tags.includes(TAG_CUSTOM_CODE) ? ", trust_remote_code=True" : "";
-	if (
-		model.tags.includes("cross-encoder") ||
-		["text-classification", "text-ranking", "zero-shot-classification"].includes(model.pipeline_tag || "")
-	) {
+	if (model.tags.includes("cross-encoder") || model.pipeline_tag == "text-ranking") {
 		return [
 			`from sentence_transformers import CrossEncoder
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -920,7 +920,7 @@ export const sampleFactory = (model: ModelData): string[] => [
 
 function get_widget_examples_from_st_model(model: ModelData): string[] | undefined {
 	const widgetExample = model.widgetData?.[0] as WidgetExampleSentenceSimilarityInput | undefined;
-	if (widgetExample) {
+	if (widgetExample?.source_sentence && widgetExample?.sentences?.length) {
 		return [widgetExample.source_sentence, ...widgetExample.sentences];
 	}
 }

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -927,6 +927,28 @@ function get_widget_examples_from_st_model(model: ModelData): string[] | undefin
 
 export const sentenceTransformers = (model: ModelData): string[] => {
 	const remote_code_snippet = model.tags.includes(TAG_CUSTOM_CODE) ? ", trust_remote_code=True" : "";
+	if (
+		model.tags.includes("cross-encoder") ||
+		["text-classification", "text-ranking", "zero-shot-classification"].includes(model.pipeline_tag || "")
+	) {
+		return [
+			`from sentence_transformers import CrossEncoder
+
+model = CrossEncoder("${model.id}"${remote_code_snippet})
+
+query = "Which planet is known as the Red Planet?"
+passages = [
+	"Venus is often called Earth's twin because of its similar size and proximity.",
+	"Mars, known for its reddish appearance, is often referred to as the Red Planet.",
+	"Jupiter, the largest planet in our solar system, has a prominent red spot.",
+	"Saturn, famous for its rings, is sometimes mistaken for the Red Planet."
+]
+
+scores = model.predict([(query, passage) for passage in passages])
+print(scores)`,
+		];
+	}
+
 	const exampleSentences = get_widget_examples_from_st_model(model) ?? [
 		"The weather is lovely today.",
 		"It's so sunny outside!",


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add CrossEncoder to the Sentence Transformers "How to Use" snippet
* Patch "How to Use" for SetFit models (that are also tagged as Sentence Transformers)

## Details
This PR adds the `CrossEncoder` class to the "How to Use" snippets. I'm working on feature parity of these models with the more common `SentenceTransformer` models, and the recent Sentence Transformers v4.0 release was a big step in that. 
We're already at 150 models: https://huggingface.co/models?pipeline_tag=text-ranking&library=sentence-transformers

Beyond that, this ensures that `[widgetExample.source_sentence, ...widgetExample.sentences]` doesn't crash, apparently that currently happens for some SetFit models, e.g.: https://huggingface.co/faodl/setfit-paraphrase-mpnet-base-v2-5ClassesDesc-multilabel-augmented?library=sentence-transformers

- Tom Aarsen