### PR TITLE
update xet reconstruction API call to use v1 prefix

### DIFF
--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -158,10 +158,10 @@ export class XetBlob extends Blob {
 			const connParams = await getAccessToken(this.accessToken, this.fetch, this.refreshUrl);
 
 			// debug(
-			// 	`curl '${connParams.casUrl}/reconstruction/${this.hash}' -H 'Authorization: Bearer ${connParams.accessToken}'`
+			// 	`curl '${connParams.casUrl}/v1/reconstruction/${this.hash}' -H 'Authorization: Bearer ${connParams.accessToken}'`
 			// );
 
-			const resp = await this.fetch(this.reconstructionUrl ?? `${connParams.casUrl}/reconstruction/${this.hash}`, {
+			const resp = await this.fetch(this.reconstructionUrl ?? `${connParams.casUrl}/v1/reconstruction/${this.hash}`, {
 				headers: {
 					Authorization: `Bearer ${connParams.accessToken}`,
 					Range: `bytes=${this.start}-${this.end - 1}`,


### PR DESCRIPTION
Update the reconstruction api path to use the `/v1` prefix (the old path is maintained by the server for backwards compatibility clients should use the updated path when possible).