### PR TITLE
Skip chat completion generation in CI

### DIFF
--- a/packages/tasks-gen/scripts/inference-codegen.ts
+++ b/packages/tasks-gen/scripts/inference-codegen.ts
@@ -287,6 +287,11 @@ for (const { task, dirPath } of allTasks) {
 	}
 	console.debug(`✨ Generating types for task`, task);
 
+	if (task === "chat-completion") {
+		console.debug("   🙈 Skipping chat-completion (maintained manually)");
+		continue;
+	}
+
 	console.debug("   📦 Building input data");
 	const inputData = await buildInputData(task, taskSpecDir, allSpecFiles);
 


### PR DESCRIPTION
We handle it manually now (it's already mature + we slightly diverged since quicktype doesn't handle well the unions)