### PR TITLE
Update tiny-agent format to follow VSCode format

### DIFF
--- a/packages/tiny-agents/src/lib/types.ts
+++ b/packages/tiny-agents/src/lib/types.ts
@@ -8,53 +8,20 @@ export interface TinyAgentConfig {
 export const ServerConfigSchema = z.discriminatedUnion("type", [
 	z.object({
 		type: z.literal("stdio"),
-		config: z.object({
-			command: z.string(),
-			args: z.array(z.string()).optional(),
-			env: z.record(z.string()).optional(),
-			cwd: z.string().optional(),
-		}),
+		command: z.string(),
+		args: z.array(z.string()).optional(),
+		env: z.record(z.string()).optional(),
+		cwd: z.string().optional(),
 	}),
 	z.object({
 		type: z.literal("http"),
-		config: z.object({
-			url: z.union([z.string(), z.string().url()]),
-			options: z
-				.object({
-					/**
-					 * Customizes HTTP requests to the server.
-					 */
-					requestInit: z
-						.object({
-							headers: z.record(z.string()).optional(),
-						})
-						.optional(),
-					/**
-					 * Session ID for the connection. This is used to identify the session on the server.
-					 * When not provided and connecting to a server that supports session IDs, the server will generate a new session ID.
-					 */
-					sessionId: z.string().optional(),
-				})
-				.optional(),
-		}),
+		url: z.union([z.string(), z.string().url()]),
+		headers: z.record(z.string()).optional(),
 	}),
 	z.object({
 		type: z.literal("sse"),
-		config: z.object({
-			url: z.union([z.string(), z.string().url()]),
-			options: z
-				.object({
-					/**
-					 * Customizes HTTP requests to the server.
-					 */
-					requestInit: z
-						.object({
-							headers: z.record(z.string()).optional(),
-						})
-						.optional(),
-				})
-				.optional(),
-		}),
+		url: z.union([z.string(), z.string().url()]),
+		headers: z.record(z.string()).optional(),
 	}),
 ]);
 

--- a/packages/tiny-agents/test/ServerConfigSchema.spec.ts
+++ b/packages/tiny-agents/test/ServerConfigSchema.spec.ts
@@ -5,10 +5,8 @@ describe("ServerConfigSchema", () => {
 	it("You can parse a server config", async () => {
 		const config = ServerConfigSchema.parse({
 			type: "stdio",
-			config: {
-				command: "npx",
-				args: ["@playwright/mcp@latest"],
-			},
+			command: "npx",
+			args: ["@playwright/mcp@latest"],
 		});
 		expect(config).toBeDefined();
 		expect(config.type).toBe("stdio");


### PR DESCRIPTION
Same PR as https://github.com/huggingface/huggingface_hub/pull/3166 in Python.

This PR introduces breaking changes but I think it's best to do it now. Goal is to have the same format as [VSCode MCP config](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_configuration-format) e.g.

```json
{
  "model": "Qwen/Qwen2.5-72B-Instruct",
  "provider": "nebius",
  "inputs": [
    {
      "type": "promptString",
      "id": "hf-token",
      "description": "Token for Hugging Face API access",
      "password": true
    }
  ],
  "servers": [
    {
      "type": "http",
      "url": "https://huggingface.co/mcp",
      "headers": {
        "Authorization": "Bearer ${input:hf-token}"
      }
    }
  ]
}
```

breaking changes:
- no more `config` nested mapping => everything at root level
- `headers` at root level instead of inside options.requestInit
- updated the way values are pulled from ENV (based on input id)


Once this PR and https://github.com/huggingface/huggingface_hub/pull/3166 are approved, we can merge + release them at the same time + update the config in https://huggingface.co/datasets/tiny-agents/tiny-agents to follow the new convention. For now, only [wauplin/library-pr-reviewer](https://huggingface.co/datasets/tiny-agents/tiny-agents/tree/main/wauplin/library-pr-reviewer) has been updated for testing.

```
pnpm run cli run wauplin/library-pr-reviewer
```