### PR TITLE
Xet upload: backtrack when dedup info is received

### DIFF
--- a/packages/hub/.gitignore
+++ b/packages/hub/.gitignore
@@ -1,1 +1,3 @@
 xet-core-wasm-build
+shard.bin
+xorb.bin

--- a/packages/hub/scripts/bench.ts
+++ b/packages/hub/scripts/bench.ts
@@ -23,10 +23,17 @@ const FILES_TO_DOWNLOAD = [
 	{
 		url: "https://huggingface.co/openai-community/gpt2/resolve/main/64-8bits.tflite?download=true",
 		filename: "64-8bits.tflite",
+		sha256: "c966da3b74697803352ca7c6f2f220e7090a557b619de9da0c6b34d89f7825c1",
 	},
 	{
 		url: "https://huggingface.co/openai-community/gpt2/resolve/main/64-fp16.tflite?download=true",
 		filename: "64-fp16.tflite",
+		sha256: "1ceafd82e733dd4b21570b2a86cf27556a983041806c033a55d086e0ed782cd3",
+	},
+	{
+		url: "https://huggingface.co/openai-community/gpt2/resolve/main/64.tflite?download=true",
+		filename: "64.tflite",
+		sha256: "cfcd510b239d90b71ee87d4e57a5a8c2d55b2a941e5d9fe5852298268ddbe61b",
 	},
 ];
 

--- a/packages/hub/src/utils/ChunkCache.ts
+++ b/packages/hub/src/utils/ChunkCache.ts
@@ -43,7 +43,10 @@ export class ChunkCache {
 
 	getChunk(
 		hash: string,
-		hmacFunction: (hash: string, key: string) => string
+		/**
+		 * Set to null if you only want to check against locally created chunks, or the hash is already a hmac
+		 */
+		hmacFunction: ((hash: string, key: string) => string) | null
 	):
 		| {
 				xorbIndex: number;
@@ -51,7 +54,7 @@ export class ChunkCache {
 		  }
 		| undefined {
 		let index = this.map.get(hash);
-		if (index === undefined) {
+		if (index === undefined && hmacFunction !== null) {
 			for (const hmac of this.hmacs) {
 				index = this.map.get(hmacFunction(hash, hmac));
 				if (index !== undefined) {
@@ -66,5 +69,9 @@ export class ChunkCache {
 			xorbIndex: this.xorbIndices[index],
 			chunkIndex: this.chunkIndices[index],
 		};
+	}
+
+	removeChunkFromCache(hash: string): void {
+		this.map.delete(hash);
 	}
 }

--- a/packages/hub/src/utils/createXorbs.ts
+++ b/packages/hub/src/utils/createXorbs.ts
@@ -133,7 +133,7 @@ export async function* createXorbs(
 			// todo: have the wasm function to compute file hash be able to take data chunk by chunk instead of all at once
 			const fileChunks: Array<{ hash: string; length: number }> = [];
 			// Collect chunk metadata to build representation at the end
-			// todo: build representation at the end of each xorb
+			// todo: build partial representation at the end of each xorb, to avoid having to store all chunks in memory
 			const chunkMetadata: Array<{
 				xorbId: number | string;
 				chunkIndex: number;

--- a/packages/hub/src/utils/createXorbs.ts
+++ b/packages/hub/src/utils/createXorbs.ts
@@ -112,8 +112,11 @@ export async function* createXorbs(
 			const reader = fileSource.content.stream().getReader();
 			let processedBytes = 0;
 			let dedupedBytes = 0; // Track bytes that were deduplicated
+			// Needed to compute the final file hash
+			// todo: have the wasm function to compute file hash be able to take data chunk by chunk instead of all at once
 			const fileChunks: Array<{ hash: string; length: number }> = [];
 			// Collect chunk metadata to build representation at the end
+			// todo: build representation at the end of each xorb
 			const chunkMetadata: Array<{
 				xorbId: number | string;
 				chunkIndex: number;

--- a/packages/hub/src/utils/createXorbs.ts
+++ b/packages/hub/src/utils/createXorbs.ts
@@ -73,6 +73,14 @@ export async function* createXorbs(
 	 */
 	let xorbFileProgress: Record<string, number> = {};
 
+	const resetXorb = () => {
+		xorbId++;
+		xorbOffset = 0;
+		xorbChunks = [];
+		xorbFileProgress = {};
+		xorb = new Uint8Array(XORB_SIZE);
+	};
+
 	const pendingFileEvents: Array<{
 		event: "file";
 		path: string;
@@ -182,11 +190,9 @@ export async function* createXorbs(
 								id: xorbId,
 								files: Object.entries(xorbFileProgress).map(([path, progress]) => ({ path, progress })),
 							};
-							xorbId++;
-							xorb = new Uint8Array(XORB_SIZE);
+							resetXorb();
 							chunkIndex = 0;
 							chunkXorbId = xorbId;
-							xorbFileProgress = {};
 
 							for (const event of pendingFileEvents) {
 								event.representation = event.representation.map((rep) => ({
@@ -229,11 +235,7 @@ export async function* createXorbs(
 							id: xorbId,
 							files: Object.entries(xorbFileProgress).map(([path, progress]) => ({ path, progress })),
 						};
-						xorbId++;
-						xorbOffset = 0;
-						xorbChunks = [];
-						xorbFileProgress = {};
-						xorb = new Uint8Array(XORB_SIZE);
+						resetXorb();
 
 						for (const event of pendingFileEvents) {
 							event.representation = event.representation.map((rep) => ({


### PR DESCRIPTION
Fix #1703 

cc @assafvayner for viz, cc @Kakulukian too

## Note 

Only backtrack since the end of the last file, and only in the current xorb.

It means that we maybe lose ~2MB on average at the end of a xorb - only if we filled the first 60MB of the xorb with new data

## Improvement

Running `pnpm --filter hub bench`:

```console
=== BENCHMARK RESULTS ===
File Statistics:
================

📄 64-8bits.tflite:
   Size: 119.36 MB
   Deduplication: 99.90%

📄 64-fp16.tflite:
   Size: 236.77 MB
   Deduplication: 100.00%

=== SUMMARY ===
Total files: 2
Total size: 356.13 MB
Total xorbs: 1
Total shards: 1
Total xorb bytes: 119 926 bytes
Total shard bytes: 1 400 bytes
Average deduplication: 99.95%
```

we bump the second file from 83% to 100% dedup
