### PR TITLE
[inference provider] Add wavespeed.ai as an inference provider

### DIFF
--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -62,6 +62,7 @@ Currently, we support the following providers:
 - [Cohere](https://cohere.com)
 - [Cerebras](https://cerebras.ai/)
 - [Groq](https://groq.com)
+- [Wavespeed.ai](https://wavespeed.ai/)
 
 To send requests to a third-party provider, you have to pass the `provider` parameter to the inference function. Make sure your request is authenticated with an access token.
 ```ts
@@ -92,6 +93,7 @@ Only a subset of models are supported when requesting third-party providers. You
 - [Cohere supported models](https://huggingface.co/api/partners/cohere/models)
 - [Cerebras supported models](https://huggingface.co/api/partners/cerebras/models)
 - [Groq supported models](https://console.groq.com/docs/models)
+- [Wavespeed.ai supported models](https://huggingface.co/api/partners/wavespeed-ai/models)
 - [HF Inference API (serverless)](https://huggingface.co/models?inference=warm&sort=trending)
 
 ❗**Important note:** To be compatible, the third-party API must adhere to the "standard" shape API we expect on HF model pages for each pipeline task type.

--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -47,6 +47,7 @@ import type {
 import * as Replicate from "../providers/replicate";
 import * as Sambanova from "../providers/sambanova";
 import * as Together from "../providers/together";
+import * as WavesppedAI from "../providers/wavespeed-ai";
 import type { InferenceProvider, InferenceTask } from "../types";
 
 export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, TaskProviderHelper>>> = {
@@ -144,6 +145,12 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 		"text-to-image": new Together.TogetherTextToImageTask(),
 		conversational: new Together.TogetherConversationalTask(),
 		"text-generation": new Together.TogetherTextGenerationTask(),
+	},
+	"wavespeed-ai": {
+		"text-to-image": new WavesppedAI.WavespeedAITextToImageTask(),
+		"text-to-video": new WavesppedAI.WavespeedAITextToVideoTask(),
+		"image-to-image": new WavesppedAI.WavespeedAIImageToImageTask(),
+		"image-to-video": new WavesppedAI.WavespeedAIImageToVideoTask(),
 	},
 };
 

--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -150,7 +150,6 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 		"text-to-image": new WavesppedAI.WavespeedAITextToImageTask(),
 		"text-to-video": new WavesppedAI.WavespeedAITextToVideoTask(),
 		"image-to-image": new WavesppedAI.WavespeedAIImageToImageTask(),
-		"image-to-video": new WavesppedAI.WavespeedAIImageToVideoTask(),
 	},
 };
 

--- a/packages/inference/src/providers/consts.ts
+++ b/packages/inference/src/providers/consts.ts
@@ -36,4 +36,5 @@ export const HARDCODED_MODEL_INFERENCE_MAPPING: Record<
 	replicate: {},
 	sambanova: {},
 	together: {},
+	"wavespeed-ai": {},
 };

--- a/packages/inference/src/providers/wavespeed-ai.ts
+++ b/packages/inference/src/providers/wavespeed-ai.ts
@@ -1,0 +1,176 @@
+import { InferenceOutputError } from "../lib/InferenceOutputError";
+import type { BodyParams, HeaderParams, UrlParams } from "../types";
+import { delay } from "../utils/delay";
+import { omit } from "../utils/omit";
+import {
+	TaskProviderHelper,
+	TextToImageTaskHelper,
+	TextToVideoTaskHelper,
+	ImageToImageTaskHelper,
+} from "./providerHelper";
+
+const WAVESPEEDAI_API_BASE_URL = "https://api.wavespeed.ai";
+
+/**
+ * Common response structure for all WaveSpeed AI API responses
+ */
+interface WaveSpeedAICommonResponse<T> {
+	code: number;
+	message: string;
+	data: T;
+}
+
+/**
+ * Response structure for task status and results
+ */
+interface WaveSpeedAITaskResponse {
+	id: string;
+	model: string;
+	outputs: string[];
+	urls: {
+		get: string;
+	};
+	has_nsfw_contents: boolean[];
+	status: "created" | "processing" | "completed" | "failed";
+	created_at: string;
+	error: string;
+	executionTime: number;
+	timings: {
+		inference: number;
+	};
+}
+
+/**
+ * Response structure for initial task submission
+ */
+interface WaveSpeedAISubmitResponse {
+	id: string;
+	urls: {
+		get: string;
+	};
+}
+
+type WaveSpeedAIResponse<T = WaveSpeedAITaskResponse> = WaveSpeedAICommonResponse<T>;
+
+abstract class WavespeedAITask extends TaskProviderHelper {
+	private accessToken: string | undefined;
+
+	constructor(url?: string) {
+		super("wavespeed-ai", url || WAVESPEEDAI_API_BASE_URL);
+	}
+
+	makeRoute(params: UrlParams): string {
+		return `/api/v2/${params.model}`;
+	}
+	preparePayload(params: BodyParams): Record<string, unknown> {
+		console.log("params", params);
+		return {
+			...omit(params.args, ["inputs", "parameters"]),
+			...(params.args.parameters as Record<string, unknown>),
+			prompt: params.args.inputs,
+		};
+	}
+
+	override prepareHeaders(params: HeaderParams, isBinary: boolean): Record<string, string> {
+		this.accessToken = params.accessToken;
+		const headers: Record<string, string> = { Authorization: `Bearer ${params.accessToken}` };
+		if (!isBinary) {
+			headers["Content-Type"] = "application/json";
+		}
+		return headers;
+	}
+
+	override async getResponse(
+		response: WaveSpeedAIResponse<WaveSpeedAISubmitResponse>,
+		url?: string,
+		headers?: Record<string, string>
+	): Promise<Blob> {
+		console.log("getResponse headers", headers);
+		console.log("getResponse response", response);
+		console.log("getResponse url", url);
+
+		if (!headers && this.accessToken) {
+			headers = { Authorization: `Bearer ${this.accessToken}` };
+		}
+		if (!headers) {
+			throw new InferenceOutputError("Headers are required for WaveSpeed AI API calls");
+		}
+
+		const resultUrl = response.data.urls.get;
+		console.log("getResponse resultUrl", resultUrl);
+
+		// Poll for results until completion
+		while (true) {
+			const resultResponse = await fetch(resultUrl, { headers });
+
+			if (!resultResponse.ok) {
+				throw new InferenceOutputError(`Failed to get result: ${resultResponse.statusText}`);
+			}
+
+			const result: WaveSpeedAIResponse = await resultResponse.json();
+			if (result.code !== 200) {
+				throw new InferenceOutputError(`API request failed with code ${result.code}: ${result.message}`);
+			}
+
+			const taskResult = result.data;
+
+			switch (taskResult.status) {
+				case "completed": {
+					// Get the video data from the first output URL
+					if (!taskResult.outputs?.[0]) {
+						throw new InferenceOutputError("No video URL in completed response");
+					}
+					const videoResponse = await fetch(taskResult.outputs[0]);
+					if (!videoResponse.ok) {
+						throw new InferenceOutputError("Failed to fetch video data");
+					}
+					return await videoResponse.blob();
+				}
+				case "failed": {
+					throw new InferenceOutputError(taskResult.error || "Task failed");
+				}
+				case "processing":
+				case "created":
+					// Wait before polling again
+					await delay(100);
+					continue;
+
+				default: {
+					throw new InferenceOutputError(`Unknown status: ${taskResult.status}`);
+				}
+			}
+		}
+	}
+}
+
+export class WavespeedAITextToImageTask extends WavespeedAITask implements TextToImageTaskHelper {
+	constructor() {
+		super(WAVESPEEDAI_API_BASE_URL);
+	}
+}
+
+export class WavespeedAITextToVideoTask extends WavespeedAITask implements TextToVideoTaskHelper {
+	constructor() {
+		super(WAVESPEEDAI_API_BASE_URL);
+	}
+}
+
+export class WavespeedAIImageToImageTask extends WavespeedAITask implements ImageToImageTaskHelper {
+	constructor() {
+		super(WAVESPEEDAI_API_BASE_URL);
+	}
+
+	override preparePayload(params: BodyParams): Record<string, unknown> {
+		return {
+			...omit(params.args, ["inputs", "parameters"]),
+			...(params.args.parameters as Record<string, unknown>),
+			image: params.args.inputs,
+		};
+	}
+}
+
+export class WavespeedAIImageToVideoTask extends WavespeedAITask implements TextToVideoTaskHelper {
+	constructor() {
+		super(WAVESPEEDAI_API_BASE_URL);
+	}
+}

--- a/packages/inference/src/providers/wavespeed-ai.ts
+++ b/packages/inference/src/providers/wavespeed-ai.ts
@@ -63,7 +63,6 @@ abstract class WavespeedAITask extends TaskProviderHelper {
 		return `/api/v2/${params.model}`;
 	}
 	preparePayload(params: BodyParams): Record<string, unknown> {
-		console.log("params", params);
 		return {
 			...omit(params.args, ["inputs", "parameters"]),
 			...(params.args.parameters as Record<string, unknown>),
@@ -85,10 +84,6 @@ abstract class WavespeedAITask extends TaskProviderHelper {
 		url?: string,
 		headers?: Record<string, string>
 	): Promise<Blob> {
-		console.log("getResponse headers", headers);
-		console.log("getResponse response", response);
-		console.log("getResponse url", url);
-
 		if (!headers && this.accessToken) {
 			headers = { Authorization: `Bearer ${this.accessToken}` };
 		}
@@ -97,7 +92,6 @@ abstract class WavespeedAITask extends TaskProviderHelper {
 		}
 
 		const resultUrl = response.data.urls.get;
-		console.log("getResponse resultUrl", resultUrl);
 
 		// Poll for results until completion
 		while (true) {
@@ -166,11 +160,5 @@ export class WavespeedAIImageToImageTask extends WavespeedAITask implements Imag
 			...(params.args.parameters as Record<string, unknown>),
 			image: params.args.inputs,
 		};
-	}
-}
-
-export class WavespeedAIImageToVideoTask extends WavespeedAITask implements TextToVideoTaskHelper {
-	constructor() {
-		super(WAVESPEEDAI_API_BASE_URL);
 	}
 }

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -55,6 +55,7 @@ export const INFERENCE_PROVIDERS = [
 	"replicate",
 	"sambanova",
 	"together",
+	"wavespeed-ai",
 ] as const;
 
 export const PROVIDERS_OR_POLICIES = [...INFERENCE_PROVIDERS, "auto"] as const;

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -2071,21 +2071,6 @@ describe.skip("InferenceClient", () => {
 				});
 				expect(res).toBeInstanceOf(Blob);
 			});
-
-			it(`imageToVideo - wavespeed-ai/wan-2.1/i2v-480p`, async () => {
-				const res = await client.imageToImage({
-					model: "wavespeed-ai/wan-2.1/i2v-480p",
-					provider: "wavespeed-ai",
-					inputs: new Blob([readTestFile("cheetah.png")], { type: "image / png" }),
-					parameters: {
-						prompt: "The leopard chases its prey",
-						guidance_scale: 5,
-						num_inference_steps: 30,
-						seed: -1,
-					},
-				});
-				expect(res).toBeInstanceOf(Blob);
-			});
 		},
 		60000 * 5
 	);

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -1996,4 +1996,97 @@ describe.skip("InferenceClient", () => {
 		},
 		TIMEOUT
 	);
+	describe.concurrent(
+		"Wavespeed AI",
+		() => {
+			const client = new InferenceClient(env.HF_WAVESPEED_KEY ?? "dummy");
+
+			HARDCODED_MODEL_INFERENCE_MAPPING["wavespeed-ai"] = {
+				"wavespeed-ai/flux-schnell": {
+					hfModelId: "wavespeed-ai/flux-schnell",
+					providerId: "wavespeed-ai/flux-schnell",
+					status: "live",
+					task: "text-to-image",
+				},
+				"wavespeed-ai/wan-2.1/t2v-480p": {
+					hfModelId: "wavespeed-ai/wan-2.1/t2v-480p",
+					providerId: "wavespeed-ai/wan-2.1/t2v-480p",
+					status: "live",
+					task: "text-to-video",
+				},
+				"wavespeed-ai/hidream-e1-full": {
+					hfModelId: "wavespeed-ai/hidream-e1-full",
+					providerId: "wavespeed-ai/hidream-e1-full",
+					status: "live",
+					task: "image-to-image",
+				},
+				"wavespeed-ai/wan-2.1/i2v-480p": {
+					hfModelId: "wavespeed-ai/wan-2.1/i2v-480p",
+					providerId: "wavespeed-ai/wan-2.1/i2v-480p",
+					status: "live",
+					task: "image-to-video",
+				},
+			};
+
+			it(`textToImage - wavespeed-ai/flux-schnell`, async () => {
+				const res = await client.textToImage({
+					model: "wavespeed-ai/flux-schnell",
+					provider: "wavespeed-ai",
+					inputs:
+						"Cute boy with a hat, exploring nature, holding a telescope, backpack, surrounded by flowers, cartoon style, vibrant colors.",
+				});
+				expect(res).toBeInstanceOf(Blob);
+			});
+
+			it(`textToVideo - wavespeed-ai/wan-2.1/t2v-480p`, async () => {
+				const res = await client.textToVideo({
+					model: "wavespeed-ai/wan-2.1/t2v-480p",
+					provider: "wavespeed-ai",
+					inputs:
+						"A cool street dancer, wearing a baggy hoodie and hip-hop pants, dancing in front of a graffiti wall, night neon background, quick camera cuts, urban trends.",
+					parameters: {
+						guidance_scale: 5,
+						num_inference_steps: 30,
+						seed: -1,
+					},
+					duration: 5,
+					enable_safety_checker: true,
+					flow_shift: 2.9,
+					size: "480*832",
+				});
+				expect(res).toBeInstanceOf(Blob);
+			});
+
+			it(`imageToImage - wavespeed-ai/hidream-e1-full`, async () => {
+				const res = await client.imageToImage({
+					model: "wavespeed-ai/hidream-e1-full",
+					provider: "wavespeed-ai",
+					inputs: new Blob([readTestFile("cheetah.png")], { type: "image / png" }),
+					parameters: {
+						prompt: "The leopard chases its prey",
+						guidance_scale: 5,
+						num_inference_steps: 30,
+						seed: -1,
+					},
+				});
+				expect(res).toBeInstanceOf(Blob);
+			});
+
+			it(`imageToVideo - wavespeed-ai/wan-2.1/i2v-480p`, async () => {
+				const res = await client.imageToImage({
+					model: "wavespeed-ai/wan-2.1/i2v-480p",
+					provider: "wavespeed-ai",
+					inputs: new Blob([readTestFile("cheetah.png")], { type: "image / png" }),
+					parameters: {
+						prompt: "The leopard chases its prey",
+						guidance_scale: 5,
+						num_inference_steps: 30,
+						seed: -1,
+					},
+				});
+				expect(res).toBeInstanceOf(Blob);
+			});
+		},
+		60000 * 5
+	);
 });


### PR DESCRIPTION
**What’s in this PR**
[WaveSpeedAI](https://wavespeed.ai/) is a high-performance AI image and video generation service platform, offering industry-leading generation speeds. Now, want to be listed as an Inference Provider on the Hugging Face Hub

The JS Client Integration was completed based on the inference-providers help documentation and passed the test. I am submitting the pr now and look forward to further communication with you

**Test**
```
pnpm --filter @huggingface/inference test "test/InferenceClient.spec.ts" -t "^Wavespeed AI"

> @huggingface/inference@3.11.0 test /Users/shanliu/work/huggingface.js/packages/inference
> vitest run --config vitest.config.mts "test/InferenceClient.spec.ts"


 RUN  v0.34.6 /Users/shanliu/work/huggingface.js/packages/inference

 ✓ test/InferenceClient.spec.ts (104) 198160ms
   ✓ InferenceClient (104) 198160ms
     ✓ backward compatibility (1)
       ✓ works with old HfInference name
     ↓ HF Inference (49) [skipped]
       ↓ throws error if model does not exist [skipped]
       ↓ fillMask [skipped]
       ↓ works without model [skipped]
       ↓ summarization [skipped]
       ↓ questionAnswering [skipped]
       ↓ tableQuestionAnswering [skipped]
       ↓ documentQuestionAnswering [skipped]
       ↓ documentQuestionAnswering with non-array output [skipped]
       ↓ visualQuestionAnswering [skipped]
       ↓ textClassification [skipped]
       ↓ textGeneration - gpt2 [skipped]
       ↓ textGeneration - openai-community/gpt2 [skipped]
       ↓ textGenerationStream - meta-llama/Llama-3.2-3B [skipped]
       ↓ textGenerationStream - catch error [skipped]
       ↓ textGenerationStream - Abort [skipped]
       ↓ tokenClassification [skipped]
       ↓ translation [skipped]
       ↓ zeroShotClassification [skipped]
       ↓ sentenceSimilarity [skipped]
       ↓ FeatureExtraction [skipped]
       ↓ FeatureExtraction - auto-compatibility sentence similarity [skipped]
       ↓ FeatureExtraction - facebook/bart-base [skipped]
       ↓ FeatureExtraction - facebook/bart-base, list input [skipped]
       ↓ automaticSpeechRecognition [skipped]
       ↓ audioClassification [skipped]
       ↓ audioToAudio [skipped]
       ↓ textToSpeech [skipped]
       ↓ imageClassification [skipped]
       ↓ zeroShotImageClassification [skipped]
       ↓ objectDetection [skipped]
       ↓ imageSegmentation [skipped]
       ↓ imageToImage [skipped]
       ↓ imageToImage blob data [skipped]
       ↓ textToImage [skipped]
       ↓ textToImage with parameters [skipped]
       ↓ imageToText [skipped]
       ↓ request - openai-community/gpt2 [skipped]
       ↓ tabularRegression [skipped]
       ↓ tabularClassification [skipped]
       ↓ endpoint - makes request to specified endpoint [skipped]
       ↓ endpoint - makes request to specified endpoint - alternative syntax [skipped]
       ↓ chatCompletion modelId - OpenAI Specs [skipped]
       ↓ chatCompletionStream modelId - OpenAI Specs [skipped]
       ↓ chatCompletionStream modelId Fail - OpenAI Specs [skipped]
       ↓ chatCompletion - OpenAI Specs [skipped]
       ↓ chatCompletionStream - OpenAI Specs [skipped]
       ↓ custom mistral - OpenAI Specs [skipped]
       ↓ custom openai - OpenAI Specs [skipped]
       ↓ OpenAI client side routing - model should have provider as prefix [skipped]
     ↓ Fal AI (4) [skipped]
       ↓ textToImage - black-forest-labs/FLUX.1-schnell [skipped]
       ↓ textToImage - SD LoRAs [skipped]
       ↓ textToImage - Flux LoRAs [skipped]
       ↓ automaticSpeechRecognition - openai/whisper-large-v3 [skipped]
     ↓ Featherless (3) [skipped]
       ↓ chatCompletion [skipped]
       ↓ chatCompletion stream [skipped]
       ↓ textGeneration [skipped]
     ↓ Replicate (10) [skipped]
       ↓ textToImage canonical - black-forest-labs/FLUX.1-schnell [skipped]
       ↓ textToImage canonical - black-forest-labs/FLUX.1-dev [skipped]
       ↓ textToImage canonical - stabilityai/stable-diffusion-3.5-large-turbo [skipped]
       ↓ textToImage versioned - ByteDance/SDXL-Lightning [skipped]
       ↓ textToImage versioned - ByteDance/Hyper-SD [skipped]
       ↓ textToImage versioned - playgroundai/playground-v2.5-1024px-aesthetic [skipped]
       ↓ textToImage versioned - stabilityai/stable-diffusion-xl-base-1.0 [skipped]
       ↓ textToSpeech versioned [skipped]
       ↓ textToSpeech OuteTTS -  usually Cold [skipped]
       ↓ textToSpeech Kokoro [skipped]
     ↓ SambaNova (3) [skipped]
       ↓ chatCompletion [skipped]
       ↓ chatCompletion stream [skipped]
       ↓ featureExtraction [skipped]
     ↓ Together (4) [skipped]
       ↓ chatCompletion [skipped]
       ↓ chatCompletion stream [skipped]
       ↓ textToImage [skipped]
       ↓ textGeneration [skipped]
     ↓ Nebius (3) [skipped]
       ↓ chatCompletion [skipped]
       ↓ chatCompletion stream [skipped]
       ↓ textToImage [skipped]
     ↓ 3rd party providers (1) [skipped]
       ↓ chatCompletion - fails with unsupported model [skipped]
     ↓ Fireworks (2) [skipped]
       ↓ chatCompletion [skipped]
       ↓ chatCompletion stream [skipped]
     ↓ Hyperbolic (4) [skipped]
       ↓ chatCompletion - hyperbolic [skipped]
       ↓ chatCompletion stream [skipped]
       ↓ textToImage [skipped]
       ↓ textGeneration [skipped]
     ↓ Novita (2) [skipped]
       ↓ chatCompletion [skipped]
       ↓ chatCompletion stream [skipped]
     ↓ Black Forest Labs (2) [skipped]
       ↓ textToImage [skipped]
       ↓ textToImage URL [skipped]
     ↓ Cohere (2) [skipped]
       ↓ chatCompletion [skipped]
       ↓ chatCompletion stream [skipped]
     ↓ Cerebras (2) [skipped]
       ↓ chatCompletion [skipped]
       ↓ chatCompletion stream [skipped]
     ↓ Nscale (3) [skipped]
       ↓ chatCompletion [skipped]
       ↓ chatCompletion stream [skipped]
       ↓ textToImage [skipped]
     ↓ Groq (2) [skipped]
       ↓ chatCompletion [skipped]
       ↓ chatCompletion stream [skipped]
     ↓ OVHcloud (4) [skipped]
       ↓ chatCompletion [skipped]
       ↓ chatCompletion stream [skipped]
       ↓ textGeneration [skipped]
       ↓ textGeneration stream [skipped]
     ✓ Wavespeed AI (3) 198159ms
       ✓ textToImage - wavespeed-ai/flux-schnell 4893ms
       ✓ textToVideo - wavespeed-ai/wan-2.1/t2v-480p 198158ms
       ✓ imageToImage - wavespeed-ai/hidream-e1-full 16646ms

 Test Files  1 passed (1)
      Tests  4 passed | 100 skipped (104)
   Start at  10:16:14
   Duration  198.68s (transform 280ms, setup 11ms, collect 325ms, tests 198.16s, environment 0ms, prepare 60ms)

```