### PR TITLE
Fix GGUF quant label parsing for Unsloth Dynamic (UD) prefixed filenames

### DIFF
--- a/packages/gguf/src/gguf.spec.ts
+++ b/packages/gguf/src/gguf.spec.ts
@@ -289,6 +289,7 @@ describe("gguf", () => {
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-F32-Q2_K.gguf")).toEqual("Q2_K"); // gguf name with two quant labels [F32, Q2_K]
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-IQ3_XS.gguf")).toEqual("IQ3_XS");
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-Q4_0_4_4.gguf")).toEqual("Q4_0"); // TODO: investigate Q4_0_4_4
+		expect(parseGGUFQuantLabel("Qwen3-4B-UD-Q2_K_XL.gguf")).toEqual("UD-Q2_K_XL"); // unsloth UD (Unsloth Dynamic) prefix
 	});
 
 	it("calculate tensor data offset", async () => {

--- a/packages/tasks/src/gguf.ts
+++ b/packages/tasks/src/gguf.ts
@@ -53,7 +53,9 @@ export enum GGMLFileQuantizationType {
 }
 
 const ggufQuants = Object.values(GGMLFileQuantizationType).filter((v): v is string => typeof v === "string");
-export const GGUF_QUANT_RE = new RegExp(`(?<quant>${ggufQuants.join("|")})` + "(_(?<sizeVariation>[A-Z]+))?");
+export const GGUF_QUANT_RE = new RegExp(
+	"(?<prefix>UD-)?" + `(?<quant>${ggufQuants.join("|")})` + "(_(?<sizeVariation>[A-Z]+))?",
+);
 export const GGUF_QUANT_RE_GLOBAL = new RegExp(GGUF_QUANT_RE, "g");
 
 export function parseGGUFQuantLabel(fname: string): string | undefined {


### PR DESCRIPTION
## Summary

- GGUF filenames with the [Unsloth Dynamic "UD-" prefix ](https://unsloth.ai/docs/basics/unsloth-dynamic-2.0-ggufs)(e.g. `Qwen3-4B-UD-Q2_K_XL.gguf`) have their quant labels parsed, but the "UD-" prefix gets dropped — so `parseGGUFQuantLabel` returns `"Q2_K_XL"` instead of `"UD-Q2_K_XL"`. This means the "Hardware compatibility" section on model pages like https://huggingface.co/unsloth/Qwen3-4B-GGUF doesn't distinguish UD quants from regular ones.
- Updates `GGUF_QUANT_RE` to capture an optional `(?<prefix>UD-)?` named group before the quant type, so `parseGGUFQuantLabel` now returns `"UD-Q2_K_XL"` preserving the full label.
- Adds a test case in `gguf.spec.ts` for the UD-prefixed filename pattern.

<img width="484" height="346" alt="image" src="https://github.com/user-attachments/assets/30e922ff-7000-49a0-acb8-a7cf69ef2d3e" />
