### PR TITLE
checkbox to bypass dep checks during publish checks

### DIFF
--- a/.github/workflows/gguf-publish.yml
+++ b/.github/workflows/gguf-publish.yml
@@ -11,6 +11,10 @@ on:
           - patch
           - minor
           - major
+      bypass_deps_check:
+        type: boolean
+        description: "Bypass dependency checking"
+        default: false
 
 concurrency:
   group: "push-to-main"
@@ -50,7 +54,8 @@ jobs:
           git commit . -m "🔖 @huggingface/gguf $BUMPED_VERSION"
           git tag "gguf-v$BUMPED_VERSION"
 
-      - name: "Check Deps are published before publishing this package"
+      - if: ${{ !github.event.inputs.bypass_deps_check }}
+        name: "Check Deps are published before publishing this package"
         run: pnpm -w check-deps tasks
 
       - run: pnpm publish --no-git-checks .

--- a/.github/workflows/hub-publish.yml
+++ b/.github/workflows/hub-publish.yml
@@ -11,6 +11,10 @@ on:
           - patch
           - minor
           - major
+      bypass_deps_check:
+        type: boolean
+        description: "Bypass dependency checking"
+        default: false
 
 concurrency:
   group: "push-to-main"
@@ -53,7 +57,8 @@ jobs:
           git commit -m "🔖 @huggingface/hub $BUMPED_VERSION"
           git tag "hub-v$BUMPED_VERSION"
 
-      - name: "Check Deps are published before publishing this package"
+      - if: ${{ !github.event.inputs.bypass_deps_check }}
+        name: "Check Deps are published before publishing this package"
         run: pnpm -w check-deps tasks
 
       - run: pnpm publish --no-git-checks .

--- a/.github/workflows/inference-publish.yml
+++ b/.github/workflows/inference-publish.yml
@@ -11,6 +11,10 @@ on:
           - patch
           - minor
           - major
+      bypass_deps_check:
+        type: boolean
+        description: "Bypass dependency checking"
+        default: false
 
 concurrency:
   group: "push-to-main"
@@ -53,7 +57,8 @@ jobs:
           git commit -m "🔖 @huggingface/inference $BUMPED_VERSION"
           git tag "inference-v$BUMPED_VERSION"
 
-      - name: "Check Deps are published before publishing this package"
+      - if: ${{ !github.event.inputs.bypass_deps_check }}
+        name: "Check Deps are published before publishing this package"
         run: pnpm -w check-deps tasks
 
       - run: pnpm publish --no-git-checks .

--- a/.github/workflows/mcp-client-publish.yml
+++ b/.github/workflows/mcp-client-publish.yml
@@ -11,6 +11,10 @@ on:
           - patch
           - minor
           - major
+      bypass_deps_check:
+        type: boolean
+        description: "Bypass dependency checking"
+        default: false
 
 concurrency:
   group: "push-to-main"
@@ -49,7 +53,8 @@ jobs:
           git tag "mcp-client-v$BUMPED_VERSION"
 
       # Add checks for dependencies if needed, similar to hub-publish.yml
-      - name: "Check Deps are published before publishing this package"
+      - if: ${{ !github.event.inputs.bypass_deps_check }}
+        name: "Check Deps are published before publishing this package"
         run: pnpm -w check-deps inference && pnpm -w check-deps tasks
 
       - run: pnpm publish --no-git-checks .


### PR DESCRIPTION
Eg sometimes it's not important to have up-to-date `@huggingface/tasks` requirement