### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/agents-publish.yml
+++ b/.github/workflows/agents-publish.yml
@@ -28,7 +28,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -36,7 +36,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -59,8 +59,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm --filter agents... build && pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/blake3-wasm-publish.yml
+++ b/.github/workflows/blake3-wasm-publish.yml
@@ -28,7 +28,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -36,7 +36,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -56,8 +56,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/blob-publish.yml
+++ b/.github/workflows/blob-publish.yml
@@ -28,7 +28,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -36,7 +36,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -56,8 +56,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/dduf-publish.yml
+++ b/.github/workflows/dduf-publish.yml
@@ -28,7 +28,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -36,7 +36,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -59,8 +59,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/gearhash-wasm-publish.yml
+++ b/.github/workflows/gearhash-wasm-publish.yml
@@ -28,7 +28,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -36,7 +36,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -56,8 +56,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/gguf-publish.yml
+++ b/.github/workflows/gguf-publish.yml
@@ -32,7 +32,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -40,7 +40,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -64,8 +64,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/hub-publish.yml
+++ b/.github/workflows/hub-publish.yml
@@ -32,7 +32,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -40,7 +40,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -69,7 +69,7 @@ jobs:
       - run: pnpm publish --no-git-checks .
 
       # hack - reuse actions/setup-node@v3 just to set a new registry
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/inference-publish.yml
+++ b/.github/workflows/inference-publish.yml
@@ -32,7 +32,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -40,7 +40,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -68,8 +68,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/jinja-publish.yml
+++ b/.github/workflows/jinja-publish.yml
@@ -28,7 +28,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -36,7 +36,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -56,8 +56,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/languages-publish.yml
+++ b/.github/workflows/languages-publish.yml
@@ -28,7 +28,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -36,7 +36,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -56,8 +56,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           # Could use something like rmacklin/fetch-through-merge-base@v0 instead when the repo gets bigger
           fetch-depth: 0
@@ -31,7 +31,7 @@ jobs:
 
       - run: npm install -g corepack@latest && corepack enable
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/mcp-client-publish.yml
+++ b/.github/workflows/mcp-client-publish.yml
@@ -32,11 +32,11 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -64,8 +64,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/ollama-template-update.yml
+++ b/.github/workflows/ollama-template-update.yml
@@ -14,7 +14,7 @@ jobs:
   update-ollama-templates:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         if: github.repository == 'huggingface/huggingface.js'
 
       - name: Prepare
@@ -76,7 +76,7 @@ jobs:
 
       - name: Create PR
         if: steps.changes.outputs.HAS_CHANGES == 'true' && github.repository == 'huggingface/huggingface.js'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         env:
           CURRENT_DATE: ${{ steps.prepare.outputs.CURRENT_DATE }}
           NEW_BRANCH: ${{ steps.changes.outputs.NEW_BRANCH }}

--- a/.github/workflows/ollama-utils-publish.yml
+++ b/.github/workflows/ollama-utils-publish.yml
@@ -28,7 +28,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -36,7 +36,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -59,8 +59,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/space-header-publish.yml
+++ b/.github/workflows/space-header-publish.yml
@@ -28,7 +28,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -36,7 +36,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -56,8 +56,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/splitmix64-wasm-publish.yml
+++ b/.github/workflows/splitmix64-wasm-publish.yml
@@ -28,7 +28,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -36,7 +36,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -56,8 +56,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/tasks-publish.yml
+++ b/.github/workflows/tasks-publish.yml
@@ -28,7 +28,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -36,7 +36,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -56,8 +56,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           # Could use something like rmacklin/fetch-through-merge-base@v0 instead when the repo gets bigger
           fetch-depth: 0
@@ -30,7 +30,7 @@ jobs:
 
       - run: npm install -g corepack@latest && corepack enable
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           # Could use something like rmacklin/fetch-through-merge-base@v0 instead when the repo gets bigger
           fetch-depth: 0
@@ -70,7 +70,7 @@ jobs:
 
       - run: npm install -g corepack@latest && corepack enable
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "pnpm"
@@ -90,11 +90,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - run: npm install -g corepack@latest && corepack enable
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/tiny-agents-publish.yml
+++ b/.github/workflows/tiny-agents-publish.yml
@@ -32,11 +32,11 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -64,8 +64,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Secret Scanning

--- a/.github/workflows/update-specs.yml
+++ b/.github/workflows/update-specs.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Setup
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
       - name: Install pnpm

--- a/.github/workflows/xetchunk-wasm-publish.yml
+++ b/.github/workflows/xetchunk-wasm-publish.yml
@@ -28,7 +28,7 @@ jobs:
   version_and_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Needed to push the tag and the commit on the main branch, otherwise we get:
           # > Run git push --follow-tags
@@ -36,7 +36,7 @@ jobs:
           # remote: error: Changes must be made through a pull request. Required status check "lint" is expected.
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - run: npm install -g corepack@latest && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -56,8 +56,8 @@ jobs:
       - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
 
       - run: pnpm publish --no-git-checks .
-      # hack - reuse actions/setup-node@v4 just to set a new registry
-      - uses: actions/setup-node@v4
+      # hack - reuse actions/setup-node@v6 just to set a new registry
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"


### PR DESCRIPTION
## Summary
This PR upgrades GitHub Actions to their latest versions for Node.js 24 compatibility and security updates.

## Changes

| Action | Old Version(s) | New Version | Files |
|--------|---------------|-------------|-------|
| actions/checkout | v3, v4, v5 | v6 | agents-publish.yml, blake3-wasm-publish.yml, blob-publish.yml, dduf-publish.yml, gearhash-wasm-publish.yml, gguf-publish.yml, hub-publish.yml, inference-publish.yml, jinja-publish.yml, languages-publish.yml, lint.yml, mcp-client-publish.yml, ollama-template-update.yml, ollama-utils-publish.yml, space-header-publish.yml, splitmix64-wasm-publish.yml, tasks-publish.yml, test.yml, tiny-agents-publish.yml, trufflehog.yml, update-specs.yml, xetchunk-wasm-publish.yml |
| actions/github-script | v6 | v8 | ollama-template-update.yml |
| actions/setup-node | v3, v4 | v6 | agents-publish.yml, blake3-wasm-publish.yml, blob-publish.yml, dduf-publish.yml, gearhash-wasm-publish.yml, gguf-publish.yml, hub-publish.yml, inference-publish.yml, jinja-publish.yml, languages-publish.yml, lint.yml, mcp-client-publish.yml, ollama-utils-publish.yml, space-header-publish.yml, splitmix64-wasm-publish.yml, tasks-publish.yml, test.yml, tiny-agents-publish.yml, update-specs.yml, xetchunk-wasm-publish.yml |

## Why these changes?
- Keeps actions up to date with latest stable releases
- Updated actions include security fixes and new features

## Testing
These changes only update action versions and don't modify workflow logic.
