### PR TITLE
Use origin instead of hostname to compare host change

### DIFF
--- a/packages/hub/src/lib/file-download-info.ts
+++ b/packages/hub/src/lib/file-download-info.ts
@@ -144,7 +144,7 @@ export async function fileDownloadInfo(
 		// Cannot use resp.url in case it's a S3 url and the user adds an Authorization header to it.
 		url:
 			resp.url &&
-			(new URL(resp.url).hostname === new URL(hubUrl).hostname || resp.headers.get("X-Cache")?.endsWith(" cloudfront"))
+			(new URL(resp.url).origin === new URL(hubUrl).origin || resp.headers.get("X-Cache")?.endsWith(" cloudfront"))
 				? resp.url
 				: url,
 	};


### PR DESCRIPTION
Eg if hub is on localhost:3000 and S3 on localhost:9000 the authorization header would be forwarded to the S3 causing errors.

(change could alternatively be made in `downloadFile`)