### PR TITLE
[InferenceSnippets] Document model:provider syntax

### DIFF
--- a/packages/inference/src/snippets/templates/python/requests/conversational.jinja
+++ b/packages/inference/src/snippets/templates/python/requests/conversational.jinja
@@ -3,7 +3,7 @@ def query(payload):
     return response.json()
 
 response = query({
-{{ providerInputs.asJsonString }}
+{{ autoInputs.asJsonString }}
 })
 
 print(response["choices"][0]["message"])

--- a/packages/inference/src/snippets/templates/python/requests/conversationalStream.jinja
+++ b/packages/inference/src/snippets/templates/python/requests/conversationalStream.jinja
@@ -8,7 +8,7 @@ def query(payload):
         yield json.loads(line.decode("utf-8").lstrip("data:").rstrip("/n"))
 
 chunks = query({
-{{ providerInputs.asJsonString }},
+{{ autoInputs.asJsonString }},
     "stream": True,
 })
 

--- a/packages/inference/src/snippets/templates/sh/curl/conversational.jinja
+++ b/packages/inference/src/snippets/templates/sh/curl/conversational.jinja
@@ -5,6 +5,6 @@ curl {{ fullUrl }} \
     -H 'X-HF-Bill-To: {{ billTo }}' \
 {% endif %}
     -d '{
-{{ providerInputs.asCurlString }},
+{{ autoInputs.asCurlString }},
         "stream": false
     }'

--- a/packages/inference/src/snippets/templates/sh/curl/conversationalStream.jinja
+++ b/packages/inference/src/snippets/templates/sh/curl/conversationalStream.jinja
@@ -5,6 +5,6 @@ curl {{ fullUrl }} \
     -H 'X-HF-Bill-To: {{ billTo }}' \
 {% endif %}
     -d '{
-{{ providerInputs.asCurlString }},
+{{ autoInputs.asCurlString }},
         "stream": true
     }'

--- a/packages/tasks-gen/snippets-fixtures/bill-to-param/js/openai/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/bill-to-param/js/openai/0.hf-inference.js
@@ -1,7 +1,7 @@
 import { OpenAI } from "openai";
 
 const client = new OpenAI({
-	baseURL: "https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1",
+	baseURL: "https://router.huggingface.co/v1",
 	apiKey: process.env.HF_TOKEN,
 	defaultHeaders: {
 		"X-HF-Bill-To": "huggingface" 
@@ -9,7 +9,7 @@ const client = new OpenAI({
 });
 
 const chatCompletion = await client.chat.completions.create({
-	model: "meta-llama/Llama-3.1-8B-Instruct",
+	model: "meta-llama/Llama-3.1-8B-Instruct:hf-inference",
     messages: [
         {
             role: "user",

--- a/packages/tasks-gen/snippets-fixtures/bill-to-param/python/openai/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/bill-to-param/python/openai/0.hf-inference.py
@@ -2,7 +2,7 @@ import os
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1",
+    base_url="https://router.huggingface.co/v1",
     api_key=os.environ["HF_TOKEN"],
     default_headers={
         "X-HF-Bill-To": "huggingface"
@@ -10,7 +10,7 @@ client = OpenAI(
 )
 
 completion = client.chat.completions.create(
-    model="meta-llama/Llama-3.1-8B-Instruct",
+    model="meta-llama/Llama-3.1-8B-Instruct:hf-inference",
     messages=[
         {
             "role": "user",

--- a/packages/tasks-gen/snippets-fixtures/bill-to-param/python/requests/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/bill-to-param/python/requests/0.hf-inference.py
@@ -1,7 +1,7 @@
 import os
 import requests
 
-API_URL = "https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1/chat/completions"
+API_URL = "https://router.huggingface.co/v1/chat/completions"
 headers = {
     "Authorization": f"Bearer {os.environ['HF_TOKEN']}",
     "X-HF-Bill-To": "huggingface"
@@ -18,7 +18,7 @@ response = query({
             "content": "What is the capital of France?"
         }
     ],
-    "model": "meta-llama/Llama-3.1-8B-Instruct"
+    "model": "meta-llama/Llama-3.1-8B-Instruct:hf-inference"
 })
 
 print(response["choices"][0]["message"])

--- a/packages/tasks-gen/snippets-fixtures/bill-to-param/sh/curl/0.hf-inference.sh
+++ b/packages/tasks-gen/snippets-fixtures/bill-to-param/sh/curl/0.hf-inference.sh
@@ -1,4 +1,4 @@
-curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1/chat/completions \
+curl https://router.huggingface.co/v1/chat/completions \
     -H "Authorization: Bearer $HF_TOKEN" \
     -H 'Content-Type: application/json' \
     -H 'X-HF-Bill-To: huggingface' \
@@ -9,6 +9,6 @@ curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-I
                 "content": "What is the capital of France?"
             }
         ],
-        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "model": "meta-llama/Llama-3.1-8B-Instruct:hf-inference",
         "stream": false
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/openai/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/openai/0.hf-inference.js
@@ -1,12 +1,12 @@
 import { OpenAI } from "openai";
 
 const client = new OpenAI({
-	baseURL: "https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1",
+	baseURL: "https://router.huggingface.co/v1",
 	apiKey: process.env.HF_TOKEN,
 });
 
 const chatCompletion = await client.chat.completions.create({
-	model: "meta-llama/Llama-3.1-8B-Instruct",
+	model: "meta-llama/Llama-3.1-8B-Instruct:hf-inference",
     messages: [
         {
             role: "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/openai/0.together.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/openai/0.together.js
@@ -1,12 +1,12 @@
 import { OpenAI } from "openai";
 
 const client = new OpenAI({
-	baseURL: "https://router.huggingface.co/together/v1",
+	baseURL: "https://router.huggingface.co/v1",
 	apiKey: process.env.HF_TOKEN,
 });
 
 const chatCompletion = await client.chat.completions.create({
-	model: "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
+	model: "meta-llama/Llama-3.1-8B-Instruct:together",
     messages: [
         {
             role: "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/openai/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/openai/0.hf-inference.py
@@ -2,12 +2,12 @@ import os
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1",
+    base_url="https://router.huggingface.co/v1",
     api_key=os.environ["HF_TOKEN"],
 )
 
 completion = client.chat.completions.create(
-    model="meta-llama/Llama-3.1-8B-Instruct",
+    model="meta-llama/Llama-3.1-8B-Instruct:hf-inference",
     messages=[
         {
             "role": "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/openai/0.together.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/openai/0.together.py
@@ -2,12 +2,12 @@ import os
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://router.huggingface.co/together/v1",
+    base_url="https://router.huggingface.co/v1",
     api_key=os.environ["HF_TOKEN"],
 )
 
 completion = client.chat.completions.create(
-    model="<together alias for meta-llama/Llama-3.1-8B-Instruct>",
+    model="meta-llama/Llama-3.1-8B-Instruct:together",
     messages=[
         {
             "role": "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/requests/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/requests/0.hf-inference.py
@@ -1,7 +1,7 @@
 import os
 import requests
 
-API_URL = "https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1/chat/completions"
+API_URL = "https://router.huggingface.co/v1/chat/completions"
 headers = {
     "Authorization": f"Bearer {os.environ['HF_TOKEN']}",
 }
@@ -17,7 +17,7 @@ response = query({
             "content": "What is the capital of France?"
         }
     ],
-    "model": "meta-llama/Llama-3.1-8B-Instruct"
+    "model": "meta-llama/Llama-3.1-8B-Instruct:hf-inference"
 })
 
 print(response["choices"][0]["message"])

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/requests/0.together.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/requests/0.together.py
@@ -1,7 +1,7 @@
 import os
 import requests
 
-API_URL = "https://router.huggingface.co/together/v1/chat/completions"
+API_URL = "https://router.huggingface.co/v1/chat/completions"
 headers = {
     "Authorization": f"Bearer {os.environ['HF_TOKEN']}",
 }
@@ -17,7 +17,7 @@ response = query({
             "content": "What is the capital of France?"
         }
     ],
-    "model": "<together alias for meta-llama/Llama-3.1-8B-Instruct>"
+    "model": "meta-llama/Llama-3.1-8B-Instruct:together"
 })
 
 print(response["choices"][0]["message"])

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/sh/curl/0.hf-inference.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/sh/curl/0.hf-inference.sh
@@ -1,4 +1,4 @@
-curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1/chat/completions \
+curl https://router.huggingface.co/v1/chat/completions \
     -H "Authorization: Bearer $HF_TOKEN" \
     -H 'Content-Type: application/json' \
     -d '{
@@ -8,6 +8,6 @@ curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-I
                 "content": "What is the capital of France?"
             }
         ],
-        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "model": "meta-llama/Llama-3.1-8B-Instruct:hf-inference",
         "stream": false
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/sh/curl/0.together.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/sh/curl/0.together.sh
@@ -1,4 +1,4 @@
-curl https://router.huggingface.co/together/v1/chat/completions \
+curl https://router.huggingface.co/v1/chat/completions \
     -H "Authorization: Bearer $HF_TOKEN" \
     -H 'Content-Type: application/json' \
     -d '{
@@ -8,6 +8,6 @@ curl https://router.huggingface.co/together/v1/chat/completions \
                 "content": "What is the capital of France?"
             }
         ],
-        "model": "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
+        "model": "meta-llama/Llama-3.1-8B-Instruct:together",
         "stream": false
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.hf-inference.js
@@ -1,12 +1,12 @@
 import { OpenAI } from "openai";
 
 const client = new OpenAI({
-	baseURL: "https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1",
+	baseURL: "https://router.huggingface.co/v1",
 	apiKey: process.env.HF_TOKEN,
 });
 
 const stream = await client.chat.completions.create({
-    model: "meta-llama/Llama-3.1-8B-Instruct",
+    model: "meta-llama/Llama-3.1-8B-Instruct:hf-inference",
     messages: [
         {
             role: "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.together.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.together.js
@@ -1,12 +1,12 @@
 import { OpenAI } from "openai";
 
 const client = new OpenAI({
-	baseURL: "https://router.huggingface.co/together/v1",
+	baseURL: "https://router.huggingface.co/v1",
 	apiKey: process.env.HF_TOKEN,
 });
 
 const stream = await client.chat.completions.create({
-    model: "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
+    model: "meta-llama/Llama-3.1-8B-Instruct:together",
     messages: [
         {
             role: "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/openai/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/openai/0.hf-inference.py
@@ -2,12 +2,12 @@ import os
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1",
+    base_url="https://router.huggingface.co/v1",
     api_key=os.environ["HF_TOKEN"],
 )
 
 stream = client.chat.completions.create(
-    model="meta-llama/Llama-3.1-8B-Instruct",
+    model="meta-llama/Llama-3.1-8B-Instruct:hf-inference",
     messages=[
         {
             "role": "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/openai/0.together.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/openai/0.together.py
@@ -2,12 +2,12 @@ import os
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://router.huggingface.co/together/v1",
+    base_url="https://router.huggingface.co/v1",
     api_key=os.environ["HF_TOKEN"],
 )
 
 stream = client.chat.completions.create(
-    model="<together alias for meta-llama/Llama-3.1-8B-Instruct>",
+    model="meta-llama/Llama-3.1-8B-Instruct:together",
     messages=[
         {
             "role": "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/requests/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/requests/0.hf-inference.py
@@ -2,7 +2,7 @@ import os
 import json
 import requests
 
-API_URL = "https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1/chat/completions"
+API_URL = "https://router.huggingface.co/v1/chat/completions"
 headers = {
     "Authorization": f"Bearer {os.environ['HF_TOKEN']}",
 }
@@ -23,7 +23,7 @@ chunks = query({
             "content": "What is the capital of France?"
         }
     ],
-    "model": "meta-llama/Llama-3.1-8B-Instruct",
+    "model": "meta-llama/Llama-3.1-8B-Instruct:hf-inference",
     "stream": True,
 })
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/requests/0.together.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/requests/0.together.py
@@ -2,7 +2,7 @@ import os
 import json
 import requests
 
-API_URL = "https://router.huggingface.co/together/v1/chat/completions"
+API_URL = "https://router.huggingface.co/v1/chat/completions"
 headers = {
     "Authorization": f"Bearer {os.environ['HF_TOKEN']}",
 }
@@ -23,7 +23,7 @@ chunks = query({
             "content": "What is the capital of France?"
         }
     ],
-    "model": "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
+    "model": "meta-llama/Llama-3.1-8B-Instruct:together",
     "stream": True,
 })
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/sh/curl/0.hf-inference.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/sh/curl/0.hf-inference.sh
@@ -1,4 +1,4 @@
-curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1/chat/completions \
+curl https://router.huggingface.co/v1/chat/completions \
     -H "Authorization: Bearer $HF_TOKEN" \
     -H 'Content-Type: application/json' \
     -d '{
@@ -8,6 +8,6 @@ curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-I
                 "content": "What is the capital of France?"
             }
         ],
-        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "model": "meta-llama/Llama-3.1-8B-Instruct:hf-inference",
         "stream": true
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/sh/curl/0.together.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/sh/curl/0.together.sh
@@ -1,4 +1,4 @@
-curl https://router.huggingface.co/together/v1/chat/completions \
+curl https://router.huggingface.co/v1/chat/completions \
     -H "Authorization: Bearer $HF_TOKEN" \
     -H 'Content-Type: application/json' \
     -d '{
@@ -8,6 +8,6 @@ curl https://router.huggingface.co/together/v1/chat/completions \
                 "content": "What is the capital of France?"
             }
         ],
-        "model": "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
+        "model": "meta-llama/Llama-3.1-8B-Instruct:together",
         "stream": true
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/openai/0.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/openai/0.fireworks-ai.js
@@ -1,12 +1,12 @@
 import { OpenAI } from "openai";
 
 const client = new OpenAI({
-	baseURL: "https://router.huggingface.co/fireworks-ai/inference/v1",
+	baseURL: "https://router.huggingface.co/v1",
 	apiKey: process.env.HF_TOKEN,
 });
 
 const chatCompletion = await client.chat.completions.create({
-	model: "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
+	model: "meta-llama/Llama-3.2-11B-Vision-Instruct:fireworks-ai",
     messages: [
         {
             role: "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/openai/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/openai/0.hf-inference.js
@@ -1,12 +1,12 @@
 import { OpenAI } from "openai";
 
 const client = new OpenAI({
-	baseURL: "https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.2-11B-Vision-Instruct/v1",
+	baseURL: "https://router.huggingface.co/v1",
 	apiKey: process.env.HF_TOKEN,
 });
 
 const chatCompletion = await client.chat.completions.create({
-	model: "meta-llama/Llama-3.2-11B-Vision-Instruct",
+	model: "meta-llama/Llama-3.2-11B-Vision-Instruct:hf-inference",
     messages: [
         {
             role: "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/openai/0.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/openai/0.fireworks-ai.py
@@ -2,12 +2,12 @@ import os
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://router.huggingface.co/fireworks-ai/inference/v1",
+    base_url="https://router.huggingface.co/v1",
     api_key=os.environ["HF_TOKEN"],
 )
 
 completion = client.chat.completions.create(
-    model="<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
+    model="meta-llama/Llama-3.2-11B-Vision-Instruct:fireworks-ai",
     messages=[
         {
             "role": "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/openai/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/openai/0.hf-inference.py
@@ -2,12 +2,12 @@ import os
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.2-11B-Vision-Instruct/v1",
+    base_url="https://router.huggingface.co/v1",
     api_key=os.environ["HF_TOKEN"],
 )
 
 completion = client.chat.completions.create(
-    model="meta-llama/Llama-3.2-11B-Vision-Instruct",
+    model="meta-llama/Llama-3.2-11B-Vision-Instruct:hf-inference",
     messages=[
         {
             "role": "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/requests/0.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/requests/0.fireworks-ai.py
@@ -1,7 +1,7 @@
 import os
 import requests
 
-API_URL = "https://router.huggingface.co/fireworks-ai/inference/v1/chat/completions"
+API_URL = "https://router.huggingface.co/v1/chat/completions"
 headers = {
     "Authorization": f"Bearer {os.environ['HF_TOKEN']}",
 }
@@ -28,7 +28,7 @@ response = query({
             ]
         }
     ],
-    "model": "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>"
+    "model": "meta-llama/Llama-3.2-11B-Vision-Instruct:fireworks-ai"
 })
 
 print(response["choices"][0]["message"])

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/requests/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/requests/0.hf-inference.py
@@ -1,7 +1,7 @@
 import os
 import requests
 
-API_URL = "https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.2-11B-Vision-Instruct/v1/chat/completions"
+API_URL = "https://router.huggingface.co/v1/chat/completions"
 headers = {
     "Authorization": f"Bearer {os.environ['HF_TOKEN']}",
 }
@@ -28,7 +28,7 @@ response = query({
             ]
         }
     ],
-    "model": "meta-llama/Llama-3.2-11B-Vision-Instruct"
+    "model": "meta-llama/Llama-3.2-11B-Vision-Instruct:hf-inference"
 })
 
 print(response["choices"][0]["message"])

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/sh/curl/0.fireworks-ai.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/sh/curl/0.fireworks-ai.sh
@@ -1,4 +1,4 @@
-curl https://router.huggingface.co/fireworks-ai/inference/v1/chat/completions \
+curl https://router.huggingface.co/v1/chat/completions \
     -H "Authorization: Bearer $HF_TOKEN" \
     -H 'Content-Type: application/json' \
     -d '{
@@ -19,6 +19,6 @@ curl https://router.huggingface.co/fireworks-ai/inference/v1/chat/completions \
                 ]
             }
         ],
-        "model": "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
+        "model": "meta-llama/Llama-3.2-11B-Vision-Instruct:fireworks-ai",
         "stream": false
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/sh/curl/0.hf-inference.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/sh/curl/0.hf-inference.sh
@@ -1,4 +1,4 @@
-curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.2-11B-Vision-Instruct/v1/chat/completions \
+curl https://router.huggingface.co/v1/chat/completions \
     -H "Authorization: Bearer $HF_TOKEN" \
     -H 'Content-Type: application/json' \
     -d '{
@@ -19,6 +19,6 @@ curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.2-11B-
                 ]
             }
         ],
-        "model": "meta-llama/Llama-3.2-11B-Vision-Instruct",
+        "model": "meta-llama/Llama-3.2-11B-Vision-Instruct:hf-inference",
         "stream": false
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.fireworks-ai.js
@@ -1,12 +1,12 @@
 import { OpenAI } from "openai";
 
 const client = new OpenAI({
-	baseURL: "https://router.huggingface.co/fireworks-ai/inference/v1",
+	baseURL: "https://router.huggingface.co/v1",
 	apiKey: process.env.HF_TOKEN,
 });
 
 const stream = await client.chat.completions.create({
-    model: "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
+    model: "meta-llama/Llama-3.2-11B-Vision-Instruct:fireworks-ai",
     messages: [
         {
             role: "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.hf-inference.js
@@ -1,12 +1,12 @@
 import { OpenAI } from "openai";
 
 const client = new OpenAI({
-	baseURL: "https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.2-11B-Vision-Instruct/v1",
+	baseURL: "https://router.huggingface.co/v1",
 	apiKey: process.env.HF_TOKEN,
 });
 
 const stream = await client.chat.completions.create({
-    model: "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    model: "meta-llama/Llama-3.2-11B-Vision-Instruct:hf-inference",
     messages: [
         {
             role: "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/openai/0.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/openai/0.fireworks-ai.py
@@ -2,12 +2,12 @@ import os
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://router.huggingface.co/fireworks-ai/inference/v1",
+    base_url="https://router.huggingface.co/v1",
     api_key=os.environ["HF_TOKEN"],
 )
 
 stream = client.chat.completions.create(
-    model="<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
+    model="meta-llama/Llama-3.2-11B-Vision-Instruct:fireworks-ai",
     messages=[
         {
             "role": "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/openai/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/openai/0.hf-inference.py
@@ -2,12 +2,12 @@ import os
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.2-11B-Vision-Instruct/v1",
+    base_url="https://router.huggingface.co/v1",
     api_key=os.environ["HF_TOKEN"],
 )
 
 stream = client.chat.completions.create(
-    model="meta-llama/Llama-3.2-11B-Vision-Instruct",
+    model="meta-llama/Llama-3.2-11B-Vision-Instruct:hf-inference",
     messages=[
         {
             "role": "user",

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/requests/0.fireworks-ai.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/requests/0.fireworks-ai.py
@@ -2,7 +2,7 @@ import os
 import json
 import requests
 
-API_URL = "https://router.huggingface.co/fireworks-ai/inference/v1/chat/completions"
+API_URL = "https://router.huggingface.co/v1/chat/completions"
 headers = {
     "Authorization": f"Bearer {os.environ['HF_TOKEN']}",
 }
@@ -34,7 +34,7 @@ chunks = query({
             ]
         }
     ],
-    "model": "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
+    "model": "meta-llama/Llama-3.2-11B-Vision-Instruct:fireworks-ai",
     "stream": True,
 })
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/requests/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/requests/0.hf-inference.py
@@ -2,7 +2,7 @@ import os
 import json
 import requests
 
-API_URL = "https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.2-11B-Vision-Instruct/v1/chat/completions"
+API_URL = "https://router.huggingface.co/v1/chat/completions"
 headers = {
     "Authorization": f"Bearer {os.environ['HF_TOKEN']}",
 }
@@ -34,7 +34,7 @@ chunks = query({
             ]
         }
     ],
-    "model": "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    "model": "meta-llama/Llama-3.2-11B-Vision-Instruct:hf-inference",
     "stream": True,
 })
 

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/sh/curl/0.fireworks-ai.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/sh/curl/0.fireworks-ai.sh
@@ -1,4 +1,4 @@
-curl https://router.huggingface.co/fireworks-ai/inference/v1/chat/completions \
+curl https://router.huggingface.co/v1/chat/completions \
     -H "Authorization: Bearer $HF_TOKEN" \
     -H 'Content-Type: application/json' \
     -d '{
@@ -19,6 +19,6 @@ curl https://router.huggingface.co/fireworks-ai/inference/v1/chat/completions \
                 ]
             }
         ],
-        "model": "<fireworks-ai alias for meta-llama/Llama-3.2-11B-Vision-Instruct>",
+        "model": "meta-llama/Llama-3.2-11B-Vision-Instruct:fireworks-ai",
         "stream": true
     }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/sh/curl/0.hf-inference.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/sh/curl/0.hf-inference.sh
@@ -1,4 +1,4 @@
-curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.2-11B-Vision-Instruct/v1/chat/completions \
+curl https://router.huggingface.co/v1/chat/completions \
     -H "Authorization: Bearer $HF_TOKEN" \
     -H 'Content-Type: application/json' \
     -d '{
@@ -19,6 +19,6 @@ curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.2-11B-
                 ]
             }
         ],
-        "model": "meta-llama/Llama-3.2-11B-Vision-Instruct",
+        "model": "meta-llama/Llama-3.2-11B-Vision-Instruct:hf-inference",
         "stream": true
     }'

--- a/packages/tasks-gen/snippets-fixtures/with-access-token/js/openai/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/with-access-token/js/openai/0.hf-inference.js
@@ -1,12 +1,12 @@
 import { OpenAI } from "openai";
 
 const client = new OpenAI({
-	baseURL: "https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1",
+	baseURL: "https://router.huggingface.co/v1",
 	apiKey: "hf_xxx",
 });
 
 const chatCompletion = await client.chat.completions.create({
-	model: "meta-llama/Llama-3.1-8B-Instruct",
+	model: "meta-llama/Llama-3.1-8B-Instruct:hf-inference",
     messages: [
         {
             role: "user",

--- a/packages/tasks-gen/snippets-fixtures/with-access-token/python/openai/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/with-access-token/python/openai/0.hf-inference.py
@@ -1,12 +1,12 @@
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1",
+    base_url="https://router.huggingface.co/v1",
     api_key="hf_xxx",
 )
 
 completion = client.chat.completions.create(
-    model="meta-llama/Llama-3.1-8B-Instruct",
+    model="meta-llama/Llama-3.1-8B-Instruct:hf-inference",
     messages=[
         {
             "role": "user",

--- a/packages/tasks-gen/snippets-fixtures/with-access-token/python/requests/0.hf-inference.py
+++ b/packages/tasks-gen/snippets-fixtures/with-access-token/python/requests/0.hf-inference.py
@@ -1,6 +1,6 @@
 import requests
 
-API_URL = "https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1/chat/completions"
+API_URL = "https://router.huggingface.co/v1/chat/completions"
 headers = {
     "Authorization": "Bearer hf_xxx",
 }
@@ -16,7 +16,7 @@ response = query({
             "content": "What is the capital of France?"
         }
     ],
-    "model": "meta-llama/Llama-3.1-8B-Instruct"
+    "model": "meta-llama/Llama-3.1-8B-Instruct:hf-inference"
 })
 
 print(response["choices"][0]["message"])

--- a/packages/tasks-gen/snippets-fixtures/with-access-token/sh/curl/0.hf-inference.sh
+++ b/packages/tasks-gen/snippets-fixtures/with-access-token/sh/curl/0.hf-inference.sh
@@ -1,4 +1,4 @@
-curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-Instruct/v1/chat/completions \
+curl https://router.huggingface.co/v1/chat/completions \
     -H 'Authorization: Bearer hf_xxx' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -8,6 +8,6 @@ curl https://router.huggingface.co/hf-inference/models/meta-llama/Llama-3.1-8B-I
                 "content": "What is the capital of France?"
             }
         ],
-        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "model": "meta-llama/Llama-3.1-8B-Instruct:hf-inference",
         "stream": false
     }'


### PR DESCRIPTION
This PR updates the inference snippets to take showcase `https://router.huggingface.co/v1` "auto" route + the new syntax to select a model+provider e.g. `model="meta-llama/Llama-3.1-8B-Instruct:together"`.

Many details to take into account but I reviewed all the examples one by one and I think they're good now. Once merged, we won't need any modification in moon-landing code.