### PR TITLE
Add molecules as task

### DIFF
--- a/packages/tasks/src/pipelines.ts
+++ b/packages/tasks/src/pipelines.ts
@@ -693,6 +693,12 @@ export const PIPELINE_DATA = {
 		color: "yellow",
 		hideInDatasets: true,
 	},
+	"molecules": {
+		name: "Molecules",
+		modality: "other",
+		color: "green",
+		hideInDatasets: true,
+	},
 	other: {
 		name: "Other",
 		modality: "other",

--- a/packages/tasks/src/tasks/index.ts
+++ b/packages/tasks/src/tasks/index.ts
@@ -221,6 +221,7 @@ export const TASKS_DATA: Record<PipelineType, TaskData | undefined> = {
 	"keypoint-detection": getData("keypoint-detection", keypointDetection),
 	"mask-generation": getData("mask-generation", maskGeneration),
 	"multiple-choice": undefined,
+	"molecules": undefined,
 	"object-detection": getData("object-detection", objectDetection),
 	"video-classification": getData("video-classification", videoClassification),
 	other: undefined,


### PR DESCRIPTION
cc @NielsRogge @julien-c inspired by facebook OMol release I did a full text search "molecules" and saw 853 results in /models. I think it makes sense to add it as a task under "others" 
Also opened another PR to add the icon 