### PR TITLE
Update chat-completion json_schema specs (JS)

### DIFF
--- a/packages/tasks/src/tasks/chat-completion/inference.ts
+++ b/packages/tasks/src/tasks/chat-completion/inference.ts
@@ -136,17 +136,35 @@ export interface ChatCompletionInputFunctionDefinition {
 	[property: string]: unknown;
 }
 export interface ChatCompletionInputGrammarType {
+	json_schema?: ChatCompletionInputJSONSchemaConfig;
 	type: ChatCompletionInputGrammarTypeType;
-	/**
-	 * A string that represents a [JSON Schema](https://json-schema.org/).
-	 *
-	 * JSON Schema is a declarative language that allows to annotate JSON documents
-	 * with types and descriptions.
-	 */
-	value: unknown;
 	[property: string]: unknown;
 }
-export type ChatCompletionInputGrammarTypeType = "json" | "regex" | "json_schema";
+export interface ChatCompletionInputJSONSchemaConfig {
+	/**
+	 * A description of what the response format is for, used by the model to determine how to
+	 * respond in the format.
+	 */
+	description?: string;
+	/**
+	 * The name of the response format.
+	 */
+	name: string;
+	/**
+	 * The schema for the response format, described as a JSON Schema object. Learn how to build
+	 * JSON schemas [here](https://json-schema.org/).
+	 */
+	schema?: {
+		[key: string]: unknown;
+	};
+	/**
+	 * Whether to enable strict schema adherence when generating the output. If set to true, the
+	 * model will always follow the exact schema defined in the `schema` field.
+	 */
+	strict?: boolean;
+	[property: string]: unknown;
+}
+export type ChatCompletionInputGrammarTypeType = "text" | "json_schema" | "json_object";
 export interface ChatCompletionInputStreamOptions {
 	/**
 	 * If set, an additional chunk will be streamed before the data: [DONE] message. The usage

--- a/packages/tasks/src/tasks/chat-completion/spec/input.json
+++ b/packages/tasks/src/tasks/chat-completion/spec/input.json
@@ -291,61 +291,75 @@
 		"ChatCompletionInputGrammarType": {
 			"oneOf": [
 				{
-					"type": "object",
-					"required": ["type", "value"],
-					"properties": {
-						"type": {
-							"type": "string",
-							"enum": ["json"]
-						},
-						"value": {
-							"description": "A string that represents a [JSON Schema](https://json-schema.org/).\n\nJSON Schema is a declarative language that allows to annotate JSON documents\nwith types and descriptions."
-						}
-					}
+					"$ref": "#/$defs/ChatCompletionInputResponseFormatText"
 				},
 				{
-					"type": "object",
-					"required": ["type", "value"],
-					"properties": {
-						"type": {
-							"type": "string",
-							"enum": ["regex"]
-						},
-						"value": {
-							"type": "string"
-						}
-					}
+					"$ref": "#/$defs/ChatCompletionInputResponseFormatJSONSchema"
 				},
 				{
-					"type": "object",
-					"required": ["type", "value"],
-					"properties": {
-						"type": {
-							"type": "string",
-							"enum": ["json_schema"]
-						},
-						"value": {
-							"$ref": "#/$defs/ChatCompletionInputJsonSchemaConfig"
-						}
-					}
+					"$ref": "#/$defs/ChatCompletionInputResponseFormatJSONObject"
 				}
 			],
-			"discriminator": {
-				"propertyName": "type"
-			},
 			"title": "ChatCompletionInputGrammarType"
+		},
+		"ChatCompletionInputResponseFormatText": {
+			"type": "object",
+			"required": ["type"],
+			"properties": {
+				"type": {
+					"type": "string",
+					"enum": ["text"]
+				}
+			},
+			"title": "ChatCompletionInputResponseFormatText"
+		},
+		"ChatCompletionInputResponseFormatJSONSchema": {
+			"type": "object",
+			"required": ["type", "json_schema"],
+			"properties": {
+				"type": {
+					"type": "string",
+					"enum": ["json_schema"]
+				},
+				"json_schema": {
+					"$ref": "#/$defs/ChatCompletionInputJsonSchemaConfig"
+				}
+			},
+			"title": "ChatCompletionInputResponseFormatJSONSchema"
+		},
+		"ChatCompletionInputResponseFormatJSONObject": {
+			"type": "object",
+			"required": ["type"],
+			"properties": {
+				"type": {
+					"type": "string",
+					"enum": ["json_object"]
+				}
+			},
+			"title": "ChatCompletionInputResponseFormatJSONObject"
 		},
 		"ChatCompletionInputJsonSchemaConfig": {
 			"type": "object",
-			"required": ["schema"],
+			"required": ["name"],
 			"properties": {
 				"name": {
 					"type": "string",
-					"description": "Optional name identifier for the schema",
+					"description": "The name of the response format."
+				},
+				"description": {
+					"type": "string",
+					"description": "A description of what the response format is for, used by the model to determine how to respond in the format.",
 					"nullable": true
 				},
 				"schema": {
-					"description": "The actual JSON schema definition"
+					"type": "object",
+					"description": "The schema for the response format, described as a JSON Schema object. Learn how to build JSON schemas [here](https://json-schema.org/).",
+					"nullable": true
+				},
+				"strict": {
+					"type": "boolean",
+					"description": "Whether to enable strict schema adherence when generating the output. If set to true, the model will always follow the exact schema defined in the `schema` field.",
+					"nullable": true
 				}
 			},
 			"title": "ChatCompletionInputJsonSchemaConfig"


### PR DESCRIPTION
In https://github.com/huggingface/huggingface_hub/pull/3082 @hanouticelina fixed the Python inference types for chat completion grammar input.  Biggest update was:

```py
@dataclass_with_extra
class ChatCompletionInputResponseFormatText(BaseInferenceType):
    type: Literal["text"]


@dataclass_with_extra
class ChatCompletionInputResponseFormatJSONSchema(BaseInferenceType):
    type: Literal["json_schema"]
    json_schema: ChatCompletionInputJSONSchema


@dataclass_with_extra
class ChatCompletionInputResponseFormatJSONObject(BaseInferenceType):
    type: Literal["json_object"]


ChatCompletionInputGrammarType = Union[
    ChatCompletionInputResponseFormatText,
    ChatCompletionInputResponseFormatJSONSchema,
    ChatCompletionInputResponseFormatJSONObject,
]
```

---

This PR reflects "officially" this update in the JS specs. It makes JS and Python specs aligned again (was not the case for the last month, ending up with annoying PRs like this one https://github.com/huggingface/huggingface_hub/pull/3104). The result is not as satisfying as what a manual implementation would give because the 3 objects are merged in 1 with optional fields (see `export type ChatCompletionInputGrammarTypeType = "text" | "json_schema" | "json_object";`). This is because quicktype do not handle properly unions (see https://github.com/glideapps/quicktype/issues/1266 - 6 yo :confused: ). It's not the only case like this in our specs but first time I find out about it. Not a problem since we don't enforce data structures.


In Python, the data structure will result in this: https://github.com/huggingface/huggingface_hub/pull/3167
