### PR TITLE
[safetnesors] increase index.json parse limit from 10MB -> 20MB

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -302,4 +302,15 @@ describe("parseSafetensorsMetadata", () => {
 		assert.strictEqual(parameterCount.FP4, 20000);
 		assert.strictEqual(parameterCount.UE8, 5000);
 	});
+
+	it("fetch info for large index file (>10MB) with many experts (moonshotai/Kimi-K2-Instruct-0905)", async () => {
+		// This model has a 13.5MB index file due to having 384 experts per layer
+		const parse = await parseSafetensorsMetadata({
+			repo: "moonshotai/Kimi-K2-Instruct-0905",
+			revision: "7152993552508c9f22042b3bb93b5e6acd06ce73",
+		});
+
+		assert(parse.sharded);
+		assert.strictEqual(Object.keys(parse.headers).length, 62);
+	});
 });

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -190,7 +190,7 @@ async function parseShardedIndex(
 
 	try {
 		// no validation for now, we assume it's a valid IndexJson.
-		const index = JSON.parse(await indexBlob.slice(0, 10_000_000).text());
+		const index = JSON.parse(await indexBlob.slice(0, 20_000_000).text());
 		return index;
 	} catch (error) {
 		throw new SafetensorParseError(`Failed to parse file ${path}: not a valid JSON.`);


### PR DESCRIPTION
## Fix parsing of large safetensors index files (>10MB)

### Problem
Models with large index files (>10MB) were failing to parse. The code was truncating index files at 10MB, causing JSON parsing errors for models with many experts/shards.

**Failure example:** [moonshotai/Kimi-K2-Instruct-0905](https://huggingface.co/moonshotai/Kimi-K2-Instruct-0905) has a 13.5MB index file (384 experts per layer, 62 shards) and was failing with:
```
Failed to parse file model.safetensors.index.json: not a valid JSON.
```

### Solution
- Increased index file size limit from 10MB to 20MB in `parse-safetensors-metadata.ts`
- Added test case for large index files using the moonshotai model

### Changes
- `packages/hub/src/lib/parse-safetensors-metadata.ts`: Bump limit from `10_000_000` to `20_000_000` bytes
- `packages/hub/src/lib/parse-safetensors-metadata.spec.ts`: Add comprehensive test for large index files