### PR TITLE
Fix typo in hardware name for Ryzen AI Max 395

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -552,7 +552,7 @@ export const SKUS = {
 				tflops: 26.11,
 				memory: [16, 32],
 			},
-			"Ryzen AI Max 395+": {
+			"Ryzen AI Max+ 395": {
 				tflops: 59.4,
 				memory: [64, 96, 128],
 			},


### PR DESCRIPTION
Ryzen AI Max+ 395 instead of Ryzen AI Max 395+