### PR TITLE
Add Lance to library list

### DIFF
--- a/packages/tasks/src/dataset-libraries.ts
+++ b/packages/tasks/src/dataset-libraries.ts
@@ -65,6 +65,12 @@ export const DATASET_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/voxel51/fiftyone",
 		docsUrl: "https://huggingface.co/docs/hub/datasets-fiftyone",
 	},
+	lance: {
+		prettyLabel: "Lance",
+		repoName: "lance",
+		repoUrl: "https://github.com/lance-format/lance",
+		docsUrl: "https://huggingface.co/docs/hub/datasets-lance",
+	},
 	argilla: {
 		prettyLabel: "Argilla",
 		repoName: "argilla",


### PR DESCRIPTION
Adds Lance to the list of libraries supported by Hugging Face!

> [!NOTE]
> This PR depends on: https://github.com/huggingface/hub-docs/pull/2164

[Lance](https://lance.org) is an open multimodal lakehouse table format for AI. It's now possible to stream data from the Hugging Face `datasets` API as well as Lance's `dataset` API. This allows users to scan and search Lance datasets on the Hugging Face Hub without having to copy the entire dataset locally.