### PR TITLE
Add RX 5500 XT and Ryzen 7 3800X specifications

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -549,7 +549,7 @@ export const SKUS = {
 				memory: [8],
 			},
 			"RX 5500 XT": {
-				tflops: 5.2,
+				tflops: 10.39,
 				memory: [4, 8],
 			},
 			"Radeon Pro VII": {


### PR DESCRIPTION
Added My AMD GPU and CPU for the list. AMD Radeon RX 5500 XT GPU, and Ryzen 7 3800X (16 threads) CPU

with these chipsets, they are limited to 32B models and smaller, based on my current system.
often speeds are between less than 1 token a second, and up to 10 tokens on smaller 12b and lower models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only additions to a static hardware SKU map; main risk is inaccurate values or mismatched keys affecting downstream lookups.
> 
> **Overview**
> Extends the `SKUS` hardware specification list in `hardware.ts` with two additional AMD entries used for TFLOPS/memory-based sizing.
> 
> Adds an `RX 5500 XT` GPU spec (10.39 TFLOPS, 4/8GB) and a `Ryzen 7 3800X (16)` CPU spec (1.73 TFLOPS).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f15af7693c55c5b0ce40847b0971813d0a26aa89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->