### PR TITLE
[Inference Providers] Update fal-ai input for text-to-speech

### DIFF
--- a/packages/inference/src/providers/fal-ai.ts
+++ b/packages/inference/src/providers/fal-ai.ts
@@ -241,7 +241,7 @@ export class FalAITextToSpeechTask extends FalAITask {
 		return {
 			...omit(params.args, ["inputs", "parameters"]),
 			...(params.args.parameters as Record<string, unknown>),
-			lyrics: params.args.inputs,
+			text: params.args.inputs,
 		};
 	}
 


### PR DESCRIPTION
context in this slack [message](https://huggingface.slack.com/archives/C0664PDFGSJ/p1745395082617929?thread_ts=1745388278.838629&cid=C0664PDFGSJ) (internal link).

tested the PR with [Dia](https://huggingface.co/nari-labs/Dia-1.6B) by overriding `HARDCODED_MODEL_INFERENCE_MAPPING` with:
```js
...
"fal-ai": {
    "nari-labs/Dia-1.6B": {
	  providerId: "fal-ai/dia-tts",
	  hfModelId: "nari-labs/Dia-1.6B",
	  task: "text-to-speech",
	  status: "live",
		},
	},
...
```