### PR TITLE
Deprecate pendingSSO, missingMFA fields

### DIFF
--- a/packages/hub/src/lib/oauth-handle-redirect.ts
+++ b/packages/hub/src/lib/oauth-handle-redirect.ts
@@ -77,17 +77,26 @@ export interface UserInfo {
 		 */
 		roleInOrg?: string;
 		/**
+		 * @deprecated Use securityRestrictions instead with "sso"
 		 * HuggingFace field. When the user granted the oauth app access to the org, but didn't complete SSO.
 		 *
 		 * Should never happen directly after the oauth flow.
 		 */
 		pendingSSO?: boolean;
 		/**
+		 * @deprecated Use securityRestrictions instead with "mfa"
+		 *
 		 * HuggingFace field. When the user granted the oauth app access to the org, but didn't complete MFA.
 		 *
 		 * Should never happen directly after the oauth flow.
 		 */
 		missingMFA?: boolean;
+		/**
+		 * HuggingFace field. When the user granted the oauth app access to the org, but didn't complete following security restrictions.
+		 *
+		 * Should never happen directly after the oauth flow.
+		 */
+		securityRestrictions?: ("mfa" | "sso" | "ip" | "token-policy")[];
 	}>;
 }
 


### PR DESCRIPTION
This pull request updates the `UserInfo` interface in `packages/hub/src/lib/oauth-handle-redirect.ts` to improve how security restrictions are represented. It introduces a new `securityRestrictions` field and marks two existing fields as deprecated.

### Updates to the `UserInfo` interface:

* Added a new `securityRestrictions` field to represent various security restrictions (`"mfa"`, `"sso"`, `"ip"`, `"token-policy"`) in a unified way.
* Deprecated the `pendingSSO` field, recommending the use of `securityRestrictions` with `"sso"` instead.
* Deprecated the `missingMFA` field, recommending the use of `securityRestrictions` with `"mfa"` instead.