### PR TITLE
Fix `huggingface_hub` snippets

### DIFF
--- a/packages/inference/src/snippets/getInferenceSnippets.ts
+++ b/packages/inference/src/snippets/getInferenceSnippets.ts
@@ -285,6 +285,16 @@ const prepareConversationalInput = (
 	};
 };
 
+const prepareQuestionAnsweringInput = (model: ModelDataMinimal): object => {
+	const data = JSON.parse(getModelInputSnippet(model) as string);
+	return { question: data.question, context: data.context };
+};
+
+const prepareTableQuestionAnsweringInput = (model: ModelDataMinimal): object => {
+	const data = JSON.parse(getModelInputSnippet(model) as string);
+	return { query: data.query, table: JSON.stringify(data.table) };
+};
+
 const snippets: Partial<
 	Record<
 		PipelineType,
@@ -309,12 +319,12 @@ const snippets: Partial<
 	"image-to-image": snippetGenerator("imageToImage", prepareImageToImageInput),
 	"image-to-text": snippetGenerator("basicImage"),
 	"object-detection": snippetGenerator("basicImage"),
-	"question-answering": snippetGenerator("basic"),
+	"question-answering": snippetGenerator("questionAnswering", prepareQuestionAnsweringInput),
 	"sentence-similarity": snippetGenerator("basic"),
 	summarization: snippetGenerator("basic"),
 	"tabular-classification": snippetGenerator("tabular"),
 	"tabular-regression": snippetGenerator("tabular"),
-	"table-question-answering": snippetGenerator("basic"),
+	"table-question-answering": snippetGenerator("tableQuestionAnswering", prepareTableQuestionAnsweringInput),
 	"text-classification": snippetGenerator("basic"),
 	"text-generation": snippetGenerator("basic"),
 	"text-to-audio": snippetGenerator("textToAudio"),

--- a/packages/inference/src/snippets/templates/python/huggingface_hub/basic.jinja
+++ b/packages/inference/src/snippets/templates/python/huggingface_hub/basic.jinja
@@ -1,4 +1,4 @@
 result = client.{{ methodName }}(
-    inputs={{ inputs.asObj.inputs }},
+    {{ inputs.asObj.inputs }},
     model="{{ model.id }}",
 )

--- a/packages/inference/src/snippets/templates/python/huggingface_hub/questionAnswering.jinja
+++ b/packages/inference/src/snippets/templates/python/huggingface_hub/questionAnswering.jinja
@@ -1,0 +1,5 @@
+answer = client.question_answering(
+    question="{{ inputs.asObj.question }}",
+    context="{{ inputs.asObj.context }}",
+    model="{{ model.id }}",
+) 

--- a/packages/inference/src/snippets/templates/python/huggingface_hub/tableQuestionAnswering.jinja
+++ b/packages/inference/src/snippets/templates/python/huggingface_hub/tableQuestionAnswering.jinja
@@ -1,0 +1,5 @@
+answer = client.question_answering(
+    query="{{ inputs.asObj.query }}",
+    table={{ inputs.asObj.table }},
+    model="{{ model.id }}",
+) 

--- a/packages/tasks-gen/scripts/generate-snippets-fixtures.ts
+++ b/packages/tasks-gen/scripts/generate-snippets-fixtures.ts
@@ -250,6 +250,39 @@ const TEST_CASES: {
 		},
 		providers: ["fal-ai"],
 	},
+	{
+		testName: "feature-extraction",
+		task: "feature-extraction",
+		model: {
+			id: "intfloat/multilingual-e5-large-instruct",
+			pipeline_tag: "feature-extraction",
+			tags: [],
+			inference: "",
+		},
+		providers: ["hf-inference"],
+	},
+	{
+		testName: "question-answering",
+		task: "question-answering",
+		model: {
+			id: "google-bert/bert-large-uncased-whole-word-masking-finetuned-squad",
+			pipeline_tag: "question-answering",
+			tags: [],
+			inference: "",
+		},
+		providers: ["hf-inference"],
+	},
+	{
+		testName: "table-question-answering",
+		task: "table-question-answering",
+		model: {
+			id: "google-bert/bert-large-uncased-whole-word-masking-finetuned-squad",
+			pipeline_tag: "table-question-answering",
+			tags: [],
+			inference: "",
+		},
+		providers: ["hf-inference"],
+	},
 ] as const;
 
 const rootDirFinder = (): string => {

--- a/packages/tasks-gen/snippets-fixtures/basic-snippet--token-classification/python/huggingface_hub/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/basic-snippet--token-classification/python/huggingface_hub/0.hf-inference.py
@@ -6,6 +6,6 @@ client = InferenceClient(
 )
 
 result = client.token_classification(
-    inputs="My name is Sarah Jessica Parker but you can call me Jessica",
+    "My name is Sarah Jessica Parker but you can call me Jessica",
     model="FacebookAI/xlm-roberta-large-finetuned-conll03-english",
 )

--- a/packages/tasks-gen/snippets-fixtures/feature-extraction/js/fetch/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/feature-extraction/js/fetch/0.hf-inference.js
@@ -1,0 +1,19 @@
+async function query(data) {
+	const response = await fetch(
+		"https://router.huggingface.co/hf-inference/models/intfloat/multilingual-e5-large-instruct/pipeline/feature-extraction",
+		{
+			headers: {
+				Authorization: "Bearer api_token",
+				"Content-Type": "application/json",
+			},
+			method: "POST",
+			body: JSON.stringify(data),
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query({ inputs: "Today is a sunny day and I will get some ice cream." }).then((response) => {
+    console.log(JSON.stringify(response));
+});

--- a/packages/tasks-gen/snippets-fixtures/feature-extraction/js/huggingface.js/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/feature-extraction/js/huggingface.js/0.hf-inference.js
@@ -1,0 +1,11 @@
+import { InferenceClient } from "@huggingface/inference";
+
+const client = new InferenceClient("api_token");
+
+const output = await client.featureExtraction({
+	model: "intfloat/multilingual-e5-large-instruct",
+	inputs: "Today is a sunny day and I will get some ice cream.",
+	provider: "hf-inference",
+});
+
+console.log(output);

--- a/packages/tasks-gen/snippets-fixtures/feature-extraction/python/huggingface_hub/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/feature-extraction/python/huggingface_hub/0.hf-inference.py
@@ -1,0 +1,11 @@
+from huggingface_hub import InferenceClient
+
+client = InferenceClient(
+    provider="hf-inference",
+    api_key="api_token",
+)
+
+result = client.feature_extraction(
+    "Today is a sunny day and I will get some ice cream.",
+    model="intfloat/multilingual-e5-large-instruct",
+)

--- a/packages/tasks-gen/snippets-fixtures/feature-extraction/python/requests/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/feature-extraction/python/requests/0.hf-inference.py
@@ -1,0 +1,14 @@
+import requests
+
+API_URL = "https://router.huggingface.co/hf-inference/models/intfloat/multilingual-e5-large-instruct/pipeline/feature-extraction"
+headers = {
+    "Authorization": "Bearer api_token",
+}
+
+def query(payload):
+    response = requests.post(API_URL, headers=headers, json=payload)
+    return response.json()
+
+output = query({
+    "inputs": "Today is a sunny day and I will get some ice cream.",
+})

--- a/packages/tasks-gen/snippets-fixtures/feature-extraction/sh/curl/0.hf-inference.sh
+++ b/packages/tasks-gen/snippets-fixtures/feature-extraction/sh/curl/0.hf-inference.sh
@@ -1,0 +1,7 @@
+curl https://router.huggingface.co/hf-inference/models/intfloat/multilingual-e5-large-instruct/pipeline/feature-extraction \
+    -X POST \
+    -H 'Authorization: Bearer api_token' \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "inputs": "\"Today is a sunny day and I will get some ice cream.\""
+    }'

--- a/packages/tasks-gen/snippets-fixtures/question-answering/python/huggingface_hub/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/question-answering/python/huggingface_hub/0.hf-inference.py
@@ -1,0 +1,12 @@
+from huggingface_hub import InferenceClient
+
+client = InferenceClient(
+    provider="hf-inference",
+    api_key="api_token",
+)
+
+answer = client.question_answering(
+    question="What is my name?",
+    context="My name is Clara and I live in Berkeley.",
+    model="google-bert/bert-large-uncased-whole-word-masking-finetuned-squad",
+)

--- a/packages/tasks-gen/snippets-fixtures/table-question-answering/python/huggingface_hub/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/table-question-answering/python/huggingface_hub/0.hf-inference.py
@@ -1,0 +1,12 @@
+from huggingface_hub import InferenceClient
+
+client = InferenceClient(
+    provider="hf-inference",
+    api_key="api_token",
+)
+
+answer = client.question_answering(
+    query="How many stars does the transformers repository have?",
+    table={"Repository":["Transformers","Datasets","Tokenizers"],"Stars":["36542","4512","3934"],"Contributors":["651","77","34"],"Programming language":["Python","Python","Rust, Python and NodeJS"]},
+    model="google-bert/bert-large-uncased-whole-word-masking-finetuned-squad",
+)

--- a/packages/tasks-gen/snippets-fixtures/text-classification/python/huggingface_hub/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/text-classification/python/huggingface_hub/0.hf-inference.py
@@ -6,6 +6,6 @@ client = InferenceClient(
 )
 
 result = client.text_classification(
-    inputs="I like you. I love you",
+    "I like you. I love you",
     model="distilbert/distilbert-base-uncased-finetuned-sst-2-english",
 )


### PR DESCRIPTION
Fixes #1440. 
Thank you @tomaarsen for flagging this! This PR addresses all the incorrect snippets mentioned in the issue.

I've added example snippets for `feature-extraction`, `question-answering`,` table-question-answering`, and `text-classification` to ensure everything is now correct.