### PR TITLE
Add AMD Radeon AI R9700 PRO to hardware list

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -446,7 +446,7 @@ export const SKUS = {
 			},
 			"R9700 PRO": {
 				tflops: 95.7,
-				memory: [32]
+				memory: [32],
 			},
 			"RX 9070 XT": {
 				tflops: 97.32,


### PR DESCRIPTION
Adds AMD Radeon AI R9700 PRO to packages/tasks/src/hardware.ts for the Hub “My Hardware” dropdown.

Entry:
"R9700 PRO": { tflops: 95.7, memory: [32] }

Rationale:
hardware.ts uses approximate FP16 for GPUs.
AMD specs list FP16 Vector = 95.7 TFLOPS and VRAM = 32GB.

Sources:
https://www.amd.com/content/dam/amd/en/documents/partner-hub/radeon-pro/radeon-ai-pro-r9700-datasheet.pdf
https://www.amd.com/en/products/graphics/workstations/radeon-ai-pro/ai-9000-series/amd-radeon-ai-pro-r9700.html
