### PR TITLE
[Inference Providers] isolate `image-to-image` payload build for HF Inference API

### DIFF
--- a/packages/inference/src/providers/fal-ai.ts
+++ b/packages/inference/src/providers/fal-ai.ts
@@ -14,10 +14,12 @@
  *
  * Thanks!
  */
+import { base64FromBytes } from "../utils/base64FromBytes";
+
 import type { AutomaticSpeechRecognitionOutput } from "@huggingface/tasks";
 import { InferenceOutputError } from "../lib/InferenceOutputError";
 import { isUrl } from "../lib/isUrl";
-import type { BodyParams, HeaderParams, ModelId, UrlParams } from "../types";
+import type { BodyParams, HeaderParams, ModelId, RequestArgs, UrlParams } from "../types";
 import { delay } from "../utils/delay";
 import { omit } from "../utils/omit";
 import {
@@ -27,6 +29,7 @@ import {
 	type TextToVideoTaskHelper,
 } from "./providerHelper";
 import { HF_HUB_URL } from "../config";
+import type { AutomaticSpeechRecognitionArgs } from "../tasks/audio/automaticSpeechRecognition";
 
 export interface FalAiQueueOutput {
 	request_id: string;
@@ -223,6 +226,28 @@ export class FalAIAutomaticSpeechRecognitionTask extends FalAITask implements Au
 			);
 		}
 		return { text: res.text };
+	}
+
+	async prepareAsyncPayload(args: AutomaticSpeechRecognitionArgs): Promise<RequestArgs> {
+		const blob = "data" in args && args.data instanceof Blob ? args.data : "inputs" in args ? args.inputs : undefined;
+		const contentType = blob?.type;
+		if (!contentType) {
+			throw new Error(
+				`Unable to determine the input's content-type. Make sure your are passing a Blob when using provider fal-ai.`
+			);
+		}
+		if (!FAL_AI_SUPPORTED_BLOB_TYPES.includes(contentType)) {
+			throw new Error(
+				`Provider fal-ai does not support blob type ${contentType} - supported content types are: ${FAL_AI_SUPPORTED_BLOB_TYPES.join(
+					", "
+				)}`
+			);
+		}
+		const base64audio = base64FromBytes(new Uint8Array(await blob.arrayBuffer()));
+		return {
+			...("data" in args ? omit(args, "data") : omit(args, "inputs")),
+			audio_url: `data:${contentType};base64,${base64audio}`,
+		};
 	}
 }
 

--- a/packages/inference/src/providers/fal-ai.ts
+++ b/packages/inference/src/providers/fal-ai.ts
@@ -228,7 +228,7 @@ export class FalAIAutomaticSpeechRecognitionTask extends FalAITask implements Au
 		return { text: res.text };
 	}
 
-	async prepareAsyncPayload(args: AutomaticSpeechRecognitionArgs): Promise<RequestArgs> {
+	async preparePayloadAsync(args: AutomaticSpeechRecognitionArgs): Promise<RequestArgs> {
 		const blob = "data" in args && args.data instanceof Blob ? args.data : "inputs" in args ? args.inputs : undefined;
 		const contentType = blob?.type;
 		if (!contentType) {

--- a/packages/inference/src/providers/hf-inference.ts
+++ b/packages/inference/src/providers/hf-inference.ts
@@ -225,7 +225,7 @@ export class HFInferenceAutomaticSpeechRecognitionTask
 		return response;
 	}
 
-	async prepareAsyncPayload(args: AutomaticSpeechRecognitionArgs): Promise<RequestArgs> {
+	async preparePayloadAsync(args: AutomaticSpeechRecognitionArgs): Promise<RequestArgs> {
 		return "data" in args
 			? args
 			: {
@@ -333,7 +333,7 @@ export class HFInferenceImageToTextTask extends HFInferenceTask implements Image
 }
 
 export class HFInferenceImageToImageTask extends HFInferenceTask implements ImageToImageTaskHelper {
-	async prepareAsyncPayload(args: ImageToImageArgs): Promise<RequestArgs> {
+	async preparePayloadAsync(args: ImageToImageArgs): Promise<RequestArgs> {
 		if (!args.parameters) {
 			return {
 				...args,

--- a/packages/inference/src/providers/hf-inference.ts
+++ b/packages/inference/src/providers/hf-inference.ts
@@ -36,7 +36,7 @@ import type {
 import { HF_ROUTER_URL } from "../config";
 import { InferenceOutputError } from "../lib/InferenceOutputError";
 import type { TabularClassificationOutput } from "../tasks/tabular/tabularClassification";
-import type { BodyParams, UrlParams } from "../types";
+import type { BodyParams, RequestArgs, UrlParams } from "../types";
 import { toArray } from "../utils/toArray";
 import type {
 	AudioClassificationTaskHelper,
@@ -70,7 +70,10 @@ import type {
 } from "./providerHelper";
 
 import { TaskProviderHelper } from "./providerHelper";
-
+import { base64FromBytes } from "../utils/base64FromBytes";
+import type { ImageToImageArgs } from "../tasks/cv/imageToImage";
+import type { AutomaticSpeechRecognitionArgs } from "../tasks/audio/automaticSpeechRecognition";
+import { omit } from "../utils/omit";
 interface Base64ImageGeneration {
 	data: Array<{
 		b64_json: string;
@@ -221,6 +224,15 @@ export class HFInferenceAutomaticSpeechRecognitionTask
 	override async getResponse(response: AutomaticSpeechRecognitionOutput): Promise<AutomaticSpeechRecognitionOutput> {
 		return response;
 	}
+
+	async prepareAsyncPayload(args: AutomaticSpeechRecognitionArgs): Promise<RequestArgs> {
+		return "data" in args
+			? args
+			: {
+					...omit(args, "inputs"),
+					data: args.inputs,
+			  };
+	}
 }
 
 export class HFInferenceAudioToAudioTask extends HFInferenceTask implements AudioToAudioTaskHelper {
@@ -321,6 +333,23 @@ export class HFInferenceImageToTextTask extends HFInferenceTask implements Image
 }
 
 export class HFInferenceImageToImageTask extends HFInferenceTask implements ImageToImageTaskHelper {
+	async prepareAsyncPayload(args: ImageToImageArgs): Promise<RequestArgs> {
+		if (!args.parameters) {
+			return {
+				...args,
+				model: args.model,
+				data: args.inputs,
+			};
+		} else {
+			return {
+				...args,
+				inputs: base64FromBytes(
+					new Uint8Array(args.inputs instanceof ArrayBuffer ? args.inputs : await (args.inputs as Blob).arrayBuffer())
+				),
+			};
+		}
+	}
+
 	override async getResponse(response: Blob): Promise<Blob> {
 		if (response instanceof Blob) {
 			return response;

--- a/packages/inference/src/providers/providerHelper.ts
+++ b/packages/inference/src/providers/providerHelper.ts
@@ -144,7 +144,7 @@ export interface TextToVideoTaskHelper {
 export interface ImageToImageTaskHelper {
 	getResponse(response: unknown, url?: string, headers?: HeadersInit): Promise<Blob>;
 	preparePayload(params: BodyParams<ImageToImageInput & BaseArgs>): Record<string, unknown>;
-	prepareAsyncPayload(args: ImageToImageArgs): Promise<RequestArgs>;
+	preparePayloadAsync(args: ImageToImageArgs): Promise<RequestArgs>;
 }
 
 export interface ImageSegmentationTaskHelper {
@@ -248,7 +248,7 @@ export interface AudioToAudioTaskHelper {
 export interface AutomaticSpeechRecognitionTaskHelper {
 	getResponse(response: unknown, url?: string, headers?: HeadersInit): Promise<AutomaticSpeechRecognitionOutput>;
 	preparePayload(params: BodyParams<AutomaticSpeechRecognitionInput & BaseArgs>): Record<string, unknown> | BodyInit;
-	prepareAsyncPayload(args: AutomaticSpeechRecognitionArgs): Promise<RequestArgs>;
+	preparePayloadAsync(args: AutomaticSpeechRecognitionArgs): Promise<RequestArgs>;
 }
 
 export interface AudioClassificationTaskHelper {

--- a/packages/inference/src/providers/providerHelper.ts
+++ b/packages/inference/src/providers/providerHelper.ts
@@ -48,8 +48,10 @@ import type {
 import { HF_ROUTER_URL } from "../config";
 import { InferenceOutputError } from "../lib/InferenceOutputError";
 import type { AudioToAudioOutput } from "../tasks/audio/audioToAudio";
-import type { BaseArgs, BodyParams, HeaderParams, InferenceProvider, UrlParams } from "../types";
+import type { BaseArgs, BodyParams, HeaderParams, InferenceProvider, RequestArgs, UrlParams } from "../types";
 import { toArray } from "../utils/toArray";
+import type { ImageToImageArgs } from "../tasks/cv/imageToImage";
+import type { AutomaticSpeechRecognitionArgs } from "../tasks/audio/automaticSpeechRecognition";
 
 /**
  * Base class for task-specific provider helpers
@@ -142,6 +144,7 @@ export interface TextToVideoTaskHelper {
 export interface ImageToImageTaskHelper {
 	getResponse(response: unknown, url?: string, headers?: HeadersInit): Promise<Blob>;
 	preparePayload(params: BodyParams<ImageToImageInput & BaseArgs>): Record<string, unknown>;
+	prepareAsyncPayload(args: ImageToImageArgs): Promise<RequestArgs>;
 }
 
 export interface ImageSegmentationTaskHelper {
@@ -245,6 +248,7 @@ export interface AudioToAudioTaskHelper {
 export interface AutomaticSpeechRecognitionTaskHelper {
 	getResponse(response: unknown, url?: string, headers?: HeadersInit): Promise<AutomaticSpeechRecognitionOutput>;
 	preparePayload(params: BodyParams<AutomaticSpeechRecognitionInput & BaseArgs>): Record<string, unknown> | BodyInit;
+	prepareAsyncPayload(args: AutomaticSpeechRecognitionArgs): Promise<RequestArgs>;
 }
 
 export interface AudioClassificationTaskHelper {

--- a/packages/inference/src/tasks/audio/automaticSpeechRecognition.ts
+++ b/packages/inference/src/tasks/audio/automaticSpeechRecognition.ts
@@ -2,13 +2,9 @@ import type { AutomaticSpeechRecognitionInput, AutomaticSpeechRecognitionOutput 
 import { resolveProvider } from "../../lib/getInferenceProviderMapping";
 import { getProviderHelper } from "../../lib/getProviderHelper";
 import { InferenceOutputError } from "../../lib/InferenceOutputError";
-import { FAL_AI_SUPPORTED_BLOB_TYPES } from "../../providers/fal-ai";
-import type { BaseArgs, Options, RequestArgs } from "../../types";
-import { base64FromBytes } from "../../utils/base64FromBytes";
-import { omit } from "../../utils/omit";
+import type { BaseArgs, Options } from "../../types";
 import { innerRequest } from "../../utils/request";
 import type { LegacyAudioInput } from "./utils";
-import { preparePayload } from "./utils";
 
 export type AutomaticSpeechRecognitionArgs = BaseArgs & (AutomaticSpeechRecognitionInput | LegacyAudioInput);
 /**
@@ -21,7 +17,7 @@ export async function automaticSpeechRecognition(
 ): Promise<AutomaticSpeechRecognitionOutput> {
 	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
 	const providerHelper = getProviderHelper(provider, "automatic-speech-recognition");
-	const payload = await buildPayload(args);
+	const payload = await providerHelper.prepareAsyncPayload(args);
 	const { data: res } = await innerRequest<AutomaticSpeechRecognitionOutput>(payload, providerHelper, {
 		...options,
 		task: "automatic-speech-recognition",
@@ -31,30 +27,4 @@ export async function automaticSpeechRecognition(
 		throw new InferenceOutputError("Expected {text: string}");
 	}
 	return providerHelper.getResponse(res);
-}
-
-async function buildPayload(args: AutomaticSpeechRecognitionArgs): Promise<RequestArgs> {
-	if (args.provider === "fal-ai") {
-		const blob = "data" in args && args.data instanceof Blob ? args.data : "inputs" in args ? args.inputs : undefined;
-		const contentType = blob?.type;
-		if (!contentType) {
-			throw new Error(
-				`Unable to determine the input's content-type. Make sure your are passing a Blob when using provider fal-ai.`
-			);
-		}
-		if (!FAL_AI_SUPPORTED_BLOB_TYPES.includes(contentType)) {
-			throw new Error(
-				`Provider fal-ai does not support blob type ${contentType} - supported content types are: ${FAL_AI_SUPPORTED_BLOB_TYPES.join(
-					", "
-				)}`
-			);
-		}
-		const base64audio = base64FromBytes(new Uint8Array(await blob.arrayBuffer()));
-		return {
-			...("data" in args ? omit(args, "data") : omit(args, "inputs")),
-			audio_url: `data:${contentType};base64,${base64audio}`,
-		};
-	} else {
-		return preparePayload(args);
-	}
 }

--- a/packages/inference/src/tasks/audio/automaticSpeechRecognition.ts
+++ b/packages/inference/src/tasks/audio/automaticSpeechRecognition.ts
@@ -17,7 +17,7 @@ export async function automaticSpeechRecognition(
 ): Promise<AutomaticSpeechRecognitionOutput> {
 	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
 	const providerHelper = getProviderHelper(provider, "automatic-speech-recognition");
-	const payload = await providerHelper.prepareAsyncPayload(args);
+	const payload = await providerHelper.preparePayloadAsync(args);
 	const { data: res } = await innerRequest<AutomaticSpeechRecognitionOutput>(payload, providerHelper, {
 		...options,
 		task: "automatic-speech-recognition",

--- a/packages/inference/src/tasks/cv/imageToImage.ts
+++ b/packages/inference/src/tasks/cv/imageToImage.ts
@@ -13,7 +13,7 @@ export type ImageToImageArgs = BaseArgs & ImageToImageInput;
 export async function imageToImage(args: ImageToImageArgs, options?: Options): Promise<Blob> {
 	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
 	const providerHelper = getProviderHelper(provider, "image-to-image");
-	const payload = await providerHelper.prepareAsyncPayload(args);
+	const payload = await providerHelper.preparePayloadAsync(args);
 	const { data: res } = await innerRequest<Blob>(payload, providerHelper, {
 		...options,
 		task: "image-to-image",

--- a/packages/inference/src/tasks/cv/imageToImage.ts
+++ b/packages/inference/src/tasks/cv/imageToImage.ts
@@ -1,8 +1,7 @@
 import type { ImageToImageInput } from "@huggingface/tasks";
 import { resolveProvider } from "../../lib/getInferenceProviderMapping";
 import { getProviderHelper } from "../../lib/getProviderHelper";
-import type { BaseArgs, Options, RequestArgs } from "../../types";
-import { base64FromBytes } from "../../utils/base64FromBytes";
+import type { BaseArgs, Options } from "../../types";
 import { innerRequest } from "../../utils/request";
 
 export type ImageToImageArgs = BaseArgs & ImageToImageInput;
@@ -14,31 +13,10 @@ export type ImageToImageArgs = BaseArgs & ImageToImageInput;
 export async function imageToImage(args: ImageToImageArgs, options?: Options): Promise<Blob> {
 	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
 	const providerHelper = getProviderHelper(provider, "image-to-image");
-	const payload = await buildPayload(args);
+	const payload = await providerHelper.prepareAsyncPayload(args);
 	const { data: res } = await innerRequest<Blob>(payload, providerHelper, {
 		...options,
 		task: "image-to-image",
 	});
 	return providerHelper.getResponse(res);
-}
-
-async function buildPayload(args: ImageToImageArgs): Promise<RequestArgs> {
-	if (args.provider === "hf-inference") {
-		if (!args.parameters) {
-			return {
-				accessToken: args.accessToken,
-				model: args.model,
-				data: args.inputs,
-			};
-		} else {
-			return {
-				...args,
-				inputs: base64FromBytes(
-					new Uint8Array(args.inputs instanceof ArrayBuffer ? args.inputs : await args.inputs.arrayBuffer())
-				),
-			};
-		}
-	} else {
-		return args;
-	}
 }

--- a/packages/inference/src/tasks/cv/imageToImage.ts
+++ b/packages/inference/src/tasks/cv/imageToImage.ts
@@ -14,24 +14,31 @@ export type ImageToImageArgs = BaseArgs & ImageToImageInput;
 export async function imageToImage(args: ImageToImageArgs, options?: Options): Promise<Blob> {
 	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
 	const providerHelper = getProviderHelper(provider, "image-to-image");
-	let reqArgs: RequestArgs;
-	if (!args.parameters) {
-		reqArgs = {
-			accessToken: args.accessToken,
-			model: args.model,
-			data: args.inputs,
-		};
-	} else {
-		reqArgs = {
-			...args,
-			inputs: base64FromBytes(
-				new Uint8Array(args.inputs instanceof ArrayBuffer ? args.inputs : await args.inputs.arrayBuffer())
-			),
-		};
-	}
-	const { data: res } = await innerRequest<Blob>(reqArgs, providerHelper, {
+	const payload = await buildPayload(args);
+	const { data: res } = await innerRequest<Blob>(payload, providerHelper, {
 		...options,
 		task: "image-to-image",
 	});
 	return providerHelper.getResponse(res);
+}
+
+async function buildPayload(args: ImageToImageArgs): Promise<RequestArgs> {
+	if (args.provider === "hf-inference") {
+		if (!args.parameters) {
+			return {
+				accessToken: args.accessToken,
+				model: args.model,
+				data: args.inputs,
+			};
+		} else {
+			return {
+				...args,
+				inputs: base64FromBytes(
+					new Uint8Array(args.inputs instanceof ArrayBuffer ? args.inputs : await args.inputs.arrayBuffer())
+				),
+			};
+		}
+	} else {
+		return args;
+	}
 }


### PR DESCRIPTION
This PR is a prerequisite for #1427. 

It refactors the payload construction for `hf-inference` by isolating it into a separate async function. Note that adding a new async function to build the payload is necessary because `HFInferenceImageToImageTask.preparePayload` cannot be made async, yet the payload construction requires asynchronous operations. A similar pattern has already been implemented for [automaticSpeechRecognition](https://github.com/huggingface/huggingface.js/blob/361a0fad4c68943592f0bcbe41592d785eedcb81/packages/inference/src/tasks/audio/automaticSpeechRecognition.ts#L36) with fal.