### PR TITLE
Enhance token generation by including isPullRequest flag in xetWriteToken and related functions for better handling of pull requests

### DIFF
--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -410,6 +410,7 @@ export async function* commitIter(params: CommitParams): AsyncGenerator<CommitPr
 								repo: repoId,
 								// todo: maybe leave empty if PR?
 								rev: params.branch ?? "main",
+								isPullRequest: params.isPullRequest,
 								yieldCallback: (event) => yieldCallback({ ...event, state: "uploading" }),
 							})) {
 								if (event.event === "file") {

--- a/packages/hub/src/utils/createXorbs.ts
+++ b/packages/hub/src/utils/createXorbs.ts
@@ -199,7 +199,7 @@ export async function* createXorbs(
 
 					let cacheData = chunkCache.getChunk(chunk.hash, chunkModule.compute_hmac);
 					if (cacheData === undefined && chunk.dedup && bytesSinceRemoteDedup >= INTERVAL_BETWEEN_REMOTE_DEDUP) {
-						const token = await xetWriteToken(params);
+						const token = await xetWriteToken({ ...params, isPullRequest: params.isPullRequest });
 						bytesSinceRemoteDedup = 0;
 
 						const shardResp = await (params.fetch ?? fetch)(token.casUrl + "/v1/chunks/default/" + chunk.hash, {
@@ -680,7 +680,7 @@ async function loadDedupInfoToCache(
 
 				// Try remote dedup lookup if conditions are met
 				if (chunk.dedup && bytesSinceRemoteDedup >= INTERVAL_BETWEEN_REMOTE_DEDUP) {
-					const token = await xetWriteToken(params);
+					const token = await xetWriteToken({ ...params, isPullRequest: params.isPullRequest });
 					bytesSinceRemoteDedup = 0;
 
 					const shardResp = await (params.fetch ?? fetch)(token.casUrl + "/v1/chunks/default/" + chunk.hash, {

--- a/packages/hub/src/utils/uploadShards.ts
+++ b/packages/hub/src/utils/uploadShards.ts
@@ -57,6 +57,7 @@ interface UploadShardsParams {
 	fetch?: typeof fetch;
 	repo: RepoId;
 	rev: string;
+	isPullRequest?: boolean;
 	yieldCallback: (event: { event: "fileProgress"; path: string; progress: number }) => void;
 }
 
@@ -357,7 +358,7 @@ async function uploadXorb(
 	xorb: { hash: string; xorb: Uint8Array; files: Array<{ path: string; progress: number; lastSentProgress: number }> },
 	params: UploadShardsParams
 ) {
-	const token = await xetWriteToken(params);
+	const token = await xetWriteToken({ ...params, isPullRequest: params.isPullRequest });
 
 	const resp = await (params.fetch ?? fetch)(`${token.casUrl}/v1/xorbs/default/${xorb.hash}`, {
 		method: "POST",
@@ -386,7 +387,7 @@ async function uploadXorb(
 }
 
 async function uploadShard(shard: Uint8Array, params: UploadShardsParams) {
-	const token = await xetWriteToken(params);
+	const token = await xetWriteToken({ ...params, isPullRequest: params.isPullRequest });
 
 	const resp = await (params.fetch ?? fetch)(`${token.casUrl}/v1/shards`, {
 		method: "POST",

--- a/packages/hub/src/utils/xetWriteToken.ts
+++ b/packages/hub/src/utils/xetWriteToken.ts
@@ -7,13 +7,14 @@ export interface XetWriteTokenParams {
 	fetch?: typeof fetch;
 	repo: RepoId;
 	rev: string;
+	isPullRequest?: boolean;
 }
 
 const JWT_SAFETY_PERIOD = 60_000;
 const JWT_CACHE_SIZE = 1_000;
 
 function cacheKey(params: Omit<XetWriteTokenParams, "fetch">): string {
-	return JSON.stringify([params.hubUrl, params.repo, params.rev, params.accessToken]);
+	return JSON.stringify([params.hubUrl, params.repo, params.rev, params.accessToken, params.isPullRequest]);
 }
 
 const jwtPromises: Map<string, Promise<{ accessToken: string; casUrl: string }>> = new Map();
@@ -46,7 +47,8 @@ export async function xetWriteToken(params: XetWriteTokenParams): Promise<{ acce
 
 	const promise = (async () => {
 		const resp = await (params.fetch ?? fetch)(
-			`${params.hubUrl}/api/${params.repo.type}s/${params.repo.name}/xet-write-token/${params.rev}`,
+			`${params.hubUrl}/api/${params.repo.type}s/${params.repo.name}/xet-write-token/${params.rev}` +
+				(params.isPullRequest ? "?create_pr=1" : ""),
 			{
 				headers: params.accessToken
 					? {


### PR DESCRIPTION
I was getting error when trying to create pull request on repos that I do **not** own:
```
Error: Forbidden: pass `create_pr=1` as a query parameter to create a Pull Request. URL: https://huggingface.co/api/models/reach-vb/TinyLlama-1.1B-Chat-v1.0-q4_k_m-GGUF/xet-write-token/main
```

I was using new API from https://github.com/huggingface/huggingface.js/pull/1718

```ts
// Edit first kB of file
await commit({
  repo,
  accessToken: "hf_...",
  operations: [{
    type: "edit",
    originalContent: originalFile,
    edits: [{
      start: 0,
      end: 1000,
      content: new Blob(["blablabla"])
    }]
  }]
})
```

Let me know if this PR is the right way to handle this issue