### PR TITLE
Update contexttab snippet

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -133,7 +133,8 @@ ta.save("test-2.wav", wav, model.sr)`,
 ];
 
 export const contexttab = (): string[] => {
-	const preInstallSnippet = `pip uninstall torch torchvision torchaudio -y`
+	const preInstallSnippet = `# Optional, remove incompatible packages
+ pip uninstall torch torchvision torchaudio -y`;
 	
 	const installSnippet = `pip install git+https://github.com/SAP-samples/contexttab`;
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -133,6 +133,8 @@ ta.save("test-2.wav", wav, model.sr)`,
 ];
 
 export const contexttab = (): string[] => {
+	const preInstallSnippet = `pip uninstall torch torchvision torchaudio -y`
+	
 	const installSnippet = `pip install git+https://github.com/SAP-samples/contexttab`;
 
 	const classificationSnippet = `# Run a classification task
@@ -185,7 +187,7 @@ predictions = regressor.predict(X_test)
 
 r2 = r2_score(y_test, predictions)
 print("R² Score:", r2)`;
-	return [installSnippet, classificationSnippet, regressionsSnippet];
+	return [preInstallSnippet, installSnippet, classificationSnippet, regressionsSnippet];
 };
 
 export const cxr_foundation = (): string[] => [

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -133,7 +133,8 @@ ta.save("test-2.wav", wav, model.sr)`,
 ];
 
 export const contexttab = (): string[] => {
-	const preInstallSnippet = `pip uninstall torch torchvision torchaudio -y`;
+	const preInstallSnippet = `# On Colab, uninstall existing packages
+ pip uninstall torch torchvision torchaudio -y`;
 	
 	const installSnippet = `pip install git+https://github.com/SAP-samples/contexttab`;
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -133,8 +133,7 @@ ta.save("test-2.wav", wav, model.sr)`,
 ];
 
 export const contexttab = (): string[] => {
-	const preInstallSnippet = `# Optional, remove incompatible packages
- pip uninstall torch torchvision torchaudio -y`;
+	const preInstallSnippet = `pip uninstall torch torchvision torchaudio -y`;
 	
 	const installSnippet = `pip install git+https://github.com/SAP-samples/contexttab`;
 


### PR DESCRIPTION
  - Adds a preinstall snippet to contexttab snippets
  - After receiveing [user feedback](https://huggingface.co/SAP/contexttab/discussions/3), this explicit uninstall is requiring when clicking on the Use This Model with Colab button on HF. The Colab notebook has incompatible versions of torch and torchaudio, torchvision installed that made the snippet fail. This should resolve it.