### PR TITLE
feat(inference): Add BagelNet inference provider support

### DIFF
--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -47,6 +47,7 @@ Your access token should be kept private. If you need to protect it in front-end
 You can send inference requests to third-party providers with the inference client.
 
 Currently, we support the following providers:
+- [BagelNet](https://bagel.net)
 - [Fal.ai](https://fal.ai)
 - [Featherless AI](https://featherless.ai)
 - [Fireworks AI](https://fireworks.ai)
@@ -82,6 +83,7 @@ When authenticated with a Hugging Face access token, the request is routed throu
 When authenticated with a third-party provider key, the request is made directly against that provider's inference API.
 
 Only a subset of models are supported when requesting third-party providers. You can check the list of supported models per pipeline tasks here:
+- [BagelNet supported models](https://huggingface.co/api/partners/bagelnet/models)
 - [Fal.ai supported models](https://huggingface.co/api/partners/fal-ai/models)
 - [Featherless AI supported models](https://huggingface.co/api/partners/featherless-ai/models)
 - [Fireworks AI supported models](https://huggingface.co/api/partners/fireworks-ai/models)

--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -1,3 +1,4 @@
+import * as BagelNet from "../providers/bagelnet.js";
 import * as BlackForestLabs from "../providers/black-forest-labs.js";
 import * as Cerebras from "../providers/cerebras.js";
 import * as Cohere from "../providers/cohere.js";
@@ -51,6 +52,9 @@ import type { InferenceProvider, InferenceProviderOrPolicy, InferenceTask } from
 import { InferenceClientInputError } from "../errors.js";
 
 export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, TaskProviderHelper>>> = {
+	bagelnet: {
+		conversational: new BagelNet.BagelNetConversational(),
+	},
 	"black-forest-labs": {
 		"text-to-image": new BlackForestLabs.BlackForestLabsTextToImageTask(),
 	},

--- a/packages/inference/src/providers/bagelnet.ts
+++ b/packages/inference/src/providers/bagelnet.ts
@@ -1,0 +1,25 @@
+import { BaseConversationalTask } from "./providerHelper.js";
+
+export class BagelNetConversational extends BaseConversationalTask {
+	constructor() {
+		super("bagelnet", "https://api.bagel.net", false);
+	}
+
+	override makeRoute(): string {
+		return "/v1/chat/completions";
+	}
+
+	override preparePayload(params: any) {
+		return {
+			model: params.model,
+			messages: params.messages,
+			max_tokens: params.max_tokens,
+			temperature: params.temperature,
+			stream: params.stream ?? false,
+		};
+	}
+
+	override getResponse(r: any) {
+		return r;
+	}
+} 

--- a/packages/inference/src/providers/consts.ts
+++ b/packages/inference/src/providers/consts.ts
@@ -18,6 +18,7 @@ export const HARDCODED_MODEL_INFERENCE_MAPPING: Record<
 	 * Example:
 	 * "Qwen/Qwen2.5-Coder-32B-Instruct": "Qwen2.5-Coder-32B-Instruct",
 	 */
+	bagelnet: {},
 	"black-forest-labs": {},
 	cerebras: {},
 	cohere: {},

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -37,6 +37,7 @@ export interface Options {
 export type InferenceTask = Exclude<PipelineType, "other"> | "conversational";
 
 export const INFERENCE_PROVIDERS = [
+	"bagelnet",
 	"black-forest-labs",
 	"cerebras",
 	"cohere",


### PR DESCRIPTION
## Summary
This PR adds BagelNet as a new inference provider for conversational tasks.

## Changes
- Add `BagelNetConversationalTask` provider extending `BaseConversationalTask`
- Register BagelNet in provider helper and type definitions
- Update documentation with BagelNet links and information
- Base URL: `https://api.bagel.net`
- Route: `/v1/chat/completions` (OpenAI compatible)

## Testing
- [x] Local implementation tested and verified
- [x] Follows existing provider patterns exactly
- [x] Linting passes successfully

## Files Changed
- `packages/inference/src/providers/bagelnet.ts` - Core provider
- `packages/inference/src/lib/getProviderHelper.ts` - Registration
- `packages/inference/src/types.ts` - Type definitions  
- `packages/inference/README.md` - Documentation

Addresses the need for BagelNet inference provider integration as discussed in [provider registration process](https://huggingface.co/docs/inference-providers/en/register-as-a-provider).