### PR TITLE
Fix openai schema validation error for default MCP tools with empty `parameters`

### DIFF
--- a/packages/mcp-client/src/Agent.ts
+++ b/packages/mcp-client/src/Agent.ts
@@ -25,10 +25,6 @@ const taskCompletionTool: ChatCompletionInputTool = {
 	function: {
 		name: "task_complete",
 		description: "Call this tool when the task given by the user is complete",
-		parameters: {
-			type: "object",
-			properties: {},
-		},
 	},
 };
 const askQuestionTool: ChatCompletionInputTool = {
@@ -36,10 +32,6 @@ const askQuestionTool: ChatCompletionInputTool = {
 	function: {
 		name: "ask_question",
 		description: "Ask a question to the user to get more info required to solve or clarify their problem.",
-		parameters: {
-			type: "object",
-			properties: {},
-		},
 	},
 };
 const exitLoopTools = [taskCompletionTool, askQuestionTool];

--- a/packages/tasks/src/tasks/chat-completion/inference.ts
+++ b/packages/tasks/src/tasks/chat-completion/inference.ts
@@ -132,7 +132,7 @@ export interface ChatCompletionInputToolCall {
 export interface ChatCompletionInputFunctionDefinition {
 	description?: string;
 	name: string;
-	parameters: unknown;
+	parameters?: unknown;
 	[property: string]: unknown;
 }
 export interface ChatCompletionInputGrammarType {

--- a/packages/tasks/src/tasks/chat-completion/spec/input.json
+++ b/packages/tasks/src/tasks/chat-completion/spec/input.json
@@ -275,7 +275,7 @@
 		},
 		"ChatCompletionInputFunctionDefinition": {
 			"type": "object",
-			"required": ["name", "parameters"],
+			"required": ["name"],
 			"properties": {
 				"parameters": {},
 				"description": {


### PR DESCRIPTION
Fixes #1609

According to OpenAI’s function calling specs, the correct way to define a function with no arguments is to omit the `parameters` field. If `parameters` is provided with a `properties` field, it must contain at least one property.

This PR updates the default tool definitions in the `mcp-client` package (taskCompletionTool and askQuestionTool) to reflect this.
<img width="672" height="491" alt="Screenshot 2025-07-11 at 11 21 24" src="https://github.com/user-attachments/assets/96a37356-0813-4f2f-870d-36d92ff09661" />
