### PR TITLE
Update translation, summarization and image-to-text pipeline snippets to warn on v5 removal

### DIFF
--- a/packages/tasks/src/library-to-tasks.ts
+++ b/packages/tasks/src/library-to-tasks.ts
@@ -71,10 +71,5 @@ export const LIBRARY_TASK_MAPPING: Partial<Record<ModelLibraryKey, PipelineType[
 	mindspore: ["image-classification"],
 };
 
-
 // Pipeline types that were supported in legacy transformers versions (<5.0.0)
-export const REMOVED_IN_V5_TRANSFORMERS_PIPELINES: PipelineType[] = [
-	"summarization",
-	"translation",
-	"image-to-text",
-];
+export const REMOVED_IN_V5_TRANSFORMERS_PIPELINES: PipelineType[] = ["image-to-text", "summarization", "translation"];

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1713,7 +1713,7 @@ export const transformers = (model: ModelData): string[] => {
 	}
 
 	if (model.pipeline_tag && LIBRARY_TASK_MAPPING.transformers?.includes(model.pipeline_tag)) {
-		const pipelineSnippet = ["# Use a pipeline as a high-level helper"]
+		const pipelineSnippet = ["# Use a pipeline as a high-level helper"];
 		if (REMOVED_IN_V5_TRANSFORMERS_PIPELINES.includes(model.pipeline_tag)) {
 			pipelineSnippet.push(
 				`# Warning: Pipeline type "${model.pipeline_tag}" is no longer supported in transformers v5.`,


### PR DESCRIPTION
**EDIT:**

**Expectation:**  warning message displayed in the pipeline snippet on https://huggingface.co/facebook/nllb-200-distilled-1.3B?library=transformers.

```
# Warning: Pipeline type "${model.pipeline_tag}" is no longer supported in transformers v5.
# You must load the model directly (see below) or downgrade to v4.x with:
# 'pip install "transformers<5.0.0'
```

----

(related to internal slack threads [here](https://huggingface.slack.com/archives/C01N44FJDHT/p1768843199944399?thread_ts=1768482758.054089&cid=C01N44FJDHT) and [here](https://huggingface.slack.com/archives/C02FRVDEZND/p1769542989564529))

Related to `transformers v5` release, `translation`, `summarization`, and `image-to-text` pipelines no longer exist. See migration guide: https://github.com/huggingface/transformers/blob/main/MIGRATION_GUIDE_V5.md#pipelines

> pipeline classes are intended as a high-level beginner-friendly API, but for almost all text-to-text tasks a modern chat model and TextGenerationPipeline will provide much higher quality output. As a result, we felt it was misleading for beginners to offer the older pipelines.

Note that these pipelines are not defined anymore but the models are still usable with the lower-level `AutoModel` API. 

Affected models:
- https://huggingface.co/models?pipeline_tag=translation
- https://huggingface.co/models?pipeline_tag=summarization
- https://huggingface.co/models?pipeline_tag=image-to-text

cc @julien-c @LysandreJik @Rocketknight1 