### PR TITLE
📈 Download tracking for new diff-interpretation-tuning project

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -289,7 +289,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	},
 	"diff-interpretation-tuning": {
 		prettyLabel: "Diff Interpretation Tuning",
-		repoName: "diff-interpretation-tuning",
+		repoName: "Diff Interpretation Tuning",
 		repoUrl: "https://github.com/Aviously/diff-interpretation-tuning",
 		filter: false,
 		countDownloads: `path_extension:"pt"`,


### PR DESCRIPTION
Registering a new library per the instructions on https://huggingface.co/docs/hub/models-adding-libraries#register-your-library and https://huggingface.co/docs/hub/models-download-stats.

This library is used by https://huggingface.co/diff-interpretation-tuning/loras model repo, and we are adding it so that downloads can be accurately counted. Note that every .pt file contains one or more adapter files, hence we track the total number of .pt file downloads.