### PR TITLE
[Inference Providers] add text generation tasks equivalence

### DIFF
--- a/packages/inference/src/lib/getInferenceProviderMapping.ts
+++ b/packages/inference/src/lib/getInferenceProviderMapping.ts
@@ -2,7 +2,13 @@ import type { WidgetType } from "@huggingface/tasks";
 import { HF_HUB_URL } from "../config.js";
 import { HARDCODED_MODEL_INFERENCE_MAPPING } from "../providers/consts.js";
 import { EQUIVALENT_SENTENCE_TRANSFORMERS_TASKS } from "../providers/hf-inference.js";
-import type { InferenceProvider, InferenceProviderMappingEntry, InferenceProviderOrPolicy, ModelId } from "../types.js";
+import {
+	EQUIVALENT_TEXT_GENERATION_TASKS,
+	type InferenceProvider,
+	type InferenceProviderMappingEntry,
+	type InferenceProviderOrPolicy,
+	type ModelId,
+} from "../types.js";
 import { typedInclude } from "../utils/typedInclude.js";
 import { InferenceClientHubApiError, InferenceClientInputError } from "../errors.js";
 
@@ -118,9 +124,13 @@ export async function getInferenceProviderMapping(
 	const providerMapping = mappings.find((mapping) => mapping.provider === params.provider);
 	if (providerMapping) {
 		const equivalentTasks =
+			// hf-inference-specific equivalence
 			params.provider === "hf-inference" && typedInclude(EQUIVALENT_SENTENCE_TRANSFORMERS_TASKS, params.task)
 				? EQUIVALENT_SENTENCE_TRANSFORMERS_TASKS
-				: [params.task];
+				: // text-generation / text2text-generation equivalence
+				  typedInclude(EQUIVALENT_TEXT_GENERATION_TASKS, params.task)
+				  ? EQUIVALENT_TEXT_GENERATION_TASKS
+				  : [params.task];
 		if (!typedInclude(equivalentTasks, providerMapping.task)) {
 			throw new InferenceClientInputError(
 				`Model ${params.modelId} is not supported for task ${params.task} and provider ${params.provider}. Supported task: ${providerMapping.task}.`

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -62,6 +62,7 @@ export type InferenceProvider = (typeof INFERENCE_PROVIDERS)[number];
 
 export type InferenceProviderOrPolicy = (typeof PROVIDERS_OR_POLICIES)[number];
 
+export const EQUIVALENT_TEXT_GENERATION_TASKS = ["text-generation", "text2text-generation"] as const;
 export interface InferenceProviderMappingEntry {
 	adapter?: string;
 	adapterWeightsPath?: string;


### PR DESCRIPTION
This PR makes `text-generation` and `text2text-generation` equivalent. This should unlock inference for models like https://huggingface.co/mistralai/Devstral-Small-2505. More context in this [internal slack thread](https://huggingface.slack.com/archives/C08CM054RQU/p1750930968406359?thread_ts=1750930857.774099&cid=C08CM054RQU).