### PR TITLE
Update `image-to-image` target size param docstring

### DIFF
--- a/packages/tasks/src/tasks/image-to-image/inference.ts
+++ b/packages/tasks/src/tasks/image-to-image/inference.ts
@@ -41,15 +41,15 @@ export interface ImageToImageParameters {
 	 */
 	prompt?: string;
 	/**
-	 * The size in pixel of the output image. This parameter is only supported by some providers
-	 * and for specific models. It will be ignored when unsupported.
+	 * The size in pixels of the output image. This parameter is only supported by some
+	 * providers and for specific models. It will be ignored when unsupported.
 	 */
 	target_size?: TargetSize;
 	[property: string]: unknown;
 }
 /**
- * The size in pixel of the output image. This parameter is only supported by some providers
- * and for specific models. It will be ignored when unsupported.
+ * The size in pixels of the output image. This parameter is only supported by some
+ * providers and for specific models. It will be ignored when unsupported.
  */
 export interface TargetSize {
 	height: number;

--- a/packages/tasks/src/tasks/image-to-image/inference.ts
+++ b/packages/tasks/src/tasks/image-to-image/inference.ts
@@ -41,13 +41,15 @@ export interface ImageToImageParameters {
 	 */
 	prompt?: string;
 	/**
-	 * The size in pixel of the output image.
+	 * The size in pixel of the output image. This parameter is only supported by some providers
+	 * and for specific models. It will be ignored when unsupported.
 	 */
 	target_size?: TargetSize;
 	[property: string]: unknown;
 }
 /**
- * The size in pixel of the output image.
+ * The size in pixel of the output image. This parameter is only supported by some providers
+ * and for specific models. It will be ignored when unsupported.
  */
 export interface TargetSize {
 	height: number;

--- a/packages/tasks/src/tasks/image-to-image/spec/input.json
+++ b/packages/tasks/src/tasks/image-to-image/spec/input.json
@@ -38,7 +38,7 @@
 				},
 				"target_size": {
 					"type": "object",
-					"description": "The size in pixel of the output image.",
+					"description": "The size in pixel of the output image. This parameter is only supported by some providers and for specific models. It will be ignored when unsupported.",
 					"properties": {
 						"width": {
 							"type": "integer"

--- a/packages/tasks/src/tasks/image-to-image/spec/input.json
+++ b/packages/tasks/src/tasks/image-to-image/spec/input.json
@@ -38,7 +38,7 @@
 				},
 				"target_size": {
 					"type": "object",
-					"description": "The size in pixel of the output image. This parameter is only supported by some providers and for specific models. It will be ignored when unsupported.",
+					"description": "The size in pixels of the output image. This parameter is only supported by some providers and for specific models. It will be ignored when unsupported.",
 					"properties": {
 						"width": {
 							"type": "integer"


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/pull/3399, some providers or models may ignore this parameter if it's not supported. This PR updates the docstring to make that clearer and align it with the one in `huggingface_hub`.