### PR TITLE
add support for image-to-image models on Replicate

### DIFF
--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -132,6 +132,7 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 		"text-generation": new OvhCloud.OvhCloudTextGenerationTask(),
 	},
 	replicate: {
+		"image-to-image": new Replicate.ReplicateImageToImageTask(),
 		"text-to-image": new Replicate.ReplicateTextToImageTask(),
 		"text-to-speech": new Replicate.ReplicateTextToSpeechTask(),
 		"text-to-video": new Replicate.ReplicateTextToVideoTask(),

--- a/packages/inference/src/providers/replicate.ts
+++ b/packages/inference/src/providers/replicate.ts
@@ -18,7 +18,7 @@ import { InferenceOutputError } from "../lib/InferenceOutputError";
 import { isUrl } from "../lib/isUrl";
 import type { BodyParams, HeaderParams, UrlParams } from "../types";
 import { omit } from "../utils/omit";
-import { TaskProviderHelper, type TextToImageTaskHelper, type TextToVideoTaskHelper } from "./providerHelper";
+import { TaskProviderHelper, type TextToImageTaskHelper, type TextToVideoTaskHelper, type ImageToImageTaskHelper } from "./providerHelper";
 export interface ReplicateOutput {
 	output?: string | string[];
 }
@@ -137,6 +137,23 @@ export class ReplicateTextToSpeechTask extends ReplicateTask {
 }
 
 export class ReplicateTextToVideoTask extends ReplicateTask implements TextToVideoTaskHelper {
+	override async getResponse(response: ReplicateOutput): Promise<Blob> {
+		if (
+			typeof response === "object" &&
+			!!response &&
+			"output" in response &&
+			typeof response.output === "string" &&
+			isUrl(response.output)
+		) {
+			const urlResponse = await fetch(response.output);
+			return await urlResponse.blob();
+		}
+
+		throw new InferenceOutputError("Expected { output: string }");
+	}
+}
+
+export class ReplicateImageToImageTask extends ReplicateTask implements ImageToImageTaskHelper {
 	override async getResponse(response: ReplicateOutput): Promise<Blob> {
 		if (
 			typeof response === "object" &&

--- a/packages/inference/src/providers/replicate.ts
+++ b/packages/inference/src/providers/replicate.ts
@@ -18,7 +18,12 @@ import { InferenceOutputError } from "../lib/InferenceOutputError";
 import { isUrl } from "../lib/isUrl";
 import type { BodyParams, HeaderParams, UrlParams } from "../types";
 import { omit } from "../utils/omit";
-import { TaskProviderHelper, type TextToImageTaskHelper, type TextToVideoTaskHelper, type ImageToImageTaskHelper } from "./providerHelper";
+import {
+	TaskProviderHelper,
+	type TextToImageTaskHelper,
+	type TextToVideoTaskHelper,
+	type ImageToImageTaskHelper,
+} from "./providerHelper";
 export interface ReplicateOutput {
 	output?: string | string[];
 }


### PR DESCRIPTION
This PR adds support for the `image-to-image` task type for Replicate models.

Example:

- https://huggingface.co/stepfun-ai/Step1X-Edit
- https://replicate.com/zsxkib/step1x-edit

cc @hanouticelina 