### PR TITLE
[hub] Support compressed-tensors pack-quantized format in parameter counting

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -318,9 +318,12 @@ describe("parseSafetensorsMetadata", () => {
 		const parse = await parseSafetensorsMetadata({
 			repo: "moonshotai/Kimi-K2.5",
 			revision: "2426b45b6af0da48d0dcce71bbce6225e5c73adc",
+			computeParametersCount: true,
 		});
 
 		assert(parse.sharded);
 		assert.strictEqual(Object.keys(parse.headers).length, 64);
+		assert.deepStrictEqual(parse.parameterCount, { F32: 23_040, I32: 1_014_687_129_600, BF16: 43_902_267_888 });
+		assert.deepStrictEqual(sum(Object.values(parse.parameterCount)), 1_058_589_420_528);
 	});
 });


### PR DESCRIPTION
## Summary

- **Fix parameter counting for `compressed-tensors` + `pack-quantized` format**: I32 tensors in this format pack multiple quantized values per element (e.g. ×8 for 4-bit). The correct parameter count is `shape_product × (32 / num_bits)`.
- **Fix `quantization_config` lookup**: some models (e.g. `moonshotai/Kimi-K2.5`) nest `quantization_config` inside `text_config` rather than at the top level of `config.json`. We now fall back to `text_config.quantization_config`.
- **Updated test**: `moonshotai/Kimi-K2.5` now includes a parameter count assertion — correctly reporting ~1.06T parameters instead of ~170B.

## Test plan

- [x] `moonshotai/Kimi-K2.5` test passes with corrected ~1.06T parameter count
- [x] `Qwen/Qwen3-Coder-Next-Base` test passes (40 shards)
- [x] All existing `parseSafetensorsMetadata` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core parameter-counting logic for quantized weights, which can change reported model sizes across repos. Scope is contained and covered by updated regression assertions, but correctness depends on varied real-world `config.json` shapes.
> 
> **Overview**
> Improves `parseSafetensorsMetadata` parameter counting for `compressed-tensors` models in `pack-quantized` format by treating `I32` tensors as packed values (multiplier based on `num_bits` from `config_groups`).
> 
> Extends quantization config discovery to fall back from `config.json`’s top-level `quantization_config` to `text_config.quantization_config`, and updates the `moonshotai/Kimi-K2.5` test to assert the corrected ~1.06T parameter count breakdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bc64f2115326fa2e7fe31899e799069ee85b194. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->