### PR TITLE
Add support for image-to-video task type for Replicate

### DIFF
--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -140,6 +140,7 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 		"text-to-speech": new Replicate.ReplicateTextToSpeechTask(),
 		"text-to-video": new Replicate.ReplicateTextToVideoTask(),
 		"image-to-image": new Replicate.ReplicateImageToImageTask(),
+		"image-to-video": new Replicate.ReplicateImageToVideoTask(),
 	},
 	sambanova: {
 		conversational: new Sambanova.SambanovaConversationalTask(),

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -1289,6 +1289,18 @@ describe.skip("InferenceClient", () => {
 				});
 				expect(res).toBeInstanceOf(Blob);
 			});
+
+			it("imageToVideo - MeiGen-AI/MeiGen-MultiTalk", async () => {
+				const res = await client.imageToVideo({
+					model: "MeiGen-AI/MeiGen-MultiTalk",
+					provider: "replicate",
+					inputs: new Blob([readTestFile("bird_canny.png")], { type: "image/png" }),
+					parameters: {
+						prompt: "A bird flying in the sky",
+					},
+				});
+				expect(res).toBeInstanceOf(Blob);
+			});
 		},
 		TIMEOUT
 	);


### PR DESCRIPTION
This should unblock support for Replicate-powered inference for https://huggingface.co/MeiGen-AI/MeiGen-MultiTalk

cc @lucataco @apolinario @SBrandeis @Wauplin 