### PR TITLE
update xet api paths

### DIFF
--- a/packages/hub/scripts/bench.ts
+++ b/packages/hub/scripts/bench.ts
@@ -157,7 +157,7 @@ function createMockFetch(args: { write: boolean }): {
 		const url = typeof input === "string" ? input : input.toString();
 
 		// Mock successful responses for xorb and shard uploads
-		if (url.includes("/xorb/")) {
+		if (url.includes("/xorbs/")) {
 			xorbCount++;
 			const bodySize = getBodySize(init?.body);
 			xorbBytes += parseInt(bodySize);
@@ -174,7 +174,7 @@ function createMockFetch(args: { write: boolean }): {
 			});
 		}
 
-		if (url.endsWith("/shard")) {
+		if (url.endsWith("/shards")) {
 			shardCount++;
 			const bodySize = getBodySize(init?.body);
 			shardBytes += parseInt(bodySize);

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -159,10 +159,10 @@ export class XetBlob extends Blob {
 			const connParams = await getAccessToken(this.accessToken, this.fetch, this.refreshUrl);
 
 			// debug(
-			// 	`curl '${connParams.casUrl}/v1/reconstruction/${this.hash}' -H 'Authorization: Bearer ${connParams.accessToken}'`
+			// 	`curl '${connParams.casUrl}/v1/reconstructions/${this.hash}' -H 'Authorization: Bearer ${connParams.accessToken}'`
 			// );
 
-			const resp = await this.fetch(this.reconstructionUrl ?? `${connParams.casUrl}/v1/reconstruction/${this.hash}`, {
+			const resp = await this.fetch(this.reconstructionUrl ?? `${connParams.casUrl}/v1/reconstructions/${this.hash}`, {
 				headers: {
 					Authorization: `Bearer ${connParams.accessToken}`,
 					Range: `bytes=${this.start}-${this.end - 1}`,

--- a/packages/hub/src/utils/createXorbs.ts
+++ b/packages/hub/src/utils/createXorbs.ts
@@ -202,7 +202,7 @@ export async function* createXorbs(
 						const token = await xetWriteToken(params);
 						bytesSinceRemoteDedup = 0;
 
-						const shardResp = await (params.fetch ?? fetch)(token.casUrl + "/v1/chunk/default/" + chunk.hash, {
+						const shardResp = await (params.fetch ?? fetch)(token.casUrl + "/v1/chunks/default/" + chunk.hash, {
 							headers: {
 								Authorization: `Bearer ${token.accessToken}`,
 							},
@@ -683,7 +683,7 @@ async function loadDedupInfoToCache(
 					const token = await xetWriteToken(params);
 					bytesSinceRemoteDedup = 0;
 
-					const shardResp = await (params.fetch ?? fetch)(token.casUrl + "/v1/chunk/default/" + chunk.hash, {
+					const shardResp = await (params.fetch ?? fetch)(token.casUrl + "/v1/chunks/default/" + chunk.hash, {
 						headers: {
 							Authorization: `Bearer ${token.accessToken}`,
 						},

--- a/packages/hub/src/utils/uploadShards.ts
+++ b/packages/hub/src/utils/uploadShards.ts
@@ -359,7 +359,7 @@ async function uploadXorb(
 ) {
 	const token = await xetWriteToken(params);
 
-	const resp = await (params.fetch ?? fetch)(`${token.casUrl}/v1/xorb/default/${xorb.hash}`, {
+	const resp = await (params.fetch ?? fetch)(`${token.casUrl}/v1/xorbs/default/${xorb.hash}`, {
 		method: "POST",
 		body: xorb.xorb,
 		headers: {
@@ -388,7 +388,7 @@ async function uploadXorb(
 async function uploadShard(shard: Uint8Array, params: UploadShardsParams) {
 	const token = await xetWriteToken(params);
 
-	const resp = await (params.fetch ?? fetch)(`${token.casUrl}/v1/shard`, {
+	const resp = await (params.fetch ?? fetch)(`${token.casUrl}/v1/shards`, {
 		method: "POST",
 		body: shard,
 		headers: {


### PR DESCRIPTION
updates API paths to use plural nouns as consistent with specification draft and latest deployed CAS server.