### PR TITLE
Pass an `endpointUrl` directly to `InferenceClient`

### DIFF
--- a/packages/inference/src/InferenceClient.ts
+++ b/packages/inference/src/InferenceClient.ts
@@ -18,7 +18,12 @@ export class InferenceClient {
 	private readonly accessToken: string;
 	private readonly defaultOptions: Options;
 
-	constructor(accessToken = "", defaultOptions: Options = {}) {
+	constructor(
+		accessToken = "",
+		defaultOptions: Options & {
+			endpointUrl?: string;
+		} = {}
+	) {
 		this.accessToken = accessToken;
 		this.defaultOptions = defaultOptions;
 
@@ -27,7 +32,10 @@ export class InferenceClient {
 				enumerable: false,
 				value: (params: RequestArgs, options: Options) =>
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					fn({ ...params, accessToken } as any, { ...defaultOptions, ...options }),
+					fn({ endpointUrl: defaultOptions.endpointUrl, accessToken, ...params } as any, {
+						...defaultOptions,
+						...options,
+					}),
 			});
 		}
 	}

--- a/packages/inference/src/InferenceClient.ts
+++ b/packages/inference/src/InferenceClient.ts
@@ -33,13 +33,12 @@ export class InferenceClient {
 	}
 
 	/**
-	 * Returns instance of InferenceClient tied to a specified endpoint.
+	 * Returns a new instance of InferenceClient tied to a specified endpoint.
 	 *
 	 * For backward compatibility mostly.
 	 */
-	public endpoint(endpointUrl: string): this {
-		this.defaultOptions.endpointUrl = endpointUrl;
-		return this;
+	public endpoint(endpointUrl: string): InferenceClient {
+		return new InferenceClient(this.accessToken, { ...this.defaultOptions, endpointUrl });
 	}
 }
 

--- a/packages/inference/src/InferenceClient.ts
+++ b/packages/inference/src/InferenceClient.ts
@@ -1,6 +1,7 @@
 import * as tasks from "./tasks";
 import type { Options, RequestArgs } from "./types";
 import type { DistributiveOmit } from "./utils/distributive-omit";
+import { omit } from "./utils/omit";
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */

--- a/packages/inference/src/InferenceClient.ts
+++ b/packages/inference/src/InferenceClient.ts
@@ -14,13 +14,6 @@ type TaskWithNoAccessToken = {
 	) => ReturnType<Task[key]>;
 };
 
-type TaskWithNoAccessTokenNoEndpointUrl = {
-	[key in keyof Task]: (
-		args: DistributiveOmit<Parameters<Task[key]>[0], "accessToken" | "endpointUrl">,
-		options?: Parameters<Task[key]>[1]
-	) => ReturnType<Task[key]>;
-};
-
 export class InferenceClient {
 	private readonly accessToken: string;
 	private readonly defaultOptions: Options;
@@ -40,34 +33,25 @@ export class InferenceClient {
 	}
 
 	/**
-	 * Returns copy of InferenceClient tied to a specified endpoint.
+	 * Returns instance of InferenceClient tied to a specified endpoint.
+	 *
+	 * For backward compatibility mostly.
 	 */
-	public endpoint(endpointUrl: string): InferenceClientEndpoint {
-		return new InferenceClientEndpoint(endpointUrl, this.accessToken, this.defaultOptions);
-	}
-}
-
-export class InferenceClientEndpoint {
-	constructor(endpointUrl: string, accessToken = "", defaultOptions: Options = {}) {
-		accessToken;
-		defaultOptions;
-
-		for (const [name, fn] of Object.entries(tasks)) {
-			Object.defineProperty(this, name, {
-				enumerable: false,
-				value: (params: RequestArgs, options: Options) =>
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					fn({ ...params, accessToken, endpointUrl } as any, { ...defaultOptions, ...options }),
-			});
-		}
+	public endpoint(endpointUrl: string): this {
+		this.defaultOptions.endpointUrl = endpointUrl;
+		return this;
 	}
 }
 
 export interface InferenceClient extends TaskWithNoAccessToken {}
 
-export interface InferenceClientEndpoint extends TaskWithNoAccessTokenNoEndpointUrl {}
-
 /**
- * For backward compatibility only.
+ * For backward compatibility only, will remove soon.
+ * @deprecated replace with InferenceClient
  */
 export class HfInference extends InferenceClient {}
+/**
+ * For backward compatibility only, will remove soon.
+ * @deprecated replace with InferenceClient
+ */
+export class InferenceClientEndpoint extends InferenceClient {}

--- a/packages/inference/src/InferenceClient.ts
+++ b/packages/inference/src/InferenceClient.ts
@@ -33,7 +33,7 @@ export class InferenceClient {
 				value: (params: RequestArgs, options: Options) =>
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					fn({ endpointUrl: defaultOptions.endpointUrl, accessToken, ...params } as any, {
-						...defaultOptions,
+						...omit(defaultOptions, ["endpointUrl"]),
 						...options,
 					}),
 			});

--- a/packages/inference/src/lib/makeRequestOptions.ts
+++ b/packages/inference/src/lib/makeRequestOptions.ts
@@ -29,20 +29,25 @@ export async function makeRequestOptions(
 ): Promise<{ url: string; info: RequestInit }> {
 	const { model: maybeModel } = args;
 	const provider = providerHelper.provider;
-	const endpointUrl = args.endpointUrl ?? options?.endpointUrl;
 	const { task } = options ?? {};
 
 	// Validate inputs
-	if (endpointUrl && provider !== "hf-inference") {
+	if (args.endpointUrl && provider !== "hf-inference") {
 		throw new Error(`Cannot use endpointUrl with a third-party provider.`);
 	}
 	if (maybeModel && isUrl(maybeModel)) {
 		throw new Error(`Model URLs are no longer supported. Use endpointUrl instead.`);
 	}
 
-	if (endpointUrl) {
+	if (args.endpointUrl) {
 		// No need to have maybeModel, or to load default model for a task
-		return makeRequestOptionsFromResolvedModel(maybeModel ?? endpointUrl, providerHelper, args, undefined, options);
+		return makeRequestOptionsFromResolvedModel(
+			maybeModel ?? args.endpointUrl,
+			providerHelper,
+			args,
+			undefined,
+			options
+		);
 	}
 
 	if (!maybeModel && !task) {

--- a/packages/inference/src/lib/makeRequestOptions.ts
+++ b/packages/inference/src/lib/makeRequestOptions.ts
@@ -29,25 +29,20 @@ export async function makeRequestOptions(
 ): Promise<{ url: string; info: RequestInit }> {
 	const { model: maybeModel } = args;
 	const provider = providerHelper.provider;
+	const endpointUrl = args.endpointUrl ?? options?.endpointUrl;
 	const { task } = options ?? {};
 
 	// Validate inputs
-	if (args.endpointUrl && provider !== "hf-inference") {
+	if (endpointUrl && provider !== "hf-inference") {
 		throw new Error(`Cannot use endpointUrl with a third-party provider.`);
 	}
 	if (maybeModel && isUrl(maybeModel)) {
 		throw new Error(`Model URLs are no longer supported. Use endpointUrl instead.`);
 	}
 
-	if (args.endpointUrl) {
+	if (endpointUrl) {
 		// No need to have maybeModel, or to load default model for a task
-		return makeRequestOptionsFromResolvedModel(
-			maybeModel ?? args.endpointUrl,
-			providerHelper,
-			args,
-			undefined,
-			options
-		);
+		return makeRequestOptionsFromResolvedModel(maybeModel ?? endpointUrl, providerHelper, args, undefined, options);
 	}
 
 	if (!maybeModel && !task) {

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -33,6 +33,11 @@ export interface Options {
 	 * Requests can only be billed to an organization the user is a member of, and which has subscribed to Enterprise Hub.
 	 */
 	billTo?: string;
+
+	/**
+	 * Optional: override the default router.huggingface.co Inference Providers endpoint with any baseURL.
+	 */
+	endpointUrl?: string;
 }
 
 export type InferenceTask = Exclude<PipelineType, "other"> | "conversational";
@@ -84,7 +89,7 @@ export interface BaseArgs {
 	model?: ModelId;
 
 	/**
-	 * The URL of the endpoint to use. If not specified, will call huggingface.co/api/tasks to get the default endpoint for the task.
+	 * The URL of the endpoint to use. If not specified, will call Inference Providers on huggingface.co.
 	 *
 	 * If specified, will use this URL instead of the default one.
 	 */

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -89,9 +89,9 @@ export interface BaseArgs {
 	model?: ModelId;
 
 	/**
-	 * The URL of the endpoint to use. If not specified, will call Inference Providers on huggingface.co.
+	 * The URL of the endpoint to use.
 	 *
-	 * If specified, will use this URL instead of the default one.
+	 * If not specified, will call the default router.huggingface.co Inference Providers endpoint.
 	 */
 	endpointUrl?: string;
 

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -33,11 +33,6 @@ export interface Options {
 	 * Requests can only be billed to an organization the user is a member of, and which has subscribed to Enterprise Hub.
 	 */
 	billTo?: string;
-
-	/**
-	 * Optional: override the default router.huggingface.co Inference Providers endpoint with any baseURL.
-	 */
-	endpointUrl?: string;
 }
 
 export type InferenceTask = Exclude<PipelineType, "other"> | "conversational";


### PR DESCRIPTION
in the end i kept the `endpointUrl` var name so the diff is not massive.

I think keeping that name is ok.