### PR TITLE
Add code snippets for Moshi library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -860,6 +860,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "Moshi",
 		repoName: "Moshi",
 		repoUrl: "https://github.com/kyutai-labs/moshi",
+		snippets: snippets.moshi,
 		filter: false,
 		countDownloads: `path:"tokenizer-e351c8d8-checkpoint125.safetensors"`,
 	},


### PR DESCRIPTION
## Summary
- Add working snippets for the Moshi speech-to-speech library
- Supports PyTorch, MLX (macOS), and Candle backends
- Detects backend from model name (no distinguishing tags available)

## Test plan
- [x] MLX: verified imports and CLI flags locally with `uvx --python 3.12 --from moshi_mlx`
- [x] PyTorch: verified full encode/decode pipeline on HF Jobs (job `697b35c1a0153a313e164531`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds/links display snippets and uses simple model-id string matching; no runtime logic beyond snippet selection.
> 
> **Overview**
> Adds a new `snippets.moshi` generator that outputs runnable usage examples for Moshi models across **PyTorch (default)**, **MLX** (with optional `-q 4/8` flags inferred from the model id), and a **Candle** pointer snippet.
> 
> Wires the Moshi library entry in `model-libraries.ts` to use these snippets so Moshi-tagged models display the appropriate instructions on the Hub.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c198309a9f10ea749cf30f8f431d6ba433fd5369. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->