### PR TITLE
Richer conversational snippet for AutoModel

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1386,7 +1386,7 @@ export const transformers = (model: ModelData): string[] => {
 			`from transformers import ${info.processor}, ${info.auto_model}`,
 			"",
 			`${processorVarName} = ${info.processor}.from_pretrained("${model.id}"` + remote_code_snippet + ")",
-			`model = ${info.auto_model}.from_pretrained("${model.id}"` + remote_code_snippet + ")",
+			`model = ${info.auto_model}.from_pretrained("${model.id}"` + remote_code_snippet + ")"
 		);
 		if (model.tags.includes("conversational")) {
 			if (model.tags.includes("image-text-to-text")) {

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1381,13 +1381,13 @@ export const transformers = (model: ModelData): string[] => {
 				: info.processor === "AutoFeatureExtractor"
 				  ? "extractor"
 				  : "processor";
-		autoSnippet.push([
+		autoSnippet.push(
 			"# Load model directly",
 			`from transformers import ${info.processor}, ${info.auto_model}`,
 			"",
 			`${processorVarName} = ${info.processor}.from_pretrained("${model.id}"` + remote_code_snippet + ")",
 			`model = ${info.auto_model}.from_pretrained("${model.id}"` + remote_code_snippet + ")",
-		]);
+		);
 		if (model.tags.includes("conversational")) {
 			if (model.tags.includes("image-text-to-text")) {
 				autoSnippet.push(
@@ -1416,15 +1416,15 @@ export const transformers = (model: ModelData): string[] => {
 				").to(model.device)",
 				"",
 				"outputs = model.generate(**inputs, max_new_tokens=40)",
-				'print(${processorVarName}.decode(outputs[0][inputs["input_ids"].shape[-1]:]))',
+				'print(${processorVarName}.decode(outputs[0][inputs["input_ids"].shape[-1]:]))'
 			);
 		}
 	} else {
-		autoSnippet.push([
+		autoSnippet.push(
 			"# Load model directly",
 			`from transformers import ${info.auto_model}`,
-			`model = ${info.auto_model}.from_pretrained("${model.id}"` + remote_code_snippet + ', torch_dtype="auto"),',
-		]);
+			`model = ${info.auto_model}.from_pretrained("${model.id}"` + remote_code_snippet + ', torch_dtype="auto"),'
+		);
 	}
 
 	if (model.pipeline_tag && LIBRARY_TASK_MAPPING.transformers?.includes(model.pipeline_tag)) {


### PR DESCRIPTION
I can't remember if we already discussed about this. This is an attempt to make the `AutoModel` snippet more self-contained, for the particular but frequent case of conversational transformers models. The pipeline version already got this treatment in #1434, but the `AutoModel` version is currently too barebones in comparison, as shown in the screenshot below.

In my opinion this could reduce the friction for users that want to experiment with the models in Colab or Kaggle.
cc @Vaibhavs10 @ariG23498 

<img width="789" height="534" alt="Screenshot 2025-07-11 at 14 05 15" src="https://github.com/user-attachments/assets/558837e3-ec56-4100-afa1-7a54d3d79305" />