### PR TITLE
[Inference] Add Text-Generation support for Replicate provider

### DIFF
--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -153,13 +153,13 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 	publicai: {
 		conversational: new PublicAI.PublicAIConversationalTask(),
 	},
-        replicate: {
-                "text-generation": new Replicate.ReplicateTextGenerationTask(),
-                "text-to-image": new Replicate.ReplicateTextToImageTask(),
-                "text-to-speech": new Replicate.ReplicateTextToSpeechTask(),
-                "text-to-video": new Replicate.ReplicateTextToVideoTask(),
-                "image-to-image": new Replicate.ReplicateImageToImageTask(),
-                "automatic-speech-recognition": new Replicate.ReplicateAutomaticSpeechRecognitionTask(),
+	replicate: {
+		"text-generation": new Replicate.ReplicateTextGenerationTask(),
+		"text-to-image": new Replicate.ReplicateTextToImageTask(),
+		"text-to-speech": new Replicate.ReplicateTextToSpeechTask(),
+		"text-to-video": new Replicate.ReplicateTextToVideoTask(),
+		"image-to-image": new Replicate.ReplicateImageToImageTask(),
+		"automatic-speech-recognition": new Replicate.ReplicateAutomaticSpeechRecognitionTask(),
 	},
 	sambanova: {
 		conversational: new Sambanova.SambanovaConversationalTask(),

--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -153,12 +153,13 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 	publicai: {
 		conversational: new PublicAI.PublicAIConversationalTask(),
 	},
-	replicate: {
-		"text-to-image": new Replicate.ReplicateTextToImageTask(),
-		"text-to-speech": new Replicate.ReplicateTextToSpeechTask(),
-		"text-to-video": new Replicate.ReplicateTextToVideoTask(),
-		"image-to-image": new Replicate.ReplicateImageToImageTask(),
-		"automatic-speech-recognition": new Replicate.ReplicateAutomaticSpeechRecognitionTask(),
+        replicate: {
+                "text-generation": new Replicate.ReplicateTextGenerationTask(),
+                "text-to-image": new Replicate.ReplicateTextToImageTask(),
+                "text-to-speech": new Replicate.ReplicateTextToSpeechTask(),
+                "text-to-video": new Replicate.ReplicateTextToVideoTask(),
+                "image-to-image": new Replicate.ReplicateImageToImageTask(),
+                "automatic-speech-recognition": new Replicate.ReplicateAutomaticSpeechRecognitionTask(),
 	},
 	sambanova: {
 		conversational: new Sambanova.SambanovaConversationalTask(),

--- a/packages/inference/src/providers/consts.ts
+++ b/packages/inference/src/providers/consts.ts
@@ -35,7 +35,7 @@ export const HARDCODED_MODEL_INFERENCE_MAPPING: Record<
 	openai: {},
 	publicai: {},
 	ovhcloud: {},
-        replicate: {},
+	replicate: {},
 	sambanova: {},
 	scaleway: {},
 	together: {},

--- a/packages/inference/src/providers/consts.ts
+++ b/packages/inference/src/providers/consts.ts
@@ -35,7 +35,7 @@ export const HARDCODED_MODEL_INFERENCE_MAPPING: Record<
 	openai: {},
 	publicai: {},
 	ovhcloud: {},
-	replicate: {},
+        replicate: {},
 	sambanova: {},
 	scaleway: {},
 	together: {},

--- a/packages/inference/src/providers/replicate.ts
+++ b/packages/inference/src/providers/replicate.ts
@@ -19,57 +19,57 @@ import { isUrl } from "../lib/isUrl.js";
 import type { BodyParams, HeaderParams, RequestArgs, UrlParams } from "../types.js";
 import { omit } from "../utils/omit.js";
 import {
-        TaskProviderHelper,
-        type AutomaticSpeechRecognitionTaskHelper,
-        type ImageToImageTaskHelper,
-        type TextGenerationTaskHelper,
-        type TextToImageTaskHelper,
-        type TextToVideoTaskHelper,
+	TaskProviderHelper,
+	type AutomaticSpeechRecognitionTaskHelper,
+	type ImageToImageTaskHelper,
+	type TextGenerationTaskHelper,
+	type TextToImageTaskHelper,
+	type TextToVideoTaskHelper,
 } from "./providerHelper.js";
 import type { ImageToImageArgs } from "../tasks/cv/imageToImage.js";
 import type { AutomaticSpeechRecognitionArgs } from "../tasks/audio/automaticSpeechRecognition.js";
 import type { AutomaticSpeechRecognitionOutput, TextGenerationOutput } from "@huggingface/tasks";
 import { base64FromBytes } from "../utils/base64FromBytes.js";
 export interface ReplicateOutput {
-        output?: unknown;
+	output?: unknown;
 }
 
 function extractTextFromReplicateResponse(value: unknown): string | undefined {
-        if (value == null) {
-                return undefined;
-        }
-        if (typeof value === "string") {
-                return value;
-        }
-        if (Array.isArray(value)) {
-                for (const item of value) {
-                        const text = extractTextFromReplicateResponse(item);
-                        if (typeof text === "string" && text.length > 0) {
-                                return text;
-                        }
-                }
-                return undefined;
-        }
-        if (typeof value === "object") {
-                const record = value as Record<string, unknown>;
-                const directTextKeys = ["output_text", "generated_text", "text", "content"] as const;
-                for (const key of directTextKeys) {
-                        const maybeText = record[key];
-                        if (typeof maybeText === "string" && maybeText.length > 0) {
-                                return maybeText;
-                        }
-                }
-                const nestedKeys = ["output", "choices", "message", "delta", "content", "data"] as const;
-                for (const key of nestedKeys) {
-                        if (key in record) {
-                                const text = extractTextFromReplicateResponse(record[key]);
-                                if (typeof text === "string" && text.length > 0) {
-                                        return text;
-                                }
-                        }
-                }
-        }
-        return undefined;
+	if (value == null) {
+		return undefined;
+	}
+	if (typeof value === "string") {
+		return value;
+	}
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			const text = extractTextFromReplicateResponse(item);
+			if (typeof text === "string" && text.length > 0) {
+				return text;
+			}
+		}
+		return undefined;
+	}
+	if (typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		const directTextKeys = ["output_text", "generated_text", "text", "content"] as const;
+		for (const key of directTextKeys) {
+			const maybeText = record[key];
+			if (typeof maybeText === "string" && maybeText.length > 0) {
+				return maybeText;
+			}
+		}
+		const nestedKeys = ["output", "choices", "message", "delta", "content", "data"] as const;
+		for (const key of nestedKeys) {
+			if (key in record) {
+				const text = extractTextFromReplicateResponse(record[key]);
+				if (typeof text === "string" && text.length > 0) {
+					return text;
+				}
+			}
+		}
+	}
+	return undefined;
 }
 
 abstract class ReplicateTask extends TaskProviderHelper {
@@ -156,22 +156,18 @@ export class ReplicateTextToImageTask extends ReplicateTask implements TextToIma
 }
 
 export class ReplicateTextGenerationTask extends ReplicateTask implements TextGenerationTaskHelper {
-        override async getResponse(response: ReplicateOutput): Promise<TextGenerationOutput> {
-                if (response instanceof Blob) {
-                        throw new InferenceClientProviderOutputError(
-                                "Received malformed response from Replicate text-generation API"
-                        );
-                }
+	override async getResponse(response: ReplicateOutput): Promise<TextGenerationOutput> {
+		if (response instanceof Blob) {
+			throw new InferenceClientProviderOutputError("Received malformed response from Replicate text-generation API");
+		}
 
-                const text = extractTextFromReplicateResponse(response);
-                if (typeof text === "string") {
-                        return { generated_text: text };
-                }
+		const text = extractTextFromReplicateResponse(response);
+		if (typeof text === "string") {
+			return { generated_text: text };
+		}
 
-                throw new InferenceClientProviderOutputError(
-                        "Received malformed response from Replicate text-generation API"
-                );
-        }
+		throw new InferenceClientProviderOutputError("Received malformed response from Replicate text-generation API");
+	}
 }
 
 export class ReplicateTextToSpeechTask extends ReplicateTask {

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -1193,27 +1193,27 @@ describe.skip("InferenceClient", () => {
 	describe.concurrent(
 		"Replicate",
 		() => {
-                        const client = new InferenceClient(env.HF_REPLICATE_KEY ?? "dummy");
+			const client = new InferenceClient(env.HF_REPLICATE_KEY ?? "dummy");
 
-                        it("textGeneration - akhaliq/gpt-5", async () => {
-                                const res = await client.textGeneration({
-                                        model: "akhaliq/gpt-5",
-                                        provider: "replicate",
-                                        inputs: "The capital city of France is",
-                                        parameters: {
-                                                max_new_tokens: 20,
-                                                temperature: 0.2,
-                                        },
-                                });
+			it("textGeneration - akhaliq/gpt-5", async () => {
+				const res = await client.textGeneration({
+					model: "akhaliq/gpt-5",
+					provider: "replicate",
+					inputs: "The capital city of France is",
+					parameters: {
+						max_new_tokens: 20,
+						temperature: 0.2,
+					},
+				});
 
-                                expect(res).toBeDefined();
-                                expect(typeof res.generated_text).toBe("string");
-                                expect(res.generated_text.length).toBeGreaterThan(0);
-                        });
+				expect(res).toBeDefined();
+				expect(typeof res.generated_text).toBe("string");
+				expect(res.generated_text.length).toBeGreaterThan(0);
+			});
 
-                        it("textToImage canonical - black-forest-labs/FLUX.1-schnell", async () => {
-                                const res = await client.textToImage({
-                                        model: "black-forest-labs/FLUX.1-schnell",
+			it("textToImage canonical - black-forest-labs/FLUX.1-schnell", async () => {
+				const res = await client.textToImage({
+					model: "black-forest-labs/FLUX.1-schnell",
 					provider: "replicate",
 					inputs: "black forest gateau cake spelling out the words FLUX SCHNELL, tasty, food photography, dynamic shot",
 				});

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -1193,11 +1193,27 @@ describe.skip("InferenceClient", () => {
 	describe.concurrent(
 		"Replicate",
 		() => {
-			const client = new InferenceClient(env.HF_REPLICATE_KEY ?? "dummy");
+                        const client = new InferenceClient(env.HF_REPLICATE_KEY ?? "dummy");
 
-			it("textToImage canonical - black-forest-labs/FLUX.1-schnell", async () => {
-				const res = await client.textToImage({
-					model: "black-forest-labs/FLUX.1-schnell",
+                        it("textGeneration - akhaliq/gpt-5", async () => {
+                                const res = await client.textGeneration({
+                                        model: "akhaliq/gpt-5",
+                                        provider: "replicate",
+                                        inputs: "The capital city of France is",
+                                        parameters: {
+                                                max_new_tokens: 20,
+                                                temperature: 0.2,
+                                        },
+                                });
+
+                                expect(res).toBeDefined();
+                                expect(typeof res.generated_text).toBe("string");
+                                expect(res.generated_text.length).toBeGreaterThan(0);
+                        });
+
+                        it("textToImage canonical - black-forest-labs/FLUX.1-schnell", async () => {
+                                const res = await client.textToImage({
+                                        model: "black-forest-labs/FLUX.1-schnell",
 					provider: "replicate",
 					inputs: "black forest gateau cake spelling out the words FLUX SCHNELL, tasty, food photography, dynamic shot",
 				});


### PR DESCRIPTION
This PR adds support for the `Text Generation` task type for Replicate models.

Example:

- [huggingface.co/akhaliq/gpt-5](https://huggingface.co/akhaliq/gpt-5)
- [replicate.com/openai/gpt-5](https://replicate.com/openai/gpt-5)