### PR TITLE
Fix lint from #1421

### DIFF
--- a/packages/tasks/src/gguf.ts
+++ b/packages/tasks/src/gguf.ts
@@ -137,7 +137,7 @@ export function findNearestQuantType(
 	// This means finding the largest quantization that is smaller than or equal to the target.
 	for (const availableQuant of sortedAvailable) {
 		// We know the key exists due to the filter above.
-		const availableIndex = orderMap.get(availableQuant)!;
+		const availableIndex = orderMap.get(availableQuant) ?? 0;
 		if (availableIndex >= targetIndex) {
 			return availableQuant;
 		}


### PR DESCRIPTION
Linter tests passed in #1421, but then they fail with `Forbidden non-null assertion` on `main` after merging new PRs.