### PR TITLE
i think there might be something wrong with endpointUrl and no provider

### DIFF
--- a/packages/inference/src/lib/makeRequestOptions.ts
+++ b/packages/inference/src/lib/makeRequestOptions.ts
@@ -32,7 +32,7 @@ export async function makeRequestOptions(
 	const { task } = options ?? {};
 
 	// Validate inputs
-	if (args.endpointUrl && provider !== "hf-inference") {
+	if (args.endpointUrl && provider !== undefined) {
 		throw new Error(`Cannot use endpointUrl with a third-party provider.`);
 	}
 	if (maybeModel && isUrl(maybeModel)) {


### PR DESCRIPTION
i think we currently call `resolveProvider`  when a endpointUrl is passed and no provider is passed, but we shouldn't, no?