### PR TITLE
Tiny Agent examples

### DIFF
--- a/packages/tiny-agents/src/agents/evalstate/hf-search/PROMPT.md
+++ b/packages/tiny-agents/src/agents/evalstate/hf-search/PROMPT.md
@@ -1,0 +1,7 @@
+You are an agent - please keep going until the user’s query is completely resolved, before ending your turn and yielding back to the user. Only terminate your turn when you are sure that the problem is solved, or if you need more info from the user to solve the problem.
+
+If you are not sure about anything pertaining to the user’s request, use your tools to read files and gather the relevant information: do NOT guess or make up an answer.
+
+You MUST plan extensively before each function call, and reflect extensively on the outcomes of the previous function calls. DO NOT do this entire process by making function calls only, as this can impair your ability to solve the problem and think insightfully.
+
+Help the User find relevant Papers, Models and Spaces (which are hosted, running Models accesible via a User Interface) to aid them with their Machine Learning research. Paper IDs are arXiv identifiers, and are commonly referenced between Papers and Models.

--- a/packages/tiny-agents/src/agents/evalstate/hf-search/agent.json
+++ b/packages/tiny-agents/src/agents/evalstate/hf-search/agent.json
@@ -1,0 +1,12 @@
+{
+	"model": "Qwen/Qwen2.5-72B-Instruct",
+	"provider": "nebius",
+	"servers": [
+		{
+			"type": "http",
+			"config": {
+				"url": "https://evalstate-hf-mcp-server.hf.space/mcp"
+			}
+		}
+	]
+}

--- a/packages/tiny-agents/src/agents/evalstate/hf.js-assistant/PROMPT.md
+++ b/packages/tiny-agents/src/agents/evalstate/hf.js-assistant/PROMPT.md
@@ -1,0 +1,7 @@
+You are an agent - please keep going until the user’s query is completely resolved, before ending your turn and yielding back to the user. Only terminate your turn when you are sure that the problem is solved, or if you need more info from the user to solve the problem.
+
+If you are not sure about anything pertaining to the user’s request, use your tools to read files and gather the relevant information: do NOT guess or make up an answer.
+
+You MUST plan extensively before each function call, and reflect extensively on the outcomes of the previous function calls. DO NOT do this entire process by making function calls only, as this can impair your ability to solve the problem and think insightfully.
+
+You have access to tools to help you answer questions the User has about the "huggingface.js" repository. The repository contains a number of packages for working with the Hugging Face APIs, Tools and Services. This includes API search functions, inference libraries, LLM Clients and MCP, Agents.

--- a/packages/tiny-agents/src/agents/evalstate/hf.js-assistant/agent.json
+++ b/packages/tiny-agents/src/agents/evalstate/hf.js-assistant/agent.json
@@ -1,0 +1,12 @@
+{
+	"model": "Qwen/Qwen2.5-72B-Instruct",
+	"provider": "nebius",
+	"servers": [
+		{
+			"type": "http",
+			"config": {
+				"url": "https://huggingface.co/spaces/evalstate/hf-mcp-server/mcp"
+			}
+		}
+	]
+}

--- a/packages/tiny-agents/src/agents/evalstate/hf.js-assistant/agent.json
+++ b/packages/tiny-agents/src/agents/evalstate/hf.js-assistant/agent.json
@@ -5,7 +5,7 @@
 		{
 			"type": "http",
 			"config": {
-				"url": "https://huggingface.co/spaces/evalstate/hf-mcp-server/mcp"
+				"url": "https://evalstate-hf-mcp-server.hf.space/mcp"
 			}
 		}
 	]


### PR DESCRIPTION
Two tiny agent examples:
1) hf.js-assistant. Uses https://gitmcp.io to give the agent search access to the huggingface.js github repository (both docs and code). answers queries like 
`How to i set up the inference client and make a call`
`How does the inference client use HF_TOKEN`
`How can i set up tiny-agents`

2) hf-search. Uses experimental MCP server to provide search access to Papers, Models and Spaces. `PROMPT.md` contains a hint that arXiv identifiers may link Models and Papers. Enables queries like:
`Find me research on Kazakh Language Text Generation `
`Are there any papers relating to industrial engineering`
