### PR TITLE
add InferenceCore to matanyone code snippet

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -731,6 +731,9 @@ export const matanyone = (model: ModelData): string[] => [
 
 from matanyone.model.matanyone import MatAnyone
 model = MatAnyone.from_pretrained("${model.id}")`,
+	`
+from matanyone import InferenceCore
+processor = InferenceCore("${model.id}")`,
 ];
 
 export const mesh_anything = (): string[] => [


### PR DESCRIPTION
minor improvement to the matanyone code snippet following https://github.com/pq-yang/MatAnyone/pull/35 adding the second method for loading the model using the `InferenceCore` a class that automatically loads the model and easily processes videos.
this snippet is intended to be used as follows : 
```python
from matanyone.inference.inference_core import InferenceCore
processor = InferenceCore("PeiqingYang/MatAnyone")

# foreground_path, alpha_path = processor.process_video(
#     input_path = "inputs/video/test-sample1.mp4",
#     mask_path = "inputs/mask/test-sample1.png",
#     output_path = "outputs"
# )
```