### PR TITLE
Local apps: Add Paddler

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -340,6 +340,20 @@ const snippetLemonade = (model: ModelData, filepath?: string): LocalAppSnippet[]
 	];
 };
 
+const snippetPaddler = (): LocalAppSnippet[] => {
+	return [
+		{
+			title: "Run Paddler cluster",
+			setup: "# Install Paddler: https://paddler.intentee.com/docs/introduction/installation/",
+			content: [
+				"# Run the management server\npaddler balancer --management-addr 127.0.0.1:8060 --web-admin-panel-addr 127.0.0.1:8062",
+				"# Run Paddler agents to scale your setup\npaddler agent --management-addr 127.0.0.1:8060 --name agent-1",
+				"# Use `Model` tab in the Paddler admin panel to paste the link to this model\n# More info: https://paddler.intentee.com/docs/starting-out/model-swapping/",
+		  ],
+		},
+	];
+};
+
 /**
  * Add your new local app here.
  *
@@ -523,6 +537,13 @@ export const LOCAL_APPS = {
 		mainTask: "text-generation",
 		displayOnModelPage: isLlamaCppGgufModel,
 		snippet: snippetLemonade,
+	},
+	paddler: {
+		prettyLabel: "Paddler (self-hosted cluster)",
+		docsUrl: "https://paddler.intentee.com",
+		mainTask: "text-generation",
+		displayOnModelPage: isLlamaCppGgufModel,
+		snippet: snippetPaddler,
 	},
 } satisfies Record<string, LocalApp>;
 


### PR DESCRIPTION
This PR adds Paddler as a local app.

Link to the project: https://paddler.intentee.com/
GitHub repository: https://github.com/intentee/paddler

Paddler allows to run servers in a cluster, so it is really more than a local runner (it is intended for scalable deployments rather than desktop use), but it is still local, so I think it fits the category (unless you think it can be put somewhere else also?).

You can also check out the [video overview](https://www.youtube.com/watch?v=aT6QCL8lk08).

cc @Vaibhavs10 