### PR TITLE
[hub] Fix safetensors index file parsing for files >20MB

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -323,4 +323,15 @@ describe("parseSafetensorsMetadata", () => {
 		assert(parse.sharded);
 		assert.strictEqual(Object.keys(parse.headers).length, 62);
 	});
+
+	it("fetch info for moonshotai/Kimi-K2.5 (large index file >20MB)", async () => {
+		// This model has a ~23.5MB index file due to having many experts
+		const parse = await parseSafetensorsMetadata({
+			repo: "moonshotai/Kimi-K2.5",
+			revision: "2426b45b6af0da48d0dcce71bbce6225e5c73adc",
+		});
+
+		assert(parse.sharded);
+		assert.strictEqual(Object.keys(parse.headers).length, 64);
+	});
 });

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -35,7 +35,7 @@ export function parseSafetensorsShardFilename(filename: string): SafetensorsShar
 }
 
 const PARALLEL_DOWNLOADS = 20;
-const MAX_HEADER_LENGTH = 25_000_000;
+const MAX_HEADER_LENGTH = 25_000_000; // 25MB
 const GPTQ_QWEIGHT_SUFFIX = "qweight";
 
 class SafetensorParseError extends Error {}
@@ -190,7 +190,7 @@ async function parseShardedIndex(
 
 	try {
 		// no validation for now, we assume it's a valid IndexJson.
-		const index = JSON.parse(await indexBlob.slice(0, 20_000_000).text());
+		const index = JSON.parse(await indexBlob.slice(0, MAX_HEADER_LENGTH).text());
 		return index;
 	} catch (error) {
 		throw new SafetensorParseError(`Failed to parse file ${path}: not a valid JSON.`);


### PR DESCRIPTION
## Summary
- Fixed bug where `parseShardedIndex` was hardcoded to slice only the first 20MB of index files, causing parsing failures for large index files
- Changed to use the existing `MAX_HEADER_LENGTH` constant (25MB) for consistency
- Added test for `moonshotai/Kimi-K2.5` which has a ~23.5MB index file due to its many experts (64 shards)

## Test plan
- [x] Test passes for `moonshotai/Kimi-K2.5` model parsing
- [x] Existing tests continue to pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to index JSON slicing for sharded safetensors; main risk is increased memory/IO for very large index files, but it stays bounded by the existing 25MB limit.
> 
> **Overview**
> Fixes a sharded safetensors parsing bug where `parseShardedIndex` only read the first 20MB of `model.safetensors.index.json`, causing JSON parse failures on larger index files; it now slices up to the existing `MAX_HEADER_LENGTH` (25MB) for consistency.
> 
> Adds a regression test for `moonshotai/Kimi-K2.5`, whose ~23.5MB index file previously would exceed the hardcoded limit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3429a6d6a2b0dc1463eb5de7aa00e24a530bfc28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->