### PR TITLE
[Tiny Agents] Add dummy `parameters` field to exit loop tools

### DIFF
--- a/packages/mcp-client/src/Agent.ts
+++ b/packages/mcp-client/src/Agent.ts
@@ -25,6 +25,15 @@ const taskCompletionTool: ChatCompletionInputTool = {
 	function: {
 		name: "task_complete",
 		description: "Call this tool when the task given by the user is complete",
+		parameters: {
+			type: "object",
+			properties: {
+				trigger: {
+					type: "boolean",
+					description: "Set to true to trigger this function",
+				},
+			},
+		},
 	},
 };
 const askQuestionTool: ChatCompletionInputTool = {
@@ -32,6 +41,15 @@ const askQuestionTool: ChatCompletionInputTool = {
 	function: {
 		name: "ask_question",
 		description: "Ask a question to the user to get more info required to solve or clarify their problem.",
+		parameters: {
+			type: "object",
+			properties: {
+				trigger: {
+					type: "boolean",
+					description: "Set to true to trigger this function",
+				},
+			},
+		},
 	},
 };
 const exitLoopTools = [taskCompletionTool, askQuestionTool];


### PR DESCRIPTION
Follow-up PR to #1610.
Some LLM engines (like llama.cpp) strictly validate the `parameters` field in function definitions, even for tools that take no arguments. To avoid parsing issues, this PR adds an explicit dummy `parameters` field.
(See: https://github.com/huggingface/huggingface_hub/issues/3218)
✅ I tested the PR with different providers/models to make sure it's backward compatible.