### PR TITLE
Add Cloud Agents

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -208,7 +208,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://huggingface.co/OpenPeerAI/Cloud-Agents",
 		filter: false,
 		countDownloads: `path:"setup.py"`,
-	},	
+	},
 	colpali: {
 		prettyLabel: "ColPali",
 		repoName: "ColPali",


### PR DESCRIPTION
Hi, we are doing a PR to track downloads for this training agent repo. If anything else is needed, let me know. 

Adding the Cloud Agents Training System by OpenPeerAI: https://huggingface.co/OpenPeerAI/Cloud-Agents