### PR TITLE
Add NVIDIA B200 to hardware.ts

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -38,6 +38,10 @@ export const DEFAULT_MEMORY_OPTIONS = [
 export const SKUS = {
 	GPU: {
 		NVIDIA: {
+			B200: {
+				tflops: 496.6,
+				memory: [192],
+			},
 			H200: {
 				tflops: 241.3,
 				memory: [141],


### PR DESCRIPTION
Source: https://www.techpowerup.com/gpu-specs/b200-sxm-192-gb.c4210

Add NVIDIA B200 to hardware list. The VRAM per GPU most commonly advertised by datacenters is 180GB, but some sources (like the link above) list the theoretical value at 192GB.