### PR TITLE
Update local-apps.ts to include Cactus

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -94,6 +94,10 @@ function isAmdRyzenModel(model: ModelData) {
 	return model.tags.includes("ryzenai-hybrid") || model.tags.includes("ryzenai-npu");
 }
 
+function isCactusModel(model: ModelData) {
+	return model.tags.includes("cactus");
+}
+
 function isMlxModel(model: ModelData) {
 	return model.tags.includes("mlx");
 }
@@ -361,6 +365,21 @@ const snippetLemonade = (model: ModelData, filepath?: string): LocalAppSnippet[]
 	];
 };
 
+const snippetCactus = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
+	return [
+		{
+			title: "Install Cactus for Flutter",
+			setup: "flutter pub get cactus",
+			content: "Follow the documentation",
+		},
+		{
+			title: "Install Cactus for React Native",
+			setup: "npm install cactus-react-native",
+			content: "Follow the documentation",
+		},
+	];
+};
+
 /**
  * Add your new local app here.
  *
@@ -544,6 +563,13 @@ export const LOCAL_APPS = {
 		mainTask: "text-generation",
 		displayOnModelPage: (model) => isLlamaCppGgufModel(model) || isAmdRyzenModel(model),
 		snippet: snippetLemonade,
+	},
+	cactus: {
+		prettyLabel: "Cactus",
+		docsUrl: "https://cactuscompute.com/docs",
+		mainTask: "text-generation",
+		displayOnModelPage: isCactusModel,
+		snippet: snippetCactus
 	},
 } satisfies Record<string, LocalApp>;
 


### PR DESCRIPTION
Hi! Submitting this PR to add Cactus as an local inference option.

Cactus is the fastest runtime for deploying models on smartphones and ships bindings for all most-used cross-platform SDKs.

https://cactuscompute.com/
https://github.com/cactus-compute/cactus