### PR TITLE
Improve vLLM snippets

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -205,9 +205,12 @@ const snippetVllm = (model: ModelData): LocalAppSnippet[] => {
 		: "";
 
 	const setup = isMistral
-		? ["# Install vLLM from pip:", "pip install vllm", "# Install mistral-common:", "pip install --upgrade mistral-common"].join(
-				"\n"
-			)
+		? [
+				"# Install vLLM from pip:",
+				"pip install vllm",
+				"# Install mistral-common:",
+				"pip install --upgrade mistral-common",
+			].join("\n")
 		: ["# Install vLLM from pip:", "pip install vllm"].join("\n");
 
 	const serverCommand = `# Start the vLLM server:


### PR DESCRIPTION
AFTER/BEFORE

<img width="1940" height="1252" alt="image" src="https://github.com/user-attachments/assets/91a8ef63-037e-4a88-8519-e431757b973a" />



## Summary
- Add "(OpenAI-compatible API)" to curl comments for consistency
- Change title to "Install from pip and serve model"
- Use `HF_TOKEN` env var (shorter, matches SGLang)
- Remove `--runtime nvidia` (redundant with `--gpus all`)
- Use template literal for docker command (cleaner formatting)
- Remove redundant `docker exec` command (docker run already starts serving)
- Simplify mistral-common handling with flags variable

This aligns the vLLM snippet structure with the SGLang snippet for consistency across local apps.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only snippet refactor; no runtime logic changes beyond what commands are shown to users.
> 
> **Overview**
> Updates the `vLLM` local-app snippets to better reflect an OpenAI-compatible workflow and to align structure with the `SGLang` snippets.
> 
> The pip path now explicitly includes starting `vllm serve` (with a clearer title), the Docker path is simplified to a single `docker run ... vllm/vllm-openai` command (using `HF_TOKEN` and dropping redundant flags/`docker exec`), and Mistral-specific setup is consolidated behind a reusable `mistralFlags` toggle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c039240a0cf33c9c1eb0ff0f708041c8ee3c6a40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->