### PR TITLE
[Inference] top-down injection of providerHelper

### DIFF
--- a/packages/inference/src/lib/makeRequestOptions.ts
+++ b/packages/inference/src/lib/makeRequestOptions.ts
@@ -1,7 +1,7 @@
 import { name as packageName, version as packageVersion } from "../../package.json";
 import { HF_HEADER_X_BILL_TO, HF_HUB_URL } from "../config";
 import type { InferenceTask, Options, RequestArgs } from "../types";
-import { getProviderHelper } from "./getProviderHelper";
+import type { getProviderHelper } from "./getProviderHelper";
 import { getProviderModelId } from "./getProviderModelId";
 import { isUrl } from "./isUrl";
 
@@ -20,6 +20,7 @@ export async function makeRequestOptions(
 		data?: Blob | ArrayBuffer;
 		stream?: boolean;
 	},
+	providerHelper: ReturnType<typeof getProviderHelper>,
 	options?: Options & {
 		/** In most cases (unless we pass a endpointUrl) we know the task */
 		task?: InferenceTask;
@@ -28,6 +29,7 @@ export async function makeRequestOptions(
 	const { provider: maybeProvider, model: maybeModel } = args;
 	const provider = maybeProvider ?? "hf-inference";
 	const { task } = options ?? {};
+
 	// Validate inputs
 	if (args.endpointUrl && provider !== "hf-inference") {
 		throw new Error(`Cannot use endpointUrl with a third-party provider.`);
@@ -38,7 +40,7 @@ export async function makeRequestOptions(
 
 	if (args.endpointUrl) {
 		// No need to have maybeModel, or to load default model for a task
-		return makeRequestOptionsFromResolvedModel(maybeModel ?? args.endpointUrl, args, options);
+		return makeRequestOptionsFromResolvedModel(maybeModel ?? args.endpointUrl, providerHelper, args, options);
 	}
 
 	if (!maybeModel && !task) {
@@ -47,7 +49,6 @@ export async function makeRequestOptions(
 
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	const hfModel = maybeModel ?? (await loadDefaultModel(task!));
-	const providerHelper = getProviderHelper(provider, task);
 
 	if (providerHelper.clientSideRoutingOnly && !maybeModel) {
 		throw new Error(`Provider ${provider} requires a model ID to be passed directly.`);
@@ -62,7 +63,7 @@ export async function makeRequestOptions(
 		  });
 
 	// Use the sync version with the resolved model
-	return makeRequestOptionsFromResolvedModel(resolvedModel, args, options);
+	return makeRequestOptionsFromResolvedModel(resolvedModel, providerHelper, args, options);
 }
 
 /**
@@ -71,6 +72,7 @@ export async function makeRequestOptions(
  */
 export function makeRequestOptionsFromResolvedModel(
 	resolvedModel: string,
+	providerHelper: ReturnType<typeof getProviderHelper>,
 	args: RequestArgs & {
 		data?: Blob | ArrayBuffer;
 		stream?: boolean;
@@ -85,7 +87,6 @@ export function makeRequestOptionsFromResolvedModel(
 	const provider = maybeProvider ?? "hf-inference";
 
 	const { includeCredentials, task, signal, billTo } = options ?? {};
-	const providerHelper = getProviderHelper(provider, task);
 	const authMethod = (() => {
 		if (providerHelper.clientSideRoutingOnly) {
 			// Closed-source providers require an accessToken (cannot be routed).

--- a/packages/inference/src/providers/hf-inference.ts
+++ b/packages/inference/src/providers/hf-inference.ts
@@ -385,13 +385,13 @@ export class HFInferenceQuestionAnsweringTask extends HFInferenceTask implements
 							typeof elem.end === "number" &&
 							typeof elem.score === "number" &&
 							typeof elem.start === "number"
-					)
+				  )
 				: typeof response === "object" &&
-					!!response &&
-					typeof response.answer === "string" &&
-					typeof response.end === "number" &&
-					typeof response.score === "number" &&
-					typeof response.start === "number"
+				  !!response &&
+				  typeof response.answer === "string" &&
+				  typeof response.end === "number" &&
+				  typeof response.score === "number" &&
+				  typeof response.start === "number"
 		) {
 			return Array.isArray(response) ? response[0] : response;
 		}

--- a/packages/inference/src/tasks/audio/audioToAudio.ts
+++ b/packages/inference/src/tasks/audio/audioToAudio.ts
@@ -38,7 +38,7 @@ export interface AudioToAudioOutput {
 export async function audioToAudio(args: AudioToAudioArgs, options?: Options): Promise<AudioToAudioOutput[]> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "audio-to-audio");
 	const payload = preparePayload(args);
-	const { data: res } = await innerRequest<AudioToAudioOutput>(payload, {
+	const { data: res } = await innerRequest<AudioToAudioOutput>(payload, providerHelper, {
 		...options,
 		task: "audio-to-audio",
 	});

--- a/packages/inference/src/tasks/audio/automaticSpeechRecognition.ts
+++ b/packages/inference/src/tasks/audio/automaticSpeechRecognition.ts
@@ -20,7 +20,7 @@ export async function automaticSpeechRecognition(
 ): Promise<AutomaticSpeechRecognitionOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "automatic-speech-recognition");
 	const payload = await buildPayload(args);
-	const { data: res } = await innerRequest<AutomaticSpeechRecognitionOutput>(payload, {
+	const { data: res } = await innerRequest<AutomaticSpeechRecognitionOutput>(payload, providerHelper, {
 		...options,
 		task: "automatic-speech-recognition",
 	});

--- a/packages/inference/src/tasks/audio/textToSpeech.ts
+++ b/packages/inference/src/tasks/audio/textToSpeech.ts
@@ -14,7 +14,7 @@ interface OutputUrlTextToSpeechGeneration {
 export async function textToSpeech(args: TextToSpeechArgs, options?: Options): Promise<Blob> {
 	const provider = args.provider ?? "hf-inference";
 	const providerHelper = getProviderHelper(provider, "text-to-speech");
-	const { data: res } = await innerRequest<Blob | OutputUrlTextToSpeechGeneration>(args, {
+	const { data: res } = await innerRequest<Blob | OutputUrlTextToSpeechGeneration>(args, providerHelper, {
 		...options,
 		task: "text-to-speech",
 	});

--- a/packages/inference/src/tasks/custom/request.ts
+++ b/packages/inference/src/tasks/custom/request.ts
@@ -1,3 +1,4 @@
+import { getProviderHelper } from "../../lib/getProviderHelper";
 import type { InferenceTask, Options, RequestArgs } from "../../types";
 import { innerRequest } from "../../utils/request";
 
@@ -15,6 +16,7 @@ export async function request<T>(
 	console.warn(
 		"The request method is deprecated and will be removed in a future version of huggingface.js. Use specific task functions instead."
 	);
-	const result = await innerRequest<T>(args, options);
+	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", options?.task);
+	const result = await innerRequest<T>(args, providerHelper, options);
 	return result.data;
 }

--- a/packages/inference/src/tasks/cv/imageClassification.ts
+++ b/packages/inference/src/tasks/cv/imageClassification.ts
@@ -16,7 +16,7 @@ export async function imageClassification(
 ): Promise<ImageClassificationOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "image-classification");
 	const payload = preparePayload(args);
-	const { data: res } = await innerRequest<ImageClassificationOutput>(payload, {
+	const { data: res } = await innerRequest<ImageClassificationOutput>(payload, providerHelper, {
 		...options,
 		task: "image-classification",
 	});

--- a/packages/inference/src/tasks/cv/imageSegmentation.ts
+++ b/packages/inference/src/tasks/cv/imageSegmentation.ts
@@ -16,7 +16,7 @@ export async function imageSegmentation(
 ): Promise<ImageSegmentationOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "image-segmentation");
 	const payload = preparePayload(args);
-	const { data: res } = await innerRequest<ImageSegmentationOutput>(payload, {
+	const { data: res } = await innerRequest<ImageSegmentationOutput>(payload, providerHelper, {
 		...options,
 		task: "image-segmentation",
 	});

--- a/packages/inference/src/tasks/cv/imageToImage.ts
+++ b/packages/inference/src/tasks/cv/imageToImage.ts
@@ -27,7 +27,7 @@ export async function imageToImage(args: ImageToImageArgs, options?: Options): P
 			),
 		};
 	}
-	const { data: res } = await innerRequest<Blob>(reqArgs, {
+	const { data: res } = await innerRequest<Blob>(reqArgs, providerHelper, {
 		...options,
 		task: "image-to-image",
 	});

--- a/packages/inference/src/tasks/cv/imageToText.ts
+++ b/packages/inference/src/tasks/cv/imageToText.ts
@@ -12,7 +12,7 @@ export type ImageToTextArgs = BaseArgs & (ImageToTextInput | LegacyImageInput);
 export async function imageToText(args: ImageToTextArgs, options?: Options): Promise<ImageToTextOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "image-to-text");
 	const payload = preparePayload(args);
-	const { data: res } = await innerRequest<[ImageToTextOutput]>(payload, {
+	const { data: res } = await innerRequest<[ImageToTextOutput]>(payload, providerHelper, {
 		...options,
 		task: "image-to-text",
 	});

--- a/packages/inference/src/tasks/cv/objectDetection.ts
+++ b/packages/inference/src/tasks/cv/objectDetection.ts
@@ -13,7 +13,7 @@ export type ObjectDetectionArgs = BaseArgs & (ObjectDetectionInput | LegacyImage
 export async function objectDetection(args: ObjectDetectionArgs, options?: Options): Promise<ObjectDetectionOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "object-detection");
 	const payload = preparePayload(args);
-	const { data: res } = await innerRequest<ObjectDetectionOutput>(payload, {
+	const { data: res } = await innerRequest<ObjectDetectionOutput>(payload, providerHelper, {
 		...options,
 		task: "object-detection",
 	});

--- a/packages/inference/src/tasks/cv/textToImage.ts
+++ b/packages/inference/src/tasks/cv/textToImage.ts
@@ -25,11 +25,11 @@ export async function textToImage(
 export async function textToImage(args: TextToImageArgs, options?: TextToImageOptions): Promise<Blob | string> {
 	const provider = args.provider ?? "hf-inference";
 	const providerHelper = getProviderHelper(provider, "text-to-image");
-	const { data: res } = await innerRequest<Record<string, unknown>>(args, {
+	const { data: res } = await innerRequest<Record<string, unknown>>(args, providerHelper, {
 		...options,
 		task: "text-to-image",
 	});
 
-	const { url, info } = await makeRequestOptions(args, { ...options, task: "text-to-image" });
+	const { url, info } = await makeRequestOptions(args, providerHelper, { ...options, task: "text-to-image" });
 	return providerHelper.getResponse(res, url, info.headers as Record<string, string>, options?.outputType);
 }

--- a/packages/inference/src/tasks/cv/textToVideo.ts
+++ b/packages/inference/src/tasks/cv/textToVideo.ts
@@ -14,10 +14,14 @@ export type TextToVideoOutput = Blob;
 export async function textToVideo(args: TextToVideoArgs, options?: Options): Promise<TextToVideoOutput> {
 	const provider = args.provider ?? "hf-inference";
 	const providerHelper = getProviderHelper(provider, "text-to-video");
-	const { data: response } = await innerRequest<FalAiQueueOutput | ReplicateOutput | NovitaOutput>(args, {
-		...options,
-		task: "text-to-video",
-	});
-	const { url, info } = await makeRequestOptions(args, { ...options, task: "text-to-video" });
+	const { data: response } = await innerRequest<FalAiQueueOutput | ReplicateOutput | NovitaOutput>(
+		args,
+		providerHelper,
+		{
+			...options,
+			task: "text-to-video",
+		}
+	);
+	const { url, info } = await makeRequestOptions(args, providerHelper, { ...options, task: "text-to-video" });
 	return providerHelper.getResponse(response, url, info.headers as Record<string, string>);
 }

--- a/packages/inference/src/tasks/cv/zeroShotImageClassification.ts
+++ b/packages/inference/src/tasks/cv/zeroShotImageClassification.ts
@@ -46,7 +46,7 @@ export async function zeroShotImageClassification(
 ): Promise<ZeroShotImageClassificationOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "zero-shot-image-classification");
 	const payload = await preparePayload(args);
-	const { data: res } = await innerRequest<ZeroShotImageClassificationOutput>(payload, {
+	const { data: res } = await innerRequest<ZeroShotImageClassificationOutput>(payload, providerHelper, {
 		...options,
 		task: "zero-shot-image-classification",
 	});

--- a/packages/inference/src/tasks/multimodal/documentQuestionAnswering.ts
+++ b/packages/inference/src/tasks/multimodal/documentQuestionAnswering.ts
@@ -30,6 +30,7 @@ export async function documentQuestionAnswering(
 	} as RequestArgs;
 	const { data: res } = await innerRequest<DocumentQuestionAnsweringOutput | DocumentQuestionAnsweringOutput[number]>(
 		reqArgs,
+		providerHelper,
 		{
 			...options,
 			task: "document-question-answering",

--- a/packages/inference/src/tasks/multimodal/visualQuestionAnswering.ts
+++ b/packages/inference/src/tasks/multimodal/visualQuestionAnswering.ts
@@ -29,7 +29,7 @@ export async function visualQuestionAnswering(
 		},
 	} as RequestArgs;
 
-	const { data: res } = await innerRequest<VisualQuestionAnsweringOutput>(reqArgs, {
+	const { data: res } = await innerRequest<VisualQuestionAnsweringOutput>(reqArgs, providerHelper, {
 		...options,
 		task: "visual-question-answering",
 	});

--- a/packages/inference/src/tasks/nlp/chatCompletion.ts
+++ b/packages/inference/src/tasks/nlp/chatCompletion.ts
@@ -11,7 +11,7 @@ export async function chatCompletion(
 	options?: Options
 ): Promise<ChatCompletionOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "conversational");
-	const { data: response } = await innerRequest<ChatCompletionOutput>(args, {
+	const { data: response } = await innerRequest<ChatCompletionOutput>(args, providerHelper, {
 		...options,
 		task: "conversational",
 	});

--- a/packages/inference/src/tasks/nlp/featureExtraction.ts
+++ b/packages/inference/src/tasks/nlp/featureExtraction.ts
@@ -18,7 +18,7 @@ export async function featureExtraction(
 	options?: Options
 ): Promise<FeatureExtractionOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "feature-extraction");
-	const { data: res } = await innerRequest<FeatureExtractionOutput>(args, {
+	const { data: res } = await innerRequest<FeatureExtractionOutput>(args, providerHelper, {
 		...options,
 		task: "feature-extraction",
 	});

--- a/packages/inference/src/tasks/nlp/fillMask.ts
+++ b/packages/inference/src/tasks/nlp/fillMask.ts
@@ -10,7 +10,7 @@ export type FillMaskArgs = BaseArgs & FillMaskInput;
  */
 export async function fillMask(args: FillMaskArgs, options?: Options): Promise<FillMaskOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "fill-mask");
-	const { data: res } = await innerRequest<FillMaskOutput>(args, {
+	const { data: res } = await innerRequest<FillMaskOutput>(args, providerHelper, {
 		...options,
 		task: "fill-mask",
 	});

--- a/packages/inference/src/tasks/nlp/questionAnswering.ts
+++ b/packages/inference/src/tasks/nlp/questionAnswering.ts
@@ -13,9 +13,13 @@ export async function questionAnswering(
 	options?: Options
 ): Promise<QuestionAnsweringOutput[number]> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "question-answering");
-	const { data: res } = await innerRequest<QuestionAnsweringOutput | QuestionAnsweringOutput[number]>(args, {
-		...options,
-		task: "question-answering",
-	});
+	const { data: res } = await innerRequest<QuestionAnsweringOutput | QuestionAnsweringOutput[number]>(
+		args,
+		providerHelper,
+		{
+			...options,
+			task: "question-answering",
+		}
+	);
 	return providerHelper.getResponse(res);
 }

--- a/packages/inference/src/tasks/nlp/sentenceSimilarity.ts
+++ b/packages/inference/src/tasks/nlp/sentenceSimilarity.ts
@@ -13,7 +13,7 @@ export async function sentenceSimilarity(
 	options?: Options
 ): Promise<SentenceSimilarityOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "sentence-similarity");
-	const { data: res } = await innerRequest<SentenceSimilarityOutput>(args, {
+	const { data: res } = await innerRequest<SentenceSimilarityOutput>(args, providerHelper, {
 		...options,
 		task: "sentence-similarity",
 	});

--- a/packages/inference/src/tasks/nlp/summarization.ts
+++ b/packages/inference/src/tasks/nlp/summarization.ts
@@ -10,7 +10,7 @@ export type SummarizationArgs = BaseArgs & SummarizationInput;
  */
 export async function summarization(args: SummarizationArgs, options?: Options): Promise<SummarizationOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "summarization");
-	const { data: res } = await innerRequest<SummarizationOutput[]>(args, {
+	const { data: res } = await innerRequest<SummarizationOutput[]>(args, providerHelper, {
 		...options,
 		task: "summarization",
 	});

--- a/packages/inference/src/tasks/nlp/tableQuestionAnswering.ts
+++ b/packages/inference/src/tasks/nlp/tableQuestionAnswering.ts
@@ -13,9 +13,13 @@ export async function tableQuestionAnswering(
 	options?: Options
 ): Promise<TableQuestionAnsweringOutput[number]> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "table-question-answering");
-	const { data: res } = await innerRequest<TableQuestionAnsweringOutput | TableQuestionAnsweringOutput[number]>(args, {
-		...options,
-		task: "table-question-answering",
-	});
+	const { data: res } = await innerRequest<TableQuestionAnsweringOutput | TableQuestionAnsweringOutput[number]>(
+		args,
+		providerHelper,
+		{
+			...options,
+			task: "table-question-answering",
+		}
+	);
 	return providerHelper.getResponse(res);
 }

--- a/packages/inference/src/tasks/nlp/textClassification.ts
+++ b/packages/inference/src/tasks/nlp/textClassification.ts
@@ -13,7 +13,7 @@ export async function textClassification(
 	options?: Options
 ): Promise<TextClassificationOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "text-classification");
-	const { data: res } = await innerRequest<TextClassificationOutput>(args, {
+	const { data: res } = await innerRequest<TextClassificationOutput>(args, providerHelper, {
 		...options,
 		task: "text-classification",
 	});

--- a/packages/inference/src/tasks/nlp/textGeneration.ts
+++ b/packages/inference/src/tasks/nlp/textGeneration.ts
@@ -17,7 +17,7 @@ export async function textGeneration(
 	const providerHelper = getProviderHelper(provider, "text-generation");
 	const { data: response } = await innerRequest<
 		HyperbolicTextCompletionOutput | TextGenerationOutput | TextGenerationOutput[]
-	>(args, {
+	>(args, providerHelper, {
 		...options,
 		task: "text-generation",
 	});

--- a/packages/inference/src/tasks/nlp/tokenClassification.ts
+++ b/packages/inference/src/tasks/nlp/tokenClassification.ts
@@ -13,9 +13,13 @@ export async function tokenClassification(
 	options?: Options
 ): Promise<TokenClassificationOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "token-classification");
-	const { data: res } = await innerRequest<TokenClassificationOutput[number] | TokenClassificationOutput>(args, {
-		...options,
-		task: "token-classification",
-	});
+	const { data: res } = await innerRequest<TokenClassificationOutput[number] | TokenClassificationOutput>(
+		args,
+		providerHelper,
+		{
+			...options,
+			task: "token-classification",
+		}
+	);
 	return providerHelper.getResponse(res);
 }

--- a/packages/inference/src/tasks/nlp/translation.ts
+++ b/packages/inference/src/tasks/nlp/translation.ts
@@ -9,7 +9,7 @@ export type TranslationArgs = BaseArgs & TranslationInput;
  */
 export async function translation(args: TranslationArgs, options?: Options): Promise<TranslationOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "translation");
-	const { data: res } = await innerRequest<TranslationOutput>(args, {
+	const { data: res } = await innerRequest<TranslationOutput>(args, providerHelper, {
 		...options,
 		task: "translation",
 	});

--- a/packages/inference/src/tasks/nlp/zeroShotClassification.ts
+++ b/packages/inference/src/tasks/nlp/zeroShotClassification.ts
@@ -13,9 +13,13 @@ export async function zeroShotClassification(
 	options?: Options
 ): Promise<ZeroShotClassificationOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "zero-shot-classification");
-	const { data: res } = await innerRequest<ZeroShotClassificationOutput[number] | ZeroShotClassificationOutput>(args, {
-		...options,
-		task: "zero-shot-classification",
-	});
+	const { data: res } = await innerRequest<ZeroShotClassificationOutput[number] | ZeroShotClassificationOutput>(
+		args,
+		providerHelper,
+		{
+			...options,
+			task: "zero-shot-classification",
+		}
+	);
 	return providerHelper.getResponse(res);
 }

--- a/packages/inference/src/tasks/tabular/tabularClassification.ts
+++ b/packages/inference/src/tasks/tabular/tabularClassification.ts
@@ -26,7 +26,7 @@ export async function tabularClassification(
 	options?: Options
 ): Promise<TabularClassificationOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "tabular-classification");
-	const { data: res } = await innerRequest<TabularClassificationOutput>(args, {
+	const { data: res } = await innerRequest<TabularClassificationOutput>(args, providerHelper, {
 		...options,
 		task: "tabular-classification",
 	});

--- a/packages/inference/src/tasks/tabular/tabularRegression.ts
+++ b/packages/inference/src/tasks/tabular/tabularRegression.ts
@@ -26,7 +26,7 @@ export async function tabularRegression(
 	options?: Options
 ): Promise<TabularRegressionOutput> {
 	const providerHelper = getProviderHelper(args.provider ?? "hf-inference", "tabular-regression");
-	const { data: res } = await innerRequest<TabularRegressionOutput>(args, {
+	const { data: res } = await innerRequest<TabularRegressionOutput>(args, providerHelper, {
 		...options,
 		task: "tabular-regression",
 	});


### PR DESCRIPTION
cc @hanouticelina @Wauplin 

Prompted by: https://huggingface.slack.com/archives/C02EMARJ65P/p1744370608755449 (internal)

This PR reduces the number of places where we call `getProviderHelper` by enforcing it's passed as an argument by the caller when needed

Because `getProviderHelper` is fallible, calling it from different places (sometimes deep in the function call chain) can be dangerous and result in unexpected bugs.

This PR reduces this risk by reducing the number of different places where we call `getProviderHelper` , and instead pass it as an argument top-down

It also has the benefits of clearly indicating which functions depend on provider-specific logic