### PR TITLE
Add RTX 2060 and RTX 2060 12GB to hardware

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -311,7 +311,7 @@ export const SKUS = {
 				memory: [6],
 			},
 			"RTX 2060": {
-				tflops: 12.90,
+				tflops: 12.9,
 				memory: [6],
 			},
 			"RTX 2060 12GB": {


### PR DESCRIPTION
This adds the memory and tflops information for 2 RTX 2060 GPUs.

I have added them separately as the tflops values are different, due to the 12GB version having other changes aside from increased VRAM capacity (more cores and tmus). These may be merged into a single item with the lower tflops value if preferred. Just let me know and I will update the PR.

The values were taken from these 2 pages respectively:
- https://www.techpowerup.com/gpu-specs/geforce-rtx-2060.c3310
- https://www.techpowerup.com/gpu-specs/geforce-rtx-2060-12-gb.c3836

Just to note that I own multiple RTX 2060 12GB, but no RTX 2060 cards. I added the latter due to their distinct differences.