### PR TITLE
Add Strix Halo

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -548,6 +548,10 @@ export const SKUS = {
 				tflops: 26.11,
 				memory: [16, 32],
 			},
+			"Ryzen AI Max+ 395": {
+				tflops: 36.9,
+				memory: [128],
+			},
 		},
 		INTEL: {
 			"Arc A750": {


### PR DESCRIPTION
Add Strix Halo with approximate TFLOPS as per:
https://www.reddit.com/r/LocalLLaMA/comments/1kmi3ra/amd_strix_halo_ryzen_ai_max_395_gpu_llm/

I considered adding the 32, 64 memory versions. But I think they are other models. 