### PR TITLE
[Inference Providers] Fix fal `image-to-image` API payload 

### DIFF
--- a/packages/inference/src/providers/fal-ai.ts
+++ b/packages/inference/src/providers/fal-ai.ts
@@ -245,11 +245,11 @@ export class FalAIImageToImageTask extends FalAiQueueTask implements ImageToImag
 		)}`;
 		return {
 			...omit(args, ["inputs", "parameters"]),
-			...args.parameters,
 			image_url: imageDataUrl,
+			...args.parameters,
+			...args,
 			// Some fal endpoints (e.g. FLUX.2-dev) expect `image_urls` (array) instead of `image_url`
 			image_urls: [imageDataUrl],
-			...args,
 		};
 	}
 


### PR DESCRIPTION
this should fix inference for https://huggingface.co/black-forest-labs/FLUX.2-dev

it seems like some fal `image-to-image` endpoints expect `image_urls` as an array, not `image_url` as a string (see the specs for Flux.2 [here](https://fal.ai/models/fal-ai/flux-2/lora/edit/api#schema-input)). Note that other models like [Qwen-Image-Edit](https://huggingface.co/Qwen/Qwen-Image-Edit?inference_provider=fal-ai) still expects `image_url` as input (specs [here](https://fal.ai/models/fal-ai/qwen-image-edit/api#schema-input)). 