### PR TITLE
GitHub releases integration

### DIFF
--- a/.github/workflows/agents-publish.yml
+++ b/.github/workflows/agents-publish.yml
@@ -75,7 +75,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/blake3-wasm-publish.yml
+++ b/.github/workflows/blake3-wasm-publish.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/blob-publish.yml
+++ b/.github/workflows/blob-publish.yml
@@ -72,7 +72,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dduf-publish.yml
+++ b/.github/workflows/dduf-publish.yml
@@ -75,7 +75,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gearhash-wasm-publish.yml
+++ b/.github/workflows/gearhash-wasm-publish.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gguf-publish.yml
+++ b/.github/workflows/gguf-publish.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/hub-publish.yml
+++ b/.github/workflows/hub-publish.yml
@@ -84,7 +84,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/inference-publish.yml
+++ b/.github/workflows/inference-publish.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/jinja-publish.yml
+++ b/.github/workflows/jinja-publish.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/languages-publish.yml
+++ b/.github/workflows/languages-publish.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mcp-client-publish.yml
+++ b/.github/workflows/mcp-client-publish.yml
@@ -80,7 +80,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ollama-utils-publish.yml
+++ b/.github/workflows/ollama-utils-publish.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/space-header-publish.yml
+++ b/.github/workflows/space-header-publish.yml
@@ -72,7 +72,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/splitmix64-wasm-publish.yml
+++ b/.github/workflows/splitmix64-wasm-publish.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tasks-publish.yml
+++ b/.github/workflows/tasks-publish.yml
@@ -72,7 +72,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tiny-agents-publish.yml
+++ b/.github/workflows/tiny-agents-publish.yml
@@ -80,7 +80,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/xetchunk-wasm-publish.yml
+++ b/.github/workflows/xetchunk-wasm-publish.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: gh release create "$RELEASE_TAG" --generate-notes
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update all `-publish.yml` workflows to create GitHub releases after successful npm publishing.

---
[Slack Thread](https://huggingface.slack.com/archives/C04PJ0H35UM/p1772013010657709?thread_ts=1772013010.657709&cid=C04PJ0H35UM)

<p><a href="https://cursor.com/agents/bc-100beb1a-0b20-56eb-a976-4a9696f8ed8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-100beb1a-0b20-56eb-a976-4a9696f8ed8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds an extra `gh` CLI step after publishing; primary risk is CI failures if a release already exists or the runner lacks required `gh` behavior/permissions.
> 
> **Overview**
> After a package publish workflow runs, it now also creates a corresponding GitHub Release for the newly pushed tag.
> 
> Each `*-publish.yml` workflow captures the generated tag into `RELEASE_TAG` and adds a final `gh release create "$RELEASE_TAG"` step (using `GITHUB_TOKEN`), so npm publishes and GitHub releases stay in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbe3080dba73224db4669250a7db737495cc80bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->