### PR TITLE
Add RKLLM library and count .rkllm downloads

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -854,7 +854,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	},
 	rkllm: {
 		prettyLabel: "RKLLM",
-		repoName: "rknn-llm",
+		repoName: "RKLLM",
 		repoUrl: "https://github.com/airockchip/rknn-llm",
 		countDownloads: `path_extension:"rkllm"`,
 	},

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -852,7 +852,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/revdotcom/reverb",
 		filter: false,
 	},
-	"rkllm": {
+	rkllm: {
 		prettyLabel: "RKLLM",
 		repoName: "rknn-llm",
 		repoUrl: "https://github.com/airockchip/rknn-llm",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -852,6 +852,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/revdotcom/reverb",
 		filter: false,
 	},
+	"rkllm": {
+		prettyLabel: "RKLLM",
+		repoName: "rknn-llm",
+		repoUrl: "https://github.com/airockchip/rknn-llm",
+		countDownloads: `path_extension:"rkllm"`,
+	},
 	saelens: {
 		prettyLabel: "SAELens",
 		repoName: "SAELens",


### PR DESCRIPTION
Adds support for the RKLLM library (Rockchip’s RKNN-LLM toolkit) to Hugging Face Hub.