### PR TITLE
[Tasks] Add gfxVersion to AMD GPUs in hardware.ts

### DIFF
--- a/packages/tasks/src/hardware-amd.ts
+++ b/packages/tasks/src/hardware-amd.ts
@@ -1,0 +1,138 @@
+import type { HardwareSpec } from "./hardware.js";
+
+export interface AmdGpuHardwareSpec extends HardwareSpec {
+	/**
+	 * GFX version / LLVM ISA target (AMD GPUs only), e.g. "gfx1100"
+	 *
+	 * potential source https://llvm.org/docs/AMDGPUUsage.html#processors
+	 */
+	gfxVersion: string;
+}
+
+export const AMD_GPU_SKUS: Record<string, AmdGpuHardwareSpec> = {
+	MI300: {
+		tflops: 383.0,
+		memory: [192],
+		gfxVersion: "gfx942",
+	},
+	MI250: {
+		tflops: 362.1,
+		memory: [128],
+		gfxVersion: "gfx90a",
+	},
+	MI210: {
+		tflops: 181.0,
+		memory: [64],
+		gfxVersion: "gfx90a",
+	},
+	MI100: {
+		tflops: 184.6,
+		memory: [32],
+		gfxVersion: "gfx908",
+	},
+	MI60: {
+		tflops: 29.5,
+		memory: [32],
+		gfxVersion: "gfx906",
+	},
+	MI50: {
+		tflops: 26.5,
+		memory: [16, 32],
+		gfxVersion: "gfx906",
+	},
+	"R9700 PRO": {
+		tflops: 95.7,
+		memory: [32],
+		gfxVersion: "gfx1201",
+	},
+	"RX 9070 XT": {
+		tflops: 97.32,
+		memory: [16],
+		gfxVersion: "gfx1201",
+	},
+	"RX 9070": {
+		tflops: 72.25,
+		memory: [16],
+		gfxVersion: "gfx1201",
+	},
+	"RX 7900 XTX": {
+		tflops: 122.8,
+		memory: [24],
+		gfxVersion: "gfx1100",
+	},
+	"RX 7900 XT": {
+		tflops: 103.0,
+		memory: [20],
+		gfxVersion: "gfx1100",
+	},
+	"RX 7900 GRE": {
+		tflops: 91.96,
+		memory: [16],
+		gfxVersion: "gfx1100",
+	},
+	"RX 7800 XT": {
+		tflops: 74.65,
+		memory: [16],
+		gfxVersion: "gfx1101",
+	},
+	"RX 7700 XT": {
+		tflops: 70.34,
+		memory: [12],
+		gfxVersion: "gfx1101",
+	},
+	"RX 7600 XT": {
+		tflops: 45.14,
+		memory: [16, 8],
+		gfxVersion: "gfx1102",
+	},
+	"RX 6950 XT": {
+		tflops: 47.31,
+		memory: [16],
+		gfxVersion: "gfx1030",
+	},
+	"RX 6800": {
+		tflops: 32.33,
+		memory: [16],
+		gfxVersion: "gfx1030",
+	},
+	"RX 6700 XT": {
+		tflops: 26.43,
+		memory: [12],
+		gfxVersion: "gfx1031",
+	},
+	"RX 6700": {
+		tflops: 22.58,
+		memory: [10],
+		gfxVersion: "gfx1031",
+	},
+	"RX 6650 XT": {
+		tflops: 21.59,
+		memory: [8],
+		gfxVersion: "gfx1032",
+	},
+	"RX 6600 XT": {
+		tflops: 21.21,
+		memory: [8],
+		gfxVersion: "gfx1032",
+	},
+	"RX 6600": {
+		tflops: 17.86,
+		memory: [8],
+		gfxVersion: "gfx1032",
+	},
+	"RX 5500 XT": {
+		tflops: 10.39,
+		memory: [4, 8],
+		gfxVersion: "gfx1012",
+	},
+	"Radeon Pro VII": {
+		tflops: 26.11,
+		memory: [16, 32],
+		gfxVersion: "gfx906",
+	},
+	"Ryzen AI Max+ 395": {
+		tflops: 59.4,
+		memory: [64, 96, 128],
+		gfxVersion: "gfx1151",
+	},
+};

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -1,3 +1,4 @@
+import { AMD_GPU_SKUS } from "./hardware-amd.js";
 import { NVIDIA_SKUS } from "./hardware-nvidia.js";
 
 /**
@@ -31,10 +32,6 @@ export interface HardwareSpec {
 	 * e.g. an A100 exists in 40 or 80 GB.
 	 */
 	memory?: number[];
-	/**
-	 * GFX version / LLVM ISA target (AMD GPUs only), e.g. 11.0 for gfx1100
-	 */
-	gfxVersion?: number;
 }
 
 export const DEFAULT_MEMORY_OPTIONS = [
@@ -44,132 +41,7 @@ export const DEFAULT_MEMORY_OPTIONS = [
 export const SKUS = {
 	GPU: {
 		NVIDIA: NVIDIA_SKUS,
-		AMD: {
-			MI300: {
-				tflops: 383.0,
-				memory: [192],
-				gfxVersion: 9.42,
-			},
-			MI250: {
-				tflops: 362.1,
-				memory: [128],
-				gfxVersion: 9.1,
-			},
-			MI210: {
-				tflops: 181.0,
-				memory: [64],
-				gfxVersion: 9.1,
-			},
-			MI100: {
-				tflops: 184.6,
-				memory: [32],
-				gfxVersion: 9.08,
-			},
-			MI60: {
-				tflops: 29.5,
-				memory: [32],
-				gfxVersion: 9.06,
-			},
-			MI50: {
-				tflops: 26.5,
-				memory: [16, 32],
-				gfxVersion: 9.06,
-			},
-			"R9700 PRO": {
-				tflops: 95.7,
-				memory: [32],
-				gfxVersion: 12.01,
-			},
-			"RX 9070 XT": {
-				tflops: 97.32,
-				memory: [16],
-				gfxVersion: 12.01,
-			},
-			"RX 9070": {
-				tflops: 72.25,
-				memory: [16],
-				gfxVersion: 12.01,
-			},
-			"RX 7900 XTX": {
-				tflops: 122.8,
-				memory: [24],
-				gfxVersion: 11,
-			},
-			"RX 7900 XT": {
-				tflops: 103.0,
-				memory: [20],
-				gfxVersion: 11,
-			},
-			"RX 7900 GRE": {
-				tflops: 91.96,
-				memory: [16],
-				gfxVersion: 11,
-			},
-			"RX 7800 XT": {
-				tflops: 74.65,
-				memory: [16],
-				gfxVersion: 11.01,
-			},
-			"RX 7700 XT": {
-				tflops: 70.34,
-				memory: [12],
-				gfxVersion: 11.01,
-			},
-			"RX 7600 XT": {
-				tflops: 45.14,
-				memory: [16, 8],
-				gfxVersion: 11.02,
-			},
-			"RX 6950 XT": {
-				tflops: 47.31,
-				memory: [16],
-				gfxVersion: 10.3,
-			},
-			"RX 6800": {
-				tflops: 32.33,
-				memory: [16],
-				gfxVersion: 10.3,
-			},
-			"RX 6700 XT": {
-				tflops: 26.43,
-				memory: [12],
-				gfxVersion: 10.31,
-			},
-			"RX 6700": {
-				tflops: 22.58,
-				memory: [10],
-				gfxVersion: 10.31,
-			},
-			"RX 6650 XT": {
-				tflops: 21.59,
-				memory: [8],
-				gfxVersion: 10.32,
-			},
-			"RX 6600 XT": {
-				tflops: 21.21,
-				memory: [8],
-				gfxVersion: 10.32,
-			},
-			"RX 6600": {
-				tflops: 17.86,
-				memory: [8],
-				gfxVersion: 10.32,
-			},
-			"RX 5500 XT": {
-				tflops: 10.39,
-				memory: [4, 8],
-			},
-			"Radeon Pro VII": {
-				tflops: 26.11,
-				memory: [16, 32],
-				gfxVersion: 9.06,
-			},
-			"Ryzen AI Max+ 395": {
-				tflops: 59.4,
-				memory: [64, 96, 128],
-				gfxVersion: 11.51,
-			},
-		},
+		AMD: AMD_GPU_SKUS,
 		INTEL: {
 			"Arc A750": {
 				tflops: 34.41,

--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -59,6 +59,7 @@ export {
 
 export { SKUS, DEFAULT_MEMORY_OPTIONS } from "./hardware.js";
 export type { HardwareSpec, SkuType } from "./hardware.js";
+export type { AmdGpuHardwareSpec } from "./hardware-amd.js";
 export type { NvidiaHardwareSpec } from "./hardware-nvidia.js";
 export { LOCAL_APPS } from "./local-apps.js";
 export type { LocalApp, LocalAppKey, LocalAppSnippet } from "./local-apps.js";


### PR DESCRIPTION
## Summary
- Add `gfxVersion` optional field to `HardwareSpec` interface — the AMD equivalent of NVIDIA's `computeCapability`
- Populate `gfxVersion` for all 24 AMD GPU entries, derived from GFX targets (LLVM ISA)
- Stacked on #2010

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Grep confirms all 24 AMD GPUs have a `gfxVersion` entry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk data-model change: adds a new AMD-only field and refactors SKU constants into a dedicated module, with minimal impact beyond any consumers that may now read/expect `gfxVersion`.
> 
> **Overview**
> Adds an AMD-specific hardware spec (`AmdGpuHardwareSpec`) with required `gfxVersion` (LLVM GFX/ISA target) and populates it for all AMD GPU SKUs.
> 
> Refactors AMD GPU definitions out of `hardware.ts` into a new `hardware-amd.ts`, wires `SKUS.GPU.AMD` to the new `AMD_GPU_SKUS` export, and re-exports the new type from `index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 380e49c6b11e96f9cd1d2ef7f8903ef7ce3c8af5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->