### PR TITLE
Add image-matching-models to model libraries

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -510,8 +510,8 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/Tencent-Hunyuan/HunyuanWorld-Voyager",
 	},
 	"image-matching-models": {
-		prettyLabel: "image-matching-models",
-		repoName: "image-matching-models",
+		prettyLabel: "Image Matching Models",
+		repoName: "Image Matching Models",
 		repoUrl: "https://github.com/alexstoken/image-matching-models",
 		filter: false,
 		countDownloads: `path_extension:"safetensors"`,


### PR DESCRIPTION
CC: @pcuenca (from our conversation about image matching models repository)

For others:
1. The mother issue: https://github.com/alexstoken/image-matching-models/issues/45
2. The image matching models org: https://huggingface.co/image-matching-models
3. I would like to tag the models on the org with `image-matching-models` and that would count the `safetensors` download