### PR TITLE
InferenceClient methods have the proper types now

### DIFF
--- a/packages/inference/src/InferenceClient.ts
+++ b/packages/inference/src/InferenceClient.ts
@@ -48,15 +48,15 @@ export class InferenceClient {
 	}
 }
 
-export interface InferenceClient extends Task { }
+export interface InferenceClient extends Task {}
 
 /**
  * For backward compatibility only, will remove soon.
  * @deprecated replace with InferenceClient
  */
-export class HfInference extends InferenceClient { }
+export class HfInference extends InferenceClient {}
 /**
  * For backward compatibility only, will remove soon.
  * @deprecated replace with InferenceClient
  */
-export class InferenceClientEndpoint extends InferenceClient { }
+export class InferenceClientEndpoint extends InferenceClient {}

--- a/packages/inference/src/InferenceClient.ts
+++ b/packages/inference/src/InferenceClient.ts
@@ -27,13 +27,13 @@ export class InferenceClient {
 				value: (params: Parameters<typeof fn>[0], options: Parameters<typeof fn>[1]) =>
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					(fn as any)(
+						/// ^ The cast of fn to any is necessary, otherwise TS can't compile because the generated union type is too complex
 						{ endpointUrl: defaultOptions.endpointUrl, accessToken, ...params },
 						{
 							...omit(defaultOptions, ["endpointUrl"]),
 							...options,
 						}
 					),
-				/// ^The cast of fn to any is necessary, otherwise TS can't compile because the generated union type is too complex
 			});
 		}
 	}

--- a/packages/inference/src/InferenceClient.ts
+++ b/packages/inference/src/InferenceClient.ts
@@ -26,10 +26,13 @@ export class InferenceClient {
 				enumerable: false,
 				value: (params: Parameters<typeof fn>[0], options: Parameters<typeof fn>[1]) =>
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					(fn as any)({ endpointUrl: defaultOptions.endpointUrl, accessToken, ...params }, {
-						...omit(defaultOptions, ["endpointUrl"]),
-						...options,
-					}),
+					(fn as any)(
+						{ endpointUrl: defaultOptions.endpointUrl, accessToken, ...params },
+						{
+							...omit(defaultOptions, ["endpointUrl"]),
+							...options,
+						}
+					),
 				/// ^The cast of fn to any is necessary, otherwise TS can't compile because the generated union type is too complex
 			});
 		}

--- a/packages/inference/src/lib/getInferenceProviderMapping.ts
+++ b/packages/inference/src/lib/getInferenceProviderMapping.ts
@@ -115,7 +115,7 @@ export async function resolveProvider(
 		provider = Object.keys(inferenceProviderMapping)[0] as InferenceProvider | undefined;
 	}
 	if (!provider) {
-		provider = "hf-inference";
+		throw new Error(`No Inference Provider available for model ${modelId}.`);
 	}
 	return provider;
 }

--- a/packages/inference/src/lib/getInferenceProviderMapping.ts
+++ b/packages/inference/src/lib/getInferenceProviderMapping.ts
@@ -112,7 +112,10 @@ export async function resolveProvider(
 			throw new Error("Specifying a model is required when provider is 'auto'");
 		}
 		const inferenceProviderMapping = await fetchInferenceProviderMappingForModel(modelId);
-		provider = Object.keys(inferenceProviderMapping)[0] as InferenceProvider;
+		provider = Object.keys(inferenceProviderMapping)[0] as InferenceProvider | undefined;
+	}
+	if (!provider) {
+		provider = "hf-inference"
 	}
 	return provider;
 }

--- a/packages/inference/src/lib/getInferenceProviderMapping.ts
+++ b/packages/inference/src/lib/getInferenceProviderMapping.ts
@@ -115,7 +115,7 @@ export async function resolveProvider(
 		provider = Object.keys(inferenceProviderMapping)[0] as InferenceProvider | undefined;
 	}
 	if (!provider) {
-		provider = "hf-inference"
+		provider = "hf-inference";
 	}
 	return provider;
 }

--- a/packages/inference/src/utils/typedEntries.ts
+++ b/packages/inference/src/utils/typedEntries.ts
@@ -1,4 +1,5 @@
-
-export function typedEntries<T extends { [s: string]: T[keyof T] } | ArrayLike<T[keyof T]>>(obj: T): [keyof T, T[keyof T]][] {
+export function typedEntries<T extends { [s: string]: T[keyof T] } | ArrayLike<T[keyof T]>>(
+	obj: T
+): [keyof T, T[keyof T]][] {
 	return Object.entries(obj) as [keyof T, T[keyof T]];
 }

--- a/packages/inference/src/utils/typedEntries.ts
+++ b/packages/inference/src/utils/typedEntries.ts
@@ -1,5 +1,5 @@
 export function typedEntries<T extends { [s: string]: T[keyof T] } | ArrayLike<T[keyof T]>>(
 	obj: T
 ): [keyof T, T[keyof T]][] {
-	return Object.entries(obj) as [keyof T, T[keyof T]];
+	return Object.entries(obj) as [keyof T, T[keyof T]][];
 }

--- a/packages/inference/src/utils/typedEntries.ts
+++ b/packages/inference/src/utils/typedEntries.ts
@@ -1,0 +1,4 @@
+
+export function typedEntries<T extends { [s: string]: T[keyof T] } | ArrayLike<T[keyof T]>>(obj: T): [keyof T, T[keyof T]][] {
+	return Object.entries(obj) as [keyof T, T[keyof T]];
+}

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -294,7 +294,7 @@ describe.skip("InferenceClient", () => {
 					await hf.tableQuestionAnswering({
 						model: "google/tapas-base-finetuned-wtq",
 						inputs: {
-							query: "How many stars does the transformers repository have?",
+							question: "How many stars does the transformers repository have?",
 							table: {
 								Repository: ["Transformers", "Datasets", "Tokenizers"],
 								Stars: ["36542", "4512", "3934"],
@@ -488,7 +488,8 @@ describe.skip("InferenceClient", () => {
 				expect(
 					await hf.translation({
 						model: "t5-base",
-						inputs: ["My name is Wolfgang and I live in Berlin", "I work as programmer"],
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						inputs: ["My name is Wolfgang and I live in Berlin", "I work as programmer"] as any,
 					})
 				).toMatchObject([
 					{
@@ -505,7 +506,8 @@ describe.skip("InferenceClient", () => {
 						model: "facebook/bart-large-mnli",
 						inputs: [
 							"Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!",
-						],
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						] as any,
 						parameters: { candidate_labels: ["refund", "legal", "faq"] },
 					})
 				).toEqual(

--- a/packages/mcp-client/src/McpClient.ts
+++ b/packages/mcp-client/src/McpClient.ts
@@ -2,7 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { StdioServerParameters } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { InferenceClient } from "@huggingface/inference";
-import type { InferenceClientEndpoint, InferenceProvider } from "@huggingface/inference";
+import type { InferenceClientEndpoint, InferenceProvider, InferenceProviderOrPolicy } from "@huggingface/inference";
 import type {
 	ChatCompletionInputMessage,
 	ChatCompletionInputTool,
@@ -23,7 +23,7 @@ export interface ChatCompletionInputMessageTool extends ChatCompletionInputMessa
 
 export class McpClient {
 	protected client: InferenceClient | InferenceClientEndpoint;
-	protected provider: string | undefined;
+	protected provider: InferenceProviderOrPolicy;
 
 	protected model: string;
 	private clients: Map<ToolName, Client> = new Map();
@@ -48,7 +48,7 @@ export class McpClient {
 		apiKey: string;
 	}) {
 		this.client = baseUrl ? new InferenceClient(apiKey).endpoint(baseUrl) : new InferenceClient(apiKey);
-		this.provider = provider;
+		this.provider = provider ?? "auto";
 		this.model = model;
 	}
 

--- a/packages/mcp-client/src/McpClient.ts
+++ b/packages/mcp-client/src/McpClient.ts
@@ -23,7 +23,7 @@ export interface ChatCompletionInputMessageTool extends ChatCompletionInputMessa
 
 export class McpClient {
 	protected client: InferenceClient | InferenceClientEndpoint;
-	protected provider: InferenceProviderOrPolicy;
+	protected provider: InferenceProviderOrPolicy | undefined;
 
 	protected model: string;
 	private clients: Map<ToolName, Client> = new Map();
@@ -36,19 +36,19 @@ export class McpClient {
 		apiKey,
 	}: (
 		| {
-				provider: InferenceProvider;
-				baseUrl?: undefined;
-		  }
+			provider: InferenceProviderOrPolicy;
+			baseUrl?: undefined;
+		}
 		| {
-				baseUrl: string;
-				provider?: undefined;
-		  }
+			baseUrl: string;
+			provider?: undefined;
+		}
 	) & {
 		model: string;
 		apiKey: string;
 	}) {
 		this.client = baseUrl ? new InferenceClient(apiKey).endpoint(baseUrl) : new InferenceClient(apiKey);
-		this.provider = provider ?? "auto";
+		this.provider = provider;
 		this.model = model;
 	}
 

--- a/packages/mcp-client/src/McpClient.ts
+++ b/packages/mcp-client/src/McpClient.ts
@@ -2,7 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { StdioServerParameters } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { InferenceClient } from "@huggingface/inference";
-import type { InferenceClientEndpoint, InferenceProvider, InferenceProviderOrPolicy } from "@huggingface/inference";
+import type { InferenceClientEndpoint, InferenceProviderOrPolicy } from "@huggingface/inference";
 import type {
 	ChatCompletionInputMessage,
 	ChatCompletionInputTool,
@@ -36,13 +36,13 @@ export class McpClient {
 		apiKey,
 	}: (
 		| {
-			provider: InferenceProviderOrPolicy;
-			baseUrl?: undefined;
-		}
+				provider: InferenceProviderOrPolicy;
+				baseUrl?: undefined;
+		  }
 		| {
-			baseUrl: string;
-			provider?: undefined;
-		}
+				baseUrl: string;
+				provider?: undefined;
+		  }
 	) & {
 		model: string;
 		apiKey: string;


### PR DESCRIPTION
# TL;DR

Types of `InferenceClient` methods are now correct 🥳 

```typescript
const client = new InferenceClient();

const output = client.textToImage(
    {
        inputs: "test input",
        parameters: {
            /// Correctly typed! And auto-completion works!
        },
    },
    options
)
```