### PR TITLE
Remove mistral-common from modeling libraries

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -2024,23 +2024,4 @@ torchaudio.save("sample.wav", audio, model.autoencoder.sampling_rate)
 `,
 ];
 
-export const mistral_common = (model: ModelData): string[] => [
-	`# We recommend to use vLLM to serve Mistral AI models.
-pip install vllm
-
-# Make sure to have installed the latest version of mistral-common.
-pip install --upgrade mistral-common[image,audio]
-
-# Serve the model with an OpenAI-compatible API.
-vllm serve ${model.id} --tokenizer_mode mistral --config_format mistral --load_format mistral --tool-call-parser mistral --enable-auto-tool-choice
-
-# Query the model with curl in a separate terminal.
-curl http://localhost:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "${model.id}",
-    "messages": [{"role": "user", "content": "What is the capital of France?"}]
-  }'`,
-];
-
 //#endregion

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -32,7 +32,7 @@ export interface LibraryUiElement {
 	 * Elastic query used to count this library's model downloads
 	 *
 	 * By default, those files are counted:
-	 * "config.json", "config.yaml", "hyperparams.yaml", "meta.yaml"
+	 * "config.json", "config.yaml", "hyperparams.yaml", "params.json", "meta.yaml"
 	 */
 	countDownloads?: ElasticSearchQuery;
 	/**

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -631,14 +631,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_extension:"ckpt"`,
 	},
-	mistral_common: {
-		prettyLabel: "mistral-common",
-		repoName: "mistral-common",
-		repoUrl: "https://github.com/mistralai/mistral-common",
-		docsUrl: "https://mistralai.github.io/mistral-common/",
-		snippets: snippets.mistral_common,
-		countDownloads: `path:"config.json" OR path:"params.json"`,
-	},
 	mitie: {
 		prettyLabel: "MITIE",
 		repoName: "MITIE",


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface.js/pull/1641 and especially https://github.com/huggingface/huggingface.js/pull/1641#issuecomment-3109540608 (cc @LysandreJik @juliendenize).

The plan is:
- set
```yaml
library_name: transformers
tags:
- mistral-common
```
in model cards metadata
- remove `mistral-common` from registered libraries as it's not a modelling library but more of a set of utils
- count downloads on both `config.json` AND `params.json` for those repos (will be handled server-side, see [private PR](https://github.com/huggingface-internal/moon-landing/pull/14564))
- keep custom indications in the vLLM snippets for `mistral-common` repos