### PR TITLE
CI lint format split

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,13 +44,32 @@ jobs:
         run: |
           pnpm --filter ...[${{ steps.since.outputs.SINCE }}] lint:check
 
+      - name: Check types
+        run: pnpm --filter ...[${{ steps.since.outputs.SINCE }}] check
+
+  format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Could use something like rmacklin/fetch-through-merge-base@v0 instead when the repo gets bigger
+          fetch-depth: 0
+
+      - run: npm install -g corepack@latest && corepack enable
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: "**/pnpm-lock.yaml"
+      - run: pnpm install --frozen-lockfile --filter .
+
       - name: "Checking format errors"
         run: |
-          # Could also use pnpm --filter [${{ steps.since.outputs.SINCE }}] format:check
+          # Could also use package-level format:check scripts
           # But this way we can see the diff
           pnpm -r format
           git diff | head -n 100
           git diff --name-only --exit-code
-
-      - name: Check types
-        run: pnpm --filter ...[${{ steps.since.outputs.SINCE }}] check


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Split the CI `lint` job into separate `lint` and `format` jobs to clearly distinguish failures.

---
[Slack Thread](https://huggingface.slack.com/archives/C0627F75ETT/p1773140829369649?thread_ts=1773140829.369649&cid=C0627F75ETT)

<p><a href="https://cursor.com/agents/bc-132cbb8c-ef01-534d-9eff-a08f295cbfcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-132cbb8c-ef01-534d-9eff-a08f295cbfcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->