### PR TITLE
Release tag push issue

### DIFF
--- a/.github/workflows/agents-publish.yml
+++ b/.github/workflows/agents-publish.yml
@@ -57,7 +57,7 @@ jobs:
           git tag "agents-v$BUMPED_VERSION"
           echo "RELEASE_TAG=agents-v$BUMPED_VERSION" >> $GITHUB_ENV
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm --filter agents... build && pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -75,9 +75,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/blake3-wasm-publish.yml
+++ b/.github/workflows/blake3-wasm-publish.yml
@@ -54,7 +54,7 @@ jobs:
           git tag "blake3-wasm-v$BUMPED_VERSION"
           echo "RELEASE_TAG=blake3-wasm-v$BUMPED_VERSION" >> $GITHUB_ENV
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -67,9 +67,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/blob-publish.yml
+++ b/.github/workflows/blob-publish.yml
@@ -54,7 +54,7 @@ jobs:
           git tag "blob-v$BUMPED_VERSION"
           echo "RELEASE_TAG=blob-v$BUMPED_VERSION" >> $GITHUB_ENV
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -72,9 +72,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dduf-publish.yml
+++ b/.github/workflows/dduf-publish.yml
@@ -57,7 +57,7 @@ jobs:
       - name: "Check Deps are published before publishing this package"
         run: pnpm -w check-deps blob
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -75,9 +75,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gearhash-wasm-publish.yml
+++ b/.github/workflows/gearhash-wasm-publish.yml
@@ -54,7 +54,7 @@ jobs:
           git tag "gearhash-wasm-v$BUMPED_VERSION"
           echo "RELEASE_TAG=gearhash-wasm-v$BUMPED_VERSION" >> $GITHUB_ENV
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -67,9 +67,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gguf-publish.yml
+++ b/.github/workflows/gguf-publish.yml
@@ -62,7 +62,7 @@ jobs:
         name: "Check Deps are published before publishing this package"
         run: pnpm -w check-deps tasks
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -75,9 +75,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/hub-publish.yml
+++ b/.github/workflows/hub-publish.yml
@@ -65,7 +65,7 @@ jobs:
         name: "Check Deps are published before publishing this package"
         run: pnpm -w check-deps tasks
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
 
@@ -84,9 +84,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/inference-publish.yml
+++ b/.github/workflows/inference-publish.yml
@@ -66,7 +66,7 @@ jobs:
         name: "Check Deps are published before publishing this package"
         run: pnpm -w check-deps tasks
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -79,9 +79,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/jinja-publish.yml
+++ b/.github/workflows/jinja-publish.yml
@@ -54,7 +54,7 @@ jobs:
           git tag "jinja-v$BUMPED_VERSION"
           echo "RELEASE_TAG=jinja-v$BUMPED_VERSION" >> $GITHUB_ENV
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -67,9 +67,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/languages-publish.yml
+++ b/.github/workflows/languages-publish.yml
@@ -54,7 +54,7 @@ jobs:
           git tag "languages-v$BUMPED_VERSION"
           echo "RELEASE_TAG=languages-v$BUMPED_VERSION" >> $GITHUB_ENV
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -67,9 +67,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mcp-client-publish.yml
+++ b/.github/workflows/mcp-client-publish.yml
@@ -62,7 +62,7 @@ jobs:
         name: "Check Deps are published before publishing this package"
         run: pnpm -w check-deps inference && pnpm -w check-deps tasks
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -80,9 +80,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ollama-utils-publish.yml
+++ b/.github/workflows/ollama-utils-publish.yml
@@ -57,7 +57,7 @@ jobs:
       - name: "Check Deps are published before publishing this package"
         run: pnpm -w check-deps tasks
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -70,9 +70,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/space-header-publish.yml
+++ b/.github/workflows/space-header-publish.yml
@@ -54,7 +54,7 @@ jobs:
           git tag "space-header-v$BUMPED_VERSION"
           echo "RELEASE_TAG=space-header-v$BUMPED_VERSION" >> $GITHUB_ENV
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -72,9 +72,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/splitmix64-wasm-publish.yml
+++ b/.github/workflows/splitmix64-wasm-publish.yml
@@ -54,7 +54,7 @@ jobs:
           git tag "splitmix64-wasm-v$BUMPED_VERSION"
           echo "RELEASE_TAG=splitmix64-wasm-v$BUMPED_VERSION" >> $GITHUB_ENV
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -67,9 +67,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tasks-publish.yml
+++ b/.github/workflows/tasks-publish.yml
@@ -54,7 +54,7 @@ jobs:
           git tag "tasks-v$BUMPED_VERSION"
           echo "RELEASE_TAG=tasks-v$BUMPED_VERSION" >> $GITHUB_ENV
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -72,9 +72,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tiny-agents-publish.yml
+++ b/.github/workflows/tiny-agents-publish.yml
@@ -62,7 +62,7 @@ jobs:
         name: "Check Deps are published before publishing this package"
         run: pnpm -w check-deps inference && pnpm -w check-deps tasks # Review if these specific deps apply to tiny-agents
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -80,9 +80,7 @@ jobs:
           event-type: doc-build
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/xetchunk-wasm-publish.yml
+++ b/.github/workflows/xetchunk-wasm-publish.yml
@@ -54,7 +54,7 @@ jobs:
           git tag "xetchunk-wasm-v$BUMPED_VERSION"
           echo "RELEASE_TAG=xetchunk-wasm-v$BUMPED_VERSION" >> $GITHUB_ENV
 
-      - run: (git pull --rebase && git push --follow-tags) || (git pull --rebase && git push --follow-tags)
+      - run: (git pull --rebase && git push && git push origin "$RELEASE_TAG") || (git pull --rebase && git push && git push origin "$RELEASE_TAG")
 
       - run: pnpm publish --no-git-checks .
       # hack - reuse actions/setup-node@v4 just to set a new registry
@@ -67,9 +67,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        run: |
-          git push origin "$RELEASE_TAG"
-          gh release create "$RELEASE_TAG"
+        run: gh release create "$RELEASE_TAG"
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Explicitly push the release tag before creating the GitHub release to prevent `gh release create` failures.

The `gh release create` command can fail if a tag exists locally but hasn't been pushed to the remote, which can occur in edge cases even when `git push --follow-tags` is used (e.g., after a rebase or if the tag is not reachable from pushed commits). This PR adds an explicit `git push origin "$RELEASE_TAG"` step to ensure the tag is always available on the remote before the release is created.

---
[Slack Thread](https://huggingface.slack.com/archives/C04PJ0H35UM/p1772013010657709?thread_ts=1772013010.657709&cid=C04PJ0H35UM)

<p><a href="https://cursor.com/agents/bc-ca356eaf-57e0-5da6-b15b-8f7236389379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca356eaf-57e0-5da6-b15b-8f7236389379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adjusts `git push` behavior; risk is limited to release automation potentially failing or pushing tags unexpectedly if `$RELEASE_TAG` is miscomputed.
> 
> **Overview**
> Prevents `gh release create` from failing due to a locally-created tag not being present on the remote by **explicitly pushing the computed `$RELEASE_TAG`**.
> 
> Across all package publish workflows, the post-bump push step is changed from `git push --follow-tags` to `git push` plus `git push origin "$RELEASE_TAG"` (still wrapped with a `git pull --rebase` retry), ensuring the release tag is always available before the GitHub release is created.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21317384af0f3f8c36247d57784fa5214f8aeda2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->