### PR TITLE
[Hub] safetensors parse remove redundant large index file test

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -313,17 +313,6 @@ describe("parseSafetensorsMetadata", () => {
 		assert.strictEqual(parameterCount.UE8, 5000);
 	});
 
-	it("fetch info for large index file (>10MB) with many experts (moonshotai/Kimi-K2-Instruct-0905)", async () => {
-		// This model has a 13.5MB index file due to having 384 experts per layer
-		const parse = await parseSafetensorsMetadata({
-			repo: "moonshotai/Kimi-K2-Instruct-0905",
-			revision: "7152993552508c9f22042b3bb93b5e6acd06ce73",
-		});
-
-		assert(parse.sharded);
-		assert.strictEqual(Object.keys(parse.headers).length, 62);
-	});
-
 	it("fetch info for moonshotai/Kimi-K2.5 (large index file >20MB)", async () => {
 		// This model has a ~23.5MB index file due to having many experts
 		const parse = await parseSafetensorsMetadata({


### PR DESCRIPTION
This removes the test for `moonshotai/Kimi-K2-Instruct-0905` (large index file >10MB) because it is redundant: we already check large index file behavior in `parse-safetensors-metadata.spec.ts` at lines 316-317 with the `moonshotai/Kimi-K2.5` test, which uses an even larger index file (~23.5MB).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deletion with no production code changes; risk is limited to slightly reduced coverage for that specific model/revision.
> 
> **Overview**
> Removes the integration test that fetches safetensors metadata for `moonshotai/Kimi-K2-Instruct-0905` (a >10MB index file), leaving the existing `moonshotai/Kimi-K2.5` test as the sole coverage for handling very large index files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f020dd5139d4737c07647d1190df52d78584e719. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->