### PR TITLE
Add SAME (embodied navigation) as library

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1466,17 +1466,6 @@ outputs = estimator.process_one_image(image)
 rend_img = visualize_sample_together(image, outputs, estimator.faces)`,
 ];
 
-export const same = (model: ModelData): string[] => [
-	`# Download pretrained weights
-python download.py --checkpoints
-
-# Or load checkpoint directly with PyTorch
-import torch
-from huggingface_hub import hf_hub_download
-
-checkpoint = torch.load(hf_hub_download("${model.id}", "ckpt/SAME.pt"))`,
-];
-
 export const sampleFactory = (model: ModelData): string[] => [
 	`python -m sample_factory.huggingface.load_from_hub -r ${model.id} -d ./train_dir`,
 ];

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1034,8 +1034,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "SAME",
 		repoUrl: "https://github.com/GengzeZhou/SAME",
 		filter: false,
-		snippets: snippets.same,
-		countDownloads: `path_extension:"pt"`,
+		countDownloads: `path:"ckpt/SAME.pt" OR path:"pretrain/Attnq_pretrained_ckpt.pt"`,
 	},
 	"sample-factory": {
 		prettyLabel: "sample-factory",


### PR DESCRIPTION
## Description

Adds download tracking support for [SAME](https://github.com/GengzeZhou/SAME) (State-Adaptive Mixture of Experts), an ICCV 2025 paper on generic language-guided visual navigation.

SAME distributes pretrained model weights as `.pt` files on HuggingFace: https://huggingface.co/ZGZzz/SAME

## Changes

- Added `same` entry to `model-libraries.ts` with `countDownloads` for `.pt` extension
- Added usage snippet to `model-libraries-snippets.ts`

## Related

- Paper: [SAME: Learning Generic Language-Guided Visual Navigation with State-Adaptive Mixture of Experts](https://arxiv.org/abs/2412.05552)
- GitHub: https://github.com/GengzeZhou/SAME
- HuggingFace: https://huggingface.co/ZGZzz/SAME