### PR TITLE
Fix linting in `@huggingface/inference` (remove unused vars)

### DIFF
--- a/packages/inference/src/tasks/nlp/tokenClassification.ts
+++ b/packages/inference/src/tasks/nlp/tokenClassification.ts
@@ -2,7 +2,6 @@ import type { TokenClassificationInput, TokenClassificationOutput } from "@huggi
 import { getProviderHelper } from "../../lib/getProviderHelper";
 import type { BaseArgs, Options } from "../../types";
 import { innerRequest } from "../../utils/request";
-import { toArray } from "../../utils/toArray";
 
 export type TokenClassificationArgs = BaseArgs & TokenClassificationInput;
 

--- a/packages/inference/src/tasks/nlp/zeroShotClassification.ts
+++ b/packages/inference/src/tasks/nlp/zeroShotClassification.ts
@@ -2,7 +2,6 @@ import type { ZeroShotClassificationInput, ZeroShotClassificationOutput } from "
 import { getProviderHelper } from "../../lib/getProviderHelper";
 import type { BaseArgs, Options } from "../../types";
 import { innerRequest } from "../../utils/request";
-import { toArray } from "../../utils/toArray";
 
 export type ZeroShotClassificationArgs = BaseArgs & ZeroShotClassificationInput;
 


### PR DESCRIPTION
Fixes failing lint CI:
```
packages/inference lint:check: /home/runner/work/huggingface.js/huggingface.js/packages/inference/src/tasks/nlp/tokenClassification.ts
packages/inference lint:check:   5:10  error  'toArray' is defined but never used  @typescript-eslint/no-unused-vars
packages/inference lint:check: /home/runner/work/huggingface.js/huggingface.js/packages/inference/src/tasks/nlp/zeroShotClassification.ts
packages/inference lint:check:   5:10  error  'toArray' is defined but never used  @typescript-eslint/no-unused-vars
packages/inference lint:check: ✖ 2 problems (2 errors, 0 warnings)
packages/inference lint:check: Failed
```

From https://github.com/huggingface/huggingface.js/pull/1315 (cc @hanouticelina for viz). Strange that in that PR, the CI didn't catch it (the last [commit](https://github.com/huggingface/huggingface.js/pull/1315/commits/21f9d34423a3e695f5029e36838e54a1da2af2e4) was marked as ✅). May need to investigate (cc @coyotte508)