### PR TITLE
xet: Commit operation to edit part of file (optimized for handling edits at beginning of file)

### DIFF
--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -82,6 +82,25 @@ for await (const progressEvent of await hub.uploadFilesWithProgress({
   console.log(progressEvent);
 }
 
+// Edit a file by adding prefix & suffix
+await commit({
+  repo,
+  accessToken: "hf_...",
+  operations: [{
+    type: "edit",
+    originalContent: originalFile,
+    edits: [{
+      start: 0,
+      end: 0,
+      content: new Blob(["prefix"])
+    }, {
+      start: originalFile.length,
+      end: originalFile.length,
+      content: new Blob(["suffix"])
+    }]
+  }]
+})
+
 await hub.deleteFile({repo, accessToken: "hf_...", path: "myfile.bin"});
 
 await (await hub.downloadFile({ repo, path: "README.md" })).text();

--- a/packages/hub/scripts/bench.ts
+++ b/packages/hub/scripts/bench.ts
@@ -8,7 +8,6 @@ import type { RepoId } from "../src/types/public.js";
 import { toRepoId } from "../src/utils/toRepoId.js";
 import type { CommitOperation } from "../src/index.js";
 import { commitIter, downloadFile } from "../src/index.js";
-import { WebBlob } from "../src/utils/WebBlob.js";
 import { SplicedBlob } from "../src/utils/SplicedBlob.js";
 import { pathToFileURL } from "node:url";
 

--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -55,10 +55,12 @@ export interface SpliceFile {
 	path: string;
 	/** Later, will be ContentSource. For now simpler to just handle blobs */
 	content: Blob;
-	start: number;
-	end: number;
-	/** Later, will be ContentSource. For now simpler to just handle blobs */
-	insert: Blob;
+	splice: Array<{
+		/** Later, will be ContentSource. For now simpler to just handle blobs */
+		content: Blob;
+		start: number;
+		end: number;
+	}>;
 }
 
 type CommitBlob = Omit<CommitFile, "content"> & { content: Blob };
@@ -202,9 +204,10 @@ export async function* commitIter(params: CommitParams): AsyncGenerator<CommitPr
 
 					if (operation.operation === "splice") {
 						// Convert SpliceFile operation to a file operation with SplicedBlob
-						const splicedBlob = SplicedBlob.create(operation.content, [
-							{ insert: operation.insert, start: operation.start, end: operation.end },
-						]);
+						const splicedBlob = SplicedBlob.create(
+							operation.content,
+							operation.splice.map((splice) => ({ insert: splice.content, start: splice.start, end: splice.end }))
+						);
 						return {
 							operation: "addOrUpdate" as const,
 							path: operation.path,

--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -122,9 +122,6 @@ export type CommitParams = {
 	fetch?: typeof fetch;
 	abortSignal?: AbortSignal;
 	// Credentials are optional due to custom fetch functions or cookie auth
-	/**
-	 * @deprecated Not yet ready for production use
-	 */
 	useXet?: boolean;
 } & Partial<CredentialsParams>;
 

--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -202,7 +202,9 @@ export async function* commitIter(params: CommitParams): AsyncGenerator<CommitPr
 
 					if (operation.operation === "splice") {
 						// Convert SpliceFile operation to a file operation with SplicedBlob
-						const splicedBlob = SplicedBlob.create(operation.content, operation.insert, operation.start, operation.end);
+						const splicedBlob = SplicedBlob.create(operation.content, [
+							{ insert: operation.insert, start: operation.start, end: operation.end },
+						]);
 						return {
 							operation: "addOrUpdate" as const,
 							path: operation.path,

--- a/packages/hub/src/lib/dataset-info.ts
+++ b/packages/hub/src/lib/dataset-info.ts
@@ -37,7 +37,6 @@ export async function datasetInfo<
 		{
 			headers: {
 				...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-				Accepts: "application/json",
 			},
 		}
 	);

--- a/packages/hub/src/lib/model-info.ts
+++ b/packages/hub/src/lib/model-info.ts
@@ -38,7 +38,6 @@ export async function modelInfo<
 		{
 			headers: {
 				...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-				Accepts: "application/json",
 			},
 		}
 	);

--- a/packages/hub/src/lib/space-info.ts
+++ b/packages/hub/src/lib/space-info.ts
@@ -38,7 +38,6 @@ export async function spaceInfo<
 		{
 			headers: {
 				...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-				Accepts: "application/json",
 			},
 		}
 	);

--- a/packages/hub/src/lib/upload-file.ts
+++ b/packages/hub/src/lib/upload-file.ts
@@ -15,9 +15,6 @@ export function uploadFile(
 		fetch?: CommitParams["fetch"];
 		useWebWorkers?: CommitParams["useWebWorkers"];
 		abortSignal?: CommitParams["abortSignal"];
-		/**
-		 * @deprecated Not yet ready for production use
-		 */
 		useXet?: CommitParams["useXet"];
 	} & Partial<CredentialsParams>
 ): Promise<CommitOutput> {

--- a/packages/hub/src/lib/upload-files-with-progress.ts
+++ b/packages/hub/src/lib/upload-files-with-progress.ts
@@ -29,9 +29,6 @@ export async function* uploadFilesWithProgress(
 		parentCommit?: CommitParams["parentCommit"];
 		abortSignal?: CommitParams["abortSignal"];
 		maxFolderDepth?: CommitParams["maxFolderDepth"];
-		/**
-		 * @deprecated Not yet ready for production use
-		 */
 		useXet?: CommitParams["useXet"];
 		/**
 		 * Set this to true in order to have progress events for hashing

--- a/packages/hub/src/lib/upload-files.ts
+++ b/packages/hub/src/lib/upload-files.ts
@@ -16,9 +16,6 @@ export function uploadFiles(
 		useWebWorkers?: CommitParams["useWebWorkers"];
 		maxFolderDepth?: CommitParams["maxFolderDepth"];
 		abortSignal?: CommitParams["abortSignal"];
-		/**
-		 * @deprecated Not yet ready for production use
-		 */
 		useXet?: CommitParams["useXet"];
 	} & Partial<CredentialsParams>
 ): Promise<CommitOutput> {

--- a/packages/hub/src/utils/SplicedBlob.spec.ts
+++ b/packages/hub/src/utils/SplicedBlob.spec.ts
@@ -1,0 +1,454 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { SplicedBlob } from "./SplicedBlob";
+
+describe("SplicedBlob", () => {
+	let originalBlob: Blob;
+	let insertBlob: Blob;
+	let replaceBlob: Blob;
+
+	beforeEach(() => {
+		// originalBlob: "0123456789" (10 chars)
+		originalBlob = new Blob(["0123456789"]);
+		// insertBlob: "ABC" (3 chars) - used in tests where we insert something into the blob
+		insertBlob = new Blob(["ABC"]);
+		// replaceBlob: "XY" (2 chars) - used in tests where part of the blob is replaced
+		replaceBlob = new Blob(["XY"]);
+	});
+
+	describe("create", () => {
+		it("should create a SplicedBlob with valid parameters", () => {
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			expect(splicedBlob).toBeInstanceOf(SplicedBlob);
+		});
+
+		it("should throw error for negative start", () => {
+			expect(() => SplicedBlob.create(originalBlob, insertBlob, -1, 5)).toThrow(
+				"Invalid start/end positions for SplicedBlob"
+			);
+		});
+
+		it("should throw error for negative end", () => {
+			expect(() => SplicedBlob.create(originalBlob, insertBlob, 5, -1)).toThrow(
+				"Invalid start/end positions for SplicedBlob"
+			);
+		});
+
+		it("should throw error for start > original.size", () => {
+			expect(() => SplicedBlob.create(originalBlob, insertBlob, 15, 5)).toThrow(
+				"Invalid start/end positions for SplicedBlob"
+			);
+		});
+
+		it("should throw error for end > original.size", () => {
+			expect(() => SplicedBlob.create(originalBlob, insertBlob, 5, 15)).toThrow(
+				"Invalid start/end positions for SplicedBlob"
+			);
+		});
+
+		it("should throw error for start > end", () => {
+			expect(() => SplicedBlob.create(originalBlob, insertBlob, 7, 5)).toThrow(
+				"Invalid start/end positions for SplicedBlob"
+			);
+		});
+	});
+
+	describe("size and type", () => {
+		it("should calculate size correctly for insertion", () => {
+			// Insert "ABC" at position 5: "01234ABC56789" = 13 chars
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			expect(splicedBlob.size).toBe(13);
+		});
+
+		it("should calculate size correctly for replacement", () => {
+			// Replace "345" with "XY": "012XY6789" = 9 chars
+			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			expect(splicedBlob.size).toBe(9);
+		});
+
+		it("should return original blob type", () => {
+			const typedBlob = new Blob(["test"], { type: "text/plain" });
+			const splicedBlob = SplicedBlob.create(typedBlob, insertBlob, 2, 2);
+			expect(splicedBlob.type).toBe("text/plain");
+		});
+	});
+
+	describe("text method", () => {
+		it("should insert at beginning", async () => {
+			// Insert "ABC" at start: "ABC0123456789"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 0, 0);
+			const text = await splicedBlob.text();
+			expect(text).toBe("ABC0123456789");
+		});
+
+		it("should insert at end", async () => {
+			// Insert "ABC" at end: "0123456789ABC"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 10, 10);
+			const text = await splicedBlob.text();
+			expect(text).toBe("0123456789ABC");
+		});
+
+		it("should insert in middle", async () => {
+			// Insert "ABC" at position 5: "01234ABC56789"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const text = await splicedBlob.text();
+			expect(text).toBe("01234ABC56789");
+		});
+
+		it("should replace content", async () => {
+			// Replace "345" with "XY": "012XY6789"
+			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const text = await splicedBlob.text();
+			expect(text).toBe("012XY6789");
+		});
+
+		it("should replace everything", async () => {
+			// Replace entire content with "ABC": "ABC"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 0, 10);
+			const text = await splicedBlob.text();
+			expect(text).toBe("ABC");
+		});
+	});
+
+	describe("slice method - basic cases", () => {
+		it("should return empty blob for start >= end", async () => {
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(5, 5);
+			expect(slice.size).toBe(0);
+			expect(await slice.text()).toBe("");
+		});
+
+		it("should handle slice beyond size", async () => {
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(10, 20);
+			const text = await slice.text();
+			expect(text).toBe("789"); // Only gets what's available
+		});
+
+		it("should throw error for negative start/end", () => {
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			expect(() => splicedBlob.slice(-1, 5)).toThrow("Unsupported negative start/end on SplicedBlob.slice");
+			expect(() => splicedBlob.slice(0, -1)).toThrow("Unsupported negative start/end on SplicedBlob.slice");
+		});
+	});
+
+	describe("slice method - before segment only", () => {
+		it("should slice entirely in before segment", async () => {
+			// SplicedBlob: "01234ABC56789", slice(1, 4) = "123"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(1, 4);
+			const text = await slice.text();
+			expect(text).toBe("123");
+		});
+
+		it("should slice from start of before segment", async () => {
+			// SplicedBlob: "01234ABC56789", slice(0, 3) = "012"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(0, 3);
+			const text = await slice.text();
+			expect(text).toBe("012");
+		});
+
+		it("should slice to end of before segment", async () => {
+			// SplicedBlob: "01234ABC56789", slice(2, 5) = "234"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(2, 5);
+			const text = await slice.text();
+			expect(text).toBe("234");
+		});
+	});
+
+	describe("slice method - insert segment only", () => {
+		it("should slice entirely in insert segment", async () => {
+			// SplicedBlob: "01234ABC56789", slice(6, 7) = "B"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(6, 7);
+			const text = await slice.text();
+			expect(text).toBe("B");
+		});
+
+		it("should slice entire insert segment", async () => {
+			// SplicedBlob: "01234ABC56789", slice(5, 8) = "ABC"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(5, 8);
+			const text = await slice.text();
+			expect(text).toBe("ABC");
+		});
+
+		it("should slice from start of insert segment", async () => {
+			// SplicedBlob: "01234ABC56789", slice(5, 7) = "AB"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(5, 7);
+			const text = await slice.text();
+			expect(text).toBe("AB");
+		});
+
+		it("should slice to end of insert segment", async () => {
+			// SplicedBlob: "01234ABC56789", slice(6, 8) = "BC"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(6, 8);
+			const text = await slice.text();
+			expect(text).toBe("BC");
+		});
+	});
+
+	describe("slice method - after segment only", () => {
+		it("should slice entirely in after segment", async () => {
+			// SplicedBlob: "01234ABC56789", slice(9, 12) = "678"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(9, 12);
+			const text = await slice.text();
+			expect(text).toBe("678");
+		});
+
+		it("should slice from start of after segment", async () => {
+			// SplicedBlob: "01234ABC56789", slice(8, 11) = "567"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(8, 11);
+			const text = await slice.text();
+			expect(text).toBe("567");
+		});
+
+		it("should slice to end of after segment", async () => {
+			// SplicedBlob: "01234ABC56789", slice(10, 13) = "789"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(10, 13);
+			const text = await slice.text();
+			expect(text).toBe("789");
+		});
+	});
+
+	describe("slice method - spanning before and insert", () => {
+		it("should slice spanning before and insert segments", async () => {
+			// SplicedBlob: "01234ABC56789", slice(3, 7) = "34AB"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(3, 7);
+			const text = await slice.text();
+			expect(text).toBe("34AB");
+		});
+
+		it("should slice from start spanning before and insert", async () => {
+			// SplicedBlob: "01234ABC56789", slice(0, 6) = "01234A"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(0, 6);
+			const text = await slice.text();
+			expect(text).toBe("01234A");
+		});
+
+		it("should slice to end of insert spanning before and insert", async () => {
+			// SplicedBlob: "01234ABC56789", slice(4, 8) = "4ABC"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(4, 8);
+			const text = await slice.text();
+			expect(text).toBe("4ABC");
+		});
+	});
+
+	describe("slice method - spanning insert and after", () => {
+		it("should slice spanning insert and after segments", async () => {
+			// SplicedBlob: "01234ABC56789", slice(6, 10) = "BC56"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(6, 10);
+			const text = await slice.text();
+			expect(text).toBe("BC56");
+		});
+
+		it("should slice from start of insert to end", async () => {
+			// SplicedBlob: "01234ABC56789", slice(5, 13) = "ABC56789"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(5, 13);
+			const text = await slice.text();
+			expect(text).toBe("ABC56789");
+		});
+
+		it("should slice from middle of insert spanning to after", async () => {
+			// SplicedBlob: "01234ABC56789", slice(7, 11) = "C567"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(7, 11);
+			const text = await slice.text();
+			expect(text).toBe("C567");
+		});
+	});
+
+	describe("slice method - spanning all three segments", () => {
+		it("should slice spanning all three segments", async () => {
+			// SplicedBlob: "01234ABC56789", slice(3, 10) = "34ABC56"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(3, 10);
+			const text = await slice.text();
+			expect(text).toBe("34ABC56");
+		});
+
+		it("should slice entire spliced blob", async () => {
+			// SplicedBlob: "01234ABC56789", slice(0, 13) = "01234ABC56789"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(0, 13);
+			const text = await slice.text();
+			expect(text).toBe("01234ABC56789");
+		});
+
+		it("should slice most of spliced blob", async () => {
+			// SplicedBlob: "01234ABC56789", slice(1, 12) = "1234ABC5678"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice = splicedBlob.slice(1, 12);
+			const text = await slice.text();
+			expect(text).toBe("1234ABC5678");
+		});
+	});
+
+	describe("slice method - with replacement", () => {
+		it("should slice before replacement", async () => {
+			// Replace "345" with "XY": "012XY6789", slice(0, 3) = "012"
+			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const slice = splicedBlob.slice(0, 3);
+			const text = await slice.text();
+			expect(text).toBe("012");
+		});
+
+		it("should slice replacement only", async () => {
+			// Replace "345" with "XY": "012XY6789", slice(3, 5) = "XY"
+			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const slice = splicedBlob.slice(3, 5);
+			const text = await slice.text();
+			expect(text).toBe("XY");
+		});
+
+		it("should slice after replacement", async () => {
+			// Replace "345" with "XY": "012XY6789", slice(5, 9) = "6789"
+			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const slice = splicedBlob.slice(5, 9);
+			const text = await slice.text();
+			expect(text).toBe("6789");
+		});
+
+		it("should slice spanning before and replacement", async () => {
+			// Replace "345" with "XY": "012XY6789", slice(1, 4) = "12X"
+			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const slice = splicedBlob.slice(1, 4);
+			const text = await slice.text();
+			expect(text).toBe("12X");
+		});
+
+		it("should slice spanning replacement and after", async () => {
+			// Replace "345" with "XY": "012XY6789", slice(4, 7) = "Y67"
+			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const slice = splicedBlob.slice(4, 7);
+			const text = await slice.text();
+			expect(text).toBe("Y67");
+		});
+
+		it("should slice spanning all segments with replacement", async () => {
+			// Replace "345" with "XY": "012XY6789", slice(1, 8) = "12XY678"
+			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const slice = splicedBlob.slice(1, 8);
+			const text = await slice.text();
+			expect(text).toBe("12XY678");
+		});
+	});
+
+	describe("slice method - edge cases", () => {
+		it("should handle empty insert blob", async () => {
+			const emptyBlob = new Blob([""]);
+			// Replace "345" with "": "0126789"
+			const splicedBlob = SplicedBlob.create(originalBlob, emptyBlob, 3, 6);
+			const text = await splicedBlob.text();
+			expect(text).toBe("0126789");
+
+			const slice = splicedBlob.slice(2, 5);
+			expect(await slice.text()).toBe("267");
+		});
+
+		it("should handle slice at segment boundaries", async () => {
+			// SplicedBlob: "01234ABC56789", exact boundary slices
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+
+			// End of before segment
+			expect(await splicedBlob.slice(4, 5).text()).toBe("4");
+			// Start of insert segment
+			expect(await splicedBlob.slice(5, 6).text()).toBe("A");
+			// End of insert segment
+			expect(await splicedBlob.slice(7, 8).text()).toBe("C");
+			// Start of after segment
+			expect(await splicedBlob.slice(8, 9).text()).toBe("5");
+		});
+
+		it("should handle insert at beginning with slice", async () => {
+			// Insert "ABC" at start: "ABC0123456789"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 0, 0);
+			const slice = splicedBlob.slice(1, 5);
+			expect(await slice.text()).toBe("BC01");
+		});
+
+		it("should handle insert at end with slice", async () => {
+			// Insert "ABC" at end: "0123456789ABC"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 10, 10);
+			const slice = splicedBlob.slice(8, 12);
+			expect(await slice.text()).toBe("89AB");
+		});
+	});
+
+	describe("arrayBuffer method", () => {
+		it("should return correct ArrayBuffer for insertion", async () => {
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const buffer = await splicedBlob.arrayBuffer();
+			const text = new TextDecoder().decode(buffer);
+			expect(text).toBe("01234ABC56789");
+			expect(buffer.byteLength).toBe(13);
+		});
+
+		it("should return correct ArrayBuffer for replacement", async () => {
+			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const buffer = await splicedBlob.arrayBuffer();
+			const text = new TextDecoder().decode(buffer);
+			expect(text).toBe("012XY6789");
+			expect(buffer.byteLength).toBe(9);
+		});
+	});
+
+	describe("stream method", () => {
+		it("should return correct stream for insertion", async () => {
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const stream = splicedBlob.stream();
+			const response = new Response(stream);
+			const text = await response.text();
+			expect(text).toBe("01234ABC56789");
+		});
+
+		it("should return correct stream for replacement", async () => {
+			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const stream = splicedBlob.stream();
+			const response = new Response(stream);
+			const text = await response.text();
+			expect(text).toBe("012XY6789");
+		});
+
+		it("should handle empty segments in stream", async () => {
+			const emptyBlob = new Blob([""]);
+			const splicedBlob = SplicedBlob.create(originalBlob, emptyBlob, 5, 5);
+			const stream = splicedBlob.stream();
+			const response = new Response(stream);
+			const text = await response.text();
+			expect(text).toBe("0123456789");
+		});
+	});
+
+	describe("nested slicing", () => {
+		it("should allow slicing of sliced blob", async () => {
+			// SplicedBlob: "01234ABC56789", slice(3, 10) = "34ABC56", then slice(2, 5) = "ABC"
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const firstSlice = splicedBlob.slice(3, 10);
+			const secondSlice = firstSlice.slice(2, 5);
+			const text = await secondSlice.text();
+			expect(text).toBe("ABC");
+		});
+
+		it("should handle multiple levels of slicing", async () => {
+			// Complex slicing chain
+			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const slice1 = splicedBlob.slice(2, 11); // "234ABC567"
+			const slice2 = slice1.slice(1, 7); // "34ABC5"
+			const slice3 = slice2.slice(2, 5); // "ABC"
+			const text = await slice3.text();
+			expect(text).toBe("ABC");
+		});
+	});
+});

--- a/packages/hub/src/utils/SplicedBlob.spec.ts
+++ b/packages/hub/src/utils/SplicedBlob.spec.ts
@@ -17,36 +17,36 @@ describe("SplicedBlob", () => {
 
 	describe("create", () => {
 		it("should create a SplicedBlob with valid parameters", () => {
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			expect(splicedBlob).toBeInstanceOf(SplicedBlob);
 		});
 
 		it("should throw error for negative start", () => {
-			expect(() => SplicedBlob.create(originalBlob, insertBlob, -1, 5)).toThrow(
+			expect(() => SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: -1, end: 5 }])).toThrow(
 				"Invalid start/end positions for SplicedBlob"
 			);
 		});
 
 		it("should throw error for negative end", () => {
-			expect(() => SplicedBlob.create(originalBlob, insertBlob, 5, -1)).toThrow(
+			expect(() => SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: -1 }])).toThrow(
 				"Invalid start/end positions for SplicedBlob"
 			);
 		});
 
 		it("should throw error for start > original.size", () => {
-			expect(() => SplicedBlob.create(originalBlob, insertBlob, 15, 5)).toThrow(
+			expect(() => SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 15, end: 5 }])).toThrow(
 				"Invalid start/end positions for SplicedBlob"
 			);
 		});
 
 		it("should throw error for end > original.size", () => {
-			expect(() => SplicedBlob.create(originalBlob, insertBlob, 5, 15)).toThrow(
+			expect(() => SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 15 }])).toThrow(
 				"Invalid start/end positions for SplicedBlob"
 			);
 		});
 
 		it("should throw error for start > end", () => {
-			expect(() => SplicedBlob.create(originalBlob, insertBlob, 7, 5)).toThrow(
+			expect(() => SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 7, end: 5 }])).toThrow(
 				"Invalid start/end positions for SplicedBlob"
 			);
 		});
@@ -55,19 +55,19 @@ describe("SplicedBlob", () => {
 	describe("size and type", () => {
 		it("should calculate size correctly for insertion", () => {
 			// Insert "ABC" at position 5: "01234ABC56789" = 13 chars
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			expect(splicedBlob.size).toBe(13);
 		});
 
 		it("should calculate size correctly for replacement", () => {
 			// Replace "345" with "XY": "012XY6789" = 9 chars
-			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: replaceBlob, start: 3, end: 6 }]);
 			expect(splicedBlob.size).toBe(9);
 		});
 
 		it("should return original blob type", () => {
 			const typedBlob = new Blob(["test"], { type: "text/plain" });
-			const splicedBlob = SplicedBlob.create(typedBlob, insertBlob, 2, 2);
+			const splicedBlob = SplicedBlob.create(typedBlob, [{ insert: insertBlob, start: 2, end: 2 }]);
 			expect(splicedBlob.type).toBe("text/plain");
 		});
 	});
@@ -75,35 +75,35 @@ describe("SplicedBlob", () => {
 	describe("text method", () => {
 		it("should insert at beginning", async () => {
 			// Insert "ABC" at start: "ABC0123456789"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 0, 0);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 0, end: 0 }]);
 			const text = await splicedBlob.text();
 			expect(text).toBe("ABC0123456789");
 		});
 
 		it("should insert at end", async () => {
 			// Insert "ABC" at end: "0123456789ABC"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 10, 10);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 10, end: 10 }]);
 			const text = await splicedBlob.text();
 			expect(text).toBe("0123456789ABC");
 		});
 
 		it("should insert in middle", async () => {
 			// Insert "ABC" at position 5: "01234ABC56789"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const text = await splicedBlob.text();
 			expect(text).toBe("01234ABC56789");
 		});
 
 		it("should replace content", async () => {
 			// Replace "345" with "XY": "012XY6789"
-			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: replaceBlob, start: 3, end: 6 }]);
 			const text = await splicedBlob.text();
 			expect(text).toBe("012XY6789");
 		});
 
 		it("should replace everything", async () => {
 			// Replace entire content with "ABC": "ABC"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 0, 10);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 0, end: 10 }]);
 			const text = await splicedBlob.text();
 			expect(text).toBe("ABC");
 		});
@@ -111,21 +111,21 @@ describe("SplicedBlob", () => {
 
 	describe("slice method - basic cases", () => {
 		it("should return empty blob for start >= end", async () => {
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(5, 5);
 			expect(slice.size).toBe(0);
 			expect(await slice.text()).toBe("");
 		});
 
 		it("should handle slice beyond size", async () => {
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(10, 20);
 			const text = await slice.text();
 			expect(text).toBe("789"); // Only gets what's available
 		});
 
 		it("should throw error for negative start/end", () => {
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			expect(() => splicedBlob.slice(-1, 5)).toThrow("Unsupported negative start/end on SplicedBlob.slice");
 			expect(() => splicedBlob.slice(0, -1)).toThrow("Unsupported negative start/end on SplicedBlob.slice");
 		});
@@ -134,7 +134,7 @@ describe("SplicedBlob", () => {
 	describe("slice method - before segment only", () => {
 		it("should slice entirely in before segment", async () => {
 			// SplicedBlob: "01234ABC56789", slice(1, 4) = "123"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(1, 4);
 			const text = await slice.text();
 			expect(text).toBe("123");
@@ -142,7 +142,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice from start of before segment", async () => {
 			// SplicedBlob: "01234ABC56789", slice(0, 3) = "012"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(0, 3);
 			const text = await slice.text();
 			expect(text).toBe("012");
@@ -150,7 +150,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice to end of before segment", async () => {
 			// SplicedBlob: "01234ABC56789", slice(2, 5) = "234"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(2, 5);
 			const text = await slice.text();
 			expect(text).toBe("234");
@@ -160,7 +160,7 @@ describe("SplicedBlob", () => {
 	describe("slice method - insert segment only", () => {
 		it("should slice entirely in insert segment", async () => {
 			// SplicedBlob: "01234ABC56789", slice(6, 7) = "B"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(6, 7);
 			const text = await slice.text();
 			expect(text).toBe("B");
@@ -168,7 +168,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice entire insert segment", async () => {
 			// SplicedBlob: "01234ABC56789", slice(5, 8) = "ABC"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(5, 8);
 			const text = await slice.text();
 			expect(text).toBe("ABC");
@@ -176,7 +176,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice from start of insert segment", async () => {
 			// SplicedBlob: "01234ABC56789", slice(5, 7) = "AB"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(5, 7);
 			const text = await slice.text();
 			expect(text).toBe("AB");
@@ -184,7 +184,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice to end of insert segment", async () => {
 			// SplicedBlob: "01234ABC56789", slice(6, 8) = "BC"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(6, 8);
 			const text = await slice.text();
 			expect(text).toBe("BC");
@@ -194,7 +194,7 @@ describe("SplicedBlob", () => {
 	describe("slice method - after segment only", () => {
 		it("should slice entirely in after segment", async () => {
 			// SplicedBlob: "01234ABC56789", slice(9, 12) = "678"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(9, 12);
 			const text = await slice.text();
 			expect(text).toBe("678");
@@ -202,7 +202,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice from start of after segment", async () => {
 			// SplicedBlob: "01234ABC56789", slice(8, 11) = "567"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(8, 11);
 			const text = await slice.text();
 			expect(text).toBe("567");
@@ -210,7 +210,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice to end of after segment", async () => {
 			// SplicedBlob: "01234ABC56789", slice(10, 13) = "789"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(10, 13);
 			const text = await slice.text();
 			expect(text).toBe("789");
@@ -220,7 +220,7 @@ describe("SplicedBlob", () => {
 	describe("slice method - spanning before and insert", () => {
 		it("should slice spanning before and insert segments", async () => {
 			// SplicedBlob: "01234ABC56789", slice(3, 7) = "34AB"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(3, 7);
 			const text = await slice.text();
 			expect(text).toBe("34AB");
@@ -228,7 +228,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice from start spanning before and insert", async () => {
 			// SplicedBlob: "01234ABC56789", slice(0, 6) = "01234A"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(0, 6);
 			const text = await slice.text();
 			expect(text).toBe("01234A");
@@ -236,7 +236,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice to end of insert spanning before and insert", async () => {
 			// SplicedBlob: "01234ABC56789", slice(4, 8) = "4ABC"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(4, 8);
 			const text = await slice.text();
 			expect(text).toBe("4ABC");
@@ -246,7 +246,7 @@ describe("SplicedBlob", () => {
 	describe("slice method - spanning insert and after", () => {
 		it("should slice spanning insert and after segments", async () => {
 			// SplicedBlob: "01234ABC56789", slice(6, 10) = "BC56"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(6, 10);
 			const text = await slice.text();
 			expect(text).toBe("BC56");
@@ -254,7 +254,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice from start of insert to end", async () => {
 			// SplicedBlob: "01234ABC56789", slice(5, 13) = "ABC56789"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(5, 13);
 			const text = await slice.text();
 			expect(text).toBe("ABC56789");
@@ -262,7 +262,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice from middle of insert spanning to after", async () => {
 			// SplicedBlob: "01234ABC56789", slice(7, 11) = "C567"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(7, 11);
 			const text = await slice.text();
 			expect(text).toBe("C567");
@@ -272,7 +272,7 @@ describe("SplicedBlob", () => {
 	describe("slice method - spanning all three segments", () => {
 		it("should slice spanning all three segments", async () => {
 			// SplicedBlob: "01234ABC56789", slice(3, 10) = "34ABC56"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(3, 10);
 			const text = await slice.text();
 			expect(text).toBe("34ABC56");
@@ -280,7 +280,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice entire spliced blob", async () => {
 			// SplicedBlob: "01234ABC56789", slice(0, 13) = "01234ABC56789"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(0, 13);
 			const text = await slice.text();
 			expect(text).toBe("01234ABC56789");
@@ -288,7 +288,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice most of spliced blob", async () => {
 			// SplicedBlob: "01234ABC56789", slice(1, 12) = "1234ABC5678"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice = splicedBlob.slice(1, 12);
 			const text = await slice.text();
 			expect(text).toBe("1234ABC5678");
@@ -298,7 +298,7 @@ describe("SplicedBlob", () => {
 	describe("slice method - with replacement", () => {
 		it("should slice before replacement", async () => {
 			// Replace "345" with "XY": "012XY6789", slice(0, 3) = "012"
-			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: replaceBlob, start: 3, end: 6 }]);
 			const slice = splicedBlob.slice(0, 3);
 			const text = await slice.text();
 			expect(text).toBe("012");
@@ -306,7 +306,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice replacement only", async () => {
 			// Replace "345" with "XY": "012XY6789", slice(3, 5) = "XY"
-			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: replaceBlob, start: 3, end: 6 }]);
 			const slice = splicedBlob.slice(3, 5);
 			const text = await slice.text();
 			expect(text).toBe("XY");
@@ -314,7 +314,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice after replacement", async () => {
 			// Replace "345" with "XY": "012XY6789", slice(5, 9) = "6789"
-			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: replaceBlob, start: 3, end: 6 }]);
 			const slice = splicedBlob.slice(5, 9);
 			const text = await slice.text();
 			expect(text).toBe("6789");
@@ -322,7 +322,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice spanning before and replacement", async () => {
 			// Replace "345" with "XY": "012XY6789", slice(1, 4) = "12X"
-			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: replaceBlob, start: 3, end: 6 }]);
 			const slice = splicedBlob.slice(1, 4);
 			const text = await slice.text();
 			expect(text).toBe("12X");
@@ -330,7 +330,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice spanning replacement and after", async () => {
 			// Replace "345" with "XY": "012XY6789", slice(4, 7) = "Y67"
-			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: replaceBlob, start: 3, end: 6 }]);
 			const slice = splicedBlob.slice(4, 7);
 			const text = await slice.text();
 			expect(text).toBe("Y67");
@@ -338,7 +338,7 @@ describe("SplicedBlob", () => {
 
 		it("should slice spanning all segments with replacement", async () => {
 			// Replace "345" with "XY": "012XY6789", slice(1, 8) = "12XY678"
-			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: replaceBlob, start: 3, end: 6 }]);
 			const slice = splicedBlob.slice(1, 8);
 			const text = await slice.text();
 			expect(text).toBe("12XY678");
@@ -349,7 +349,7 @@ describe("SplicedBlob", () => {
 		it("should handle empty insert blob", async () => {
 			const emptyBlob = new Blob([""]);
 			// Replace "345" with "": "0126789"
-			const splicedBlob = SplicedBlob.create(originalBlob, emptyBlob, 3, 6);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: emptyBlob, start: 3, end: 6 }]);
 			const text = await splicedBlob.text();
 			expect(text).toBe("0126789");
 
@@ -359,7 +359,7 @@ describe("SplicedBlob", () => {
 
 		it("should handle slice at segment boundaries", async () => {
 			// SplicedBlob: "01234ABC56789", exact boundary slices
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 
 			// End of before segment
 			expect(await splicedBlob.slice(4, 5).text()).toBe("4");
@@ -373,14 +373,14 @@ describe("SplicedBlob", () => {
 
 		it("should handle insert at beginning with slice", async () => {
 			// Insert "ABC" at start: "ABC0123456789"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 0, 0);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 0, end: 0 }]);
 			const slice = splicedBlob.slice(1, 5);
 			expect(await slice.text()).toBe("BC01");
 		});
 
 		it("should handle insert at end with slice", async () => {
 			// Insert "ABC" at end: "0123456789ABC"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 10, 10);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 10, end: 10 }]);
 			const slice = splicedBlob.slice(8, 12);
 			expect(await slice.text()).toBe("89AB");
 		});
@@ -388,7 +388,7 @@ describe("SplicedBlob", () => {
 
 	describe("arrayBuffer method", () => {
 		it("should return correct ArrayBuffer for insertion", async () => {
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const buffer = await splicedBlob.arrayBuffer();
 			const text = new TextDecoder().decode(buffer);
 			expect(text).toBe("01234ABC56789");
@@ -396,7 +396,7 @@ describe("SplicedBlob", () => {
 		});
 
 		it("should return correct ArrayBuffer for replacement", async () => {
-			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: replaceBlob, start: 3, end: 6 }]);
 			const buffer = await splicedBlob.arrayBuffer();
 			const text = new TextDecoder().decode(buffer);
 			expect(text).toBe("012XY6789");
@@ -406,7 +406,7 @@ describe("SplicedBlob", () => {
 
 	describe("stream method", () => {
 		it("should return correct stream for insertion", async () => {
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const stream = splicedBlob.stream();
 			const response = new Response(stream);
 			const text = await response.text();
@@ -414,7 +414,7 @@ describe("SplicedBlob", () => {
 		});
 
 		it("should return correct stream for replacement", async () => {
-			const splicedBlob = SplicedBlob.create(originalBlob, replaceBlob, 3, 6);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: replaceBlob, start: 3, end: 6 }]);
 			const stream = splicedBlob.stream();
 			const response = new Response(stream);
 			const text = await response.text();
@@ -423,7 +423,7 @@ describe("SplicedBlob", () => {
 
 		it("should handle empty segments in stream", async () => {
 			const emptyBlob = new Blob([""]);
-			const splicedBlob = SplicedBlob.create(originalBlob, emptyBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: emptyBlob, start: 5, end: 5 }]);
 			const stream = splicedBlob.stream();
 			const response = new Response(stream);
 			const text = await response.text();
@@ -434,7 +434,7 @@ describe("SplicedBlob", () => {
 	describe("nested slicing", () => {
 		it("should allow slicing of sliced blob", async () => {
 			// SplicedBlob: "01234ABC56789", slice(3, 10) = "34ABC56", then slice(2, 5) = "ABC"
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const firstSlice = splicedBlob.slice(3, 10);
 			const secondSlice = firstSlice.slice(2, 5);
 			const text = await secondSlice.text();
@@ -443,7 +443,7 @@ describe("SplicedBlob", () => {
 
 		it("should handle multiple levels of slicing", async () => {
 			// Complex slicing chain
-			const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 5, 5);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			const slice1 = splicedBlob.slice(2, 11); // "234ABC567"
 			const slice2 = slice1.slice(1, 7); // "34ABC5"
 			const slice3 = slice2.slice(2, 5); // "ABC"

--- a/packages/hub/src/utils/SplicedBlob.ts
+++ b/packages/hub/src/utils/SplicedBlob.ts
@@ -1,0 +1,219 @@
+import { sum } from "./sum";
+
+/**
+ * @internal
+ *
+ * A SplicedBlob is a Blob that represents the result of splicing an insert blob
+ * into an original blob at a specified position, replacing content between start and end.
+ *
+ * It is a drop-in replacement for the Blob class, so you can use it as a Blob.
+ * The splicing is done virtually without copying data until accessed.
+ *
+ * @example
+ * const originalBlob = new Blob(["Hello, World!"]);
+ * const insertBlob = new Blob(["Beautiful "]);
+ * const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 7, 7);
+ * // Result represents: "Hello, Beautiful World!"
+ */
+export class SplicedBlob extends Blob {
+	/**
+	 * Creates a new SplicedBlob by splicing an insert blob into an original blob.
+	 *
+	 * @param originalBlob The original blob to splice into
+	 * @param insertBlob The blob to insert
+	 * @param start The position where splicing starts (inclusive)
+	 * @param end The position where splicing ends (exclusive). Content between start and end is replaced.
+	 */
+	static create(originalBlob: Blob, insertBlob: Blob, start: number, end: number): SplicedBlob {
+		if (start < 0 || end < 0 || start > originalBlob.size || end > originalBlob.size || start > end) {
+			throw new TypeError("Invalid start/end positions for SplicedBlob");
+		}
+
+		return new SplicedBlob(originalBlob, insertBlob, start, end);
+	}
+
+	private originalBlob: Blob;
+	private insertBlob: Blob;
+	private spliceStart: number;
+	private spliceEnd: number;
+
+	private constructor(originalBlob: Blob, insertBlob: Blob, start: number, end: number) {
+		super();
+
+		this.originalBlob = originalBlob;
+		this.insertBlob = insertBlob;
+		this.spliceStart = start;
+		this.spliceEnd = end;
+	}
+
+	/**
+	 * Returns the size of the spliced blob.
+	 * Size = (original size - replaced segment size) + insert size
+	 */
+	override get size(): number {
+		return this.originalBlob.size - (this.spliceEnd - this.spliceStart) + this.insertBlob.size;
+	}
+
+	/**
+	 * Returns the MIME type of the original blob.
+	 */
+	override get type(): string {
+		return this.originalBlob.type;
+	}
+
+	/**
+	 * Returns a new instance of SplicedBlob that is a slice of the current one.
+	 *
+	 * The slice is inclusive of the start and exclusive of the end.
+	 * The slice method does not support negative start/end.
+	 *
+	 * @param start beginning of the slice
+	 * @param end end of the slice
+	 */
+	override slice(start = 0, end = this.size): Blob {
+		if (start < 0 || end < 0) {
+			throw new TypeError("Unsupported negative start/end on SplicedBlob.slice");
+		}
+
+		start = Math.min(start, this.size);
+		end = Math.min(end, this.size);
+
+		if (start >= end) {
+			return new Blob([]);
+		}
+
+		// Calculate segment boundaries
+		const beforeSegmentSize = this.spliceStart;
+		const insertSegmentSize = this.insertBlob.size;
+		const afterSegmentStart = beforeSegmentSize + insertSegmentSize;
+
+		// Determine which segments the slice spans
+		if (end <= beforeSegmentSize) {
+			// Slice is entirely in the before segment
+			return this.originalBlob.slice(start, end);
+		}
+
+		if (start >= afterSegmentStart) {
+			// Slice is entirely in the after segment
+			const afterStart = start - afterSegmentStart + this.spliceEnd;
+			const afterEnd = end - afterSegmentStart + this.spliceEnd;
+			return this.originalBlob.slice(afterStart, afterEnd);
+		}
+
+		if (start >= beforeSegmentSize && end <= afterSegmentStart) {
+			// Slice is entirely in the insert segment
+			return this.insertBlob.slice(start - beforeSegmentSize, end - beforeSegmentSize);
+		}
+
+		// Slice spans multiple segments - need to create a new SplicedBlob or combine blobs
+		const segments: Blob[] = [];
+
+		if (start < beforeSegmentSize) {
+			// Include part of before segment
+			segments.push(this.originalBlob.slice(start, Math.min(end, beforeSegmentSize)));
+		}
+
+		if (start < afterSegmentStart && end > beforeSegmentSize) {
+			// Include part of insert segment
+			const insertStart = Math.max(0, start - beforeSegmentSize);
+			const insertEnd = Math.min(insertSegmentSize, end - beforeSegmentSize);
+			segments.push(this.insertBlob.slice(insertStart, insertEnd));
+		}
+
+		if (end > afterSegmentStart) {
+			// Include part of after segment
+			const afterStart = Math.max(this.spliceEnd, this.spliceEnd + (start - afterSegmentStart));
+			const afterEnd = this.spliceEnd + (end - afterSegmentStart);
+			segments.push(this.originalBlob.slice(afterStart, afterEnd));
+		}
+
+		return new Blob(segments);
+	}
+
+	/**
+	 * Read the spliced blob content and returns it as an ArrayBuffer.
+	 */
+	override async arrayBuffer(): Promise<ArrayBuffer> {
+		const segments = this.segments;
+		const buffers = await Promise.all(segments.map((segment) => segment.arrayBuffer()));
+
+		// Concatenate all buffers
+		const totalSize = sum(buffers.map((buffer) => buffer.byteLength));
+		const result = new Uint8Array(totalSize);
+
+		let offset = 0;
+		for (const buffer of buffers) {
+			result.set(new Uint8Array(buffer), offset);
+			offset += buffer.byteLength;
+		}
+
+		return result.buffer;
+	}
+
+	/**
+	 * Read the spliced blob content and returns it as a string.
+	 */
+	override async text(): Promise<string> {
+		const buffer = await this.arrayBuffer();
+		return new TextDecoder().decode(buffer);
+	}
+
+	/**
+	 * Returns a stream around the spliced blob content.
+	 */
+	override stream(): ReturnType<Blob["stream"]> {
+		const readable = new ReadableStream({
+			start: async (controller) => {
+				try {
+					const segments = this.segments;
+
+					for (const segment of segments) {
+						const reader = segment.stream().getReader();
+
+						try {
+							while (true) {
+								const { done, value } = await reader.read();
+								if (done) {
+									break;
+								}
+								controller.enqueue(value);
+							}
+						} finally {
+							reader.releaseLock();
+						}
+					}
+
+					controller.close();
+				} catch (error) {
+					controller.error(error);
+				}
+			},
+		});
+
+		return readable;
+	}
+
+	/**
+	 * Get the three segments that make up the spliced blob.
+	 */
+	private get segments(): Blob[] {
+		const segments: Blob[] = [];
+
+		// Before segment (0 to start)
+		if (this.spliceStart > 0) {
+			segments.push(this.originalBlob.slice(0, this.spliceStart));
+		}
+
+		// Insert segment (entire insert blob)
+		if (this.insertBlob.size > 0) {
+			segments.push(this.insertBlob);
+		}
+
+		// After segment (end to original.size)
+		if (this.spliceEnd < this.originalBlob.size) {
+			segments.push(this.originalBlob.slice(this.spliceEnd));
+		}
+
+		return segments;
+	}
+}

--- a/packages/hub/src/utils/SplicedBlob.ts
+++ b/packages/hub/src/utils/SplicedBlob.ts
@@ -32,12 +32,12 @@ export class SplicedBlob extends Blob {
 		return new SplicedBlob(originalBlob, insertBlob, start, end);
 	}
 
-	private originalBlob: Blob;
-	private insertBlob: Blob;
-	private spliceStart: number;
-	private spliceEnd: number;
+	public originalBlob: Blob;
+	public insertBlob: Blob;
+	public spliceStart: number;
+	public spliceEnd: number;
 
-	private constructor(originalBlob: Blob, insertBlob: Blob, start: number, end: number) {
+	constructor(originalBlob: Blob, insertBlob: Blob, start: number, end: number) {
 		super();
 
 		this.originalBlob = originalBlob;

--- a/packages/hub/src/utils/createXorbs.ts
+++ b/packages/hub/src/utils/createXorbs.ts
@@ -135,6 +135,7 @@ export async function* createXorbs(
 
 	try {
 		for await (const fileSource of fileSources) {
+			// Load dedup info for the first chunk of the file, if it's potentially modified by the splice
 			if (fileSource.content instanceof SplicedBlob && fileSource.content.firstSpliceIndex < MAX_CHUNK_SIZE) {
 				await loadDedupInfoToCache(
 					fileSource.content.originalBlob.slice(0, fileSource.content.firstSpliceIndex),


### PR DESCRIPTION
Fix #1705 

```ts
// Edit a file by adding prefix & suffix
await commit({
  repo,
  accessToken: "hf_...",
  operations: [{
    type: "edit",
    originalContent: originalFile,
    edits: [{
      start: 0,
      end: 0,
      content: new Blob(["prefix"])
    }, {
      start: originalFile.length,
      end: originalFile.length,
      content: new Blob(["suffix"])
    }]
  }]
})
```

```ts
// Edit first kB of file
await commit({
  repo,
  accessToken: "hf_...",
  operations: [{
    type: "edit",
    originalContent: originalFile,
    edits: [{
      start: 0,
      end: 1000,
      content: new Blob(["blablabla"])
    }]
  }]
})
```


cc @mishig25 @assafvayner @jsulz 

also

- fallback to LFS for non-xet repos (even if useXet is true)
- remove invalid Accepts header

## How it works under the hood

- we load dedup info for first chunk of original file content if it's changed
- we upload the blob as normal

## Todo

 currently blob is being processed twice, once for sha256 and once for hashing. The file should be processed only once (maybe after https://github.com/huggingface/huggingface.js/issues/1704 - using workers for different processes)