### PR TITLE
Fix Typo in Test Description and Update Link Formatting in Documentation

### DIFF
--- a/packages/jinja/test/templates.test.js
+++ b/packages/jinja/test/templates.test.js
@@ -4337,7 +4337,7 @@ describe("Templates", () => {
 		// TODO add failure cases
 	});
 
-	describe("Parsing and intepretation", () => {
+	describe("Parsing and interpretation", () => {
 		describe("should interpret an AST", () => {
 			for (const [name, text] of Object.entries(TEST_PARSED)) {
 				const ast = parse(text);

--- a/packages/tasks/src/tasks/text-generation/about.md
+++ b/packages/tasks/src/tasks/text-generation/about.md
@@ -101,7 +101,7 @@ Would you like to learn more about the topic? Awesome! Here you can find some cu
 
 - You can use [PEFT](https://github.com/huggingface/peft) to adapt large language models in efficient way.
 - [ChatUI](https://github.com/huggingface/chat-ui) is the open-source interface to conversate with Large Language Models.
-- [text-generation-inferface](https://github.com/huggingface/text-generation-inference)
+- [text-generation-interface](https://github.com/huggingface/text-generation-inference)
 - [HuggingChat](https://huggingface.co/chat/) is a chat interface powered by Hugging Face to chat with powerful models like Meta Llama 3 70B, Mixtral 8x7B, etc.
 
 ### Documentation


### PR DESCRIPTION


Description:  
This pull request addresses two minor issues:
1. Corrects a typo in the test suite description from "interpretation" to "interpretation" in `packages/jinja/test/templates.test.js`.
2. Updates the link formatting for the text-generation-inference repository in the documentation file `packages/tasks/src/tasks/text-generation/about.md` for consistency.

