### PR TITLE
docs: add tiny-agents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This is a collection of JS libraries to interact with the Hugging Face API, with
 - [@huggingface/jinja](packages/jinja/README.md): A minimalistic JS implementation of the Jinja templating engine, to be used for ML chat templates.
 - [@huggingface/space-header](packages/space-header/README.md): Use the Space `mini_header` outside Hugging Face
 - [@huggingface/ollama-utils](packages/ollama-utils/README.md): Various utilities for maintaining Ollama compatibility with models on the Hugging Face Hub.
+- [@huggingface/tiny-agents](packages/tiny-agents/README.md): A tiny, model-agnostic library for building AI agents that can use tools.
 
 
 We use modern features to avoid polyfills and dependencies, so the libraries will only work on modern browsers / Node.js >= 18 / Bun / Deno.


### PR DESCRIPTION
Adds a reference to the @huggingface/tiny-agents package in the main README.md file.