### PR TITLE
[Inference Providers] fix: zero-shot-classification HF helper

### DIFF
--- a/packages/inference/src/providers/hf-inference.ts
+++ b/packages/inference/src/providers/hf-inference.ts
@@ -22,6 +22,7 @@ import type {
 	ImageToTextOutput,
 	ObjectDetectionOutput,
 	QuestionAnsweringOutput,
+	QuestionAnsweringOutputElement,
 	SentenceSimilarityOutput,
 	SummarizationOutput,
 	TableQuestionAnsweringOutput,
@@ -31,6 +32,7 @@ import type {
 	TranslationOutput,
 	VisualQuestionAnsweringOutput,
 	ZeroShotClassificationOutput,
+	ZeroShotClassificationOutputElement,
 	ZeroShotImageClassificationOutput,
 } from "@huggingface/tasks";
 import { HF_ROUTER_URL } from "../config.js";
@@ -435,7 +437,7 @@ export class HFInferenceTextClassificationTask extends HFInferenceTask implement
 export class HFInferenceQuestionAnsweringTask extends HFInferenceTask implements QuestionAnsweringTaskHelper {
 	override async getResponse(
 		response: QuestionAnsweringOutput | QuestionAnsweringOutput[number]
-	): Promise<QuestionAnsweringOutput[number]> {
+	): Promise<QuestionAnsweringOutputElement> {
 		if (
 			Array.isArray(response)
 				? response.every(
@@ -483,22 +485,44 @@ export class HFInferenceFillMaskTask extends HFInferenceTask implements FillMask
 }
 
 export class HFInferenceZeroShotClassificationTask extends HFInferenceTask implements ZeroShotClassificationTaskHelper {
-	override async getResponse(response: ZeroShotClassificationOutput): Promise<ZeroShotClassificationOutput> {
+	override async getResponse(response: unknown): Promise<ZeroShotClassificationOutput> {
+		/// Handle Legacy response format from Inference API
 		if (
-			Array.isArray(response) &&
-			response.every(
-				(x) =>
-					Array.isArray(x.labels) &&
-					x.labels.every((_label) => typeof _label === "string") &&
-					Array.isArray(x.scores) &&
-					x.scores.every((_score) => typeof _score === "number") &&
-					typeof x.sequence === "string"
-			)
+			typeof response === "object" &&
+			response !== null &&
+			"labels" in response &&
+			"scores" in response &&
+			Array.isArray(response.labels) &&
+			Array.isArray(response.scores) &&
+			response.labels.length === response.scores.length &&
+			response.labels.every((label: unknown): label is string => typeof label === "string") &&
+			response.scores.every((score: unknown): score is number => typeof score === "number")
 		) {
+			const scores = response.scores;
+			return response.labels.map((label: string, index: number) => ({
+				label,
+				score: scores[index],
+			}));
+		}
+
+		if (Array.isArray(response) && response.every(HFInferenceZeroShotClassificationTask.validateOutputElement)) {
 			return response;
 		}
 		throw new InferenceClientProviderOutputError(
-			"Received malformed response from HF-Inference zero-shot-classification API: expected Array<{labels: string[], scores: number[], sequence: string}>"
+			"Received malformed response from HF-Inference zero-shot-classification API: expected Array<{label: string, score: number}>"
+		);
+	}
+
+	private static validateOutputElement(elem: unknown): elem is ZeroShotClassificationOutputElement {
+		return (
+			typeof elem === "object" &&
+			!!elem &&
+			"label" in elem &&
+			"score" in elem &&
+			!!elem.label &&
+			typeof elem.label === "string" &&
+			!!elem.score &&
+			typeof elem.score === "number"
 		);
 	}
 }


### PR DESCRIPTION
Flagged by @oOraph 

All zero-shot classification mappings are currently failing for HF Inference 

Two things:
- The validation function was incorrect / not actually validating the expected format as defined in tasks
- The HF Inference backend does not return the expected format (it's using a "legacy" format)

This PR addresses those two issues by fixing the response validation code to match and handling previous input to ease transition of the hf-inference background