### PR TITLE
[tiny-agents] Handle env variables in tiny-agents (JS client)

### DIFF
--- a/packages/tiny-agents/src/lib/types.ts
+++ b/packages/tiny-agents/src/lib/types.ts
@@ -40,3 +40,12 @@ export const ServerConfigSchema = z.discriminatedUnion("type", [
 ]);
 
 export type ServerConfig = z.infer<typeof ServerConfigSchema>;
+
+export const InputConfigSchema = z.object({
+	id: z.string(),
+	description: z.string(),
+	type: z.string().optional(),
+	password: z.boolean().optional(),
+});
+
+export type InputConfig = z.infer<typeof InputConfigSchema>;

--- a/packages/tiny-agents/src/lib/utils.ts
+++ b/packages/tiny-agents/src/lib/utils.ts
@@ -16,4 +16,5 @@ export const ANSI = {
 	GREEN: "\x1b[32m",
 	RED: "\x1b[31m",
 	RESET: "\x1b[0m",
+	YELLOW: "\x1b[33m",
 };


### PR DESCRIPTION
This PR adds support for the inputs configuration defined by VSCode (see [docs](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server-to-your-workspace)).

PR adapted from https://github.com/huggingface/huggingface_hub/pull/3129 using Cursor. Made some minor adjustments manually. 

### How to test

```
pnpm run cli run wauplin/library-pr-reviewer
```

![image](https://github.com/user-attachments/assets/f58be215-2575-4593-9ff2-5f85a6950649)


