### PR TITLE
Fix failing lint (model arg not used)

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1982,7 +1982,7 @@ from models.birefnet import BiRefNet
 model = BiRefNet.from_pretrained("${model.id}")`,
 ];
 
-export const supertonic = (model: ModelData): string[] => [
+export const supertonic = (): string[] => [
 	`from supertonic import TTS
 
 tts = TTS(auto_download=True)


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/huggingface/huggingface.js/pull/1876 (dunno why it wasn't spotted)

CI should be green now.