### PR TITLE
Export InferenceProviderMappingEntry from types.ts

### DIFF
--- a/packages/inference/src/lib/getInferenceProviderMapping.ts
+++ b/packages/inference/src/lib/getInferenceProviderMapping.ts
@@ -2,22 +2,11 @@ import type { WidgetType } from "@huggingface/tasks";
 import { HF_HUB_URL } from "../config.js";
 import { HARDCODED_MODEL_INFERENCE_MAPPING } from "../providers/consts.js";
 import { EQUIVALENT_SENTENCE_TRANSFORMERS_TASKS } from "../providers/hf-inference.js";
-import type { InferenceProvider, InferenceProviderOrPolicy, ModelId } from "../types.js";
+import type { InferenceProvider, InferenceProviderMappingEntry, InferenceProviderOrPolicy, ModelId } from "../types.js";
 import { typedInclude } from "../utils/typedInclude.js";
 import { InferenceClientHubApiError, InferenceClientInputError } from "../errors.js";
 
 export const inferenceProviderMappingCache = new Map<ModelId, InferenceProviderMappingEntry[]>();
-
-export interface InferenceProviderMappingEntry {
-	adapter?: string;
-	adapterWeightsPath?: string;
-	hfModelId: ModelId;
-	provider: string;
-	providerId: string;
-	status: "live" | "staging";
-	task: WidgetType;
-	type?: "single-model" | "tag-filter";
-}
 
 /**
  * Normalize inferenceProviderMapping to always return an array format.

--- a/packages/inference/src/lib/makeRequestOptions.ts
+++ b/packages/inference/src/lib/makeRequestOptions.ts
@@ -1,7 +1,6 @@
 import { HF_HEADER_X_BILL_TO, HF_HUB_URL } from "../config.js";
 import { PACKAGE_NAME, PACKAGE_VERSION } from "../package.js";
-import type { InferenceTask, Options, RequestArgs } from "../types.js";
-import type { InferenceProviderMappingEntry } from "./getInferenceProviderMapping.js";
+import type { InferenceTask, InferenceProviderMappingEntry, Options, RequestArgs } from "../types.js";
 import { getInferenceProviderMapping } from "./getInferenceProviderMapping.js";
 import type { getProviderHelper } from "./getProviderHelper.js";
 import { isUrl } from "./isUrl.js";

--- a/packages/inference/src/providers/consts.ts
+++ b/packages/inference/src/providers/consts.ts
@@ -1,5 +1,4 @@
-import type { InferenceProviderMappingEntry } from "../lib/getInferenceProviderMapping.js";
-import type { InferenceProvider } from "../types.js";
+import type { InferenceProvider, InferenceProviderMappingEntry } from "../types.js";
 import { type ModelId } from "../types.js";
 
 /**

--- a/packages/inference/src/snippets/getInferenceSnippets.ts
+++ b/packages/inference/src/snippets/getInferenceSnippets.ts
@@ -8,10 +8,9 @@ import {
 } from "@huggingface/tasks";
 import type { PipelineType, WidgetType } from "@huggingface/tasks";
 import type { ChatCompletionInputMessage, GenerationParameters } from "@huggingface/tasks";
-import type { InferenceProviderMappingEntry } from "../lib/getInferenceProviderMapping.js";
 import { getProviderHelper } from "../lib/getProviderHelper.js";
 import { makeRequestOptionsFromResolvedModel } from "../lib/makeRequestOptions.js";
-import type { InferenceProviderOrPolicy, InferenceTask, RequestArgs } from "../types.js";
+import type { InferenceProviderMappingEntry, InferenceProviderOrPolicy, InferenceTask, RequestArgs } from "../types.js";
 import { templates } from "./templates.exported.js";
 
 export type InferenceSnippetOptions = {

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -1,5 +1,4 @@
-import type { ChatCompletionInput, PipelineType } from "@huggingface/tasks";
-import type { InferenceProviderMappingEntry } from "./lib/getInferenceProviderMapping.js";
+import type { ChatCompletionInput, PipelineType, WidgetType } from "@huggingface/tasks";
 
 /**
  * HF model id, like "meta-llama/Llama-3.3-70B-Instruct"
@@ -62,6 +61,17 @@ export const PROVIDERS_OR_POLICIES = [...INFERENCE_PROVIDERS, "auto"] as const;
 export type InferenceProvider = (typeof INFERENCE_PROVIDERS)[number];
 
 export type InferenceProviderOrPolicy = (typeof PROVIDERS_OR_POLICIES)[number];
+
+export interface InferenceProviderMappingEntry {
+	adapter?: string;
+	adapterWeightsPath?: string;
+	hfModelId: ModelId;
+	provider: string;
+	providerId: string;
+	status: "live" | "staging";
+	task: WidgetType;
+	type?: "single-model" | "tag-filter";
+}
 
 export interface BaseArgs {
 	/**


### PR DESCRIPTION
Currently `InferenceProviderMappingEntry` is defined in a module that is not exported. This PR moves it to the `types.ts` module for better reusability (will be useful for https://github.com/huggingface/doc-builder/pull/574#discussion_r2154102768)