### PR TITLE
[MCP] fix: stray token leak when early-exit is triggered

### DIFF
--- a/packages/mcp-client/src/McpClient.ts
+++ b/packages/mcp-client/src/McpClient.ts
@@ -145,7 +145,6 @@ export class McpClient {
 			if (opts.abortSignal?.aborted) {
 				throw new Error("AbortError");
 			}
-			yield chunk;
 			debug(chunk.choices[0]);
 			numOfChunks++;
 			const delta = chunk.choices[0]?.delta;
@@ -174,6 +173,7 @@ export class McpClient {
 				/// If no tool is present in chunk number 1 or 2, exit.
 				return;
 			}
+			yield chunk;
 		}
 
 		messages.push(message);


### PR DESCRIPTION
similar PR to https://github.com/huggingface/huggingface_hub/pull/3132.

as explained by @danielholanda in the PR, when `opts.exitIfFirstChunkNoTool` is `True`, the CLI is supposed to abort streaming if the first chunk contains no tool call. However, we currently yield the first chunk before checking the exit condition, so a "vestigial" token still reached the user. This PR fixes this behavior. 