### PR TITLE
🐛 safetensors: fix globMatch anchoring for quantization config patterns

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -1,5 +1,10 @@
 import { assert, it, describe } from "vitest";
-import { parseSafetensorsMetadata, parseSafetensorsShardFilename, globMatch, isQuantizedTensor } from "./parse-safetensors-metadata";
+import {
+	parseSafetensorsMetadata,
+	parseSafetensorsShardFilename,
+	globMatch,
+	isQuantizedTensor,
+} from "./parse-safetensors-metadata";
 import { sum } from "../utils/sum";
 
 describe("parseSafetensorsMetadata", () => {

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -402,7 +402,7 @@ export function isQuantizedTensor(tensorName: string, quantConfig?: Quantization
 	const patterns = quantConfig.modules_to_not_convert;
 	if (!patterns?.length) return true;
 	return !patterns.some((pattern) =>
-		pattern.includes("*") ? globMatch(pattern, tensorName) : tensorName.includes(pattern)
+		pattern.includes("*") ? globMatch(pattern, tensorName) : tensorName.includes(pattern),
 	);
 }
 


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/huggingface/huggingface.js/pull/2026#discussion_r2910974958

### `globMatch` — fix anchoring (was producing false positives)

The old `globMatch` only checked that literal segments appeared in order, but didn't anchor start/end. This caused incorrect matches:

| Input | Old result | Correct result |
|---|---|---|
| `globMatch("foo", "xfoox")` | `true` | `false` — no wildcards = exact match |
| `globMatch("*.txt", "file.txt.bak")` | `true` | `false` — must end with `.txt` |
| `globMatch("model.*", "my_model.bin")` | `true` | `false` — must start with `model.` |

The new implementation properly handles: no-wildcard (exact equality), start anchoring, end anchoring, and ordered middle segments.

### `isQuantizedTensor` — use substring matching for bare module names

Python's `transformers` uses plain substring matching for `modules_to_not_convert`, so bare names like `"lm_head"` should match `"model.lm_head.weight"`. The fixed `globMatch` (correctly) treats no-wildcard patterns as exact matches, which broke this use case.

`isQuantizedTensor` now dispatches based on whether the pattern contains `*`:
- **With `*`**: uses `globMatch` for proper glob matching
- **Without `*`**: uses `str.includes()` for substring matching (matching Python behavior)

### Tests

- 8 test cases for `globMatch` (exact match, leading/trailing/double-sided wildcards, multiple wildcards, wildcard-only, quantization config patterns)
- 5 test cases for `isQuantizedTensor` (no config, empty modules, bare module substring matching, glob patterns, multiple exclusion patterns)

## Test plan

- [x] All new `globMatch` and `isQuantizedTensor` tests pass
- [x] All existing `parseSafetensorsMetadata` tests still pass
- [x] Lint and format checks pass