### PR TITLE
Prevent invalid range request when downloading empty file

### DIFF
--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -4,6 +4,35 @@ import { bg4_regroup_bytes, bg4_split_bytes, XetBlob } from "./XetBlob";
 import { sum } from "./sum";
 
 describe("XetBlob", () => {
+	it("should handle empty files (size 0) without making network requests", async () => {
+		let fetchCount = 0;
+
+		const blob = new XetBlob({
+			hash: "test",
+			size: 0,
+			refreshUrl: "https://huggingface.co",
+			fetch: async () => {
+				fetchCount++;
+				return new Response();
+			},
+		});
+
+		const text = await blob.text();
+		expect(text).toBe("");
+		expect(fetchCount).toBe(0);
+
+		const arrayBuffer = await blob.arrayBuffer();
+		expect(arrayBuffer.byteLength).toBe(0);
+		expect(fetchCount).toBe(0);
+
+		const stream = blob.stream();
+		const reader = stream.getReader();
+		const result = await reader.read();
+		expect(result.done).toBe(true);
+		expect(result.value).toBeUndefined();
+		expect(fetchCount).toBe(0);
+	});
+
 	it("should lazy load the first 22 bytes", async () => {
 		const blob = new XetBlob({
 			hash: "7b3b6d07673a88cf467e67c1f7edef1a8c268cbf66e9dd9b0366322d4ab56d9b",

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -200,6 +200,14 @@ export class XetBlob extends Blob {
 	}
 
 	async #fetch(): Promise<ReadableStream<Uint8Array>> {
+		if (this.size === 0) {
+			return new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.close();
+				},
+			});
+		}
+
 		if (!this.reconstructionInfo) {
 			await this.#loadReconstructionInfo();
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Handle empty files in `XetBlob` to prevent invalid `Range` header generation.

Previously, for empty files (size 0), the `Range` header was incorrectly generated as `bytes=0--1`, which is an invalid range and caused requests to fail.

---
[Slack Thread](https://huggingface.slack.com/archives/C0A4RUVRLSC/p1772549033373789?thread_ts=1772549033.373789&cid=C0A4RUVRLSC)

<p><a href="https://cursor.com/agents/bc-ecb54da1-4186-571e-a805-5497073ff891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecb54da1-4186-571e-a805-5497073ff891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->