### PR TITLE
fix: type assertion in cache-management test using unknown

### DIFF
--- a/packages/hub/src/lib/cache-management.spec.ts
+++ b/packages/hub/src/lib/cache-management.spec.ts
@@ -87,7 +87,7 @@ describe("scanSnapshotDir", () => {
 		const cachedFiles: CachedFileInfo[] = [];
 		const blobStats = new Map<string, Stats>();
 		vi.mocked(readdir).mockResolvedValueOnce([
-			{ name: "file1", isDirectory: () => false } as Awaited<ReturnType<typeof readdir>>[0],
+			{ name: "file1", isDirectory: () => false } as unknown as Awaited<ReturnType<typeof readdir>>[0],
 		]);
 
 		vi.mocked(realpath).mockResolvedValueOnce("/fake/realpath");


### PR DESCRIPTION
fixes build error:

```
│ src/lib/cache-management.spec.ts(90,4): error TS2352: Conversion of type '{ name: string; isDirectory: () => false; }…
│   Type '{ name: string; isDirectory: () => false; }' is missing the following properties from type 'Dirent<Buffer<Arr…
│  ELIFECYCLE  Command failed with exit code 1.
└─ Failed in 1.6s at /Users/mishig/huggingface.js/packages/hub
```
