### PR TITLE
[Tasks] remove invoke.ai local app

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -517,13 +517,6 @@ export const LOCAL_APPS = {
 			model.tags.includes("coreml") && model.tags.includes("joyfusion") && model.pipeline_tag === "text-to-image",
 		deeplink: (model) => new URL(`https://joyfusion.app/import_from_hf?repo_id=${model.id}`),
 	},
-	invoke: {
-		prettyLabel: "Invoke",
-		docsUrl: "https://github.com/invoke-ai/InvokeAI",
-		mainTask: "text-to-image",
-		displayOnModelPage: (model) => model.library_name === "diffusers" && model.pipeline_tag === "text-to-image",
-		deeplink: (model) => new URL(`https://models.invoke.ai/huggingface/${model.id}`),
-	},
 	ollama: {
 		prettyLabel: "Ollama",
 		docsUrl: "https://ollama.com",


### PR DESCRIPTION
The invoke model platform has been shut down. So links from the Hugging Face Hub lead to 404. 

From [invoke.ai](https://invoke.ai/): 
> The Invoke hosted platform has been shut down as the founding team joined Adobe. 