### PR TITLE
Fix SongGeneration download count rule

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -955,10 +955,10 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	},
 	"tencent-song-generation": {
 		prettyLabel: "SongGeneration",
-		repoName: "songgeneration",
+		repoName: "SongGeneration",
 		repoUrl: "https://github.com/tencent-ailab/songgeneration",
 		filter: false,
-		countDownloads: `path:"ckpt/songgeneration_base_zh/model.pt"`,
+		countDownloads: `path:"ckpt/songgeneration_base/model.pt"`,
 	},
 	tensorflowtts: {
 		prettyLabel: "TensorFlowTTS",


### PR DESCRIPTION
Follow-up PR after https://github.com/huggingface/huggingface.js/pull/1542 cc @juhayna-zh @xianbaoqian @Vaibhavs10 
There seems to be a typo in the download count rule. Checkpoint is saved at https://huggingface.co/tencent/SongGeneration/blob/main/ckpt/songgeneration_base/model.pt (under `songgeneration_base`, not `songgeneration_base_zh`). This PR fixes this.

(I also took the opportunity to update `repoName`, it's usually best if it's the same as `prettyLabel`)