### PR TITLE
[InferenceSnippets] Fix HF_TOKEN not used if https:// in example

### DIFF
--- a/packages/inference/src/snippets/getInferenceSnippets.ts
+++ b/packages/inference/src/snippets/getInferenceSnippets.ts
@@ -466,7 +466,7 @@ function replaceAccessTokenPlaceholder(
 		!endpointUrl && // custom endpointUrl => use a generic API_TOKEN
 		(provider == "hf-inference" || // hf-inference provider => use $HF_TOKEN
 			(!directRequest && // if explicit directRequest => use provider-specific token
-				(!snippet.includes("https://") || // no URL provided => using a client => use $HF_TOKEN
+				(snippet.includes("InferenceClient") || // using a client => use $HF_TOKEN
 					snippet.includes("https://router.huggingface.co")))); // explicit routed request => use $HF_TOKEN
 	const accessTokenEnvVar = useHfToken
 		? "HF_TOKEN" // e.g. routed request or hf-inference

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/huggingface.js/0.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/huggingface.js/0.fireworks-ai.js
@@ -1,6 +1,6 @@
 import { InferenceClient } from "@huggingface/inference";
 
-const client = new InferenceClient(process.env.FIREWORKS_AI_API_KEY);
+const client = new InferenceClient(process.env.HF_TOKEN);
 
 const chatCompletion = await client.chatCompletion({
     provider: "fireworks-ai",

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/huggingface_hub/0.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/huggingface_hub/0.fireworks-ai.py
@@ -3,7 +3,7 @@ from huggingface_hub import InferenceClient
 
 client = InferenceClient(
     provider="fireworks-ai",
-    api_key=os.environ["FIREWORKS_AI_API_KEY"],
+    api_key=os.environ["HF_TOKEN"],
 )
 
 completion = client.chat.completions.create(

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/huggingface.js/0.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/huggingface.js/0.fireworks-ai.js
@@ -1,6 +1,6 @@
 import { InferenceClient } from "@huggingface/inference";
 
-const client = new InferenceClient(process.env.FIREWORKS_AI_API_KEY);
+const client = new InferenceClient(process.env.HF_TOKEN);
 
 let out = "";
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/huggingface_hub/0.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/huggingface_hub/0.fireworks-ai.py
@@ -3,7 +3,7 @@ from huggingface_hub import InferenceClient
 
 client = InferenceClient(
     provider="fireworks-ai",
-    api_key=os.environ["FIREWORKS_AI_API_KEY"],
+    api_key=os.environ["HF_TOKEN"],
 )
 
 stream = client.chat.completions.create(


### PR DESCRIPTION
I was using a condition a bit dirty to check whether the `HF_TOKEN` or the provider token should be used (based on presence of `https://` in the example). This PR makes the condition more robust by checking the presence of `InferenceClient` instead. 

**Expectation:** https://huggingface.co/Qwen/Qwen2.5-VL-32B-Instruct?inference_api=true&inference_provider=fireworks-ai&language=python should use `HF_TOKEN` instead of `api_key=os.environ["FIREWORKS_AI_API_KEY"],`.

thanks @Vaibhavs10 for [flagging](https://huggingface.slack.com/archives/C089DMDB415/p1749822922352309) (private slack)