### PR TITLE
Emit more progress events for xet upload

### DIFF
--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -24,7 +24,6 @@ import { isFrontend } from "../utils/isFrontend";
 import { createBlobs } from "../utils/createBlobs";
 import { uploadShards } from "../utils/uploadShards";
 import { splitAsyncGenerator } from "../utils/splitAsyncGenerator";
-import { mergeAsyncGenerators } from "../utils/mergeAsyncGenerators";
 import { SplicedBlob } from "../utils/SplicedBlob";
 
 const CONCURRENT_SHAS = 5;
@@ -401,33 +400,35 @@ export async function* commitIter(params: CommitParams): AsyncGenerator<CommitPr
 					}
 				})();
 				const sources = splitAsyncGenerator(source, 5);
-				yield* mergeAsyncGenerators(
-					sources.map(async function* (source) {
-						for await (const event of uploadShards(source, {
-							fetch: params.fetch,
-							accessToken,
-							hubUrl: params.hubUrl ?? HUB_URL,
-							repo: repoId,
-							// todo: maybe leave empty if PR?
-							rev: params.branch ?? "main",
-						})) {
-							if (event.event === "file") {
-								yield {
-									event: "fileProgress" as const,
-									path: event.path,
-									progress: 1,
-									state: "uploading" as const,
-								};
-							} else if (event.event === "fileProgress") {
-								yield {
-									event: "fileProgress" as const,
-									path: event.path,
-									progress: event.progress,
-									state: "uploading" as const,
-								};
+				yield* eventToGenerator((yieldCallback, returnCallback, rejectCallback) =>
+					Promise.all(
+						sources.map(async function (source) {
+							for await (const event of uploadShards(source, {
+								fetch: params.fetch,
+								accessToken,
+								hubUrl: params.hubUrl ?? HUB_URL,
+								repo: repoId,
+								// todo: maybe leave empty if PR?
+								rev: params.branch ?? "main",
+							})) {
+								if (event.event === "file") {
+									yieldCallback({
+										event: "fileProgress" as const,
+										path: event.path,
+										progress: 1,
+										state: "uploading" as const,
+									});
+								} else if (event.event === "fileProgress") {
+									yieldCallback({
+										event: "fileProgress" as const,
+										path: event.path,
+										progress: event.progress,
+										state: "uploading" as const,
+									});
+								}
 							}
-						}
-					})
+						})
+					).then(() => returnCallback(undefined), rejectCallback)
 				);
 			} else {
 				yield* eventToGenerator<CommitProgressEvent, void>((yieldCallback, returnCallback, rejectCallback) => {

--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -410,6 +410,7 @@ export async function* commitIter(params: CommitParams): AsyncGenerator<CommitPr
 								repo: repoId,
 								// todo: maybe leave empty if PR?
 								rev: params.branch ?? "main",
+								yieldCallback: (event) => yieldCallback({ ...event, state: "uploading" }),
 							})) {
 								if (event.event === "file") {
 									yieldCallback({

--- a/packages/hub/src/lib/upload-files-with-progress.ts
+++ b/packages/hub/src/lib/upload-files-with-progress.ts
@@ -74,14 +74,25 @@ export async function* uploadFilesWithProgress(
 
 			const progressHint = init.progressHint as {
 				progressCallback: (progress: number) => void;
-			} & (Record<string, never> | { part: number; numParts: number });
+			} & (
+				| Record<string, never>
+				| { part: number; numParts: number; start: undefined }
+				| { start: number; end: number; part: undefined }
+			);
 			const progressCallback = progressHint.progressCallback;
 
 			const xhr = new XMLHttpRequest();
 
 			xhr.upload.addEventListener("progress", (event) => {
 				if (event.lengthComputable) {
-					if (progressHint.part !== undefined) {
+					if (progressHint.start !== undefined) {
+						progressCallback(
+							Math.min(
+								0.9999999999,
+								progressHint.start + (event.loaded / event.total) * (progressHint.end - progressHint.start)
+							)
+						);
+					} else if (progressHint.part !== undefined) {
 						let tracking = multipartUploadTracking.get(progressCallback);
 						if (!tracking) {
 							tracking = { numParts: progressHint.numParts, partsProgress: {} };

--- a/packages/hub/src/lib/upload-files-with-progress.ts
+++ b/packages/hub/src/lib/upload-files-with-progress.ts
@@ -74,25 +74,14 @@ export async function* uploadFilesWithProgress(
 
 			const progressHint = init.progressHint as {
 				progressCallback: (progress: number) => void;
-			} & (
-				| Record<string, never>
-				| { part: number; numParts: number; start: undefined }
-				| { start: number; end: number; part: undefined }
-			);
+			} & (Record<string, never> | { part: number; numParts: number });
 			const progressCallback = progressHint.progressCallback;
 
 			const xhr = new XMLHttpRequest();
 
 			xhr.upload.addEventListener("progress", (event) => {
 				if (event.lengthComputable) {
-					if (progressHint.start !== undefined) {
-						progressCallback(
-							Math.min(
-								0.9999999999,
-								progressHint.start + (event.loaded / event.total) * (progressHint.end - progressHint.start)
-							)
-						);
-					} else if (progressHint.part !== undefined) {
+					if (progressHint.part !== undefined) {
 						let tracking = multipartUploadTracking.get(progressCallback);
 						if (!tracking) {
 							tracking = { numParts: progressHint.numParts, partsProgress: {} };

--- a/packages/hub/src/utils/uploadShards.ts
+++ b/packages/hub/src/utils/uploadShards.ts
@@ -135,7 +135,7 @@ export async function* uploadShards(
 					yield {
 						event: "fileProgress",
 						path: file.path,
-						progress: file.initialProgress + (file.progress - file.initialProgress) * 0.5,
+						progress: file.lastSentProgress,
 					};
 				}
 
@@ -354,7 +354,7 @@ function writeHashToArray(hash: string, array: Uint8Array, offset: number) {
 }
 
 async function uploadXorb(
-	xorb: { hash: string; xorb: Uint8Array; files: Array<{ path: string; progress: number; initialProgress: number }> },
+	xorb: { hash: string; xorb: Uint8Array; files: Array<{ path: string; progress: number; lastSentProgress: number }> },
 	params: UploadShardsParams
 ) {
 	const token = await xetWriteToken(params);
@@ -372,7 +372,7 @@ async function uploadXorb(
 						params.yieldCallback({
 							event: "fileProgress",
 							path: file.path,
-							progress: file.initialProgress + (file.progress - file.initialProgress) * (0.5 + progress * 0.5),
+							progress: file.lastSentProgress + (file.progress - file.lastSentProgress) * progress,
 						});
 					}
 				},


### PR DESCRIPTION
Fix #1726 

cc @assafvayner for viz

ideally it there would be two progress bars, one for uploading & one for processing data.

currently processed data count as 10% of the upload, but deduped bytes count as being uploaded