### PR TITLE
[Inference Providers] Add `image-text-to-image` and `image-text-to-video` support for wavespeed

### DIFF
--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -181,6 +181,8 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 		"text-to-video": new Wavespeed.WavespeedAITextToVideoTask(),
 		"image-to-image": new Wavespeed.WavespeedAIImageToImageTask(),
 		"image-to-video": new Wavespeed.WavespeedAIImageToVideoTask(),
+		"image-text-to-image": new Wavespeed.WavespeedAIImageTextToImageTask(),
+		"image-text-to-video": new Wavespeed.WavespeedAIImageTextToVideoTask(),
 	},
 	"zai-org": {
 		conversational: new Zai.ZaiConversationalTask(),


### PR DESCRIPTION
Discussed internally in this [thread](https://huggingface.slack.com/archives/C089DMDB415/p1765379147053229).
This PR adds support for the `image-text-to-image` and `image-text-to-video` tasks for wavespeed provider. These tasks support models that accept both optional image + text input.
For these tasks, we use the same endpoints as for `image-to-image` and `image-to-video`, when no image is provided, we send a 1x1 fully transparent image. Note that wavespeed's doesn't follow a consistent endpoint naming pattern that would allow us to have the same logic as for fal in #1879.

I've tested it (i.e. text only input) with [FLUX-2](https://huggingface.co/black-forest-labs/FLUX.2-dev) and  and the results looks reasonable to me:

"A robot playing chess in a garden"
![wavespeed_placeholder_5](https://github.com/user-attachments/assets/69afe0bb-aba7-43b8-ba3e-2cda0aadabaf)


"A butterfly landing on a flower"


https://github.com/user-attachments/assets/8e751770-765f-4000-8aa4-57978339a0bc


