### PR TITLE
Expose audio-text-to-text task

### DIFF
--- a/packages/tasks/src/tasks/index.ts
+++ b/packages/tasks/src/tasks/index.ts
@@ -122,7 +122,7 @@ export const TASKS_MODEL_LIBRARIES: Record<PipelineType, ModelLibraryKey[]> = {
 	"audio-classification": ["speechbrain", "transformers", "transformers.js"],
 	"audio-to-audio": ["asteroid", "fairseq", "speechbrain"],
 	"automatic-speech-recognition": ["espnet", "nemo", "speechbrain", "transformers", "transformers.js"],
-	"audio-text-to-text": [],
+	"audio-text-to-text": ["transformers"],
 	"depth-estimation": ["transformers", "transformers.js"],
 	"document-question-answering": ["transformers", "transformers.js"],
 	"feature-extraction": ["sentence-transformers", "transformers", "transformers.js"],


### PR DESCRIPTION
Still [not showing up](https://huggingface.co/tasks/audio-text-to-text) despite the upgrade to the tasks package being deployed yesterday.

I'm not sure if we also need a mapping to transformers in `TASKS_MODEL_LIBRARIES`.