### PR TITLE
Add mistral-common library

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -210,17 +210,16 @@ curl -X POST "http://localhost:8000/v1/completions" \\
 
 	let setup;
 	let dockerCommand;
-	
+
 	if (model.tags.includes("mistral-common")) {
 		setup = [
 			"# Install vLLM from pip:",
 			"pip install vllm",
 			"# Make sure you have the latest version of mistral-common installed:",
-			"pip install --upgrade mistral-common"
+			"pip install --upgrade mistral-common",
 		].join("\n");
 		dockerCommand = `# Load and run the model:\ndocker exec -it my_vllm_container bash -c "vllm serve ${model.id} --tokenizer_mode mistral --config_format mistral --load_format mistral --tool-call-parser mistral --enable-auto-tool-choice"`;
-	}
-	else {
+	} else {
 		setup = ["# Install vLLM from pip:", "pip install vllm"].join("\n");
 		dockerCommand = `# Load and run the model:\ndocker exec -it my_vllm_container bash -c "vllm serve ${model.id}"`;
 	}
@@ -244,10 +243,7 @@ curl -X POST "http://localhost:8000/v1/completions" \\
 				`	vllm/vllm-openai:latest \\`,
 				`	--model ${model.id}`,
 			].join("\n"),
-			content: [
-				dockerCommand,
-				runCommand,
-			],
+			content: [dockerCommand, runCommand],
 		},
 	];
 };

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -221,7 +221,7 @@ curl -X POST "http://localhost:8000/v1/completions" \\
 		dockerCommand = `# Load and run the model:\ndocker exec -it my_vllm_container bash -c "vllm serve ${model.id} --tokenizer_mode mistral --config_format mistral --load_format mistral --tool-call-parser mistral --enable-auto-tool-choice"`;
 	}
 	else {
-		setup = ["# Install vLLM from pip:", "pip install vllm"].join("");
+		setup = ["# Install vLLM from pip:", "pip install vllm"].join("\n");
 		dockerCommand = `# Load and run the model:\ndocker exec -it my_vllm_container bash -c "vllm serve ${model.id}"`;
 	}
 

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -217,7 +217,7 @@ curl -X POST "http://localhost:8000/v1/completions" \\
 			"pip install vllm",
 			"# Make sure you have the latest version of mistral-common installed:",
 			"pip install --upgrade mistral-common"
-		].join("");
+		].join("\n");
 		dockerCommand = `# Load and run the model:\ndocker exec -it my_vllm_container bash -c "vllm serve ${model.id} --tokenizer_mode mistral --config_format mistral --load_format mistral --tool-call-parser mistral --enable-auto-tool-choice"`;
 	}
 	else {

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1893,4 +1893,26 @@ audio = model.autoencoder.decode(codes)[0].cpu()
 torchaudio.save("sample.wav", audio, model.autoencoder.sampling_rate)
 `,
 ];
+
+export const vllm = (model: ModelData): string[] => [
+	`pip install --upgrade vllm
+	
+# If serving Mistral AI models, make sure to update mistral-common:
+# pip install mistral-common --upgrade
+
+# serve the model with an OpenAI-compatible API
+vllm serve ${model.id}
+
+# for Mistral AI models, use:
+# vllm serve ${model.id} --tokenizer_mode mistral --config_format mistral --load_format mistral --tool-call-parser mistral --enable-auto-tool-choice
+
+# query the model with curl in a separate terminal
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "${model.id}",
+    "messages": [{"role": "user", "content": "What is the capital of France?"}]
+  }'`,
+];
+
 //#endregion

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1894,19 +1894,17 @@ torchaudio.save("sample.wav", audio, model.autoencoder.sampling_rate)
 `,
 ];
 
-export const vllm = (model: ModelData): string[] => [
-	`pip install --upgrade vllm
-	
-# If serving Mistral AI models, make sure to update mistral-common:
-# pip install mistral-common --upgrade
+export const mistral_common = (model: ModelData): string[] => [
+	`# We recommend to use vLLM to serve Mistral AI models.
+pip install vllm
 
-# serve the model with an OpenAI-compatible API
-vllm serve ${model.id}
+# Make sure to have installed the latest version of mistral-common.
+pip install --upgrade mistral-common[image,audio]
 
-# for Mistral AI models, use:
-# vllm serve ${model.id} --tokenizer_mode mistral --config_format mistral --load_format mistral --tool-call-parser mistral --enable-auto-tool-choice
+# Serve the model with an OpenAI-compatible API.
+vllm serve ${model.id} --tokenizer_mode mistral --config_format mistral --load_format mistral --tool-call-parser mistral --enable-auto-tool-choice
 
-# query the model with curl in a separate terminal
+# Query the model with curl in a separate terminal.
 curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1196,6 +1196,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path:"model_vae_fp16.pt"`,
 		snippets: snippets.threedtopia_xl,
 	},
+	vllm: {
+		prettyLabel: "vLLM",
+		repoName: "vllm",
+		repoUrl: "https://github.com/vllm-project/vllm",
+		docsUrl: "https://docs.vllm.ai/en/stable/",
+		snippets: snippets.vllm,
+		countDownloads: `path:"config.json" OR path:"params.json"`,
+	},
 } satisfies Record<string, LibraryUiElement>;
 
 export type ModelLibraryKey = keyof typeof MODEL_LIBRARIES_UI_ELEMENTS;

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -630,6 +630,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_extension:"ckpt"`,
 	},
+	mistral_common: {
+		prettyLabel: "mistral-common",
+		repoName: "mistral-common",
+		repoUrl: "https://github.com/mistralai/mistral-common",
+		docsUrl: "https://mistralai.github.io/mistral-common/",
+		snippets: snippets.mistral_common,
+		countDownloads: `path:"config.json" OR path:"params.json"`,
+	},
 	mitie: {
 		prettyLabel: "MITIE",
 		repoName: "MITIE",
@@ -1195,14 +1203,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"model_vae_fp16.pt"`,
 		snippets: snippets.threedtopia_xl,
-	},
-	vllm: {
-		prettyLabel: "vLLM",
-		repoName: "vllm",
-		repoUrl: "https://github.com/vllm-project/vllm",
-		docsUrl: "https://docs.vllm.ai/en/stable/",
-		snippets: snippets.vllm,
-		countDownloads: `path:"config.json" OR path:"params.json"`,
 	},
 } satisfies Record<string, LibraryUiElement>;
 


### PR DESCRIPTION
Hi !

We'd like to add [vLLM](https://docs.vllm.ai/en/stable/) as a library and track the downloads via two possible formats:
- Transformers with the `config.json`
- Mistral with the `params.json`

The code snippet suggested is through serving.

Edit:
Based on @Wauplin comment we changed the integration to instead add the `mistral-common` library