### PR TITLE
Add 4G memory options for RTX 3050 Mobile

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -308,7 +308,7 @@ export const SKUS = {
 			},
 			"RTX 3050 Mobile": {
 				tflops: 7.639,
-				memory: [6],
+				memory: [4, 6],
 			},
 			"RTX 2060": {
 				tflops: 12.9,


### PR DESCRIPTION
About https://github.com/huggingface/huggingface.js/pull/708#discussion_r1611961385

Just as he said 3050mobile has 4G version https://www.techpowerup.com/gpu-specs/geforce-rtx-3050-mobile.c3788

My laptop is using this GPU

<img width="583" height="427" alt="image" src="https://github.com/user-attachments/assets/cdcef402-89c3-41c8-a001-a47339f9b352" />