### PR TITLE
[Inference Providers] Fix structured output

### DIFF
--- a/packages/inference/src/providers/nebius.ts
+++ b/packages/inference/src/providers/nebius.ts
@@ -25,6 +25,7 @@ import {
 	type TextToImageTaskHelper,
 } from "./providerHelper.js";
 import { InferenceClientProviderOutputError } from "../errors.js";
+import type { ChatCompletionInput } from "../../../tasks/dist/commonjs/index.js";
 
 const NEBIUS_API_BASE_URL = "https://api.studio.nebius.ai";
 
@@ -45,24 +46,12 @@ export class NebiusConversationalTask extends BaseConversationalTask {
 		super("nebius", NEBIUS_API_BASE_URL);
 	}
 
-	override preparePayload(params: BodyParams): Record<string, unknown> {
+	override preparePayload(params: BodyParams<ChatCompletionInput>): Record<string, unknown> {
 		const payload = super.preparePayload(params) as Record<string, unknown>;
 
-		const responseFormat = (params.args as Record<string, unknown>)["response_format"];
-		if (
-			responseFormat &&
-			typeof responseFormat === "object" &&
-			"type" in responseFormat &&
-			(responseFormat as { type?: unknown }).type === "json_schema"
-		) {
-			const jsonSchemaDetails = (responseFormat as Record<string, unknown>)["json_schema"];
-			if (
-				jsonSchemaDetails &&
-				typeof jsonSchemaDetails === "object" &&
-				"schema" in (jsonSchemaDetails as Record<string, unknown>)
-			) {
-				payload["guided_json"] = (jsonSchemaDetails as Record<string, unknown>)["schema"];
-			}
+		const responseFormat = params.args.response_format;
+		if (responseFormat?.type === "json_schema" && responseFormat.json_schema?.schema) {
+			payload["guided_json"] = responseFormat.json_schema.schema;
 		}
 
 		return payload;

--- a/packages/inference/src/providers/sambanova.ts
+++ b/packages/inference/src/providers/sambanova.ts
@@ -19,32 +19,22 @@ import type { BodyParams } from "../types.js";
 import type { FeatureExtractionTaskHelper } from "./providerHelper.js";
 import { BaseConversationalTask, TaskProviderHelper } from "./providerHelper.js";
 import { InferenceClientProviderOutputError } from "../errors.js";
+import type { ChatCompletionInput } from "../../../tasks/dist/commonjs/index.js";
 
 export class SambanovaConversationalTask extends BaseConversationalTask {
 	constructor() {
 		super("sambanova", "https://api.sambanova.ai");
 	}
 
-	override preparePayload(params: BodyParams): Record<string, unknown> {
-		const payload = super.preparePayload(params) as Record<string, unknown>;
+	override preparePayload(params: BodyParams<ChatCompletionInput>): Record<string, unknown> {
+		const responseFormat = params.args.response_format;
 
-		const responseFormat = (params.args as Record<string, unknown>)["response_format"];
-		if (
-			responseFormat &&
-			typeof responseFormat === "object" &&
-			"type" in responseFormat &&
-			(responseFormat as { type?: unknown }).type === "json_schema"
-		) {
-			const jsonSchemaConfig = (responseFormat as Record<string, unknown>)["json_schema"] as
-				| Record<string, unknown>
-				| undefined;
-			if (jsonSchemaConfig && typeof jsonSchemaConfig === "object") {
-				const strict = jsonSchemaConfig["strict"];
-				if (strict === true || strict === undefined) {
-					jsonSchemaConfig["strict"] = false;
-				}
+		if (responseFormat?.type === "json_schema" && responseFormat.json_schema) {
+			if (responseFormat.json_schema.strict ?? true) {
+				responseFormat.json_schema.strict = false;
 			}
 		}
+		const payload = super.preparePayload(params) as Record<string, unknown>;
 
 		return payload;
 	}

--- a/packages/inference/src/providers/together.ts
+++ b/packages/inference/src/providers/together.ts
@@ -24,6 +24,7 @@ import {
 	type TextToImageTaskHelper,
 } from "./providerHelper.js";
 import { InferenceClientProviderOutputError } from "../errors.js";
+import type { ChatCompletionInput } from "../../../tasks/dist/commonjs/index.js";
 
 const TOGETHER_API_BASE_URL = "https://api.together.xyz";
 
@@ -48,7 +49,7 @@ export class TogetherConversationalTask extends BaseConversationalTask {
 		super("together", TOGETHER_API_BASE_URL);
 	}
 
-	override preparePayload(params: BodyParams): Record<string, unknown> {
+	override preparePayload(params: BodyParams<ChatCompletionInput>): Record<string, unknown> {
 		const payload = super.preparePayload(params);
 		const response_format = payload.response_format as
 			| { type: "json_schema"; json_schema: { schema: unknown } }


### PR DESCRIPTION
equivalent PR to https://github.com/huggingface/huggingface_hub/pull/3082.
`sambanova` and `nebius` don’t fully follow OpenAI’s spec for the `response_format` field. This PR adds internal mappings for each provider. Seems like `fireworks-ai` is now following OpenAI specs for this field (double checked their docs as well). 
