### PR TITLE
[inference providers] wavespeed: override base URL to use router.huggingface.co

### DIFF
--- a/packages/inference/src/providers/wavespeed.ts
+++ b/packages/inference/src/providers/wavespeed.ts
@@ -102,10 +102,10 @@ abstract class WavespeedAITask extends TaskProviderHelper {
 		const parsedUrl = new URL(url);
 		const resultPath = new URL(response.data.urls.get).pathname;
 		/// override the base url to use the router.huggingface.co if going through huggingface router
-		const baseUrl = `${parsedUrl.protocol}//${parsedUrl.host}${parsedUrl.host === "router.huggingface.co" ? "/wavespeed" : ""
-			}`;
+		const baseUrl = `${parsedUrl.protocol}//${parsedUrl.host}${
+			parsedUrl.host === "router.huggingface.co" ? "/wavespeed" : ""
+		}`;
 		const resultUrl = `${baseUrl}${resultPath}`;
-
 
 		// Poll for results until completion
 		while (true) {


### PR DESCRIPTION
Fixes CORS and authentication issues when requesting wavespeed through router.huggingface.co