### PR TITLE
Fix MXFP4 quant label

### DIFF
--- a/packages/tasks/src/gguf.ts
+++ b/packages/tasks/src/gguf.ts
@@ -40,7 +40,7 @@ export enum GGMLFileQuantizationType {
 	Q4_0_8_8 = 35,
 	TQ1_0 = 36,
 	TQ2_0 = 37,
-	MXFP4_MOE = 38,
+	MXFP4 = 38,
 
 	// custom quants used by unsloth
 	// they are not officially a scheme enum value in GGUF, but only here for naming
@@ -96,7 +96,7 @@ export const GGUF_QUANT_ORDER: GGMLFileQuantizationType[] = [
 	GGMLFileQuantizationType.Q4_1,
 	GGMLFileQuantizationType.Q4_2,
 	GGMLFileQuantizationType.Q4_3,
-	GGMLFileQuantizationType.MXFP4_MOE,
+	GGMLFileQuantizationType.MXFP4,
 
 	// 3-bit quantizations
 	GGMLFileQuantizationType.Q3_K_XL,


### PR DESCRIPTION
I noticed the MXFP4 quant type was not parsed properly for GGUF models on the hub ([see here for instance](https://huggingface.co/lmstudio-community/gpt-oss-120b-GGUF)). 

I believe the name format "MXFP4_MOE" is incorrect, it should have been referred to as "MXFP4", and since were using the enum key to parse the quant label in the file name, that's why it fails. cc @ngxson 