### PR TITLE
:wrench: Add Ryzen AI Max 395 hardware specifications

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -549,7 +549,7 @@ export const SKUS = {
 				memory: [16, 32],
 			},
 			"Ryzen AI Max 395+": {
-				tflops: 36.9,
+				tflops: 59.4,
 				memory: [64, 96, 128],
 			},
 		},


### PR DESCRIPTION
tflops value is taken from this post on reddit:

https://www.reddit.com/r/LocalLLaMA/comments/1kmi3ra/amd_strix_halo_ryzen_ai_max_395_gpu_llm/