### PR TITLE
Update terratorch library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1072,7 +1072,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/IBM/terratorch",
 		docsUrl: "https://ibm.github.io/terratorch/",
 		filter: false,
-		countDownloads: `path_extension:"pt"`,
+		countDownloads: `path_extension:"pt" OR path_extension:"ckpt"`,
 		snippets: snippets.terratorch,
 	},
 	"tic-clip": {


### PR DESCRIPTION
Adding `.ckpt` file extension because some supported models on the Hub do not use `.pt`, e.g. https://huggingface.co/ibm-granite/granite-geospatial-biomass/tree/main