### PR TITLE
Update model-libraries.ts

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -524,6 +524,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.kimi_audio,
 		filter: false,
 	},
+	kronos: {
+		prettyLabel: "KRONOS",
+		repoName: "KRONOS",
+		repoUrl: "https://github.com/mahmoodlab/KRONOS",
+		filter: false,
+	},
 	k2: {
 		prettyLabel: "K2",
 		repoName: "k2",


### PR DESCRIPTION
Adding kronos to the model libraries.
KRONOS is a panel-agnostic foundation model for spatial proteomics images. Model weights are publicly available for research use only. https://github.com/mahmoodlab/KRONOS
https://huggingface.co/MahmoodLab/KRONOS