### PR TITLE
Remove hideInDatasets for multimodal tasks

### DIFF
--- a/packages/tasks/src/pipelines.ts
+++ b/packages/tasks/src/pipelines.ts
@@ -603,7 +603,6 @@ export const PIPELINE_DATA = {
 		name: "Image-Text-to-Text",
 		modality: "multimodal",
 		color: "red",
-		hideInDatasets: true,
 	},
 	"visual-question-answering": {
 		name: "Visual Question Answering",
@@ -685,13 +684,11 @@ export const PIPELINE_DATA = {
 		name: "Visual Document Retrieval",
 		modality: "multimodal",
 		color: "yellow",
-		hideInDatasets: true,
 	},
 	"any-to-any": {
 		name: "Any-to-Any",
 		modality: "multimodal",
 		color: "yellow",
-		hideInDatasets: true,
 	},
 	other: {
 		name: "Other",


### PR DESCRIPTION
More and more datasets are showing up for multimodal tasks, and some authors are picking wrong task tags because `hideInDataset` is true, so removing them