### PR TITLE
Use xet to download by default

### DIFF
--- a/packages/hub/src/lib/download-file.ts
+++ b/packages/hub/src/lib/download-file.ts
@@ -32,11 +32,7 @@ export async function downloadFile(
 		/**
 		 * Whether to use the xet protocol to download the file (if applicable).
 		 *
-		 * Currently there's experimental support for it, so it's not enabled by default.
-		 *
-		 * It will be enabled automatically in a future minor version.
-		 *
-		 * @default false
+		 * @default true
 		 */
 		xet?: boolean;
 		/**
@@ -63,7 +59,7 @@ export async function downloadFile(
 		return null;
 	}
 
-	if (info.xet && params.xet) {
+	if (info.xet && params.xet !== false) {
 		return new XetBlob({
 			refreshUrl: info.xet.refreshUrl.href,
 			reconstructionUrl: info.xet.reconstructionUrl.href,


### PR DESCRIPTION
cc @rajaryan18 @Wauplin @julien-c @Pierrci @XciD for viz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default file-download mechanism, which may affect compatibility/performance for consumers relying on the previous HTTP download path; behavior can be reverted per call via `xet: false`.
> 
> **Overview**
> Switches `downloadFile` to **prefer the Xet download protocol by default** when the server reports Xet support.
> 
> The Xet path is now taken unless callers explicitly set `xet: false`, changing prior behavior where `xet` had to be enabled opt-in; non-Xet downloads continue to use the existing `WebBlob` fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50600398c35d195ed6ae8b73c6d29bd8e8bb8fd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->