### PR TITLE
Update tiny-agents example

### DIFF
--- a/packages/tiny-agents/README.md
+++ b/packages/tiny-agents/README.md
@@ -47,10 +47,8 @@ touch my-agent/agent.json
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": ["@playwright/mcp@latest"]
-			}
+			"command": "npx",
+			"args": ["@playwright/mcp@latest"]
 		}
 	]
 }
@@ -65,10 +63,8 @@ Or using a local or remote endpoint URL:
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": ["@playwright/mcp@latest"]
-			}
+			"command": "npx",
+			"args": ["@playwright/mcp@latest"]
 		}
 	]
 }


### PR DESCRIPTION
Fix docs example after https://github.com/huggingface/huggingface_hub/pull/3166 / https://github.com/huggingface/huggingface.js/pull/1556. Since release [0.33.2](https://github.com/huggingface/huggingface_hub/releases/tag/v0.33.2) `tiny-agents` config follow VSCode format. We made the change without a proper deprecation warning as it's still experimental and we wanted to harmonize with VSCode as quickly as possible (to avoid future conflicts).  

Related PRs:
- https://github.com/huggingface/hub-docs/pull/1816
- https://github.com/huggingface/transformers/pull/39245
- https://github.com/huggingface/huggingface_hub/pull/3205
- https://github.com/huggingface/huggingface.js/pull/1599