### PR TITLE
Add missing chat inference snippets

### DIFF
--- a/packages/inference/src/snippets/templates/js/fetch/conversational.jinja
+++ b/packages/inference/src/snippets/templates/js/fetch/conversational.jinja
@@ -1,0 +1,23 @@
+async function query(data) {
+	const response = await fetch(
+		"{{ fullUrl }}",
+		{
+			headers: {
+				Authorization: "{{ authorizationHeader }}",
+				"Content-Type": "application/json",
+{% if billTo %}
+				"X-HF-Bill-To": "{{ billTo }}",
+{% endif %}			},
+			method: "POST",
+			body: JSON.stringify(data),
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query({ 
+{{ autoInputs.asTsString }}
+}).then((response) => {
+    console.log(JSON.stringify(response));
+});

--- a/packages/tasks-gen/scripts/generate-snippets-fixtures.ts
+++ b/packages/tasks-gen/scripts/generate-snippets-fixtures.ts
@@ -56,7 +56,7 @@ const TEST_CASES: {
 			tags: ["conversational"],
 			inference: "",
 		},
-		providers: ["hf-inference", "together"],
+		providers: ["hf-inference", "together", "auto"],
 		opts: { streaming: false },
 	},
 	{
@@ -68,7 +68,7 @@ const TEST_CASES: {
 			tags: ["conversational"],
 			inference: "",
 		},
-		providers: ["hf-inference", "together"],
+		providers: ["hf-inference", "together", "auto"],
 		opts: { streaming: true },
 	},
 	{
@@ -80,7 +80,7 @@ const TEST_CASES: {
 			tags: ["conversational"],
 			inference: "",
 		},
-		providers: ["hf-inference", "fireworks-ai"],
+		providers: ["hf-inference", "fireworks-ai", "auto"],
 		opts: { streaming: false },
 	},
 	{
@@ -92,7 +92,7 @@ const TEST_CASES: {
 			tags: ["conversational"],
 			inference: "",
 		},
-		providers: ["hf-inference", "fireworks-ai"],
+		providers: ["hf-inference", "fireworks-ai", "auto"],
 		opts: { streaming: true },
 	},
 	{

--- a/packages/tasks-gen/snippets-fixtures/bill-to-param/js/fetch/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/bill-to-param/js/fetch/0.hf-inference.js
@@ -1,0 +1,28 @@
+async function query(data) {
+	const response = await fetch(
+		"https://router.huggingface.co/v1/chat/completions",
+		{
+			headers: {
+				Authorization: `Bearer ${process.env.HF_TOKEN}`,
+				"Content-Type": "application/json",
+				"X-HF-Bill-To": "huggingface",
+			},
+			method: "POST",
+			body: JSON.stringify(data),
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query({ 
+    messages: [
+        {
+            role: "user",
+            content: "What is the capital of France?",
+        },
+    ],
+    model: "meta-llama/Llama-3.1-8B-Instruct:hf-inference",
+}).then((response) => {
+    console.log(JSON.stringify(response));
+});

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-custom-endpoint/js/fetch/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-custom-endpoint/js/fetch/0.hf-inference.js
@@ -1,0 +1,27 @@
+async function query(data) {
+	const response = await fetch(
+		"http://localhost:8080/v1/chat/completions",
+		{
+			headers: {
+				Authorization: `Bearer ${process.env.API_TOKEN}`,
+				"Content-Type": "application/json",
+			},
+			method: "POST",
+			body: JSON.stringify(data),
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query({ 
+    messages: [
+        {
+            role: "user",
+            content: "What is the capital of France?",
+        },
+    ],
+    model: "meta-llama/Llama-3.1-8B-Instruct",
+}).then((response) => {
+    console.log(JSON.stringify(response));
+});

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/fetch/0.auto.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/fetch/0.auto.js
@@ -1,0 +1,27 @@
+async function query(data) {
+	const response = await fetch(
+		"https://router.huggingface.co/v1/chat/completions",
+		{
+			headers: {
+				Authorization: `Bearer ${process.env.HF_TOKEN}`,
+				"Content-Type": "application/json",
+			},
+			method: "POST",
+			body: JSON.stringify(data),
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query({ 
+    messages: [
+        {
+            role: "user",
+            content: "What is the capital of France?",
+        },
+    ],
+    model: "meta-llama/Llama-3.1-8B-Instruct",
+}).then((response) => {
+    console.log(JSON.stringify(response));
+});

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/fetch/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/fetch/0.hf-inference.js
@@ -1,0 +1,27 @@
+async function query(data) {
+	const response = await fetch(
+		"https://router.huggingface.co/v1/chat/completions",
+		{
+			headers: {
+				Authorization: `Bearer ${process.env.HF_TOKEN}`,
+				"Content-Type": "application/json",
+			},
+			method: "POST",
+			body: JSON.stringify(data),
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query({ 
+    messages: [
+        {
+            role: "user",
+            content: "What is the capital of France?",
+        },
+    ],
+    model: "meta-llama/Llama-3.1-8B-Instruct:hf-inference",
+}).then((response) => {
+    console.log(JSON.stringify(response));
+});

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/fetch/0.together.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/fetch/0.together.js
@@ -1,0 +1,27 @@
+async function query(data) {
+	const response = await fetch(
+		"https://router.huggingface.co/v1/chat/completions",
+		{
+			headers: {
+				Authorization: `Bearer ${process.env.HF_TOKEN}`,
+				"Content-Type": "application/json",
+			},
+			method: "POST",
+			body: JSON.stringify(data),
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query({ 
+    messages: [
+        {
+            role: "user",
+            content: "What is the capital of France?",
+        },
+    ],
+    model: "meta-llama/Llama-3.1-8B-Instruct:together",
+}).then((response) => {
+    console.log(JSON.stringify(response));
+});

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/huggingface.js/0.auto.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/huggingface.js/0.auto.js
@@ -1,0 +1,16 @@
+import { InferenceClient } from "@huggingface/inference";
+
+const client = new InferenceClient(process.env.HF_TOKEN);
+
+const chatCompletion = await client.chatCompletion({
+    provider: "auto",
+    model: "meta-llama/Llama-3.1-8B-Instruct",
+    messages: [
+        {
+            role: "user",
+            content: "What is the capital of France?",
+        },
+    ],
+});
+
+console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/openai/0.auto.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/js/openai/0.auto.js
@@ -1,0 +1,18 @@
+import { OpenAI } from "openai";
+
+const client = new OpenAI({
+	baseURL: "https://router.huggingface.co/v1",
+	apiKey: process.env.HF_TOKEN,
+});
+
+const chatCompletion = await client.chat.completions.create({
+	model: "meta-llama/Llama-3.1-8B-Instruct",
+    messages: [
+        {
+            role: "user",
+            content: "What is the capital of France?",
+        },
+    ],
+});
+
+console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/huggingface_hub/0.auto.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/huggingface_hub/0.auto.py
@@ -1,0 +1,19 @@
+import os
+from huggingface_hub import InferenceClient
+
+client = InferenceClient(
+    provider="auto",
+    api_key=os.environ["HF_TOKEN"],
+)
+
+completion = client.chat.completions.create(
+    model="meta-llama/Llama-3.1-8B-Instruct",
+    messages=[
+        {
+            "role": "user",
+            "content": "What is the capital of France?"
+        }
+    ],
+)
+
+print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/openai/0.auto.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/openai/0.auto.py
@@ -1,0 +1,19 @@
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://router.huggingface.co/v1",
+    api_key=os.environ["HF_TOKEN"],
+)
+
+completion = client.chat.completions.create(
+    model="meta-llama/Llama-3.1-8B-Instruct",
+    messages=[
+        {
+            "role": "user",
+            "content": "What is the capital of France?"
+        }
+    ],
+)
+
+print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/requests/0.auto.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/python/requests/0.auto.py
@@ -1,0 +1,23 @@
+import os
+import requests
+
+API_URL = "https://router.huggingface.co/v1/chat/completions"
+headers = {
+    "Authorization": f"Bearer {os.environ['HF_TOKEN']}",
+}
+
+def query(payload):
+    response = requests.post(API_URL, headers=headers, json=payload)
+    return response.json()
+
+response = query({
+    "messages": [
+        {
+            "role": "user",
+            "content": "What is the capital of France?"
+        }
+    ],
+    "model": "meta-llama/Llama-3.1-8B-Instruct"
+})
+
+print(response["choices"][0]["message"])

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/sh/curl/0.auto.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-non-stream/sh/curl/0.auto.sh
@@ -1,0 +1,13 @@
+curl https://router.huggingface.co/v1/chat/completions \
+    -H "Authorization: Bearer $HF_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "messages": [
+            {
+                "role": "user",
+                "content": "What is the capital of France?"
+            }
+        ],
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "stream": false
+    }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/huggingface.js/0.auto.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/huggingface.js/0.auto.js
@@ -1,0 +1,24 @@
+import { InferenceClient } from "@huggingface/inference";
+
+const client = new InferenceClient(process.env.HF_TOKEN);
+
+let out = "";
+
+const stream = client.chatCompletionStream({
+    provider: "auto",
+    model: "meta-llama/Llama-3.1-8B-Instruct",
+    messages: [
+        {
+            role: "user",
+            content: "What is the capital of France?",
+        },
+    ],
+});
+
+for await (const chunk of stream) {
+	if (chunk.choices && chunk.choices.length > 0) {
+		const newContent = chunk.choices[0].delta.content;
+		out += newContent;
+		console.log(newContent);
+	}
+}

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.auto.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/js/openai/0.auto.js
@@ -1,0 +1,21 @@
+import { OpenAI } from "openai";
+
+const client = new OpenAI({
+	baseURL: "https://router.huggingface.co/v1",
+	apiKey: process.env.HF_TOKEN,
+});
+
+const stream = await client.chat.completions.create({
+    model: "meta-llama/Llama-3.1-8B-Instruct",
+    messages: [
+        {
+            role: "user",
+            content: "What is the capital of France?",
+        },
+    ],
+    stream: true,
+});
+
+for await (const chunk of stream) {
+    process.stdout.write(chunk.choices[0]?.delta?.content || "");
+}

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/huggingface_hub/0.auto.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/huggingface_hub/0.auto.py
@@ -1,0 +1,21 @@
+import os
+from huggingface_hub import InferenceClient
+
+client = InferenceClient(
+    provider="auto",
+    api_key=os.environ["HF_TOKEN"],
+)
+
+stream = client.chat.completions.create(
+    model="meta-llama/Llama-3.1-8B-Instruct",
+    messages=[
+        {
+            "role": "user",
+            "content": "What is the capital of France?"
+        }
+    ],
+    stream=True,
+)
+
+for chunk in stream:
+    print(chunk.choices[0].delta.content, end="")

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/openai/0.auto.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/openai/0.auto.py
@@ -1,0 +1,21 @@
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://router.huggingface.co/v1",
+    api_key=os.environ["HF_TOKEN"],
+)
+
+stream = client.chat.completions.create(
+    model="meta-llama/Llama-3.1-8B-Instruct",
+    messages=[
+        {
+            "role": "user",
+            "content": "What is the capital of France?"
+        }
+    ],
+    stream=True,
+)
+
+for chunk in stream:
+    print(chunk.choices[0].delta.content, end="")

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/requests/0.auto.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/python/requests/0.auto.py
@@ -1,0 +1,31 @@
+import os
+import json
+import requests
+
+API_URL = "https://router.huggingface.co/v1/chat/completions"
+headers = {
+    "Authorization": f"Bearer {os.environ['HF_TOKEN']}",
+}
+
+def query(payload):
+    response = requests.post(API_URL, headers=headers, json=payload, stream=True)
+    for line in response.iter_lines():
+        if not line.startswith(b"data:"):
+            continue
+        if line.strip() == b"data: [DONE]":
+            return
+        yield json.loads(line.decode("utf-8").lstrip("data:").rstrip("/n"))
+
+chunks = query({
+    "messages": [
+        {
+            "role": "user",
+            "content": "What is the capital of France?"
+        }
+    ],
+    "model": "meta-llama/Llama-3.1-8B-Instruct",
+    "stream": True,
+})
+
+for chunk in chunks:
+    print(chunk["choices"][0]["delta"]["content"], end="")

--- a/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/sh/curl/0.auto.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-llm-stream/sh/curl/0.auto.sh
@@ -1,0 +1,13 @@
+curl https://router.huggingface.co/v1/chat/completions \
+    -H "Authorization: Bearer $HF_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "messages": [
+            {
+                "role": "user",
+                "content": "What is the capital of France?"
+            }
+        ],
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "stream": true
+    }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/fetch/0.auto.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/fetch/0.auto.js
@@ -1,0 +1,38 @@
+async function query(data) {
+	const response = await fetch(
+		"https://router.huggingface.co/v1/chat/completions",
+		{
+			headers: {
+				Authorization: `Bearer ${process.env.HF_TOKEN}`,
+				"Content-Type": "application/json",
+			},
+			method: "POST",
+			body: JSON.stringify(data),
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query({ 
+    messages: [
+        {
+            role: "user",
+            content: [
+                {
+                    type: "text",
+                    text: "Describe this image in one sentence.",
+                },
+                {
+                    type: "image_url",
+                    image_url: {
+                        url: "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg",
+                    },
+                },
+            ],
+        },
+    ],
+    model: "meta-llama/Llama-3.2-11B-Vision-Instruct",
+}).then((response) => {
+    console.log(JSON.stringify(response));
+});

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/fetch/0.fireworks-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/fetch/0.fireworks-ai.js
@@ -1,0 +1,38 @@
+async function query(data) {
+	const response = await fetch(
+		"https://router.huggingface.co/v1/chat/completions",
+		{
+			headers: {
+				Authorization: `Bearer ${process.env.HF_TOKEN}`,
+				"Content-Type": "application/json",
+			},
+			method: "POST",
+			body: JSON.stringify(data),
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query({ 
+    messages: [
+        {
+            role: "user",
+            content: [
+                {
+                    type: "text",
+                    text: "Describe this image in one sentence.",
+                },
+                {
+                    type: "image_url",
+                    image_url: {
+                        url: "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg",
+                    },
+                },
+            ],
+        },
+    ],
+    model: "meta-llama/Llama-3.2-11B-Vision-Instruct:fireworks-ai",
+}).then((response) => {
+    console.log(JSON.stringify(response));
+});

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/fetch/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/fetch/0.hf-inference.js
@@ -1,0 +1,38 @@
+async function query(data) {
+	const response = await fetch(
+		"https://router.huggingface.co/v1/chat/completions",
+		{
+			headers: {
+				Authorization: `Bearer ${process.env.HF_TOKEN}`,
+				"Content-Type": "application/json",
+			},
+			method: "POST",
+			body: JSON.stringify(data),
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query({ 
+    messages: [
+        {
+            role: "user",
+            content: [
+                {
+                    type: "text",
+                    text: "Describe this image in one sentence.",
+                },
+                {
+                    type: "image_url",
+                    image_url: {
+                        url: "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg",
+                    },
+                },
+            ],
+        },
+    ],
+    model: "meta-llama/Llama-3.2-11B-Vision-Instruct:hf-inference",
+}).then((response) => {
+    console.log(JSON.stringify(response));
+});

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/huggingface.js/0.auto.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/huggingface.js/0.auto.js
@@ -1,0 +1,27 @@
+import { InferenceClient } from "@huggingface/inference";
+
+const client = new InferenceClient(process.env.HF_TOKEN);
+
+const chatCompletion = await client.chatCompletion({
+    provider: "auto",
+    model: "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    messages: [
+        {
+            role: "user",
+            content: [
+                {
+                    type: "text",
+                    text: "Describe this image in one sentence.",
+                },
+                {
+                    type: "image_url",
+                    image_url: {
+                        url: "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg",
+                    },
+                },
+            ],
+        },
+    ],
+});
+
+console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/openai/0.auto.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/js/openai/0.auto.js
@@ -1,0 +1,29 @@
+import { OpenAI } from "openai";
+
+const client = new OpenAI({
+	baseURL: "https://router.huggingface.co/v1",
+	apiKey: process.env.HF_TOKEN,
+});
+
+const chatCompletion = await client.chat.completions.create({
+	model: "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    messages: [
+        {
+            role: "user",
+            content: [
+                {
+                    type: "text",
+                    text: "Describe this image in one sentence.",
+                },
+                {
+                    type: "image_url",
+                    image_url: {
+                        url: "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg",
+                    },
+                },
+            ],
+        },
+    ],
+});
+
+console.log(chatCompletion.choices[0].message);

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/huggingface_hub/0.auto.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/huggingface_hub/0.auto.py
@@ -1,0 +1,30 @@
+import os
+from huggingface_hub import InferenceClient
+
+client = InferenceClient(
+    provider="auto",
+    api_key=os.environ["HF_TOKEN"],
+)
+
+completion = client.chat.completions.create(
+    model="meta-llama/Llama-3.2-11B-Vision-Instruct",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Describe this image in one sentence."
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                    }
+                }
+            ]
+        }
+    ],
+)
+
+print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/openai/0.auto.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/openai/0.auto.py
@@ -1,0 +1,30 @@
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://router.huggingface.co/v1",
+    api_key=os.environ["HF_TOKEN"],
+)
+
+completion = client.chat.completions.create(
+    model="meta-llama/Llama-3.2-11B-Vision-Instruct",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Describe this image in one sentence."
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                    }
+                }
+            ]
+        }
+    ],
+)
+
+print(completion.choices[0].message)

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/requests/0.auto.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/python/requests/0.auto.py
@@ -1,0 +1,34 @@
+import os
+import requests
+
+API_URL = "https://router.huggingface.co/v1/chat/completions"
+headers = {
+    "Authorization": f"Bearer {os.environ['HF_TOKEN']}",
+}
+
+def query(payload):
+    response = requests.post(API_URL, headers=headers, json=payload)
+    return response.json()
+
+response = query({
+    "messages": [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Describe this image in one sentence."
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                    }
+                }
+            ]
+        }
+    ],
+    "model": "meta-llama/Llama-3.2-11B-Vision-Instruct"
+})
+
+print(response["choices"][0]["message"])

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/sh/curl/0.auto.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-non-stream/sh/curl/0.auto.sh
@@ -1,0 +1,24 @@
+curl https://router.huggingface.co/v1/chat/completions \
+    -H "Authorization: Bearer $HF_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Describe this image in one sentence."
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                        }
+                    }
+                ]
+            }
+        ],
+        "model": "meta-llama/Llama-3.2-11B-Vision-Instruct",
+        "stream": false
+    }'

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/huggingface.js/0.auto.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/huggingface.js/0.auto.js
@@ -1,0 +1,35 @@
+import { InferenceClient } from "@huggingface/inference";
+
+const client = new InferenceClient(process.env.HF_TOKEN);
+
+let out = "";
+
+const stream = client.chatCompletionStream({
+    provider: "auto",
+    model: "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    messages: [
+        {
+            role: "user",
+            content: [
+                {
+                    type: "text",
+                    text: "Describe this image in one sentence.",
+                },
+                {
+                    type: "image_url",
+                    image_url: {
+                        url: "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg",
+                    },
+                },
+            ],
+        },
+    ],
+});
+
+for await (const chunk of stream) {
+	if (chunk.choices && chunk.choices.length > 0) {
+		const newContent = chunk.choices[0].delta.content;
+		out += newContent;
+		console.log(newContent);
+	}
+}

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.auto.js
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/js/openai/0.auto.js
@@ -1,0 +1,32 @@
+import { OpenAI } from "openai";
+
+const client = new OpenAI({
+	baseURL: "https://router.huggingface.co/v1",
+	apiKey: process.env.HF_TOKEN,
+});
+
+const stream = await client.chat.completions.create({
+    model: "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    messages: [
+        {
+            role: "user",
+            content: [
+                {
+                    type: "text",
+                    text: "Describe this image in one sentence.",
+                },
+                {
+                    type: "image_url",
+                    image_url: {
+                        url: "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg",
+                    },
+                },
+            ],
+        },
+    ],
+    stream: true,
+});
+
+for await (const chunk of stream) {
+    process.stdout.write(chunk.choices[0]?.delta?.content || "");
+}

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/huggingface_hub/0.auto.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/huggingface_hub/0.auto.py
@@ -1,0 +1,32 @@
+import os
+from huggingface_hub import InferenceClient
+
+client = InferenceClient(
+    provider="auto",
+    api_key=os.environ["HF_TOKEN"],
+)
+
+stream = client.chat.completions.create(
+    model="meta-llama/Llama-3.2-11B-Vision-Instruct",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Describe this image in one sentence."
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                    }
+                }
+            ]
+        }
+    ],
+    stream=True,
+)
+
+for chunk in stream:
+    print(chunk.choices[0].delta.content, end="")

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/openai/0.auto.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/openai/0.auto.py
@@ -1,0 +1,32 @@
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://router.huggingface.co/v1",
+    api_key=os.environ["HF_TOKEN"],
+)
+
+stream = client.chat.completions.create(
+    model="meta-llama/Llama-3.2-11B-Vision-Instruct",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Describe this image in one sentence."
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                    }
+                }
+            ]
+        }
+    ],
+    stream=True,
+)
+
+for chunk in stream:
+    print(chunk.choices[0].delta.content, end="")

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/requests/0.auto.py
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/python/requests/0.auto.py
@@ -1,0 +1,42 @@
+import os
+import json
+import requests
+
+API_URL = "https://router.huggingface.co/v1/chat/completions"
+headers = {
+    "Authorization": f"Bearer {os.environ['HF_TOKEN']}",
+}
+
+def query(payload):
+    response = requests.post(API_URL, headers=headers, json=payload, stream=True)
+    for line in response.iter_lines():
+        if not line.startswith(b"data:"):
+            continue
+        if line.strip() == b"data: [DONE]":
+            return
+        yield json.loads(line.decode("utf-8").lstrip("data:").rstrip("/n"))
+
+chunks = query({
+    "messages": [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Describe this image in one sentence."
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                    }
+                }
+            ]
+        }
+    ],
+    "model": "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    "stream": True,
+})
+
+for chunk in chunks:
+    print(chunk["choices"][0]["delta"]["content"], end="")

--- a/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/sh/curl/0.auto.sh
+++ b/packages/tasks-gen/snippets-fixtures/conversational-vlm-stream/sh/curl/0.auto.sh
@@ -1,0 +1,24 @@
+curl https://router.huggingface.co/v1/chat/completions \
+    -H "Authorization: Bearer $HF_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Describe this image in one sentence."
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
+                        }
+                    }
+                ]
+            }
+        ],
+        "model": "meta-llama/Llama-3.2-11B-Vision-Instruct",
+        "stream": true
+    }'

--- a/packages/tasks-gen/snippets-fixtures/explicit-direct-request/js/fetch/0.together.js
+++ b/packages/tasks-gen/snippets-fixtures/explicit-direct-request/js/fetch/0.together.js
@@ -1,0 +1,27 @@
+async function query(data) {
+	const response = await fetch(
+		"https://api.together.xyz/v1/chat/completions",
+		{
+			headers: {
+				Authorization: `Bearer ${process.env.TOGETHER_API_KEY}`,
+				"Content-Type": "application/json",
+			},
+			method: "POST",
+			body: JSON.stringify(data),
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query({ 
+    messages: [
+        {
+            role: "user",
+            content: "What is the capital of France?",
+        },
+    ],
+    model: "<together alias for meta-llama/Llama-3.1-8B-Instruct>",
+}).then((response) => {
+    console.log(JSON.stringify(response));
+});

--- a/packages/tasks-gen/snippets-fixtures/with-access-token/js/fetch/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/with-access-token/js/fetch/0.hf-inference.js
@@ -1,0 +1,27 @@
+async function query(data) {
+	const response = await fetch(
+		"https://router.huggingface.co/v1/chat/completions",
+		{
+			headers: {
+				Authorization: "Bearer hf_xxx",
+				"Content-Type": "application/json",
+			},
+			method: "POST",
+			body: JSON.stringify(data),
+		}
+	);
+	const result = await response.json();
+	return result;
+}
+
+query({ 
+    messages: [
+        {
+            role: "user",
+            content: "What is the capital of France?",
+        },
+    ],
+    model: "meta-llama/Llama-3.1-8B-Instruct:hf-inference",
+}).then((response) => {
+    console.log(JSON.stringify(response));
+});


### PR DESCRIPTION
follow-up after https://github.com/huggingface/huggingface.js/pull/1636

Better to review commits individually. This PR:
- adds a snippet using JS fetch for conversational model (https://github.com/huggingface/huggingface.js/commit/e2f6c6faec2f16c7acd1f652e2412bc7e34b6212)
- adds tests for existing snippets using "auto" provider (conversational) (https://github.com/huggingface/huggingface.js/commit/435637379083ebdd36138315793566a3eb78d909)
- adds snippets for "auto" + "conversational" for cURL, Python openai, Python requests, JS openai, JS requests. (https://github.com/huggingface/huggingface.js/commit/33d30940a0520deb2e97fda2cf92d73ee7170a1f). Before that, only snippets for huggingface_hub/huggingface.js were displayed.