### PR TITLE
🛡️ gguf: cap array/KV/tensor counts to prevent OOM from crafted files (CWE-770)

### DIFF
--- a/packages/gguf/src/gguf.spec.ts
+++ b/packages/gguf/src/gguf.spec.ts
@@ -28,6 +28,8 @@ const URL_V1 =
 const URL_SHARDED_GROK =
 	"https://huggingface.co/Arki05/Grok-1-GGUF/resolve/ecafa8d8eca9b8cd75d11a0d08d3a6199dc5a068/grok-1-IQ3_XS-split-00001-of-00009.gguf";
 const URL_BIG_METADATA = "https://huggingface.co/ngxson/test_gguf_models/resolve/main/gguf_test_big_metadata.gguf";
+const URL_KIMI_K25 =
+	"https://huggingface.co/unsloth/Kimi-K2.5-GGUF/resolve/5f759b07a564a5cb9fcfa9ad456cf254e539ac77/UD-Q3_K_XL/Kimi-K2.5-UD-Q3_K_XL-00001-of-00011.gguf";
 
 describe("gguf", () => {
 	beforeAll(async () => {
@@ -252,6 +254,46 @@ describe("gguf", () => {
 			name: "output.weight",
 			shape: [64n, 512n],
 			dtype: GGMLQuantizationType.F32,
+		});
+	});
+
+	it("should parse a large MoE model (Kimi-K2.5, 160K vocab)", async () => {
+		const { metadata, typedMetadata, tensorInfos } = await gguf(URL_KIMI_K25, { typedMetadata: true });
+
+		expect(metadata).toMatchObject({
+			version: 3,
+			"general.architecture": "deepseek2",
+			"general.name": "Kimi-K2.5",
+			"deepseek2.block_count": 61,
+			"deepseek2.embedding_length": 7168,
+			"deepseek2.expert_count": 384,
+			"deepseek2.expert_used_count": 8,
+			"deepseek2.expert_shared_count": 1,
+			"deepseek2.vocab_size": 163840,
+		});
+
+		expect(typedMetadata["general.architecture"]).toEqual({
+			value: "deepseek2",
+			type: GGUFValueType.STRING,
+		});
+		expect(typedMetadata["deepseek2.expert_count"]).toEqual({
+			value: 384,
+			type: GGUFValueType.UINT32,
+		});
+		expect(typedMetadata["tokenizer.ggml.tokens"]).toMatchObject({
+			type: GGUFValueType.ARRAY,
+			subType: GGUFValueType.STRING,
+		});
+		const tokens = typedMetadata["tokenizer.ggml.tokens"].value;
+		expect(Array.isArray(tokens)).toBe(true);
+		if (Array.isArray(tokens)) {
+			expect(tokens.length).toEqual(163_840);
+		}
+
+		expect(tensorInfos.length).toBeGreaterThan(0);
+		expect(tensorInfos[0]).toMatchObject({
+			name: "output.weight",
+			shape: [7168n, 163840n],
 		});
 	});
 

--- a/packages/gguf/src/gguf.ts
+++ b/packages/gguf/src/gguf.ts
@@ -27,6 +27,15 @@ export {
 export const RE_GGUF_FILE = /\.gguf$/;
 export const RE_GGUF_SHARD_FILE = /^(?<prefix>.*?)-(?<shard>\d{5})-of-(?<total>\d{5})\.gguf$/;
 const GGUF_DEFAULT_ALIGNMENT = 32; // defined in ggml.h
+
+/**
+ * Safety limits to prevent OOM from crafted GGUF files (CWE-770).
+ * Values are set well above any known real-world model (e.g. Kimi-K2.5 at 1T params,
+ * 160K vocab, 384 experts) while still preventing billion-element allocations.
+ */
+const MAX_METADATA_ARRAY_LENGTH = 1_000_000;
+const MAX_KV_COUNT = 100_000;
+const MAX_TENSOR_COUNT = 10_000_000;
 const GGML_PAD = (x: number, n: number) => (x + n - 1) & ~(n - 1); // defined in ggml.h
 const PARALLEL_DOWNLOADS = 20;
 
@@ -223,6 +232,11 @@ function readMetadataValue(
 		case GGUFValueType.ARRAY: {
 			const arrayType = view.getUint32(offset, littleEndian);
 			const arrayLength = readVersionedSize(view, offset + 4, version, littleEndian);
+			if (arrayLength.value > MAX_METADATA_ARRAY_LENGTH) {
+				throw new Error(
+					`Metadata array length ${arrayLength.value} exceeds maximum allowed (${MAX_METADATA_ARRAY_LENGTH})`,
+				);
+			}
 			let length = 4 + arrayLength.length;
 			const arrayValues: MetadataValue[] = [];
 			for (let i = 0; i < arrayLength.value; i++) {
@@ -340,8 +354,14 @@ export async function gguf(
 	// initial offset after header
 	let offset = 8;
 	const tensorCount = readVersionedSize(r.view, offset, version, littleEndian);
+	if (tensorCount.value > MAX_TENSOR_COUNT) {
+		throw new Error(`Tensor count ${tensorCount.value} exceeds maximum allowed (${MAX_TENSOR_COUNT})`);
+	}
 	offset += tensorCount.length;
 	const numKv = readVersionedSize(r.view, offset, version, littleEndian);
+	if (numKv.value > MAX_KV_COUNT) {
+		throw new Error(`KV metadata count ${numKv.value} exceeds maximum allowed (${MAX_KV_COUNT})`);
+	}
 	offset += numKv.length;
 	const metadata: GGUFMetadata<{ strict: false }> = {
 		version,


### PR DESCRIPTION
## Summary

- **Fix CWE-770 (Allocation of Resources Without Limits)**: `readMetadataValue()` reads an array length from untrusted binary input and uses it as a loop bound with no cap. Combined with the retry-on-RangeError logic in `gguf()`, a crafted ~100-byte `.gguf` file can OOM-kill the Node.js process.
- **Add three safety limits** in `packages/gguf/src/gguf.ts`, all set well above any known real-world model:
  - `MAX_METADATA_ARRAY_LENGTH = 1,000,000` — caps the `ARRAY` branch in `readMetadataValue` (~6× largest known vocab of 163K)
  - `MAX_KV_COUNT = 100,000` — validates `numKv` in `gguf()` (~200× typical header)
  - `MAX_TENSOR_COUNT = 10,000,000` — validates `tensorCount` in `gguf()` (~140× largest known shard)
- **Add a test against [Kimi-K2.5 GGUF](https://huggingface.co/unsloth/Kimi-K2.5-GGUF)** (1T params, 163K vocab, 384 experts, deepseek2 architecture) to ensure the limits don't reject large legitimate models.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core GGUF parsing and introduces new validation failures that could reject unusually large but valid files if limits are too tight, though limits are set high and covered by a new large-model test.
> 
> **Overview**
> **Improves GGUF parser robustness against resource-exhaustion inputs (CWE-770).** The parser now enforces maximum limits for metadata array lengths, KV metadata count, and tensor count, throwing explicit errors instead of iterating/allocating unboundedly from untrusted header values.
> 
> **Adds coverage for extreme real-world headers.** Tests now include parsing a very large sharded MoE model (Kimi-K2.5, 160K vocab) and validate `typedMetadata` array handling and key model/tensor properties to ensure the new caps don’t block legitimate large models.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e03147b0e0c3ad19dbb45a14eab529d8dd22032. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->