### PR TITLE
[inference provider] Wavespeed.ai Adds Image-to-Video Generation

### DIFF
--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -178,6 +178,7 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 		"text-to-image": new Wavespeed.WavespeedAITextToImageTask(),
 		"text-to-video": new Wavespeed.WavespeedAITextToVideoTask(),
 		"image-to-image": new Wavespeed.WavespeedAIImageToImageTask(),
+		"image-to-video": new Wavespeed.WavespeedAIImageToVideoTask(),
 	},
 	"zai-org": {
 		conversational: new Zai.ZaiConversationalTask(),

--- a/packages/inference/src/providers/wavespeed.ts
+++ b/packages/inference/src/providers/wavespeed.ts
@@ -1,11 +1,17 @@
 import type { TextToImageArgs } from "../tasks/cv/textToImage.js";
 import type { ImageToImageArgs } from "../tasks/cv/imageToImage.js";
 import type { TextToVideoArgs } from "../tasks/cv/textToVideo.js";
+import type { ImageToVideoArgs } from "../tasks/cv/imageToVideo.js";
 import type { BodyParams, RequestArgs, UrlParams } from "../types.js";
 import { delay } from "../utils/delay.js";
 import { omit } from "../utils/omit.js";
 import { base64FromBytes } from "../utils/base64FromBytes.js";
-import type { TextToImageTaskHelper, TextToVideoTaskHelper, ImageToImageTaskHelper } from "./providerHelper.js";
+import type {
+	TextToImageTaskHelper,
+	TextToVideoTaskHelper,
+	ImageToImageTaskHelper,
+	ImageToVideoTaskHelper,
+} from "./providerHelper.js";
 import { TaskProviderHelper } from "./providerHelper.js";
 import {
 	InferenceClientInputError,
@@ -72,7 +78,9 @@ abstract class WavespeedAITask extends TaskProviderHelper {
 		return `/api/v3/${params.model}`;
 	}
 
-	preparePayload(params: BodyParams<ImageToImageArgs | TextToImageArgs | TextToVideoArgs>): Record<string, unknown> {
+	preparePayload(
+		params: BodyParams<ImageToImageArgs | TextToImageArgs | TextToVideoArgs | ImageToVideoArgs>
+	): Record<string, unknown> {
 		const payload: Record<string, unknown> = {
 			...omit(params.args, ["inputs", "parameters"]),
 			...params.args.parameters,
@@ -174,6 +182,22 @@ export class WavespeedAIImageToImageTask extends WavespeedAITask implements Imag
 	}
 
 	async preparePayloadAsync(args: ImageToImageArgs): Promise<RequestArgs> {
+		return {
+			...args,
+			inputs: args.parameters?.prompt,
+			image: base64FromBytes(
+				new Uint8Array(args.inputs instanceof ArrayBuffer ? args.inputs : await (args.inputs as Blob).arrayBuffer())
+			),
+		};
+	}
+}
+
+export class WavespeedAIImageToVideoTask extends WavespeedAITask implements ImageToVideoTaskHelper {
+	constructor() {
+		super(WAVESPEEDAI_API_BASE_URL);
+	}
+
+	async preparePayloadAsync(args: ImageToVideoArgs): Promise<RequestArgs> {
 		return {
 			...args,
 			inputs: args.parameters?.prompt,

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -2336,6 +2336,13 @@ describe.skip("InferenceClient", () => {
 					adapter: "lora",
 					adapterWeightsPath: "pytorch_lora_weights.safetensors",
 				},
+				"Wan-AI/Wan2.1-I2V-14B-480P": {
+					provider: "wavespeed",
+					hfModelId: "Wan-AI/Wan2.1-I2V-14B-480P",
+					providerId: "wavespeed-ai/wan-2.1/i2v-480p",
+					status: "live",
+					task: "image-to-video",
+				},
 			};
 			it(`textToImage - black-forest-labs/FLUX.1-schnell`, async () => {
 				const res = await client.textToImage({
@@ -2395,6 +2402,20 @@ describe.skip("InferenceClient", () => {
 						prompt: "The leopard chases its prey",
 						guidance_scale: 5,
 						num_inference_steps: 30,
+						seed: -1,
+					},
+				});
+				expect(res).toBeInstanceOf(Blob);
+			});
+			it(`imageToVideo - Wan-AI/Wan2.1-I2V-14B-480P`, async () => {
+				const res = await client.imageToVideo({
+					model: "Wan-AI/Wan2.1-I2V-14B-480P",
+					provider: "wavespeed",
+					inputs: new Blob([readTestFile("cheetah.png")], { type: "image/png" }),
+					parameters: {
+						prompt: "The leopard chases its prey",
+						guidance_scale: 5,
+						num_inference_steps: 29,
 						seed: -1,
 					},
 				});


### PR DESCRIPTION
**What’s in this PR**
Wavespeed.ai Adds Image-to-Video Generation

**Test**
 ```
pnpm --filter @huggingface/inference test "test/InferenceClient.spec.ts" -t "Wavespeed AI"

> @huggingface/inference@4.12.0 test /Users/shanliu/work/huggingface.js/packages/inference
> vitest run --config vitest.config.mts test/InferenceClient.spec.ts -t 'Wavespeed AI'


 RUN  v0.34.6 /Users/shanliu/work/huggingface.js/packages/inference

 ✓ test/InferenceClient.spec.ts (126) 113515ms
   ✓ InferenceClient (126) 113514ms
     ↓ backward compatibility (1) [skipped]
       ↓ works with old HfInference name [skipped]
     ↓ HF Inference (50) [skipped]
      *** ***
     ✓ Wavespeed AI (6) 113514ms
       ✓ textToImage - black-forest-labs/FLUX.1-schnell 6774ms
       ✓ textToImage - openfree/flux-chatgpt-ghibli-lora 11526ms
       ✓ textToImage - linoyts/yarn_art_Flux_LoRA 9074ms
       ✓ textToVideo - Wan-AI/Wan2.1-T2V-14B 113484ms
       ✓ imageToImage - HiDream-ai/HiDream-E1-Full 13074ms
       ✓ imageToVideo - Wan-AI/Wan2.1-I2V-14B-480P 54512ms
     ↓ PublicAI (2) [skipped]
       ↓ chatCompletion [skipped]
       ↓ chatCompletion stream [skipped]
     ↓ Baseten (2) [skipped]
       ↓ chatCompletion - Qwen3 235B Instruct [skipped]
       ↓ chatCompletion stream - Qwen3 235B [skipped]
     ↓ clarifai (2) [skipped]
       ↓ chatCompletion - DeepSeek-V3_1 [skipped]
       ↓ chatCompletion stream - DeepSeek-V3_1 [skipped]

 Test Files  1 passed (1)
      Tests  6 passed | 120 skipped (126)
```