### PR TITLE
Fix broken VLM snippets on the hub.

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1164,10 +1164,11 @@ export const transformers = (model: ModelData): string[] => {
 					].join("\n"),
 					"]"
 				);
+				pipelineSnippet.push("pipe(text=messages)");
 			} else {
 				pipelineSnippet.push("messages = [", '    {"role": "user", "content": "Who are you?"},', "]");
+				pipelineSnippet.push("pipe(messages)");
 			}
-			pipelineSnippet.push("pipe(messages)");
 		}
 
 		return [pipelineSnippet.join("\n"), autoSnippet];


### PR DESCRIPTION
TL;DR:

this is broken:

```diff
# Use a pipeline as a high-level helper
from transformers import pipeline
import torch

pipe = pipeline("image-text-to-text", model="google/gemma-3-4b-it", torch_dtype=torch.bfloat16)
messages = [
    {
        "role": "user",
        "content": [
            {"type": "image", "url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/p-blog/candy.JPG"},
            {"type": "text", "text": "What animal is on the candy?"}
        ]
    },
]
-pipe(messages)
+pipe(text=messages)
```

there's some code duplication because `text-generation` models require ` pipe(messages)` which maps to `text_inputs`

@gante is looking for a fix on transformers main but it might awhile till we actually get this in a version that works with colab.

cc: @merveenoyan @sergiopaniego for vis too.