### PR TITLE
[Inference Providers] restore `endpointUrl` support for chat completion when provider is omitted

### DIFF
--- a/packages/inference/src/tasks/nlp/chatCompletion.ts
+++ b/packages/inference/src/tasks/nlp/chatCompletion.ts
@@ -14,7 +14,10 @@ export async function chatCompletion(
 	options?: Options,
 ): Promise<ChatCompletionOutput> {
 	let providerHelper: ConversationalTaskHelper & TaskProviderHelper;
-	if (!args.provider || args.provider === "auto") {
+	if (args.endpointUrl) {
+		const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+		providerHelper = getProviderHelper(provider, "conversational");
+	} else if (!args.provider || args.provider === "auto") {
 		// Special case: we have a dedicated auto-router for conversational models. No need to fetch provider mapping.
 		providerHelper = new AutoRouterConversationalTask();
 	} else {

--- a/packages/inference/src/tasks/nlp/chatCompletionStream.ts
+++ b/packages/inference/src/tasks/nlp/chatCompletionStream.ts
@@ -14,7 +14,10 @@ export async function* chatCompletionStream(
 	options?: Options,
 ): AsyncGenerator<ChatCompletionStreamOutput> {
 	let providerHelper: ConversationalTaskHelper & TaskProviderHelper;
-	if (!args.provider || args.provider === "auto") {
+	if (args.endpointUrl) {
+		const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+		providerHelper = getProviderHelper(provider, "conversational");
+	} else if (!args.provider || args.provider === "auto") {
 		// Special case: we have a dedicated auto-router for conversational models. No need to fetch provider mapping.
 		providerHelper = new AutoRouterConversationalTask();
 	} else {


### PR DESCRIPTION
Flagged in this internal slack [message](https://huggingface.slack.com/archives/C04PJ0H35UM/p1772204275314449). cc @beurkinger

This PR fixes a regression introduced in newer versions of `huggingface/inference` where conversational calls failed with endpointUrl and no explicit provider.