### PR TITLE
[mcp-client] Make HF_TOKEN optional

### DIFF
--- a/packages/mcp-client/README.md
+++ b/packages/mcp-client/README.md
@@ -44,16 +44,16 @@ The agent will load available MCP tools (by default, connecting to a filesystem 
 
 ### Configuration (Environment Variables)
 
-*   `HF_TOKEN` (Required): Your Hugging Face API token.
+*   `HF_TOKEN` (Optional): Your Hugging Face API token. Required if you use an Inference Provider on HF.
 *   `MODEL_ID` (Optional): The model ID to use for the agent's inference. Defaults to `Qwen/Qwen2.5-72B-Instruct`.
 *   `PROVIDER` (Optional): The inference provider. Defaults to `together`. See `@huggingface/inference` for available providers.
-*   `EXPERIMENTAL_HF_MCP_SERVER` (Optional): Set to `true` to enable connection to an experimental Hugging Face MCP server (requires separate setup).
+*   `ENDPOINT_URL` or `BASE_URL` (Optional): A custom base URL (local for instance) to call.
 
 Example with custom model:
 
 ```bash
 export HF_TOKEN="hf_..."
-export MODEL_ID="mistralai/Mixtral-8x7B-Instruct-v0.1"
+export MODEL_ID="Qwen/Qwen2.5-72B-Instruct"
 pnpm agent
 ```
 

--- a/packages/mcp-client/cli.ts
+++ b/packages/mcp-client/cli.ts
@@ -62,8 +62,8 @@ async function main() {
 		process.exit(0);
 	}
 
-	if (!process.env.HF_TOKEN) {
-		console.error(`a valid HF_TOKEN must be present in the env`);
+	if (!ENDPOINT_URL && !process.env.HF_TOKEN) {
+		console.error(`To use a remote inference provider, a valid HF_TOKEN must be present in the env`);
 		process.exit(1);
 	}
 

--- a/packages/mcp-client/src/Agent.ts
+++ b/packages/mcp-client/src/Agent.ts
@@ -66,7 +66,7 @@ export class Agent extends McpClient {
 		  }
 	) & {
 		model: string;
-		apiKey: string;
+		apiKey?: string;
 		servers: (ServerConfig | StdioServerParameters)[];
 		prompt?: string;
 	}) {

--- a/packages/mcp-client/src/McpClient.ts
+++ b/packages/mcp-client/src/McpClient.ts
@@ -50,7 +50,7 @@ export class McpClient {
 		  }
 	) & {
 		model: string;
-		apiKey: string;
+		apiKey?: string;
 	}) {
 		this.client = endpointUrl ? new InferenceClient(apiKey, { endpointUrl: endpointUrl }) : new InferenceClient(apiKey);
 		this.provider = provider;

--- a/packages/mcp-client/test/McpClient.spec.ts
+++ b/packages/mcp-client/test/McpClient.spec.ts
@@ -10,7 +10,7 @@ describe("McpClient", () => {
 		const client = new McpClient({
 			provider: "together",
 			model: "Qwen/Qwen2.5-72B-Instruct",
-			apiKey: process.env.HF_TOKEN ?? "",
+			apiKey: process.env.HF_TOKEN,
 		});
 		expect(client).toBeDefined();
 		expect(client.availableTools.length).toBe(0);


### PR DESCRIPTION
in case we pass a custom baseURL, then HF_TOKEN is actually not required.