### PR TITLE
[Inference] Improve error handling

### DIFF
--- a/packages/inference/src/error.ts
+++ b/packages/inference/src/error.ts
@@ -1,0 +1,87 @@
+import type { JsonObject } from "./vendor/type-fest/basic.js";
+
+/** 
+ * Base class for all inference-related errors.
+ */
+export abstract class HfInferenceError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "HfInferenceError";
+	}
+}
+
+export class HfInferenceInputError extends HfInferenceError {
+	constructor(message: string) {
+		super(message);
+		this.name = "InputError";
+	}
+}
+
+interface HttpRequest {
+	url: string;
+	method: string;
+	headers?: Record<string, string>;
+	body?: JsonObject;
+}
+
+interface HttpResponse {
+	requestId: string;
+	status: number;
+	body: JsonObject | string;
+}
+
+abstract class HfInferenceHttpRequestError extends HfInferenceError {
+	httpRequest: HttpRequest;
+	httpResponse: HttpResponse;
+	constructor(message: string, httpRequest: HttpRequest, httpResponse: HttpResponse) {
+		super(message);
+		this.httpRequest = {
+			...httpRequest,
+			...(httpRequest.headers ? {
+				headers: {
+					...httpRequest.headers,
+					...("Authorization" in httpRequest.headers ? { Authorization: `Bearer [redacted]` } : undefined),
+					/// redact authentication in the request headers
+				},
+			} : undefined)
+		};
+		this.httpResponse = httpResponse;
+	}
+}
+
+/**
+ * Thrown when the HTTP request to the provider fails, e.g. due to API issues or server errors.
+ */
+export class HfInferenceProviderApiError extends HfInferenceHttpRequestError {
+	constructor(message: string, httpRequest: HttpRequest, httpResponse: HttpResponse) {
+		super(message, httpRequest, httpResponse);
+		this.name = "ProviderApiError";
+	}
+}
+
+/**
+ * Thrown when the HTTP request to the hub fails, e.g. due to API issues or server errors.
+ */
+export class HfInferenceHubApiError extends HfInferenceHttpRequestError {
+	constructor(message: string, httpRequest: HttpRequest, httpResponse: HttpResponse) {
+		super(message, httpRequest, httpResponse);
+		this.name = "HubApiError";
+	}
+}
+
+/**
+ * Thrown when the inference output returned by the provider is invalid / does not match the expectations 
+ */
+export class HfInferenceProviderOutputError extends HfInferenceError {
+	httpRequest: HttpRequest;
+	httpResponse: HttpResponse;
+	error: string | JsonObject;
+	constructor(message: string, httpRequest: { url: string; method: string; headers: Record<string, string>; body: JsonObject }, httpResponse: { requestId: string; status: number; headers: Record<string, string>; body: JsonObject | string }, error: string | JsonObject) {
+		super(message);
+		this.name = "ProviderOutputError";
+		this.httpRequest = httpRequest;
+		this.httpResponse = httpResponse;
+		this.error = error;
+	}
+}
+

--- a/packages/inference/src/error.ts
+++ b/packages/inference/src/error.ts
@@ -73,15 +73,9 @@ export class HfInferenceHubApiError extends HfInferenceHttpRequestError {
  * Thrown when the inference output returned by the provider is invalid / does not match the expectations 
  */
 export class HfInferenceProviderOutputError extends HfInferenceError {
-	httpRequest: HttpRequest;
-	httpResponse: HttpResponse;
-	error: string | JsonObject;
-	constructor(message: string, httpRequest: { url: string; method: string; headers: Record<string, string>; body: JsonObject }, httpResponse: { requestId: string; status: number; headers: Record<string, string>; body: JsonObject | string }, error: string | JsonObject) {
+	constructor(message: string) {
 		super(message);
 		this.name = "ProviderOutputError";
-		this.httpRequest = httpRequest;
-		this.httpResponse = httpResponse;
-		this.error = error;
 	}
 }
 

--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -1,5 +1,5 @@
 export { InferenceClient, InferenceClientEndpoint, HfInference } from "./InferenceClient.js";
-export { InferenceOutputError } from "./lib/InferenceOutputError.js";
+export * from "./error.js"
 export * from "./types.js";
 export * from "./tasks/index.js";
 import * as snippets from "./snippets/index.js";

--- a/packages/inference/src/lib/InferenceOutputError.ts
+++ b/packages/inference/src/lib/InferenceOutputError.ts
@@ -1,8 +1,0 @@
-export class InferenceOutputError extends TypeError {
-	constructor(message: string) {
-		super(
-			`Invalid inference output: ${message}. Use the 'request' method with the same parameters to do a custom call with no type checking.`
-		);
-		this.name = "InferenceOutputError";
-	}
-}

--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -48,6 +48,7 @@ import * as Replicate from "../providers/replicate.js";
 import * as Sambanova from "../providers/sambanova.js";
 import * as Together from "../providers/together.js";
 import type { InferenceProvider, InferenceProviderOrPolicy, InferenceTask } from "../types.js";
+import { HfInferenceInputError } from "../error.js";
 
 export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, TaskProviderHelper>>> = {
 	"black-forest-labs": {
@@ -281,14 +282,14 @@ export function getProviderHelper(
 		return new HFInference.HFInferenceTask();
 	}
 	if (!task) {
-		throw new Error("you need to provide a task name when using an external provider, e.g. 'text-to-image'");
+		throw new HfInferenceInputError("you need to provide a task name when using an external provider, e.g. 'text-to-image'");
 	}
 	if (!(provider in PROVIDERS)) {
-		throw new Error(`Provider '${provider}' not supported. Available providers: ${Object.keys(PROVIDERS)}`);
+		throw new HfInferenceInputError(`Provider '${provider}' not supported. Available providers: ${Object.keys(PROVIDERS)}`);
 	}
 	const providerTasks = PROVIDERS[provider];
 	if (!providerTasks || !(task in providerTasks)) {
-		throw new Error(
+		throw new HfInferenceInputError(
 			`Task '${task}' not supported for provider '${provider}'. Available tasks: ${Object.keys(providerTasks ?? {})}`
 		);
 	}

--- a/packages/inference/src/providers/black-forest-labs.ts
+++ b/packages/inference/src/providers/black-forest-labs.ts
@@ -14,8 +14,7 @@
  *
  * Thanks!
  */
-import { HfInferenceInputError } from "../error.js";
-import { InferenceOutputError } from "../lib/InferenceOutputError.js";
+import { HfInferenceInputError, HfInferenceProviderApiError, HfInferenceProviderOutputError } from "../error.js";
 import type { BodyParams, HeaderParams, UrlParams } from "../types.js";
 import { delay } from "../utils/delay.js";
 import { omit } from "../utils/omit.js";
@@ -71,7 +70,10 @@ export class BlackForestLabsTextToImageTask extends TaskProviderHelper implement
 			urlObj.searchParams.set("attempt", step.toString(10));
 			const resp = await fetch(urlObj, { headers: { "Content-Type": "application/json" } });
 			if (!resp.ok) {
-				throw new InferenceOutputError("Failed to fetch result from black forest labs API");
+				throw new HfInferenceProviderApiError("Failed to fetch result from black forest labs API",
+					{ url: urlObj.toString(), method: "GET", headers: { "Content-Type": "application/json" } },
+					{ requestId: resp.headers.get("x-request-id") ?? "", status: resp.status, body: await resp.text() }
+				);
 			}
 			const payload = await resp.json();
 			if (
@@ -93,6 +95,6 @@ export class BlackForestLabsTextToImageTask extends TaskProviderHelper implement
 				return await image.blob();
 			}
 		}
-		throw new InferenceOutputError("Failed to fetch result from black forest labs API");
+		throw new HfInferenceProviderOutputError(`Timed out while waiting for the result from black forest labs API - aborting after 5 attempts`);
 	}
 }

--- a/packages/inference/src/providers/black-forest-labs.ts
+++ b/packages/inference/src/providers/black-forest-labs.ts
@@ -14,6 +14,7 @@
  *
  * Thanks!
  */
+import { HfInferenceInputError } from "../error.js";
 import { InferenceOutputError } from "../lib/InferenceOutputError.js";
 import type { BodyParams, HeaderParams, UrlParams } from "../types.js";
 import { delay } from "../utils/delay.js";
@@ -52,7 +53,7 @@ export class BlackForestLabsTextToImageTask extends TaskProviderHelper implement
 
 	makeRoute(params: UrlParams): string {
 		if (!params) {
-			throw new Error("Params are required");
+			throw new HfInferenceInputError("Params are required");
 		}
 		return `/v1/${params.model}`;
 	}

--- a/packages/inference/src/providers/featherless-ai.ts
+++ b/packages/inference/src/providers/featherless-ai.ts
@@ -4,10 +4,10 @@ import type {
 	TextGenerationOutput,
 	TextGenerationOutputFinishReason,
 } from "@huggingface/tasks";
-import { InferenceOutputError } from "../lib/InferenceOutputError.js";
 import type { BodyParams } from "../types.js";
 import { BaseConversationalTask, BaseTextGenerationTask } from "./providerHelper.js";
 import { omit } from "../utils/omit.js";
+import { HfInferenceProviderOutputError } from "../error.js";
 
 interface FeatherlessAITextCompletionOutput extends Omit<ChatCompletionOutput, "choices"> {
 	choices: Array<{
@@ -38,9 +38,9 @@ export class FeatherlessAITextGenerationTask extends BaseTextGenerationTask {
 			...omit(params.args, ["inputs", "parameters"]),
 			...(params.args.parameters
 				? {
-						max_tokens: params.args.parameters.max_new_tokens,
-						...omit(params.args.parameters, "max_new_tokens"),
-				  }
+					max_tokens: params.args.parameters.max_new_tokens,
+					...omit(params.args.parameters, "max_new_tokens"),
+				}
 				: undefined),
 			prompt: params.args.inputs,
 		};
@@ -58,6 +58,6 @@ export class FeatherlessAITextGenerationTask extends BaseTextGenerationTask {
 				generated_text: completion.text,
 			};
 		}
-		throw new InferenceOutputError("Expected Featherless AI text generation response format");
+		throw new HfInferenceProviderOutputError("Received malformed response from Featherless AI text generation API");
 	}
 }

--- a/packages/inference/src/providers/hf-inference.ts
+++ b/packages/inference/src/providers/hf-inference.ts
@@ -34,7 +34,7 @@ import type {
 	ZeroShotImageClassificationOutput,
 } from "@huggingface/tasks";
 import { HF_ROUTER_URL } from "../config.js";
-import { InferenceOutputError } from "../lib/InferenceOutputError.js";
+import { HfInferenceProviderOutputError } from "../error.js";
 import type { TabularClassificationOutput } from "../tasks/tabular/tabularClassification.js";
 import type { BodyParams, RequestArgs, UrlParams } from "../types.js";
 import { toArray } from "../utils/toArray.js";
@@ -127,7 +127,7 @@ export class HFInferenceTextToImageTask extends HFInferenceTask implements TextT
 		outputType?: "url" | "blob"
 	): Promise<string | Blob> {
 		if (!response) {
-			throw new InferenceOutputError("response is undefined");
+			throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference text-to-image API: response is undefined");
 		}
 		if (typeof response == "object") {
 			if ("data" in response && Array.isArray(response.data) && response.data[0].b64_json) {
@@ -154,7 +154,7 @@ export class HFInferenceTextToImageTask extends HFInferenceTask implements TextT
 			}
 			return response;
 		}
-		throw new InferenceOutputError("Expected a Blob ");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference text-to-image API: expected a Blob");
 	}
 }
 
@@ -195,13 +195,12 @@ export class HFInferenceTextGenerationTask extends HFInferenceTask implements Te
 		if (Array.isArray(res) && res.every((x) => "generated_text" in x && typeof x?.generated_text === "string")) {
 			return (res as TextGenerationOutput[])?.[0];
 		}
-		throw new InferenceOutputError("Expected Array<{generated_text: string}>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference text-to-speech API: expected Array<{generated_text: string}>");
 	}
 }
 
 export class HFInferenceAudioClassificationTask extends HFInferenceTask implements AudioClassificationTaskHelper {
 	override async getResponse(response: unknown): Promise<AudioClassificationOutput> {
-		// Add type checking/validation for the 'unknown' input
 		if (
 			Array.isArray(response) &&
 			response.every(
@@ -209,18 +208,15 @@ export class HFInferenceAudioClassificationTask extends HFInferenceTask implemen
 					typeof x === "object" && x !== null && typeof x.label === "string" && typeof x.score === "number"
 			)
 		) {
-			// If validation passes, it's safe to return as AudioClassificationOutput
 			return response;
 		}
-		// If validation fails, throw an error
-		throw new InferenceOutputError("Expected Array<{label: string, score: number}> but received different format");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference audio-classification API: expected Array<{label: string, score: number}> but received different format");
 	}
 }
 
 export class HFInferenceAutomaticSpeechRecognitionTask
 	extends HFInferenceTask
-	implements AutomaticSpeechRecognitionTaskHelper
-{
+	implements AutomaticSpeechRecognitionTaskHelper {
 	override async getResponse(response: AutomaticSpeechRecognitionOutput): Promise<AutomaticSpeechRecognitionOutput> {
 		return response;
 	}
@@ -229,16 +225,16 @@ export class HFInferenceAutomaticSpeechRecognitionTask
 		return "data" in args
 			? args
 			: {
-					...omit(args, "inputs"),
-					data: args.inputs,
-			  };
+				...omit(args, "inputs"),
+				data: args.inputs,
+			};
 	}
 }
 
 export class HFInferenceAudioToAudioTask extends HFInferenceTask implements AudioToAudioTaskHelper {
 	override async getResponse(response: AudioToAudioOutput[]): Promise<AudioToAudioOutput[]> {
 		if (!Array.isArray(response)) {
-			throw new InferenceOutputError("Expected Array");
+			throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference audio-to-audio API: expected Array");
 		}
 		if (
 			!response.every((elem): elem is AudioToAudioOutput => {
@@ -254,7 +250,7 @@ export class HFInferenceAudioToAudioTask extends HFInferenceTask implements Audi
 				);
 			})
 		) {
-			throw new InferenceOutputError("Expected Array<{label: string, audio: Blob}>");
+			throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference audio-to-audio API: expected Array<{label: string, audio: Blob}>");
 		}
 		return response;
 	}
@@ -262,8 +258,7 @@ export class HFInferenceAudioToAudioTask extends HFInferenceTask implements Audi
 
 export class HFInferenceDocumentQuestionAnsweringTask
 	extends HFInferenceTask
-	implements DocumentQuestionAnsweringTaskHelper
-{
+	implements DocumentQuestionAnsweringTaskHelper {
 	override async getResponse(
 		response: DocumentQuestionAnsweringOutput
 	): Promise<DocumentQuestionAnsweringOutput[number]> {
@@ -281,7 +276,7 @@ export class HFInferenceDocumentQuestionAnsweringTask
 		) {
 			return response[0];
 		}
-		throw new InferenceOutputError("Expected Array<{answer: string, end: number, score: number, start: number}>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference document-question-answering API: expected Array<{answer: string, end: number, score: number, start: number}>");
 	}
 }
 
@@ -298,7 +293,7 @@ export class HFInferenceFeatureExtractionTask extends HFInferenceTask implements
 		if (Array.isArray(response) && isNumArrayRec(response, 3, 0)) {
 			return response;
 		}
-		throw new InferenceOutputError("Expected Array<number[][][] | number[][] | number[] | number>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference feature-extraction API: expected Array<number[][][] | number[][] | number[] | number>");
 	}
 }
 
@@ -307,7 +302,7 @@ export class HFInferenceImageClassificationTask extends HFInferenceTask implemen
 		if (Array.isArray(response) && response.every((x) => typeof x.label === "string" && typeof x.score === "number")) {
 			return response;
 		}
-		throw new InferenceOutputError("Expected Array<{label: string, score: number}>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference image-classification API: expected Array<{label: string, score: number}>");
 	}
 }
 
@@ -324,14 +319,14 @@ export class HFInferenceImageSegmentationTask extends HFInferenceTask implements
 		) {
 			return response;
 		}
-		throw new InferenceOutputError("Expected Array<{label: string, mask: string, score: number}>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference image-segmentation API: expected Array<{label: string, mask: string, score: number}>");
 	}
 }
 
 export class HFInferenceImageToTextTask extends HFInferenceTask implements ImageToTextTaskHelper {
 	override async getResponse(response: ImageToTextOutput): Promise<ImageToTextOutput> {
 		if (typeof response?.generated_text !== "string") {
-			throw new InferenceOutputError("Expected {generated_text: string}");
+			throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference image-to-text API: expected {generated_text: string}");
 		}
 		return response;
 	}
@@ -359,7 +354,7 @@ export class HFInferenceImageToImageTask extends HFInferenceTask implements Imag
 		if (response instanceof Blob) {
 			return response;
 		}
-		throw new InferenceOutputError("Expected Blob");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference image-to-image API: expected Blob");
 	}
 }
 
@@ -379,21 +374,20 @@ export class HFInferenceObjectDetectionTask extends HFInferenceTask implements O
 		) {
 			return response;
 		}
-		throw new InferenceOutputError(
-			"Expected Array<{label: string, score: number, box: {xmin: number, ymin: number, xmax: number, ymax: number}}>"
+		throw new HfInferenceProviderOutputError(
+			"Received malformed response from HF-Inference object-detection API: expected Array<{label: string, score: number, box: {xmin: number, ymin: number, xmax: number, ymax: number}}>"
 		);
 	}
 }
 
 export class HFInferenceZeroShotImageClassificationTask
 	extends HFInferenceTask
-	implements ZeroShotImageClassificationTaskHelper
-{
+	implements ZeroShotImageClassificationTaskHelper {
 	override async getResponse(response: ZeroShotImageClassificationOutput): Promise<ZeroShotImageClassificationOutput> {
 		if (Array.isArray(response) && response.every((x) => typeof x.label === "string" && typeof x.score === "number")) {
 			return response;
 		}
-		throw new InferenceOutputError("Expected Array<{label: string, score: number}>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference zero-shot-image-classification API: expected Array<{label: string, score: number}>");
 	}
 }
 
@@ -403,7 +397,7 @@ export class HFInferenceTextClassificationTask extends HFInferenceTask implement
 		if (Array.isArray(output) && output.every((x) => typeof x?.label === "string" && typeof x.score === "number")) {
 			return output;
 		}
-		throw new InferenceOutputError("Expected Array<{label: string, score: number}>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference text-classification API: expected Array<{label: string, score: number}>");
 	}
 }
 
@@ -414,24 +408,24 @@ export class HFInferenceQuestionAnsweringTask extends HFInferenceTask implements
 		if (
 			Array.isArray(response)
 				? response.every(
-						(elem) =>
-							typeof elem === "object" &&
-							!!elem &&
-							typeof elem.answer === "string" &&
-							typeof elem.end === "number" &&
-							typeof elem.score === "number" &&
-							typeof elem.start === "number"
-				  )
+					(elem) =>
+						typeof elem === "object" &&
+						!!elem &&
+						typeof elem.answer === "string" &&
+						typeof elem.end === "number" &&
+						typeof elem.score === "number" &&
+						typeof elem.start === "number"
+				)
 				: typeof response === "object" &&
-				  !!response &&
-				  typeof response.answer === "string" &&
-				  typeof response.end === "number" &&
-				  typeof response.score === "number" &&
-				  typeof response.start === "number"
+				!!response &&
+				typeof response.answer === "string" &&
+				typeof response.end === "number" &&
+				typeof response.score === "number" &&
+				typeof response.start === "number"
 		) {
 			return Array.isArray(response) ? response[0] : response;
 		}
-		throw new InferenceOutputError("Expected Array<{answer: string, end: number, score: number, start: number}>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference question-answering API: expected Array<{answer: string, end: number, score: number, start: number}>");
 	}
 }
 
@@ -449,8 +443,8 @@ export class HFInferenceFillMaskTask extends HFInferenceTask implements FillMask
 		) {
 			return response;
 		}
-		throw new InferenceOutputError(
-			"Expected Array<{score: number, sequence: string, token: number, token_str: string}>"
+		throw new HfInferenceProviderOutputError(
+			"Received malformed response from HF-Inference fill-mask API: expected Array<{score: number, sequence: string, token: number, token_str: string}>"
 		);
 	}
 }
@@ -470,7 +464,7 @@ export class HFInferenceZeroShotClassificationTask extends HFInferenceTask imple
 		) {
 			return response;
 		}
-		throw new InferenceOutputError("Expected Array<{labels: string[], scores: number[], sequence: string}>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference zero-shot-classification API: expected Array<{labels: string[], scores: number[], sequence: string}>");
 	}
 }
 
@@ -479,7 +473,7 @@ export class HFInferenceSentenceSimilarityTask extends HFInferenceTask implement
 		if (Array.isArray(response) && response.every((x) => typeof x === "number")) {
 			return response;
 		}
-		throw new InferenceOutputError("Expected Array<number>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference sentence-similarity API: expected Array<number>");
 	}
 }
 
@@ -510,8 +504,8 @@ export class HFInferenceTableQuestionAnsweringTask extends HFInferenceTask imple
 		) {
 			return Array.isArray(response) ? response[0] : response;
 		}
-		throw new InferenceOutputError(
-			"Expected {aggregator: string, answer: string, cells: string[], coordinates: number[][]}"
+		throw new HfInferenceProviderOutputError(
+			"Received malformed response from HF-Inference table-question-answering API: expected {aggregator: string, answer: string, cells: string[], coordinates: number[][]}"
 		);
 	}
 }
@@ -531,8 +525,8 @@ export class HFInferenceTokenClassificationTask extends HFInferenceTask implemen
 		) {
 			return response;
 		}
-		throw new InferenceOutputError(
-			"Expected Array<{end: number, entity_group: string, score: number, start: number, word: string}>"
+		throw new HfInferenceProviderOutputError(
+			"Received malformed response from HF-Inference token-classification API: expected Array<{end: number, entity_group: string, score: number, start: number, word: string}>"
 		);
 	}
 }
@@ -542,7 +536,7 @@ export class HFInferenceTranslationTask extends HFInferenceTask implements Trans
 		if (Array.isArray(response) && response.every((x) => typeof x?.translation_text === "string")) {
 			return response?.length === 1 ? response?.[0] : response;
 		}
-		throw new InferenceOutputError("Expected Array<{translation_text: string}>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference translation API: expected Array<{translation_text: string}>");
 	}
 }
 
@@ -551,7 +545,7 @@ export class HFInferenceSummarizationTask extends HFInferenceTask implements Sum
 		if (Array.isArray(response) && response.every((x) => typeof x?.summary_text === "string")) {
 			return response?.[0];
 		}
-		throw new InferenceOutputError("Expected Array<{summary_text: string}>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference summarization API: expected Array<{summary_text: string}>");
 	}
 }
 
@@ -566,14 +560,13 @@ export class HFInferenceTabularClassificationTask extends HFInferenceTask implem
 		if (Array.isArray(response) && response.every((x) => typeof x === "number")) {
 			return response;
 		}
-		throw new InferenceOutputError("Expected Array<number>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference tabular-classification API: expected Array<number>");
 	}
 }
 
 export class HFInferenceVisualQuestionAnsweringTask
 	extends HFInferenceTask
-	implements VisualQuestionAnsweringTaskHelper
-{
+	implements VisualQuestionAnsweringTaskHelper {
 	override async getResponse(response: VisualQuestionAnsweringOutput): Promise<VisualQuestionAnsweringOutput[number]> {
 		if (
 			Array.isArray(response) &&
@@ -584,7 +577,7 @@ export class HFInferenceVisualQuestionAnsweringTask
 		) {
 			return response[0];
 		}
-		throw new InferenceOutputError("Expected Array<{answer: string, score: number}>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference visual-question-answering API: expected Array<{answer: string, score: number}>");
 	}
 }
 
@@ -593,7 +586,7 @@ export class HFInferenceTabularRegressionTask extends HFInferenceTask implements
 		if (Array.isArray(response) && response.every((x) => typeof x === "number")) {
 			return response;
 		}
-		throw new InferenceOutputError("Expected Array<number>");
+		throw new HfInferenceProviderOutputError("Received malformed response from HF-Inference tabular-regression API: expected Array<number>");
 	}
 }
 

--- a/packages/inference/src/providers/hyperbolic.ts
+++ b/packages/inference/src/providers/hyperbolic.ts
@@ -15,7 +15,6 @@
  * Thanks!
  */
 import type { ChatCompletionOutput, TextGenerationOutput } from "@huggingface/tasks";
-import { InferenceOutputError } from "../lib/InferenceOutputError.js";
 import type { BodyParams, UrlParams } from "../types.js";
 import { omit } from "../utils/omit.js";
 import {
@@ -24,7 +23,7 @@ import {
 	TaskProviderHelper,
 	type TextToImageTaskHelper,
 } from "./providerHelper.js";
-
+import { HfInferenceProviderOutputError } from "../error.js";
 const HYPERBOLIC_API_BASE_URL = "https://api.hyperbolic.xyz";
 
 export interface HyperbolicTextCompletionOutput extends Omit<ChatCompletionOutput, "choices"> {
@@ -57,9 +56,9 @@ export class HyperbolicTextGenerationTask extends BaseTextGenerationTask {
 			messages: [{ content: params.args.inputs, role: "user" }],
 			...(params.args.parameters
 				? {
-						max_tokens: (params.args.parameters as Record<string, unknown>).max_new_tokens,
-						...omit(params.args.parameters as Record<string, unknown>, "max_new_tokens"),
-				  }
+					max_tokens: (params.args.parameters as Record<string, unknown>).max_new_tokens,
+					...omit(params.args.parameters as Record<string, unknown>, "max_new_tokens"),
+				}
 				: undefined),
 			...omit(params.args, ["inputs", "parameters"]),
 			model: params.model,
@@ -79,7 +78,7 @@ export class HyperbolicTextGenerationTask extends BaseTextGenerationTask {
 			};
 		}
 
-		throw new InferenceOutputError("Expected Hyperbolic text generation response format");
+		throw new HfInferenceProviderOutputError("Received malformed response from Hyperbolic text generation API");
 	}
 }
 
@@ -121,6 +120,6 @@ export class HyperbolicTextToImageTask extends TaskProviderHelper implements Tex
 			return fetch(`data:image/jpeg;base64,${response.images[0].image}`).then((res) => res.blob());
 		}
 
-		throw new InferenceOutputError("Expected Hyperbolic text-to-image response format");
+		throw new HfInferenceProviderOutputError("Received malformed response from Hyperbolic text-to-image API");
 	}
 }

--- a/packages/inference/src/providers/nebius.ts
+++ b/packages/inference/src/providers/nebius.ts
@@ -15,7 +15,6 @@
  * Thanks!
  */
 import type { FeatureExtractionOutput } from "@huggingface/tasks";
-import { InferenceOutputError } from "../lib/InferenceOutputError.js";
 import type { BodyParams } from "../types.js";
 import { omit } from "../utils/omit.js";
 import {
@@ -25,6 +24,7 @@ import {
 	type FeatureExtractionTaskHelper,
 	type TextToImageTaskHelper,
 } from "./providerHelper.js";
+import { HfInferenceProviderOutputError } from "../error.js";
 
 const NEBIUS_API_BASE_URL = "https://api.studio.nebius.ai";
 
@@ -92,7 +92,7 @@ export class NebiusTextToImageTask extends TaskProviderHelper implements TextToI
 			return fetch(`data:image/jpeg;base64,${base64Data}`).then((res) => res.blob());
 		}
 
-		throw new InferenceOutputError("Expected Nebius text-to-image response format");
+		throw new HfInferenceProviderOutputError("Received malformed response from Nebius text-to-image API");
 	}
 }
 

--- a/packages/inference/src/providers/nscale.ts
+++ b/packages/inference/src/providers/nscale.ts
@@ -15,10 +15,10 @@
  * Thanks!
  */
 import type { TextToImageInput } from "@huggingface/tasks";
-import { InferenceOutputError } from "../lib/InferenceOutputError.js";
 import type { BodyParams } from "../types.js";
 import { omit } from "../utils/omit.js";
 import { BaseConversationalTask, TaskProviderHelper, type TextToImageTaskHelper } from "./providerHelper.js";
+import { HfInferenceProviderOutputError } from "../error.js";
 
 const NSCALE_API_BASE_URL = "https://inference.api.nscale.com";
 
@@ -74,6 +74,6 @@ export class NscaleTextToImageTask extends TaskProviderHelper implements TextToI
 			return fetch(`data:image/jpeg;base64,${base64Data}`).then((res) => res.blob());
 		}
 
-		throw new InferenceOutputError("Expected Nscale text-to-image response format");
+		throw new HfInferenceProviderOutputError("Received malformed response from Nscale text-to-image API");
 	}
 }

--- a/packages/inference/src/providers/ovhcloud.ts
+++ b/packages/inference/src/providers/ovhcloud.ts
@@ -17,10 +17,10 @@
 
 import { BaseConversationalTask, BaseTextGenerationTask } from "./providerHelper.js";
 import type { ChatCompletionOutput, TextGenerationOutput, TextGenerationOutputFinishReason } from "@huggingface/tasks";
-import { InferenceOutputError } from "../lib/InferenceOutputError.js";
 import type { BodyParams } from "../types.js";
 import { omit } from "../utils/omit.js";
 import type { TextGenerationInput } from "@huggingface/tasks";
+import { HfInferenceProviderOutputError } from "../error.js";
 
 const OVHCLOUD_API_BASE_URL = "https://oai.endpoints.kepler.ai.cloud.ovh.net";
 
@@ -50,9 +50,9 @@ export class OvhCloudTextGenerationTask extends BaseTextGenerationTask {
 			...omit(params.args, ["inputs", "parameters"]),
 			...(params.args.parameters
 				? {
-						max_tokens: (params.args.parameters as Record<string, unknown>).max_new_tokens,
-						...omit(params.args.parameters as Record<string, unknown>, "max_new_tokens"),
-				  }
+					max_tokens: (params.args.parameters as Record<string, unknown>).max_new_tokens,
+					...omit(params.args.parameters as Record<string, unknown>, "max_new_tokens"),
+				}
 				: undefined),
 			prompt: params.args.inputs,
 		};
@@ -70,6 +70,6 @@ export class OvhCloudTextGenerationTask extends BaseTextGenerationTask {
 				generated_text: completion.text,
 			};
 		}
-		throw new InferenceOutputError("Expected OVHcloud text generation response format");
+		throw new HfInferenceProviderOutputError("Received malformed response from OVHcloud text generation API");
 	}
 }

--- a/packages/inference/src/providers/providerHelper.ts
+++ b/packages/inference/src/providers/providerHelper.ts
@@ -46,7 +46,7 @@ import type {
 	ZeroShotImageClassificationOutput,
 } from "@huggingface/tasks";
 import { HF_ROUTER_URL } from "../config.js";
-import { InferenceOutputError } from "../lib/InferenceOutputError.js";
+import { HfInferenceProviderOutputError } from "../error.js";
 import type { AudioToAudioOutput } from "../tasks/audio/audioToAudio.js";
 import type { BaseArgs, BodyParams, HeaderParams, InferenceProvider, RequestArgs, UrlParams } from "../types.js";
 import { toArray } from "../utils/toArray.js";
@@ -61,7 +61,7 @@ export abstract class TaskProviderHelper {
 		readonly provider: InferenceProvider,
 		private baseUrl: string,
 		readonly clientSideRoutingOnly: boolean = false
-	) {}
+	) { }
 
 	/**
 	 * Return the response in the expected format.
@@ -320,7 +320,7 @@ export class BaseConversationalTask extends TaskProviderHelper implements Conver
 			return response;
 		}
 
-		throw new InferenceOutputError("Expected ChatCompletionOutput");
+		throw new HfInferenceProviderOutputError("Expected ChatCompletionOutput");
 	}
 }
 
@@ -353,6 +353,6 @@ export class BaseTextGenerationTask extends TaskProviderHelper implements TextGe
 			return res[0];
 		}
 
-		throw new InferenceOutputError("Expected Array<{generated_text: string}>");
+		throw new HfInferenceProviderOutputError("Expected Array<{generated_text: string}>");
 	}
 }

--- a/packages/inference/src/providers/replicate.ts
+++ b/packages/inference/src/providers/replicate.ts
@@ -14,7 +14,7 @@
  *
  * Thanks!
  */
-import { InferenceOutputError } from "../lib/InferenceOutputError.js";
+import { HfInferenceProviderOutputError } from "../error.js";
 import { isUrl } from "../lib/isUrl.js";
 import type { BodyParams, HeaderParams, UrlParams } from "../types.js";
 import { omit } from "../utils/omit.js";
@@ -99,7 +99,7 @@ export class ReplicateTextToImageTask extends ReplicateTask implements TextToIma
 			return await urlResponse.blob();
 		}
 
-		throw new InferenceOutputError("Expected Replicate text-to-image response format");
+		throw new HfInferenceProviderOutputError("Received malformed response from Replicate text-to-image API");
 	}
 }
 
@@ -132,7 +132,7 @@ export class ReplicateTextToSpeechTask extends ReplicateTask {
 				}
 			}
 		}
-		throw new InferenceOutputError("Expected Blob or object with output");
+		throw new HfInferenceProviderOutputError("Received malformed response from Replicate text-to-speech API");
 	}
 }
 
@@ -149,6 +149,6 @@ export class ReplicateTextToVideoTask extends ReplicateTask implements TextToVid
 			return await urlResponse.blob();
 		}
 
-		throw new InferenceOutputError("Expected { output: string }");
+		throw new HfInferenceProviderOutputError("Received malformed response from Replicate text-to-video API");
 	}
 }

--- a/packages/inference/src/providers/sambanova.ts
+++ b/packages/inference/src/providers/sambanova.ts
@@ -14,12 +14,11 @@
  *
  * Thanks!
  */
-import { InferenceOutputError } from "../lib/InferenceOutputError.js";
-
 import type { FeatureExtractionOutput } from "@huggingface/tasks";
 import type { BodyParams } from "../types.js";
 import type { FeatureExtractionTaskHelper } from "./providerHelper.js";
 import { BaseConversationalTask, TaskProviderHelper } from "./providerHelper.js";
+import { HfInferenceProviderOutputError } from "../error.js";
 
 export class SambanovaConversationalTask extends BaseConversationalTask {
 	constructor() {
@@ -40,8 +39,8 @@ export class SambanovaFeatureExtractionTask extends TaskProviderHelper implement
 		if (typeof response === "object" && "data" in response && Array.isArray(response.data)) {
 			return response.data.map((item) => item.embedding);
 		}
-		throw new InferenceOutputError(
-			"Expected Sambanova feature-extraction (embeddings) response format to be {'data' : list of {'embedding' : number[]}}"
+		throw new HfInferenceProviderOutputError(
+			"Received malformed response from Sambanova feature-extraction (embeddings) API"
 		);
 	}
 

--- a/packages/inference/src/providers/together.ts
+++ b/packages/inference/src/providers/together.ts
@@ -15,7 +15,6 @@
  * Thanks!
  */
 import type { ChatCompletionOutput, TextGenerationOutput, TextGenerationOutputFinishReason } from "@huggingface/tasks";
-import { InferenceOutputError } from "../lib/InferenceOutputError.js";
 import type { BodyParams } from "../types.js";
 import { omit } from "../utils/omit.js";
 import {
@@ -24,6 +23,7 @@ import {
 	TaskProviderHelper,
 	type TextToImageTaskHelper,
 } from "./providerHelper.js";
+import { HfInferenceProviderOutputError } from "../error.js";
 
 const TOGETHER_API_BASE_URL = "https://api.together.xyz";
 
@@ -74,7 +74,7 @@ export class TogetherTextGenerationTask extends BaseTextGenerationTask {
 				generated_text: completion.text,
 			};
 		}
-		throw new InferenceOutputError("Expected Together text generation response format");
+		throw new HfInferenceProviderOutputError("Received malformed response from Together text generation API");
 	}
 }
 
@@ -113,6 +113,6 @@ export class TogetherTextToImageTask extends TaskProviderHelper implements TextT
 			return fetch(`data:image/jpeg;base64,${base64Data}`).then((res) => res.blob());
 		}
 
-		throw new InferenceOutputError("Expected Together text-to-image response format");
+		throw new HfInferenceProviderOutputError("Received malformed response from Together text-to-image API");
 	}
 }

--- a/packages/inference/src/tasks/audio/automaticSpeechRecognition.ts
+++ b/packages/inference/src/tasks/audio/automaticSpeechRecognition.ts
@@ -1,10 +1,10 @@
 import type { AutomaticSpeechRecognitionInput, AutomaticSpeechRecognitionOutput } from "@huggingface/tasks";
 import { resolveProvider } from "../../lib/getInferenceProviderMapping.js";
 import { getProviderHelper } from "../../lib/getProviderHelper.js";
-import { InferenceOutputError } from "../../lib/InferenceOutputError.js";
 import type { BaseArgs, Options } from "../../types.js";
 import { innerRequest } from "../../utils/request.js";
 import type { LegacyAudioInput } from "./utils.js";
+import { HfInferenceProviderOutputError } from "../../error.js";
 
 export type AutomaticSpeechRecognitionArgs = BaseArgs & (AutomaticSpeechRecognitionInput | LegacyAudioInput);
 /**
@@ -24,7 +24,7 @@ export async function automaticSpeechRecognition(
 	});
 	const isValidOutput = typeof res?.text === "string";
 	if (!isValidOutput) {
-		throw new InferenceOutputError("Expected {text: string}");
+		throw new HfInferenceProviderOutputError("Received malformed response from automatic-speech-recognition API");
 	}
 	return providerHelper.getResponse(res);
 }

--- a/packages/inference/src/vendor/type-fest/basic.ts
+++ b/packages/inference/src/vendor/type-fest/basic.ts
@@ -1,0 +1,31 @@
+/**
+Matches a JSON object.
+
+This type can be useful to enforce some input to be JSON-compatible or as a super-type to be extended from. Don't use this as a direct return type as the user would have to double-cast it: `jsonObject as unknown as CustomResponse`. Instead, you could extend your CustomResponse type from it to ensure your type only uses JSON-compatible types: `interface CustomResponse extends JsonObject { … }`.
+
+@category JSON
+*/
+export type JsonObject = { [Key in string]: JsonValue } & { [Key in string]?: JsonValue | undefined };
+
+/**
+Matches a JSON array.
+
+@category JSON
+*/
+export type JsonArray = JsonValue[] | readonly JsonValue[];
+
+/**
+Matches any valid JSON primitive value.
+
+@category JSON
+*/
+export type JsonPrimitive = string | number | boolean | null;
+
+/**
+Matches any valid JSON value.
+
+@see `Jsonify` if you need to transform a type to one that is assignable to `JsonValue`.
+
+@category JSON
+*/
+export type JsonValue = JsonPrimitive | JsonObject | JsonArray;

--- a/packages/inference/src/vendor/type-fest/license-cc0
+++ b/packages/inference/src/vendor/type-fest/license-cc0
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/packages/inference/src/vendor/type-fest/license-mit
+++ b/packages/inference/src/vendor/type-fest/license-mit
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Introduces new error types to allow narrower error handling downstream
Those errors hold more context, including the underlying http request / response when required

This is a breakin change because we remove the `InferenceOutputError` type and change the error types thrown by the public methods.

TODO:
- [ ] Add examples of error handling in the README