### PR TITLE
fix(hub): test list datasets

### DIFF
--- a/packages/hub/src/lib/list-datasets.spec.ts
+++ b/packages/hub/src/lib/list-datasets.spec.ts
@@ -23,7 +23,7 @@ describe("listDatasets", () => {
 			results.push(entry);
 		}
 
-		expect(results).deep.equal([
+		expect(results).toEqual(expect.arrayContaining([
 			{
 				id: "6356b19985da6f13863228bd",
 				name: "hf-doc-build/doc-build",
@@ -42,6 +42,6 @@ describe("listDatasets", () => {
 				likes: 0,
 				updatedAt: new Date(0),
 			},
-		]);
+		]));
 	});
 });

--- a/packages/hub/src/lib/list-datasets.spec.ts
+++ b/packages/hub/src/lib/list-datasets.spec.ts
@@ -7,7 +7,7 @@ describe("listDatasets", () => {
 		const results: DatasetEntry[] = [];
 
 		for await (const entry of listDatasets({ search: { owner: "hf-doc-build" } })) {
-			if (entry.name !== "hf-doc-build/doc-build-dev-test") {
+			if (entry.name !== "hf-doc-build/doc-build" && entry.name !== "hf-doc-build/doc-build-dev") {
 				continue;
 			}
 			if (typeof entry.downloads === "number") {
@@ -23,12 +23,21 @@ describe("listDatasets", () => {
 			results.push(entry);
 		}
 
-		expect(results).deep.equal([
+		expect(results.sort((a, b) => a.id.localeCompare(b.id))).to.deep.equal([
 			{
-				id: "659086ddbea632dc9491adaf",
-				name: "hf-doc-build/doc-build-dev-test",
+				id: "6356b19985da6f13863228bd",
+				name: "hf-doc-build/doc-build",
 				private: false,
 				gated: false,
+				downloads: 0,
+				likes: 0,
+				updatedAt: new Date(0),
+			},
+			{
+				id: "636a1b69f2f9ec4289c4c19e",
+				name: "hf-doc-build/doc-build-dev",
+				gated: false,
+				private: false,
 				downloads: 0,
 				likes: 0,
 				updatedAt: new Date(0),

--- a/packages/hub/src/lib/list-datasets.spec.ts
+++ b/packages/hub/src/lib/list-datasets.spec.ts
@@ -7,7 +7,7 @@ describe("listDatasets", () => {
 		const results: DatasetEntry[] = [];
 
 		for await (const entry of listDatasets({ search: { owner: "hf-doc-build" } })) {
-			if (entry.name === "hf-doc-build/doc-build-dev-test") {
+			if (entry.name !== "hf-doc-build/doc-build-dev-test") {
 				continue;
 			}
 			if (typeof entry.downloads === "number") {
@@ -23,25 +23,16 @@ describe("listDatasets", () => {
 			results.push(entry);
 		}
 
-		expect(results).toEqual(expect.arrayContaining([
+		expect(results).deep.equal([
 			{
-				id: "6356b19985da6f13863228bd",
-				name: "hf-doc-build/doc-build",
+				id: "659086ddbea632dc9491adaf",
+				name: "hf-doc-build/doc-build-dev-test",
 				private: false,
 				gated: false,
 				downloads: 0,
 				likes: 0,
 				updatedAt: new Date(0),
 			},
-			{
-				id: "636a1b69f2f9ec4289c4c19e",
-				name: "hf-doc-build/doc-build-dev",
-				gated: false,
-				private: false,
-				downloads: 0,
-				likes: 0,
-				updatedAt: new Date(0),
-			},
-		]));
+		]);
 	});
 });


### PR DESCRIPTION
Hello there 👋 

It's my first time contributing. I tried to set up the project with `pnpm` and got error when running the tests:

```bash
 ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
│  FAIL  src/lib/list-datasets.spec.ts > listDatasets > should list datasets from hf-doc-builder
│ AssertionError: expected [ { …(7) }, { …(7) } ] to deeply equal [ { …(7) }, { …(7) } ]
│ - Expected
│ + Received
│   Array [
│     Object {
│       "downloads": 0,
│       "gated": false,
│ -     "id": "6356b19985da6f13863228bd",
│ +     "id": "636a1b69f2f9ec4289c4c19e",
│       "likes": 0,
│ -     "name": "hf-doc-build/doc-build",
│ +     "name": "hf-doc-build/doc-build-dev",
│       "private": false,
│       "updatedAt": 1970-01-01T00:00:00.000Z,
│     },
│     Object {
│       "downloads": 0,
│       "gated": false,
│ -     "id": "636a1b69f2f9ec4289c4c19e",
│ +     "id": "6356b19985da6f13863228bd",
│       "likes": 0,
│ -     "name": "hf-doc-build/doc-build-dev",
│ +     "name": "hf-doc-build/doc-build",
│       "private": false,
│       "updatedAt": 1970-01-01T00:00:00.000Z,
│     },
│   ]
│  ❯ src/lib/list-datasets.spec.ts:26:24
│      24|   }
│      25| 
│      26|   expect(results).deep.equal([
│        |                        ^
│      27|    {
│      28|     id: "6356b19985da6f13863228bd",
│ ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
│  Test Files  1 failed | 39 passed (40)
│       Tests  1 failed | 135 passed (136)
│    Start at  02:32:04
│    Duration  14.37s (transform 650ms, setup 3ms, collect 2.44s, tests 65.94s, environment 3ms, prepare 2.74s)
```

So I fix it.