### PR TITLE
Track OpenPeerLLM downloads for fine-tuned Qwen artifacts

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -914,7 +914,10 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "OpenPeerLLM",
 		repoUrl: "https://huggingface.co/openpeerai/openpeerllm",
 		docsUrl: "https://huggingface.co/OpenPeerAI/OpenPeerLLM/blob/main/README.md",
-		countDownloads: `path:".meta-huggingface.json"`,
+		countDownloads: `path:".meta-huggingface.json"
+			OR path:"config.json"
+			OR path_extension:"safetensors"
+			OR path_extension:"gguf"`,
 		filter: false,
 	},
 	"open-sora": {


### PR DESCRIPTION
## Summary
- expand `openpeerllm` `countDownloads` query in `packages/tasks/src/model-libraries.ts`
- keep existing `.meta-huggingface.json` signal
- add common fine-tuned Qwen artifact signals: `config.json`, `*.safetensors`, and `*.gguf`

## Why
OpenPeerLLM models are often fine-tuned Qwen checkpoints and may not always include `.meta-huggingface.json`. This change improves download tracking coverage for those repos.

## Validation
- `pnpm -C . lint:check`
