### PR TITLE
[Inference] Overrides snippets inputs

### DIFF
--- a/packages/inference/src/snippets/getInferenceSnippets.ts
+++ b/packages/inference/src/snippets/getInferenceSnippets.ts
@@ -167,7 +167,9 @@ const snippetGenerator = (templateName: string, inputPreparationFn?: InputPrepar
 		const accessTokenOrPlaceholder = opts?.accessToken ?? placeholder;
 
 		/// Prepare inputs + make request
-		const inputs = inputPreparationFn ? inputPreparationFn(model, opts) : { inputs: getModelInputSnippet(model) };
+		const inputs = inputPreparationFn
+			? inputPreparationFn(model, opts)
+			: { inputs: opts?.inputs ?? getModelInputSnippet(model) };
 		const request = makeRequestOptionsFromResolvedModel(
 			providerModelId,
 			providerHelper,

--- a/packages/inference/src/snippets/getInferenceSnippets.ts
+++ b/packages/inference/src/snippets/getInferenceSnippets.ts
@@ -294,9 +294,9 @@ const prepareDocumentQuestionAnsweringInput = (model: ModelDataMinimal): object 
 	return JSON.parse(getModelInputSnippet(model) as string);
 };
 
-const prepareImageToImageInput = (model: ModelDataMinimal): object => {
+const prepareImageToImageInput = (model: ModelDataMinimal, opts?: { image?: string; prompt?: string }): object => {
 	const data = JSON.parse(getModelInputSnippet(model) as string);
-	return { inputs: data.image, parameters: { prompt: data.prompt } };
+	return { inputs: opts?.image ?? data.image, parameters: { prompt: opts?.prompt ?? data.prompt } };
 };
 
 const prepareConversationalInput = (
@@ -317,14 +317,20 @@ const prepareConversationalInput = (
 	};
 };
 
-const prepareQuestionAnsweringInput = (model: ModelDataMinimal): object => {
+const prepareQuestionAnsweringInput = (
+	model: ModelDataMinimal,
+	opts?: { question?: string; context?: string }
+): object => {
 	const data = JSON.parse(getModelInputSnippet(model) as string);
-	return { question: data.question, context: data.context };
+	return { question: opts?.question ?? data.question, context: opts?.context ?? data.context };
 };
 
-const prepareTableQuestionAnsweringInput = (model: ModelDataMinimal): object => {
+const prepareTableQuestionAnsweringInput = (
+	model: ModelDataMinimal,
+	opts?: { query?: string; table?: string }
+): object => {
 	const data = JSON.parse(getModelInputSnippet(model) as string);
-	return { query: data.query, table: JSON.stringify(data.table) };
+	return { query: opts?.query ?? data.query, table: opts?.table ?? JSON.stringify(data.table) };
 };
 
 const snippets: Partial<

--- a/packages/inference/src/snippets/getInferenceSnippets.ts
+++ b/packages/inference/src/snippets/getInferenceSnippets.ts
@@ -167,9 +167,11 @@ const snippetGenerator = (templateName: string, inputPreparationFn?: InputPrepar
 		const accessTokenOrPlaceholder = opts?.accessToken ?? placeholder;
 
 		/// Prepare inputs + make request
-		const inputs = inputPreparationFn
-			? inputPreparationFn(model, opts)
-			: { inputs: opts?.inputs ?? getModelInputSnippet(model) };
+		const inputs = opts?.inputs
+			? { inputs: opts.inputs }
+			: inputPreparationFn
+			  ? inputPreparationFn(model, opts)
+			  : { inputs: getModelInputSnippet(model) };
 		const request = makeRequestOptionsFromResolvedModel(
 			providerModelId,
 			providerHelper,

--- a/packages/inference/src/snippets/getInferenceSnippets.ts
+++ b/packages/inference/src/snippets/getInferenceSnippets.ts
@@ -294,9 +294,9 @@ const prepareDocumentQuestionAnsweringInput = (model: ModelDataMinimal): object 
 	return JSON.parse(getModelInputSnippet(model) as string);
 };
 
-const prepareImageToImageInput = (model: ModelDataMinimal, opts?: { image?: string; prompt?: string }): object => {
+const prepareImageToImageInput = (model: ModelDataMinimal): object => {
 	const data = JSON.parse(getModelInputSnippet(model) as string);
-	return { inputs: opts?.image ?? data.image, parameters: { prompt: opts?.prompt ?? data.prompt } };
+	return { inputs: data.image, parameters: { prompt: data.prompt } };
 };
 
 const prepareConversationalInput = (
@@ -317,20 +317,14 @@ const prepareConversationalInput = (
 	};
 };
 
-const prepareQuestionAnsweringInput = (
-	model: ModelDataMinimal,
-	opts?: { question?: string; context?: string }
-): object => {
+const prepareQuestionAnsweringInput = (model: ModelDataMinimal): object => {
 	const data = JSON.parse(getModelInputSnippet(model) as string);
-	return { question: opts?.question ?? data.question, context: opts?.context ?? data.context };
+	return { question: data.question, context: data.context };
 };
 
-const prepareTableQuestionAnsweringInput = (
-	model: ModelDataMinimal,
-	opts?: { query?: string; table?: string }
-): object => {
+const prepareTableQuestionAnsweringInput = (model: ModelDataMinimal): object => {
 	const data = JSON.parse(getModelInputSnippet(model) as string);
-	return { query: opts?.query ?? data.query, table: opts?.table ?? JSON.stringify(data.table) };
+	return { query: data.query, table: JSON.stringify(data.table) };
 };
 
 const snippets: Partial<

--- a/packages/inference/src/snippets/getInferenceSnippets.ts
+++ b/packages/inference/src/snippets/getInferenceSnippets.ts
@@ -20,6 +20,7 @@ export type InferenceSnippetOptions = {
 	accessToken?: string;
 	directRequest?: boolean; // to bypass HF routing and call the provider directly
 	endpointUrl?: string; // to call a local endpoint directly
+	inputs?: Record<string, unknown>; // overrides the default snippet's inputs
 } & Record<string, unknown>;
 
 const PYTHON_CLIENTS = ["huggingface_hub", "fal_client", "requests", "openai"] as const;


### PR DESCRIPTION
So we can call

```js
snippets.getInferenceSnippets(model, "auto", undefined, {
   inputs: `"A dog with a baseball cap"`
});
```

to get the following sample
```python
# output is a PIL.Image object
image = client.text_to_image(
    "A dog with a baseball cap",
    model="black-forest-labs/FLUX.1-dev",
)
```

instead of the default input in the snippet:
```python
image = client.text_to_image(
    "Astronaut riding a horse",
    model="black-forest-labs/FLUX.1-dev",
)
```

it's already possible to do it for `text-generation` with `opts.mesages` 

needed for (internal https://github.com/huggingface-internal/moon-landing/pull/14421)