### PR TITLE
Add custom inference logger for @hf/inference

### DIFF
--- a/packages/inference/src/index.ts
+++ b/packages/inference/src/index.ts
@@ -5,5 +5,6 @@ export * from "./tasks/index.js";
 import * as snippets from "./snippets/index.js";
 export * from "./lib/getProviderHelper.js";
 export * from "./lib/makeRequestOptions.js";
+export { setLogger } from "./lib/logger.js";
 
 export { snippets };

--- a/packages/inference/src/lib/getInferenceProviderMapping.ts
+++ b/packages/inference/src/lib/getInferenceProviderMapping.ts
@@ -2,13 +2,7 @@ import type { WidgetType } from "@huggingface/tasks";
 import { HF_HUB_URL } from "../config.js";
 import { HARDCODED_MODEL_INFERENCE_MAPPING } from "../providers/consts.js";
 import { EQUIVALENT_SENTENCE_TRANSFORMERS_TASKS } from "../providers/hf-inference.js";
-import type {
-	InferenceProvider,
-	InferenceProviderMappingEntry,
-	InferenceProviderOrPolicy,
-	ModelId,
-	Options,
-} from "../types.js";
+import type { InferenceProvider, InferenceProviderMappingEntry, InferenceProviderOrPolicy, ModelId } from "../types.js";
 import { typedInclude } from "../utils/typedInclude.js";
 import { InferenceClientHubApiError, InferenceClientInputError } from "../errors.js";
 import { getLogger } from "./logger.js";
@@ -60,7 +54,9 @@ function normalizeInferenceProviderMapping(
 export async function fetchInferenceProviderMappingForModel(
 	modelId: ModelId,
 	accessToken?: string,
-	options?: Pick<Options, "fetch">
+	options?: {
+		fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+	}
 ): Promise<InferenceProviderMappingEntry[]> {
 	let inferenceProviderMapping: InferenceProviderMappingEntry[] | null;
 	if (inferenceProviderMappingCache.has(modelId)) {

--- a/packages/inference/src/lib/logger.ts
+++ b/packages/inference/src/lib/logger.ts
@@ -1,0 +1,11 @@
+import type { Logger } from "../types.js";
+
+let globalLogger: Logger = console;
+
+export function setLogger(logger: Logger): void {
+	globalLogger = logger;
+}
+
+export function getLogger(): Logger {
+	return globalLogger;
+}

--- a/packages/inference/src/providers/black-forest-labs.ts
+++ b/packages/inference/src/providers/black-forest-labs.ts
@@ -19,6 +19,7 @@ import {
 	InferenceClientProviderApiError,
 	InferenceClientProviderOutputError,
 } from "../errors.js";
+import { getLogger } from "../lib/logger.js";
 import type { BodyParams, HeaderParams, UrlParams } from "../types.js";
 import { delay } from "../utils/delay.js";
 import { omit } from "../utils/omit.js";
@@ -67,10 +68,11 @@ export class BlackForestLabsTextToImageTask extends TaskProviderHelper implement
 		headers?: HeadersInit,
 		outputType?: "url" | "blob"
 	): Promise<string | Blob> {
+		const logger = getLogger();
 		const urlObj = new URL(response.polling_url);
 		for (let step = 0; step < 5; step++) {
 			await delay(1000);
-			console.debug(`Polling Black Forest Labs API for the result... ${step + 1}/5`);
+			logger.debug(`Polling Black Forest Labs API for the result... ${step + 1}/5`);
 			urlObj.searchParams.set("attempt", step.toString(10));
 			const resp = await fetch(urlObj, { headers: { "Content-Type": "application/json" } });
 			if (!resp.ok) {

--- a/packages/inference/src/snippets/getInferenceSnippets.ts
+++ b/packages/inference/src/snippets/getInferenceSnippets.ts
@@ -12,6 +12,7 @@ import { getProviderHelper } from "../lib/getProviderHelper.js";
 import { makeRequestOptionsFromResolvedModel } from "../lib/makeRequestOptions.js";
 import type { InferenceProviderMappingEntry, InferenceProviderOrPolicy, InferenceTask, RequestArgs } from "../types.js";
 import { templates } from "./templates.exported.js";
+import { getLogger } from "../lib/logger.js";
 
 export type InferenceSnippetOptions = {
 	streaming?: boolean;
@@ -140,6 +141,7 @@ const snippetGenerator = (templateName: string, inputPreparationFn?: InputPrepar
 		inferenceProviderMapping?: InferenceProviderMappingEntry,
 		opts?: InferenceSnippetOptions
 	): InferenceSnippet[] => {
+		const logger = getLogger();
 		const providerModelId = inferenceProviderMapping?.providerId ?? model.id;
 		/// Hacky: hard-code conversational templates here
 		let task = model.pipeline_tag as InferenceTask;
@@ -156,7 +158,7 @@ const snippetGenerator = (templateName: string, inputPreparationFn?: InputPrepar
 		try {
 			providerHelper = getProviderHelper(provider, task);
 		} catch (e) {
-			console.error(`Failed to get provider helper for ${provider} (${task})`, e);
+			logger.error(`Failed to get provider helper for ${provider} (${task})`, e);
 			return [];
 		}
 
@@ -191,7 +193,7 @@ const snippetGenerator = (templateName: string, inputPreparationFn?: InputPrepar
 			try {
 				providerInputs = JSON.parse(bodyAsObj);
 			} catch (e) {
-				console.error("Failed to parse body as JSON", e);
+				logger.error("Failed to parse body as JSON", e);
 			}
 		}
 

--- a/packages/inference/src/tasks/audio/audioClassification.ts
+++ b/packages/inference/src/tasks/audio/audioClassification.ts
@@ -16,7 +16,7 @@ export async function audioClassification(
 	args: AudioClassificationArgs,
 	options?: Options
 ): Promise<AudioClassificationOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
 	const providerHelper = getProviderHelper(provider, "audio-classification");
 	const payload = preparePayload(args);
 	const { data: res } = await innerRequest<AudioClassificationOutput>(payload, providerHelper, {

--- a/packages/inference/src/tasks/audio/audioClassification.ts
+++ b/packages/inference/src/tasks/audio/audioClassification.ts
@@ -16,7 +16,7 @@ export async function audioClassification(
 	args: AudioClassificationArgs,
 	options?: Options
 ): Promise<AudioClassificationOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "audio-classification");
 	const payload = preparePayload(args);
 	const { data: res } = await innerRequest<AudioClassificationOutput>(payload, providerHelper, {

--- a/packages/inference/src/tasks/custom/request.ts
+++ b/packages/inference/src/tasks/custom/request.ts
@@ -2,6 +2,7 @@ import { resolveProvider } from "../../lib/getInferenceProviderMapping.js";
 import { getProviderHelper } from "../../lib/getProviderHelper.js";
 import type { InferenceTask, Options, RequestArgs } from "../../types.js";
 import { innerRequest } from "../../utils/request.js";
+import { getLogger } from "../../lib/logger.js";
 
 /**
  * Primitive to make custom calls to the inference provider
@@ -14,7 +15,8 @@ export async function request<T>(
 		task?: InferenceTask;
 	}
 ): Promise<T> {
-	console.warn(
+	const logger = getLogger();
+	logger.warn(
 		"The request method is deprecated and will be removed in a future version of huggingface.js. Use specific task functions instead."
 	);
 	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);

--- a/packages/inference/src/tasks/custom/streamingRequest.ts
+++ b/packages/inference/src/tasks/custom/streamingRequest.ts
@@ -2,6 +2,7 @@ import { resolveProvider } from "../../lib/getInferenceProviderMapping.js";
 import { getProviderHelper } from "../../lib/getProviderHelper.js";
 import type { InferenceTask, Options, RequestArgs } from "../../types.js";
 import { innerStreamingRequest } from "../../utils/request.js";
+import { getLogger } from "../../lib/logger.js";
 
 /**
  * Primitive to make custom inference calls that expect server-sent events, and returns the response through a generator
@@ -14,7 +15,8 @@ export async function* streamingRequest<T>(
 		task?: InferenceTask;
 	}
 ): AsyncGenerator<T> {
-	console.warn(
+	const logger = getLogger();
+	logger.warn(
 		"The streamingRequest method is deprecated and will be removed in a future version of huggingface.js. Use specific task functions instead."
 	);
 	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -5,6 +5,14 @@ import type { ChatCompletionInput, PipelineType, WidgetType } from "@huggingface
  */
 export type ModelId = string;
 
+export interface Logger {
+	debug: (message: string, ...args: unknown[]) => void;
+	info: (message: string, ...args: unknown[]) => void;
+	warn: (message: string, ...args: unknown[]) => void;
+	error: (message: string, ...args: unknown[]) => void;
+	log: (message: string, ...args: unknown[]) => void;
+}
+
 export interface Options {
 	/**
 	 * (Default: true) Boolean. If a request 503s, the request will be retried with the same parameters.
@@ -32,6 +40,11 @@ export interface Options {
 	 * Requests can only be billed to an organization the user is a member of, and which has subscribed to Enterprise Hub.
 	 */
 	billTo?: string;
+
+	/**
+	 * Custom logger instance. Defaults to console.
+	 */
+	logger?: Logger;
 }
 
 export type InferenceTask = Exclude<PipelineType, "other"> | "conversational";

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -40,11 +40,6 @@ export interface Options {
 	 * Requests can only be billed to an organization the user is a member of, and which has subscribed to Enterprise Hub.
 	 */
 	billTo?: string;
-
-	/**
-	 * Custom logger instance. Defaults to console.
-	 */
-	logger?: Logger;
 }
 
 export type InferenceTask = Exclude<PipelineType, "other"> | "conversational";


### PR DESCRIPTION
The goal is to pass a custom logging tool (needed mainly by moon). 

I chose a global overwrite instead of an option like fetch to avoid too many code changes (btw, there are some places where fetch is not properly overwritten by the options).

I think the best approach would be to have a separate package for logging to use the same module in the hf.js ecosystem