### PR TITLE
Fix Apple Silicon memory configuration options

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -712,15 +712,15 @@ export const SKUS = {
 			},
 			"Apple M1 Pro": {
 				tflops: 5.2,
-				memory: [16, 24, 32],
+				memory: [16, 32],
 			},
 			"Apple M1 Max": {
 				tflops: 10.4,
-				memory: [16, 24, 32, 64],
+				memory: [32, 64],
 			},
 			"Apple M1 Ultra": {
 				tflops: 21,
-				memory: [16, 24, 32, 64, 96, 128],
+				memory: [64, 128],
 			},
 			"Apple M2": {
 				tflops: 3.6,
@@ -728,7 +728,7 @@ export const SKUS = {
 			},
 			"Apple M2 Pro": {
 				tflops: 6.8,
-				memory: [16, 24, 32],
+				memory: [16, 32],
 			},
 			"Apple M2 Max": {
 				tflops: 13.49,
@@ -736,7 +736,7 @@ export const SKUS = {
 			},
 			"Apple M2 Ultra": {
 				tflops: 27.2,
-				memory: [64, 96, 128, 192],
+				memory: [64, 128, 192],
 			},
 			"Apple M3": {
 				tflops: 4.1,
@@ -764,7 +764,7 @@ export const SKUS = {
 			},
 			"Apple M4 Max": {
 				tflops: 18.4,
-				memory: [36, 48, 64, 96, 128, 256, 512],
+				memory: [36, 48, 64, 128],
 			},
 			"Apple M5": {
 				tflops: 5.7,


### PR DESCRIPTION
## Summary

Corrects the memory configuration options for Apple Silicon chips to match official Apple specifications. Several chips had incorrect memory options that don't exist for those configurations.

## Changes

### M1 Family

| Chip | Before | After | Source |
|------|--------|-------|--------|
| M1 Pro | `[16, 24, 32]` | `[16, 32]` | [MacBook Pro 14" 2021 specs](https://support.apple.com/en-us/111902) |
| M1 Max | `[16, 24, 32, 64]` | `[32, 64]` | [MacBook Pro 16" 2021 specs](https://support.apple.com/en-us/111901) |
| M1 Ultra | `[16, 24, 32, 64, 96, 128]` | `[64, 128]` | [Mac Studio 2022 specs](https://support.apple.com/en-us/111900) |

### M2 Family

| Chip | Before | After | Source |
|------|--------|-------|--------|
| M2 Pro | `[16, 24, 32]` | `[16, 32]` | [MacBook Pro 14" 2023 specs](https://support.apple.com/en-us/111340) |
| M2 Ultra | `[64, 96, 128, 192]` | `[64, 128, 192]` | [Mac Studio 2023 specs](https://support.apple.com/en-us/111835) |

### M4 Family

| Chip | Before | After | Source |
|------|--------|-------|--------|
| M4 Max | `[36, 48, 64, 96, 128, 256, 512]` | `[36, 48, 64, 128]` | [MacBook Pro specs](https://www.apple.com/macbook-pro/specs/), [Mac Studio specs](https://support.apple.com/en-us/122211) |

## Notes

- 24GB was never an option for M1 Pro (only 16GB or 32GB)
- M1 Max minimum is 32GB, not 16GB
- M1 Ultra only comes in 64GB and 128GB configurations
- M2 Pro does not have a 24GB option
- M2 Ultra does not have a 96GB option (that's exclusive to M2 Max)
- M4 Max maximum is 128GB; 96GB, 256GB, and 512GB options do not exist

## Test plan

- [ ] Verify hardware.ts compiles without errors
- [ ] Verify memory options match official Apple documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Apple Silicon memory options in `packages/tasks/src/hardware.ts` with official specs.
> 
> - Updates: `M1 Pro` `[16,24,32]` -> `[16,32]`; `M1 Max` `[16,24,32,64]` -> `[32,64]`; `M1 Ultra` `[16,24,32,64,96,128]` -> `[64,128]`; `M2 Pro` `[16,24,32]` -> `[16,32]`; `M2 Ultra` `[64,96,128,192]` -> `[64,128,192]`; `M4 Max` `[36,48,64,96,128,256,512]` -> `[36,48,64,128]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c31b1940df7e9500e37c19895d2bbfe2a3c70ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->