### PR TITLE
Add Clara as a library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -246,7 +246,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "Clara",
 		filter: false,
 		repoUrl: "https://github.com/nvidia/clara",
-		countDownloads: `path_extension:"ckpt"`,
+		countDownloads: `path_extension:"ckpt" OR path:"config.json"`,
 	},
 	clipscope: {
 		prettyLabel: "clipscope",


### PR DESCRIPTION
This PR is to add Clara library (ckpt file) tracking to enable download count for the model repos in:
1. https://huggingface.co/collections/nvidia/clara-molecular
2. https://huggingface.co/collections/nvidia/clara-biology

CC: @merveenoyan as a follow up to our slack conversation