### PR TITLE
update installation instructions for mlx on CUDA.

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1804,6 +1804,7 @@ huggingface-cli download --local-dir ${nameWithoutNamespace(model.id)} ${model.i
 const mlxlm = (model: ModelData): string[] => [
 	`# Make sure mlx-lm is installed
 # pip install --upgrade mlx-lm
+# if on a CUDA device, also pip install mlx[cuda]
 
 # Generate text with mlx-lm
 from mlx_lm import load, generate


### PR DESCRIPTION
The intent is to allow users on CUDA backend to know how to install the library in addition to this, it may allow non-quantized models to work with MLX on Colab too.

cc: @awni