### PR TITLE
Add Pruna AI library snippets (no formatting changes)

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1916,6 +1916,14 @@ export const pruna = (model: ModelData): string[] => {
 		snippets = pruna_default(model);
 	}
 
+	const ensurePrunaModelImport = (snippet: string): string => {
+		if (!/^from pruna import PrunaModel/m.test(snippet)) {
+			return `from pruna import PrunaModel\n${snippet}`;
+		}
+		return snippet;
+	};
+	snippets = snippets.map(ensurePrunaModelImport);
+
 	if (model.tags.includes("pruna_pro-ai")) {
 		return snippets.map((snippet) =>
 			snippet.replace(/\bpruna\b/g, "pruna_pro").replace(/\bPrunaModel\b/g, "PrunaProModel")
@@ -1928,7 +1936,7 @@ export const pruna = (model: ModelData): string[] => {
 const pruna_diffusers = (model: ModelData): string[] => {
 	const diffusersSnippets = diffusers(model);
 
-	const rewrittenSnippets = diffusersSnippets.map((snippet) =>
+	return diffusersSnippets.map((snippet) =>
 		snippet
 			// Replace pipeline classes with PrunaModel
 			.replace(/\b\w*Pipeline\w*\b/g, "PrunaModel")
@@ -1944,14 +1952,6 @@ const pruna_diffusers = (model: ModelData): string[] => {
 			.replace(/\n\n+/g, "\n")
 			.trim()
 	);
-
-	// Ensure PrunaModel import
-	return rewrittenSnippets.map((snippet) => {
-		if (!/^from pruna import PrunaModel/m.test(snippet)) {
-			return `from pruna import PrunaModel\n${snippet}`;
-		}
-		return snippet;
-	});
 };
 
 const pruna_transformers = (model: ModelData): string[] => {
@@ -1977,13 +1977,7 @@ const pruna_transformers = (model: ModelData): string[] => {
 		);
 	}
 
-	// Ensure PrunaModel import
-	return processedSnippets.map((snippet) => {
-		if (!/^from pruna import PrunaModel/m.test(snippet)) {
-			return `from pruna import PrunaModel\n${snippet}`;
-		}
-		return snippet;
-	});
+	return processedSnippets;
 };
 
 const pruna_default = (model: ModelData): string[] => [

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1908,9 +1908,9 @@ model = StaticModel.from_pretrained("${model.id}")`,
 export const pruna = (model: ModelData): string[] => {
 	let snippets: string[];
 
-	if (model.library_name === "diffusers") {
+	if (model.tags.includes("diffusers")) {
 		snippets = pruna_diffusers(model);
-	} else if (model.library_name === "transformers") {
+	} else if (model.tags.includes("transformers")) {
 		snippets = pruna_transformers(model);
 	} else {
 		snippets = pruna_default(model);

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -815,6 +815,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.pyannote_audio,
 		filter: true,
 	},
+	"pruna-ai": {
+		prettyLabel: "Pruna AI",
+		repoName: "Pruna AI",
+		repoUrl: "https://github.com/PrunaAI/pruna",
+		snippets: snippets.pruna,
+		docsUrl: "https://docs.pruna.ai",
+	},
 	"py-feat": {
 		prettyLabel: "Py-Feat",
 		repoName: "Py-Feat",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -801,6 +801,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_extension:"pth"`,
 	},
+	"pruna-ai": {
+		prettyLabel: "Pruna AI",
+		repoName: "Pruna AI",
+		repoUrl: "https://github.com/PrunaAI/pruna",
+		snippets: snippets.pruna,
+		docsUrl: "https://docs.pruna.ai",
+	},
 	pxia: {
 		prettyLabel: "pxia",
 		repoName: "pxia",
@@ -814,13 +821,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/pyannote/pyannote-audio",
 		snippets: snippets.pyannote_audio,
 		filter: true,
-	},
-	"pruna-ai": {
-		prettyLabel: "Pruna AI",
-		repoName: "Pruna AI",
-		repoUrl: "https://github.com/PrunaAI/pruna",
-		snippets: snippets.pruna,
-		docsUrl: "https://docs.pruna.ai",
 	},
 	"py-feat": {
 		prettyLabel: "Py-Feat",


### PR DESCRIPTION
This update enhances support for Pruna AI, providing users with tailored code snippets for model integrations with Transformers and Diffusers.

- Introduced a new library entry for Pruna AI in model-libraries.
- Added main entry point and specific snippet generation functions for diffusers and transformers models.
- Cleaned up whitespace inconsistencies in existing snippets.

TLDR: Pruna API normally mimics the Transformers and Diffusers API, so we can use `PrunaModel.from_pretrained` on top of pipelines or specific models. We re-use the underlying snippets for both the library and do some greedy replacements of certain part of the code snippets.

example
```python
import torch
from diffusers import FluxFillPipeline
from diffusers.utils import load_image

image = load_image("https://huggingface.co/datasets/diffusers/diffusers-images-docs/resolve/main/cup.png")
mask = load_image("https://huggingface.co/datasets/diffusers/diffusers-images-docs/resolve/main/cup_mask.png")

pipe = FluxFillPipeline.from_pretrained("black-forest-labs/FLUX.1-Fill-dev", torch_dtype=torch.bfloat16).to("cuda")
image = pipe(
    prompt="a white paper cup",
    image=image,
    mask_image=mask,
    height=1632,
    width=1232,
    guidance_scale=30,
    num_inference_steps=50,
    max_sequence_length=512,
    generator=torch.Generator("cpu").manual_seed(0)
).images[0]
image.save(f"flux-fill-dev.png")
```

becomes
```python
import torch
from pruna import PrunaModel
from diffusers.utils import load_image

image = load_image("https://huggingface.co/datasets/diffusers/diffusers-images-docs/resolve/main/cup.png")
mask = load_image("https://huggingface.co/datasets/diffusers/diffusers-images-docs/resolve/main/cup_mask.png")

pipe = PrunaModel.from_pretrained("black-forest-labs/FLUX.1-Fill-dev", torch_dtype=torch.bfloat16).to("cuda")
image = pipe(
    prompt="a white paper cup",
    image=image,
    mask_image=mask,
    height=1632,
    width=1232,
    guidance_scale=30,
    num_inference_steps=50,
    max_sequence_length=512,
    generator=torch.Generator("cpu").manual_seed(0)
).images[0]
image.save(f"flux-fill-dev.png")
```