### PR TITLE
🛡️ gguf: harden parser against crafted files (resource exhaustion, stack overflow, infinite loop)

### DIFF
--- a/packages/gguf/src/gguf.ts
+++ b/packages/gguf/src/gguf.ts
@@ -498,14 +498,13 @@ export async function gguf(
 
 	// calculate absolute offset of tensor data
 	const rawAlignment = metadata["general.alignment"] ?? GGUF_DEFAULT_ALIGNMENT;
-	const alignment: number =
-		typeof rawAlignment === "bigint"
-			? rawAlignment > BigInt(Number.MAX_SAFE_INTEGER)
-				? (() => {
-						throw new Error(`general.alignment value ${rawAlignment} exceeds safe integer range`);
-					})()
-				: Number(rawAlignment)
-			: Number(rawAlignment);
+	if (typeof rawAlignment === "bigint" && rawAlignment > BigInt(Number.MAX_SAFE_INTEGER)) {
+		throw new Error(`general.alignment value ${rawAlignment} exceeds safe integer range`);
+	}
+	const alignment = Number(rawAlignment);
+	if (alignment <= 0 || !Number.isInteger(alignment)) {
+		throw new Error(`general.alignment must be a positive integer, got ${rawAlignment}`);
+	}
 	const tensorInfoEndBeforePadOffset = offset;
 	const tensorDataOffset = BigInt(GGML_PAD(offset, alignment));
 


### PR DESCRIPTION
## Summary

follow up to https://github.com/huggingface/huggingface.js/pull/2026 and https://github.com/huggingface/huggingface.js/pull/2020

Fixes 6 security vulnerabilities in the GGUF binary parser that could be triggered by crafted files:

- **CWE-770 (Resource Exhaustion):** Add `MAX_STRING_LENGTH` (10MB) check in `readString` — previously a crafted file could declare a huge string length (up to 2^64) causing unsafe `Number(BigInt)` conversion and potential OOM
- **CWE-770 (Resource Exhaustion):** Add `MAX_TENSOR_NDIMS` (8) check on `nDims` — previously `nDims = 0xFFFFFFFF` would trigger billions of iterations in the tensor shape loop
- **CWE-674 (Uncontrolled Recursion):** Add `MAX_ARRAY_RECURSION_DEPTH` (4) and a `depth` counter to `readMetadataValue` — a crafted file with `arrayType = ARRAY` caused unbounded recursion leading to stack overflow
- **CWE-20 (Improper Input Validation):** Validate array element type with `isGGUFValueType()` before recursing — previously an invalid element type caused `readMetadataValue` to return `undefined`, then crash on `undefined.length`
- **CWE-835 (Infinite Loop):** Add `MAX_CHUNK_FETCHES_PER_VALUE` (30) counter in the `while (!valueResult)` fetch loop — a server returning persistently truncated data could cause unbounded fetching
- **CWE-704 (Unsafe Type Conversion):** Guard `general.alignment` BigInt→Number cast — values above `Number.MAX_SAFE_INTEGER` now throw instead of silently losing precision and corrupting the tensor data offset

All existing tests pass (44/44).

Related prior hardening: #2026 (safetensors parser)

## Test plan

- [x] All 44 existing tests pass (`pnpm run test` in `packages/gguf`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new validation and hard limits in the GGUF binary parser; while security-improving, it can cause previously-accepted (or malformed) files to fail parsing and changes streaming fetch behavior.
> 
> **Overview**
> Hardens the GGUF parser against crafted inputs by adding explicit resource/recursion limits and stricter validation.
> 
> This introduces caps for string sizes, tensor dimensionality, nested metadata arrays (with recursion depth tracking and element-type validation), and bounds the retry loop that fetches additional HTTP chunks when parsing values.
> 
> It also tightens validation of `general.alignment` to avoid unsafe BigInt-to-Number casts and rejects non-positive/non-integer alignment values before computing tensor data offsets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5d4fefd650ad503b059399b48f260e4f8368c05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->