### PR TITLE
:bug: fix `Use this model snippets` for PaddleOCR models

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1056,7 +1056,6 @@ output = model.predict(
 )
 for res in output:
     res.print()
-    res.save_to_img(save_path="./output/")
     res.save_to_json(save_path="./output/res.json")`,
 		];
 	}


### PR DESCRIPTION
vlm models don't support save_to_img