### PR TITLE
Add useXet param to all commit functions

### DIFF
--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -92,7 +92,7 @@ export type CommitParams = {
 	/**
 	 * @deprecated Not yet ready for production use
 	 */
-	xet?: boolean;
+	useXet?: boolean;
 } & Partial<CredentialsParams>;
 
 export interface CommitOutput {
@@ -298,7 +298,7 @@ export async function* commitIter(params: CommitParams): AsyncGenerator<CommitPr
 
 			const shaToOperation = new Map(operations.map((op, i) => [shas[i], op]));
 
-			if (params.xet) {
+			if (params.useXet) {
 				// First get all the files that are already uploaded out of the way
 				for (const obj of json.objects) {
 					const op = shaToOperation.get(obj.oid);

--- a/packages/hub/src/lib/upload-file.ts
+++ b/packages/hub/src/lib/upload-file.ts
@@ -15,6 +15,10 @@ export function uploadFile(
 		fetch?: CommitParams["fetch"];
 		useWebWorkers?: CommitParams["useWebWorkers"];
 		abortSignal?: CommitParams["abortSignal"];
+		/**
+		 * @deprecated Not yet ready for production use
+		 */
+		useXet?: CommitParams["useXet"];
 	} & Partial<CredentialsParams>
 ): Promise<CommitOutput> {
 	const path =
@@ -43,5 +47,6 @@ export function uploadFile(
 		fetch: params.fetch,
 		useWebWorkers: params.useWebWorkers,
 		abortSignal: params.abortSignal,
+		useXet: params.useXet,
 	});
 }

--- a/packages/hub/src/lib/upload-files-with-progress.ts
+++ b/packages/hub/src/lib/upload-files-with-progress.ts
@@ -30,6 +30,10 @@ export async function* uploadFilesWithProgress(
 		abortSignal?: CommitParams["abortSignal"];
 		maxFolderDepth?: CommitParams["maxFolderDepth"];
 		/**
+		 * @deprecated Not yet ready for production use
+		 */
+		useXet?: CommitParams["useXet"];
+		/**
 		 * Set this to true in order to have progress events for hashing
 		 */
 		useWebWorkers?: CommitParams["useWebWorkers"];
@@ -51,104 +55,112 @@ export async function* uploadFilesWithProgress(
 		parentCommit: params.parentCommit,
 		useWebWorkers: params.useWebWorkers,
 		abortSignal: params.abortSignal,
-		fetch: async (input, init) => {
-			if (!init) {
-				return fetch(input);
-			}
-
-			if (
-				!typedInclude(["PUT", "POST"], init.method) ||
-				!("progressHint" in init) ||
-				!init.progressHint ||
-				typeof XMLHttpRequest === "undefined" ||
-				typeof input !== "string" ||
-				(!(init.body instanceof ArrayBuffer) &&
-					!(init.body instanceof Blob) &&
-					!(init.body instanceof File) &&
-					typeof init.body !== "string")
-			) {
-				return fetch(input, init);
-			}
-
-			const progressHint = init.progressHint as {
-				progressCallback: (progress: number) => void;
-			} & (Record<string, never> | { part: number; numParts: number });
-			const progressCallback = progressHint.progressCallback;
-
-			const xhr = new XMLHttpRequest();
-
-			xhr.upload.addEventListener("progress", (event) => {
-				if (event.lengthComputable) {
-					if (progressHint.part !== undefined) {
-						let tracking = multipartUploadTracking.get(progressCallback);
-						if (!tracking) {
-							tracking = { numParts: progressHint.numParts, partsProgress: {} };
-							multipartUploadTracking.set(progressCallback, tracking);
+		useXet: params.useXet,
+		fetch:
+			params.useXet === true
+				? // no need for custom fetch function if we use Xet, as we already have progress events in the commit function for file uploads in that case
+				  undefined
+				: async (input, init) => {
+						if (!init) {
+							return fetch(input);
 						}
-						tracking.partsProgress[progressHint.part] = event.loaded / event.total;
-						let totalProgress = 0;
-						for (const partProgress of Object.values(tracking.partsProgress)) {
-							totalProgress += partProgress;
+
+						if (
+							!typedInclude(["PUT", "POST"], init.method) ||
+							!("progressHint" in init) ||
+							!init.progressHint ||
+							typeof XMLHttpRequest === "undefined" ||
+							typeof input !== "string" ||
+							(!(init.body instanceof ArrayBuffer) &&
+								!(init.body instanceof Blob) &&
+								!(init.body instanceof File) &&
+								typeof init.body !== "string")
+						) {
+							return fetch(input, init);
 						}
-						if (totalProgress === tracking.numParts) {
-							progressCallback(0.9999999999);
-						} else {
-							progressCallback(totalProgress / tracking.numParts);
+
+						const progressHint = init.progressHint as {
+							progressCallback: (progress: number) => void;
+						} & (Record<string, never> | { part: number; numParts: number });
+						const progressCallback = progressHint.progressCallback;
+
+						const xhr = new XMLHttpRequest();
+
+						xhr.upload.addEventListener("progress", (event) => {
+							if (event.lengthComputable) {
+								if (progressHint.part !== undefined) {
+									let tracking = multipartUploadTracking.get(progressCallback);
+									if (!tracking) {
+										tracking = { numParts: progressHint.numParts, partsProgress: {} };
+										multipartUploadTracking.set(progressCallback, tracking);
+									}
+									tracking.partsProgress[progressHint.part] = event.loaded / event.total;
+									let totalProgress = 0;
+									for (const partProgress of Object.values(tracking.partsProgress)) {
+										totalProgress += partProgress;
+									}
+									if (totalProgress === tracking.numParts) {
+										progressCallback(0.9999999999);
+									} else {
+										progressCallback(totalProgress / tracking.numParts);
+									}
+								} else {
+									if (event.loaded === event.total) {
+										progressCallback(0.9999999999);
+									} else {
+										progressCallback(event.loaded / event.total);
+									}
+								}
+							}
+						});
+
+						xhr.open(init.method, input, true);
+
+						if (init.headers) {
+							const headers = new Headers(init.headers);
+							headers.forEach((value, key) => {
+								xhr.setRequestHeader(key, value);
+							});
 						}
-					} else {
-						if (event.loaded === event.total) {
-							progressCallback(0.9999999999);
-						} else {
-							progressCallback(event.loaded / event.total);
-						}
-					}
-				}
-			});
 
-			xhr.open(init.method, input, true);
+						init.signal?.throwIfAborted();
+						xhr.send(init.body);
 
-			if (init.headers) {
-				const headers = new Headers(init.headers);
-				headers.forEach((value, key) => {
-					xhr.setRequestHeader(key, value);
-				});
-			}
+						return new Promise((resolve, reject) => {
+							xhr.addEventListener("load", () => {
+								resolve(
+									new Response(xhr.responseText, {
+										status: xhr.status,
+										statusText: xhr.statusText,
+										headers: Object.fromEntries(
+											xhr
+												.getAllResponseHeaders()
+												.trim()
+												.split("\n")
+												.map((header) => [
+													header.slice(0, header.indexOf(":")),
+													header.slice(header.indexOf(":") + 1).trim(),
+												])
+										),
+									})
+								);
+							});
+							xhr.addEventListener("error", () => {
+								reject(new Error(xhr.statusText));
+							});
 
-			init.signal?.throwIfAborted();
-			xhr.send(init.body);
+							if (init.signal) {
+								init.signal.addEventListener("abort", () => {
+									xhr.abort();
 
-			return new Promise((resolve, reject) => {
-				xhr.addEventListener("load", () => {
-					resolve(
-						new Response(xhr.responseText, {
-							status: xhr.status,
-							statusText: xhr.statusText,
-							headers: Object.fromEntries(
-								xhr
-									.getAllResponseHeaders()
-									.trim()
-									.split("\n")
-									.map((header) => [header.slice(0, header.indexOf(":")), header.slice(header.indexOf(":") + 1).trim()])
-							),
-						})
-					);
-				});
-				xhr.addEventListener("error", () => {
-					reject(new Error(xhr.statusText));
-				});
-
-				if (init.signal) {
-					init.signal.addEventListener("abort", () => {
-						xhr.abort();
-
-						try {
-							init.signal?.throwIfAborted();
-						} catch (err) {
-							reject(err);
-						}
-					});
-				}
-			});
-		},
+									try {
+										init.signal?.throwIfAborted();
+									} catch (err) {
+										reject(err);
+									}
+								});
+							}
+						});
+				  },
 	});
 }

--- a/packages/hub/src/lib/upload-files.ts
+++ b/packages/hub/src/lib/upload-files.ts
@@ -16,6 +16,10 @@ export function uploadFiles(
 		useWebWorkers?: CommitParams["useWebWorkers"];
 		maxFolderDepth?: CommitParams["maxFolderDepth"];
 		abortSignal?: CommitParams["abortSignal"];
+		/**
+		 * @deprecated Not yet ready for production use
+		 */
+		useXet?: CommitParams["useXet"];
 	} & Partial<CredentialsParams>
 ): Promise<CommitOutput> {
 	return commit({
@@ -35,5 +39,6 @@ export function uploadFiles(
 		fetch: params.fetch,
 		useWebWorkers: params.useWebWorkers,
 		abortSignal: params.abortSignal,
+		useXet: params.useXet,
 	});
 }


### PR DESCRIPTION
cc @assafvayner @jsulz @Kakulukian  for viz

Still not yet prod ready but allow to test more easily (including on prod with specific accountsn through the `uploadFilesWithProgress` function) 

One nice thing is that we don't need to call `XMLHttpRequest` anymore in `uploadFilesWithProgress`, we'll be able to remove it when  100% migrated to xet