### PR TITLE
Add Apple M5 specs to SKUS hardware list

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -758,6 +758,10 @@ export const SKUS = {
 				tflops: 18.4,
 				memory: [36, 48, 64, 96, 128, 256, 512],
 			},
+			"Apple M5": {
+				tflops: 5.7,
+				memory: [16, 24, 32],
+			},
 		},
 	},
 } satisfies Record<string, Record<string, Record<string, HardwareSpec>>>;


### PR DESCRIPTION
Added Apple M5 with its TFLOPS and memory options to the SKUS hardware specification object. @Vaibhavs10 