### PR TITLE
Update TimesFM downloads

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -936,7 +936,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "timesfm",
 		repoUrl: "https://github.com/google-research/timesfm",
 		filter: false,
-		countDownloads: `path:"checkpoints/checkpoint_1100000/state/checkpoint"`,
+		countDownloads: `path:"checkpoints/checkpoint_1100000/state/checkpoint" OR path:"checkpoints/checkpoint_2150000/state/checkpoint" OR path_extension:"ckpt"`,
 	},
 	timm: {
 		prettyLabel: "timm",


### PR DESCRIPTION
This PR updates the download stats of Google's TimesFM. Supported repos:

* https://huggingface.co/google/timesfm-2.0-500m-jax
* https://huggingface.co/google/timesfm-2.0-500m-pytorch
* https://huggingface.co/google/timesfm-1.0-200m-pytorch
* https://huggingface.co/google/timesfm-1.0-200m (already supported)