### PR TITLE
[Inference Snippets] Reorder clients: openai > huggingface > requests/fetch

### DIFF
--- a/packages/inference/src/snippets/getInferenceSnippets.ts
+++ b/packages/inference/src/snippets/getInferenceSnippets.ts
@@ -24,8 +24,8 @@ export type InferenceSnippetOptions = {
 	inputs?: Record<string, unknown>; // overrides the default snippet's inputs
 } & Record<string, unknown>;
 
-const PYTHON_CLIENTS = ["huggingface_hub", "fal_client", "requests", "openai"] as const;
-const JS_CLIENTS = ["fetch", "huggingface.js", "openai"] as const;
+const PYTHON_CLIENTS = ["openai", "huggingface_hub", "fal_client", "requests"] as const;
+const JS_CLIENTS = ["openai", "huggingface.js", "fetch"] as const;
 const SH_CLIENTS = ["curl"] as const;
 
 type Client = (typeof SH_CLIENTS)[number] | (typeof PYTHON_CLIENTS)[number] | (typeof JS_CLIENTS)[number];


### PR DESCRIPTION
Quickly discussed with @hanouticelina. Order of definition of the inference snippets was a bit random. Let's always show "openai" client when possible (i.e. when `chat completion`), then `huggingface_hub`/`huggingface.js` and then the raw `fetch`/`requests`.

By default on the Hub we are already showcasing `openai` first. This update will align the snippets in the docs as well.