### PR TITLE
[Inference] get the raw response for textToImage

### DIFF
--- a/packages/inference/src/providers/black-forest-labs.ts
+++ b/packages/inference/src/providers/black-forest-labs.ts
@@ -66,8 +66,8 @@ export class BlackForestLabsTextToImageTask extends TaskProviderHelper implement
 		response: BlackForestLabsResponse,
 		url?: string,
 		headers?: HeadersInit,
-		outputType?: "url" | "blob"
-	): Promise<string | Blob> {
+		outputType?: "url" | "blob" | "json"
+	): Promise<string | Blob | Record<string, unknown>> {
 		const logger = getLogger();
 		const urlObj = new URL(response.polling_url);
 		for (let step = 0; step < 5; step++) {
@@ -95,6 +95,9 @@ export class BlackForestLabsTextToImageTask extends TaskProviderHelper implement
 				"sample" in payload.result &&
 				typeof payload.result.sample === "string"
 			) {
+				if (outputType === "json") {
+					return payload.result;
+				}
 				if (outputType === "url") {
 					return payload.result.sample;
 				}

--- a/packages/inference/src/providers/fal-ai.ts
+++ b/packages/inference/src/providers/fal-ai.ts
@@ -182,7 +182,12 @@ export class FalAITextToImageTask extends FalAITask implements TextToImageTaskHe
 		return payload;
 	}
 
-	override async getResponse(response: FalAITextToImageOutput, outputType?: "url" | "blob"): Promise<string | Blob> {
+	override async getResponse(
+		response: FalAITextToImageOutput,
+		url?: string,
+		headers?: HeadersInit,
+		outputType?: "url" | "blob" | "json"
+	): Promise<string | Blob | Record<string, unknown>> {
 		if (
 			typeof response === "object" &&
 			"images" in response &&
@@ -191,6 +196,9 @@ export class FalAITextToImageTask extends FalAITask implements TextToImageTaskHe
 			"url" in response.images[0] &&
 			typeof response.images[0].url === "string"
 		) {
+			if (outputType === "json") {
+				return { ...response };
+			}
 			if (outputType === "url") {
 				return response.images[0].url;
 			}

--- a/packages/inference/src/providers/hyperbolic.ts
+++ b/packages/inference/src/providers/hyperbolic.ts
@@ -105,8 +105,8 @@ export class HyperbolicTextToImageTask extends TaskProviderHelper implements Tex
 		response: HyperbolicTextToImageOutput,
 		url?: string,
 		headers?: HeadersInit,
-		outputType?: "url" | "blob"
-	): Promise<string | Blob> {
+		outputType?: "url" | "blob" | "json"
+	): Promise<string | Blob | Record<string, unknown>> {
 		if (
 			typeof response === "object" &&
 			"images" in response &&
@@ -114,6 +114,9 @@ export class HyperbolicTextToImageTask extends TaskProviderHelper implements Tex
 			response.images[0] &&
 			typeof response.images[0].image === "string"
 		) {
+			if (outputType === "json") {
+				return { ...response };
+			}
 			if (outputType === "url") {
 				return `data:image/jpeg;base64,${response.images[0].image}`;
 			}

--- a/packages/inference/src/providers/nebius.ts
+++ b/packages/inference/src/providers/nebius.ts
@@ -116,8 +116,8 @@ export class NebiusTextToImageTask extends TaskProviderHelper implements TextToI
 		response: NebiusBase64ImageGeneration,
 		url?: string,
 		headers?: HeadersInit,
-		outputType?: "url" | "blob"
-	): Promise<string | Blob> {
+		outputType?: "url" | "blob" | "json"
+	): Promise<string | Blob | Record<string, unknown>> {
 		if (
 			typeof response === "object" &&
 			"data" in response &&
@@ -126,6 +126,9 @@ export class NebiusTextToImageTask extends TaskProviderHelper implements TextToI
 			"b64_json" in response.data[0] &&
 			typeof response.data[0].b64_json === "string"
 		) {
+			if (outputType === "json") {
+				return { ...response };
+			}
 			const base64Data = response.data[0].b64_json;
 			if (outputType === "url") {
 				return `data:image/jpeg;base64,${base64Data}`;

--- a/packages/inference/src/providers/nscale.ts
+++ b/packages/inference/src/providers/nscale.ts
@@ -57,8 +57,8 @@ export class NscaleTextToImageTask extends TaskProviderHelper implements TextToI
 		response: NscaleCloudBase64ImageGeneration,
 		url?: string,
 		headers?: HeadersInit,
-		outputType?: "url" | "blob"
-	): Promise<string | Blob> {
+		outputType?: "url" | "blob" | "json"
+	): Promise<string | Blob | Record<string, unknown>> {
 		if (
 			typeof response === "object" &&
 			"data" in response &&
@@ -67,6 +67,9 @@ export class NscaleTextToImageTask extends TaskProviderHelper implements TextToI
 			"b64_json" in response.data[0] &&
 			typeof response.data[0].b64_json === "string"
 		) {
+			if (outputType === "json") {
+				return { ...response };
+			}
 			const base64Data = response.data[0].b64_json;
 			if (outputType === "url") {
 				return `data:image/jpeg;base64,${base64Data}`;

--- a/packages/inference/src/providers/providerHelper.ts
+++ b/packages/inference/src/providers/providerHelper.ts
@@ -137,8 +137,8 @@ export interface TextToImageTaskHelper {
 		response: unknown,
 		url?: string,
 		headers?: HeadersInit,
-		outputType?: "url" | "blob"
-	): Promise<string | Blob>;
+		outputType?: "url" | "blob" | "json"
+	): Promise<string | Blob | Record<string, unknown>>;
 	preparePayload(params: BodyParams<TextToImageInput & BaseArgs>): Record<string, unknown>;
 }
 

--- a/packages/inference/src/providers/replicate.ts
+++ b/packages/inference/src/providers/replicate.ts
@@ -88,8 +88,8 @@ export class ReplicateTextToImageTask extends ReplicateTask implements TextToIma
 		res: ReplicateOutput | Blob,
 		url?: string,
 		headers?: Record<string, string>,
-		outputType?: "url" | "blob"
-	): Promise<string | Blob> {
+		outputType?: "url" | "blob" | "json"
+	): Promise<string | Blob | Record<string, unknown>> {
 		void url;
 		void headers;
 		if (
@@ -99,6 +99,9 @@ export class ReplicateTextToImageTask extends ReplicateTask implements TextToIma
 			res.output.length > 0 &&
 			typeof res.output[0] === "string"
 		) {
+			if (outputType === "json") {
+				return { ...res };
+			}
 			if (outputType === "url") {
 				return res.output[0];
 			}

--- a/packages/inference/src/providers/together.ts
+++ b/packages/inference/src/providers/together.ts
@@ -114,7 +114,12 @@ export class TogetherTextToImageTask extends TaskProviderHelper implements TextT
 		};
 	}
 
-	async getResponse(response: TogetherBase64ImageGeneration, outputType?: "url" | "blob"): Promise<string | Blob> {
+	async getResponse(
+		response: TogetherBase64ImageGeneration,
+		url?: string,
+		headers?: HeadersInit,
+		outputType?: "url" | "blob" | "json"
+	): Promise<string | Blob | Record<string, unknown>> {
 		if (
 			typeof response === "object" &&
 			"data" in response &&
@@ -123,6 +128,9 @@ export class TogetherTextToImageTask extends TaskProviderHelper implements TextT
 			"b64_json" in response.data[0] &&
 			typeof response.data[0].b64_json === "string"
 		) {
+			if (outputType === "json") {
+				return { ...response };
+			}
 			const base64Data = response.data[0].b64_json;
 			if (outputType === "url") {
 				return `data:image/jpeg;base64,${base64Data}`;

--- a/packages/inference/src/tasks/cv/textToImage.ts
+++ b/packages/inference/src/tasks/cv/textToImage.ts
@@ -8,7 +8,7 @@ import { innerRequest } from "../../utils/request.js";
 export type TextToImageArgs = BaseArgs & TextToImageInput;
 
 interface TextToImageOptions extends Options {
-	outputType?: "url" | "blob";
+	outputType?: "url" | "blob" | "json";
 }
 
 /**
@@ -23,7 +23,14 @@ export async function textToImage(
 	args: TextToImageArgs,
 	options?: TextToImageOptions & { outputType?: undefined | "blob" }
 ): Promise<Blob>;
-export async function textToImage(args: TextToImageArgs, options?: TextToImageOptions): Promise<Blob | string> {
+export async function textToImage(
+	args: TextToImageArgs,
+	options?: TextToImageOptions & { outputType?: undefined | "json" }
+): Promise<Record<string, unknown>>;
+export async function textToImage(
+	args: TextToImageArgs,
+	options?: TextToImageOptions
+): Promise<Blob | string | Record<string, unknown>> {
 	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
 	const providerHelper = getProviderHelper(provider, "text-to-image");
 	const { data: res } = await innerRequest<Record<string, unknown>>(args, providerHelper, {

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -803,6 +803,16 @@ describe.skip("InferenceClient", () => {
 				});
 				expect(res).toBeInstanceOf(Blob);
 			});
+			it("textToImage with json output", async () => {
+				const res = await hf.textToImage({
+					inputs: "a giant tortoise",
+					model: "stabilityai/stable-diffusion-2",
+					outputType: "json",
+				});
+				expect(res).toMatchObject({
+					output: expect.any(String),
+				});
+			});
 			it("imageToText", async () => {
 				expect(
 					await hf.imageToText({


### PR DESCRIPTION
Allow to get the full response for `text-to-image` inference, instead of directly the blob or the url:

```js
const res = await textToImage({ inputs:  "A dog with a baseball cap" },{ outputType: "json" });
``` 

we have the following ouput (depends on the provider)

```json
{
  "images": [
    {
      "url": "data:image/png;base64,iVBORw0KGgoAAAAN......rkJggg==",
      "width": 1024,
      "height": 768,
      "content_type": "image/png"
    }
  ],
  "timings": {
    "inference": 1.2445615287870169
  },
  "seed": 982874191,
  "has_nsfw_concepts": [
    false
  ],
  "prompt": "A dog with a baseball cap"
} 
```

needed for (internal https://github.com/huggingface-internal/moon-landing/pull/14421)