### PR TITLE
Fix openai stream js snippet

### DIFF
--- a/packages/inference/src/snippets/getInferenceSnippets.ts
+++ b/packages/inference/src/snippets/getInferenceSnippets.ts
@@ -254,7 +254,7 @@ const prepareConversationalInput = (
 	return {
 		messages: opts?.messages ?? getModelInputSnippet(model),
 		...(opts?.temperature ? { temperature: opts?.temperature } : undefined),
-		max_tokens: opts?.max_tokens ?? 500,
+		max_tokens: opts?.max_tokens ?? 512,
 		...(opts?.top_p ? { top_p: opts?.top_p } : undefined),
 	};
 };

--- a/packages/inference/src/snippets/templates/js/openai/conversationalStream.jinja
+++ b/packages/inference/src/snippets/templates/js/openai/conversationalStream.jinja
@@ -5,18 +5,12 @@ const client = new OpenAI({
 	apiKey: "{{ accessToken }}",
 });
 
-let out = "";
-
 const stream = await client.chat.completions.create({
-    provider: "{{ provider }}",
-    model: "{{ model.id }}",
+    model: "{{ providerModelId }}",
 {{ inputs.asTsString }}
+    stream: true,
 });
 
 for await (const chunk of stream) {
-	if (chunk.choices && chunk.choices.length > 0) {
-		const newContent = chunk.choices[0].delta.content;
-		out += newContent;
-		console.log(newContent);
-	}  
+    process.stdout.write(chunk.choices[0]?.delta?.content || "");
 }

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/huggingface.js/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/huggingface.js/0.hf-inference.js
@@ -11,7 +11,7 @@ const chatCompletion = await client.chatCompletion({
             content: "What is the capital of France?",
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
 });
 
 console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/huggingface.js/0.together.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/huggingface.js/0.together.js
@@ -11,7 +11,7 @@ const chatCompletion = await client.chatCompletion({
             content: "What is the capital of France?",
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
 });
 
 console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/openai/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/openai/0.hf-inference.js
@@ -13,7 +13,7 @@ const chatCompletion = await client.chat.completions.create({
             content: "What is the capital of France?",
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
 });
 
 console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/openai/0.together.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/openai/0.together.js
@@ -13,7 +13,7 @@ const chatCompletion = await client.chat.completions.create({
             content: "What is the capital of France?",
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
 });
 
 console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/huggingface_hub/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/huggingface_hub/0.hf-inference.py
@@ -13,7 +13,7 @@ completion = client.chat.completions.create(
             "content": "What is the capital of France?"
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
 )
 
 print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/huggingface_hub/0.together.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/huggingface_hub/0.together.py
@@ -13,7 +13,7 @@ completion = client.chat.completions.create(
             "content": "What is the capital of France?"
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
 )
 
 print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/openai/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/openai/0.hf-inference.py
@@ -13,7 +13,7 @@ completion = client.chat.completions.create(
             "content": "What is the capital of France?"
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
 )
 
 print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/openai/0.together.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/openai/0.together.py
@@ -13,7 +13,7 @@ completion = client.chat.completions.create(
             "content": "What is the capital of France?"
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
 )
 
 print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/requests/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/requests/0.hf-inference.py
@@ -14,7 +14,7 @@ response = query({
             "content": "What is the capital of France?"
         }
     ],
-    "max_tokens": 500,
+    "max_tokens": 512,
     "model": "meta-llama/Llama-3.1-8B-Instruct"
 })
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/requests/0.together.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/requests/0.together.py
@@ -14,7 +14,7 @@ response = query({
             "content": "What is the capital of France?"
         }
     ],
-    "max_tokens": 500,
+    "max_tokens": 512,
     "model": "<together alias for meta-llama/Llama-3.1-8B-Instruct>"
 })
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/sh/curl/0.hf-inference.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/sh/curl/0.hf-inference.sh
@@ -8,7 +8,7 @@ curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-I
                 "content": "What is the capital of France?"
             }
         ],
-        "max_tokens": 500,
+        "max_tokens": 512,
         "model": "meta-llama/Llama-3.1-8B-Instruct",
         "stream": false
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/sh/curl/0.together.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/sh/curl/0.together.sh
@@ -8,7 +8,7 @@ curl https://api.together.xyz/v1/chat/completions \
                 "content": "What is the capital of France?"
             }
         ],
-        "max_tokens": 500,
+        "max_tokens": 512,
         "model": "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
         "stream": false
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/huggingface.js/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/huggingface.js/0.hf-inference.js
@@ -13,7 +13,7 @@ const stream = await client.chatCompletionStream({
             content: "What is the capital of France?",
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
 });
 
 for await (const chunk of stream) {

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/huggingface.js/0.together.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/huggingface.js/0.together.js
@@ -13,7 +13,7 @@ const stream = await client.chatCompletionStream({
             content: "What is the capital of France?",
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
 });
 
 for await (const chunk of stream) {

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.hf-inference.js
@@ -15,7 +15,7 @@ const stream = await client.chat.completions.create({
             content: "What is the capital of France?",
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
     stream: true,
 });
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.hf-inference.js
@@ -8,7 +8,6 @@ const client = new OpenAI({
 let out = "";
 
 const stream = await client.chat.completions.create({
-    provider: "hf-inference",
     model: "meta-llama/Llama-3.1-8B-Instruct",
     messages: [
         {
@@ -17,12 +16,9 @@ const stream = await client.chat.completions.create({
         },
     ],
     max_tokens: 500,
+    stream: true,
 });
 
 for await (const chunk of stream) {
-	if (chunk.choices && chunk.choices.length > 0) {
-		const newContent = chunk.choices[0].delta.content;
-		out += newContent;
-		console.log(newContent);
-	}  
+    process.stdout.write(chunk.choices[0]?.delta?.content || "");
 }

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.together.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.together.js
@@ -15,7 +15,7 @@ const stream = await client.chat.completions.create({
             content: "What is the capital of France?",
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
     stream: true,
 });
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.together.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.together.js
@@ -8,8 +8,7 @@ const client = new OpenAI({
 let out = "";
 
 const stream = await client.chat.completions.create({
-    provider: "together",
-    model: "meta-llama/Llama-3.1-8B-Instruct",
+    model: "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
     messages: [
         {
             role: "user",
@@ -17,12 +16,9 @@ const stream = await client.chat.completions.create({
         },
     ],
     max_tokens: 500,
+    stream: true,
 });
 
 for await (const chunk of stream) {
-	if (chunk.choices && chunk.choices.length > 0) {
-		const newContent = chunk.choices[0].delta.content;
-		out += newContent;
-		console.log(newContent);
-	}  
+    process.stdout.write(chunk.choices[0]?.delta?.content || "");
 }

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/huggingface_hub/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/huggingface_hub/0.hf-inference.py
@@ -13,7 +13,7 @@ stream = client.chat.completions.create(
             "content": "What is the capital of France?"
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
     stream=True,
 )
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/huggingface_hub/0.together.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/huggingface_hub/0.together.py
@@ -13,7 +13,7 @@ stream = client.chat.completions.create(
             "content": "What is the capital of France?"
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
     stream=True,
 )
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/openai/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/openai/0.hf-inference.py
@@ -13,7 +13,7 @@ stream = client.chat.completions.create(
             "content": "What is the capital of France?"
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
     stream=True,
 )
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/openai/0.together.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/openai/0.together.py
@@ -13,7 +13,7 @@ stream = client.chat.completions.create(
             "content": "What is the capital of France?"
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
     stream=True,
 )
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/requests/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/requests/0.hf-inference.py
@@ -20,7 +20,7 @@ chunks = query({
             "content": "What is the capital of France?"
         }
     ],
-    "max_tokens": 500,
+    "max_tokens": 512,
     "model": "meta-llama/Llama-3.1-8B-Instruct",
     "stream": True,
 })

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/requests/0.together.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/requests/0.together.py
@@ -20,7 +20,7 @@ chunks = query({
             "content": "What is the capital of France?"
         }
     ],
-    "max_tokens": 500,
+    "max_tokens": 512,
     "model": "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
     "stream": True,
 })

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/sh/curl/0.hf-inference.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/sh/curl/0.hf-inference.sh
@@ -8,7 +8,7 @@ curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-I
                 "content": "What is the capital of France?"
             }
         ],
-        "max_tokens": 500,
+        "max_tokens": 512,
         "model": "meta-llama/Llama-3.1-8B-Instruct",
         "stream": true
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/sh/curl/0.together.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/sh/curl/0.together.sh
@@ -8,7 +8,7 @@ curl https://api.together.xyz/v1/chat/completions \
                 "content": "What is the capital of France?"
             }
         ],
-        "max_tokens": 500,
+        "max_tokens": 512,
         "model": "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
         "stream": true
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/huggingface.js/0.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/huggingface.js/0.fireworks-ai.js
@@ -22,7 +22,7 @@ const chatCompletion = await client.chatCompletion({
             ],
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
 });
 
 console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/huggingface.js/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/huggingface.js/0.hf-inference.js
@@ -22,7 +22,7 @@ const chatCompletion = await client.chatCompletion({
             ],
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
 });
 
 console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/openai/0.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/openai/0.fireworks-ai.js
@@ -24,7 +24,7 @@ const chatCompletion = await client.chat.completions.create({
             ],
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
 });
 
 console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/openai/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/openai/0.hf-inference.js
@@ -24,7 +24,7 @@ const chatCompletion = await client.chat.completions.create({
             ],
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
 });
 
 console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/huggingface_hub/0.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/huggingface_hub/0.fireworks-ai.py
@@ -24,7 +24,7 @@ completion = client.chat.completions.create(
             ]
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
 )
 
 print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/huggingface_hub/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/huggingface_hub/0.hf-inference.py
@@ -24,7 +24,7 @@ completion = client.chat.completions.create(
             ]
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
 )
 
 print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/openai/0.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/openai/0.fireworks-ai.py
@@ -24,7 +24,7 @@ completion = client.chat.completions.create(
             ]
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
 )
 
 print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/openai/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/openai/0.hf-inference.py
@@ -24,7 +24,7 @@ completion = client.chat.completions.create(
             ]
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
 )
 
 print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/requests/0.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/requests/0.fireworks-ai.py
@@ -25,7 +25,7 @@ response = query({
             ]
         }
     ],
-    "max_tokens": 500,
+    "max_tokens": 512,
     "model": "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>"
 })
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/requests/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/requests/0.hf-inference.py
@@ -25,7 +25,7 @@ response = query({
             ]
         }
     ],
-    "max_tokens": 500,
+    "max_tokens": 512,
     "model": "meta-llama/Llama-3.2-11B-Vision-Instruct"
 })
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/sh/curl/0.fireworks-ai.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/sh/curl/0.fireworks-ai.sh
@@ -19,7 +19,7 @@ curl https://api.fireworks.ai/inference/v1/chat/completions \
                 ]
             }
         ],
-        "max_tokens": 500,
+        "max_tokens": 512,
         "model": "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
         "stream": false
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/sh/curl/0.hf-inference.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/sh/curl/0.hf-inference.sh
@@ -19,7 +19,7 @@ curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.2-11B-
                 ]
             }
         ],
-        "max_tokens": 500,
+        "max_tokens": 512,
         "model": "meta-llama/Llama-3.2-11B-Vision-Instruct",
         "stream": false
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/huggingface.js/0.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/huggingface.js/0.fireworks-ai.js
@@ -24,7 +24,7 @@ const stream = await client.chatCompletionStream({
             ],
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
 });
 
 for await (const chunk of stream) {

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/huggingface.js/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/huggingface.js/0.hf-inference.js
@@ -24,7 +24,7 @@ const stream = await client.chatCompletionStream({
             ],
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
 });
 
 for await (const chunk of stream) {

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.fireworks-ai.js
@@ -26,7 +26,7 @@ const stream = await client.chat.completions.create({
             ],
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
     stream: true,
 });
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.fireworks-ai.js
@@ -8,8 +8,7 @@ const client = new OpenAI({
 let out = "";
 
 const stream = await client.chat.completions.create({
-    provider: "fireworks-ai",
-    model: "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    model: "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
     messages: [
         {
             role: "user",
@@ -28,12 +27,9 @@ const stream = await client.chat.completions.create({
         },
     ],
     max_tokens: 500,
+    stream: true,
 });
 
 for await (const chunk of stream) {
-	if (chunk.choices && chunk.choices.length > 0) {
-		const newContent = chunk.choices[0].delta.content;
-		out += newContent;
-		console.log(newContent);
-	}  
+    process.stdout.write(chunk.choices[0]?.delta?.content || "");
 }

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.hf-inference.js
@@ -26,7 +26,7 @@ const stream = await client.chat.completions.create({
             ],
         },
     ],
-    max_tokens: 500,
+    max_tokens: 512,
     stream: true,
 });
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.hf-inference.js
@@ -8,7 +8,6 @@ const client = new OpenAI({
 let out = "";
 
 const stream = await client.chat.completions.create({
-    provider: "hf-inference",
     model: "meta-llama/Llama-3.2-11B-Vision-Instruct",
     messages: [
         {
@@ -28,12 +27,9 @@ const stream = await client.chat.completions.create({
         },
     ],
     max_tokens: 500,
+    stream: true,
 });
 
 for await (const chunk of stream) {
-	if (chunk.choices && chunk.choices.length > 0) {
-		const newContent = chunk.choices[0].delta.content;
-		out += newContent;
-		console.log(newContent);
-	}  
+    process.stdout.write(chunk.choices[0]?.delta?.content || "");
 }

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/huggingface_hub/0.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/huggingface_hub/0.fireworks-ai.py
@@ -24,7 +24,7 @@ stream = client.chat.completions.create(
             ]
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
     stream=True,
 )
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/huggingface_hub/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/huggingface_hub/0.hf-inference.py
@@ -24,7 +24,7 @@ stream = client.chat.completions.create(
             ]
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
     stream=True,
 )
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/openai/0.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/openai/0.fireworks-ai.py
@@ -24,7 +24,7 @@ stream = client.chat.completions.create(
             ]
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
     stream=True,
 )
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/openai/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/openai/0.hf-inference.py
@@ -24,7 +24,7 @@ stream = client.chat.completions.create(
             ]
         }
     ],
-    max_tokens=500,
+    max_tokens=512,
     stream=True,
 )
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/requests/0.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/requests/0.fireworks-ai.py
@@ -31,7 +31,7 @@ chunks = query({
             ]
         }
     ],
-    "max_tokens": 500,
+    "max_tokens": 512,
     "model": "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
     "stream": True,
 })

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/requests/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/requests/0.hf-inference.py
@@ -31,7 +31,7 @@ chunks = query({
             ]
         }
     ],
-    "max_tokens": 500,
+    "max_tokens": 512,
     "model": "meta-llama/Llama-3.2-11B-Vision-Instruct",
     "stream": True,
 })

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/sh/curl/0.fireworks-ai.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/sh/curl/0.fireworks-ai.sh
@@ -19,7 +19,7 @@ curl https://api.fireworks.ai/inference/v1/chat/completions \
                 ]
             }
         ],
-        "max_tokens": 500,
+        "max_tokens": 512,
         "model": "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
         "stream": true
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/sh/curl/0.hf-inference.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/sh/curl/0.hf-inference.sh
@@ -19,7 +19,7 @@ curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.2-11B-
                 ]
             }
         ],
-        "max_tokens": 500,
+        "max_tokens": 512,
         "model": "meta-llama/Llama-3.2-11B-Vision-Instruct",
         "stream": true
     }'


### PR DESCRIPTION
_Originally from @cfahlgren1 in [moon-landing](https://github.com/huggingface-internal/moon-landing/issues/13272) (private link):_

> In inference snippets
> - **[Bug]** We don't add `stream` flag on javascript / openai snippet
 >- **[Bug]** We pass `provider` param in openai api which causes error
> - **[Improvement]** Maybe we should have example not have `\n` after each chunk

EXample: https://huggingface.co/deepseek-ai/DeepSeek-V3-0324?inference_api=true&inference_provider=fireworks-ai&language=js

This PR addresses all 3 points.

_Originally from @gary149 on slack ([private link](https://huggingface.slack.com/archives/C07KX53FZTK/p1743771312130449)):_

> micro nit: "max_tokens": 512 everywhere instead of 500 (500 looks quite weird imo)

This PR addresses that as well.
