### PR TITLE
[Tasks] Add computeCapability to NVIDIA GPUs in hardware.ts

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -39,6 +39,24 @@ export const DEFAULT_MEMORY_OPTIONS = [
 	8, 16, 24, 32, 40, 48, 64, 80, 96, 128, 192, 256, 384, 512, 768, 1024, 1536, 2048,
 ];
 
+export enum NvidiaComputeCapabilities {
+	BLACKWELL_ULTRA = 12.1,
+	BLACKWELL_RTX = 12.0,
+	BLACKWELL = 10.0,
+	HOPPER = 9.0,
+	ADA_LOVELACE = 8.9,
+	ORIN = 8.7,
+	AMPERE_RTX = 8.6,
+	AMPERE = 8.0,
+	TURING = 7.5,
+	XAVIER = 7.2,
+	VOLTA = 7.0,
+	PASCAL_TEGRA = 6.2,
+	PASCAL = 6.1,
+	PASCAL_DATACENTER = 6.0,
+	MAXWELL = 5.3,
+}
+
 export const SKUS = {
 	GPU: {
 		NVIDIA: {


### PR DESCRIPTION
## Summary

- Adds an optional `computeCapability` field to the `HardwareSpec` interface representing the CUDA Compute Capability version number
- Populates `computeCapability` for all 105 NVIDIA GPU entries, covering architectures from Maxwell (5.3) through Blackwell (12.0/12.1)
- Enables downstream consumers to filter/group GPUs by CUDA compatibility level

## Compute Capability Mappings

| CC | Architecture | Example GPUs |
|---|---|---|
| 12.0 | Blackwell (consumer) | RTX 5090, 5080, 5070, RTX PRO 6000 |
| 12.1 | Blackwell (edge) | GB10 |
| 10.0 | Blackwell (DC) | B200 |
| 9.0 | Hopper | H200, H100 |
| 8.9 | Ada Lovelace | L40s, L4, RTX 40-series |
| 8.7 | Orin | Jetson Orin variants |
| 8.6 | Ampere (consumer) | RTX A-series, RTX 30-series |
| 8.0 | Ampere (DC) | A100, A30 |
| 7.5 | Turing | RTX 20-series, T4 |
| 7.2 | Xavier | Jetson Xavier variants |
| 7.0 | Volta | V100 |
| 6.2 | Parker | Jetson TX2 |
| 6.1 | Pascal (consumer) | GTX 10-series, P40 |
| 6.0 | Pascal (DC) | P100 |
| 5.3 | Maxwell (Tegra) | Jetson Nano |

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] Verified all 105 NVIDIA GPU entries have a `computeCapability` value

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data/typing-only change confined to the hardware catalog; main risk is incorrect compute capability values affecting any new filtering logic that relies on them.
> 
> **Overview**
> Adds an optional `computeCapability` field to `HardwareSpec` and introduces `NvidiaComputeCapabilities` constants.
> 
> Populates `computeCapability` across the NVIDIA entries in `SKUS` so downstream consumers can filter/group GPUs by CUDA compatibility level without changing existing TFLOPS/memory data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1898f1360a0b0bec5511b704e2b09319e886674b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->