### PR TITLE
feat(inference): add Corvex provider for chat completions and enable end-to-end testing

### DIFF
--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -13,6 +13,7 @@ import * as Nscale from "../providers/nscale.js";
 import * as OpenAI from "../providers/openai.js";
 import * as OvhCloud from "../providers/ovhcloud.js";
 import * as PublicAI from "../providers/publicai.js";
+import * as Corvex from "../providers/corvex.js";
 import type {
 	AudioClassificationTaskHelper,
 	AudioToAudioTaskHelper,
@@ -163,6 +164,9 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 		"text-to-image": new Together.TogetherTextToImageTask(),
 		conversational: new Together.TogetherConversationalTask(),
 		"text-generation": new Together.TogetherTextGenerationTask(),
+	},
+	corvex: {
+		conversational: new Corvex.CorvexConversationalTask(),
 	},
 };
 

--- a/packages/inference/src/providers/consts.ts
+++ b/packages/inference/src/providers/consts.ts
@@ -37,4 +37,13 @@ export const HARDCODED_MODEL_INFERENCE_MAPPING: Record<
 	sambanova: {},
 	scaleway: {},
 	together: {},
+	corvex: {
+	  tinyllama: {
+		hfModelId: "tinyllama",
+		provider: "corvex",
+		providerId: "tinyllama",
+		status: "staging",
+		task: "conversational"
+	  },
+	},
 };

--- a/packages/inference/src/providers/corvex.ts
+++ b/packages/inference/src/providers/corvex.ts
@@ -1,0 +1,51 @@
+import { BaseConversationalTask } from "./providerHelper.js";
+import type { BodyParams, HeaderParams } from "../types.js";
+import type { ChatCompletionInput } from "../../../tasks/dist/commonjs/index.js";
+
+// Allow override for dev (raw IP), default to prod domain
+const CORVEX_API_BASE_URL =
+  (typeof process !== "undefined" && (process as any)?.env?.CORVEX_API_BASE_URL) ||
+  "https://api.corvex.ai";
+
+export class CorvexConversationalTask extends BaseConversationalTask {
+  private _apiKey?: string;
+
+  constructor() {
+    super("corvex", CORVEX_API_BASE_URL);
+  }
+
+  override makeBaseUrl(_params: any): string {
+    return CORVEX_API_BASE_URL;
+  }
+
+  override makeRoute(): string {
+    return "v1/chat/completions";
+  }
+
+  // Grab key from args (router-style), scrub router-only fields, and build OpenAI-style body
+  override preparePayload(params: BodyParams<ChatCompletionInput>): Record<string, unknown> {
+    const args: any = { ...(params.args as any) };
+
+    // capture any way the key might be passed
+    this._apiKey = args.apiKey ?? args.providerApiKey ?? args.accessToken ?? this._apiKey;
+
+    // remove router-only / sensitive fields so they don't hit your API
+    delete args.apiKey;
+    delete args.providerApiKey;
+    delete args.accessToken;
+    delete args.task;
+
+    return {
+      model: params.model, // required by your API
+      ...args,             // messages, temperature, max_tokens, stream, etc.
+    };
+  }
+
+  // Authorize with Bearer using the captured key
+  override prepareHeaders(_params: HeaderParams, isBinary: boolean): Record<string, string> {
+    const headers: Record<string, string> = {};
+    if (!isBinary) headers["content-type"] = "application/json";
+    if (this._apiKey) headers["authorization"] = `Bearer ${this._apiKey}`;
+    return headers;
+  }
+}

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -64,6 +64,7 @@ export const INFERENCE_PROVIDERS = [
 	"sambanova",
 	"scaleway",
 	"together",
+	"corvex"
 ] as const;
 
 export const PROVIDERS_OR_POLICIES = [...INFERENCE_PROVIDERS, "auto"] as const;

--- a/scripts/smoke/corvex-chat.mjs
+++ b/scripts/smoke/corvex-chat.mjs
@@ -1,0 +1,68 @@
+import { InferenceClient } from "../../packages/inference/dist/esm/index.js";
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = async (url, init = {}) => {
+  try {
+    const method = init.method || "GET";
+    const headers = init.headers ? Object.fromEntries(new Headers(init.headers).entries()) : {};
+    let bodyPreview = "";
+
+    if (typeof init.body === "string") {
+      bodyPreview = init.body;
+    } else if (init.body && typeof init.body.getReader === "function") {
+      // It's a stream; skip printing to avoid consuming it
+      bodyPreview = "[stream]";
+    } else if (init.body instanceof Buffer) {
+      bodyPreview = `[Buffer ${init.body.length} bytes]`;
+    }
+
+    console.error("\n[FETCH] ", method, url);
+    console.error("[HEADERS]", headers);
+    if (bodyPreview) console.error("[BODY]   ", bodyPreview);
+
+    const res = await originalFetch(url, init);
+    const txt = await res.clone().text();
+
+    console.error("[RESPONSE]", res.status, res.statusText);
+    console.error("[RES HDRS]", Object.fromEntries(res.headers.entries()));
+    console.error("[RES BODY]", txt.slice(0, 4000)); // avoid flooding
+    return res;
+  } catch (e) {
+    console.error("[FETCH ERROR]", e);
+    throw e;
+  }
+};
+
+const VALID = process.env.CORVEX_API_KEY || "replace_me";
+const INVALID = "invalid_key";
+
+async function run(apiKey, label) {
+  const client = new InferenceClient();
+  try {
+    const out = await client.chatCompletion({
+      provider: "corvex",
+      task: "conversational",
+      apiKey,
+      model: "tinyllama",
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "What is the capital of France?" },
+      ],
+      max_tokens: 100,
+      temperature: 0.7,
+      stream: false,
+    });
+    console.log(`[${label}] OK\n`, JSON.stringify(out, null, 2));
+  } catch (e) {
+    console.error(`[${label}] ERROR`, e?.status || "", e?.message || e);
+  }
+}
+
+// Optional: point at raw IP like in your curl
+// export CORVEX_API_BASE_URL=http://34.48.240.55
+if (process.env.CORVEX_API_BASE_URL) {
+  console.log("Using CORVEX_API_BASE_URL =", process.env.CORVEX_API_BASE_URL);
+}
+
+await run(VALID, "VALID");
+await run(INVALID, "INVALID");


### PR DESCRIPTION
## What
- Adds `packages/inference/src/providers/corvex.ts`
- Registers provider in `getProviderHelper.ts` and `types.ts`
- Adds local hardcoded mapping for `tinyllama` (dev) in `providers/consts.ts`
- Forces direct calls to Corvex base URL and sets Bearer auth header

## Why
To validate our `/v1/chat/completions` endpoint end-to-end via a forked HuggingFace JS client.

## How to test (local)
```bash
pnpm -r build

# works with our public dev IP; or omit CORVEX_API_BASE_URL to use https://api.corvex.ai
CORVEX_API_BASE_URL="http://34.48.240.55" \
CORVEX_API_KEY="<valid-key>" \
node scripts/smoke/corvex-chat.mjs
