### PR TITLE
Add Jetson AGX Thor to hardware.ts

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -374,6 +374,10 @@ export const SKUS = {
 				tflops: 19.05,
 				memory: [16],
 			},
+			"Jetson AGX Thor": {
+				tflops: 517, //2070 TFLOPS (Sparse FP4); 1035 TFLOPS (Dense FP4 | Sparse FP8 | Sparse INT8); 517 TFLOPs (Dense FP8 | Sparse FP16) 
+				memory: [128],
+			},
 			"Jetson AGX Orin 64GB": {
 				tflops: 10.65,
 				memory: [64],


### PR DESCRIPTION
This adds the Jetson AGX Thor to the hardware list.

2070 TFLOPS (Sparse FP4) 1035 TFLOPS (Dense FP4 | Sparse FP8 | Sparse INT8) 517 TFLOPs (Dense FP8 | Sparse FP16) 

128 GB 256-bit LPDDR5X, 273 GB/s

Taken from:
https://developer.nvidia.com/blog/introducing-nvidia-jetson-thor-the-ultimate-platform-for-physical-ai/

<img width="612" height="475" alt="image" src="https://github.com/user-attachments/assets/7a543340-d9b1-4011-897c-0a57999188dc" />
