### PR TITLE
Update documentation link in README to current Hugging Face JS docs

### DIFF
--- a/packages/languages/README.md
+++ b/packages/languages/README.md
@@ -21,6 +21,6 @@ import { language, wikiLink, type Language } from "https://esm.sh/@huggingface/l
 import { language, wikiLink, type Language } from "npm:@huggingface/languages"
 ```
 
-Check out the [full documentation](https://huggingface.co/docs/huggingface.js/languages/README).
+Check out the [full documentation](https://huggingface.co/docs/huggingface.js/index).
 
 Acknowledging Loïck Bourdois (https://github.com/lbourdois)'s help with this package and more generally supporting languages on the HF Hub.


### PR DESCRIPTION
Replaced the outdated link to the Hugging Face JS languages documentation with the correct and up-to-date URL (https://huggingface.co/docs/huggingface.js/index) in the README. This ensures users are directed to the latest documentation.