### PR TITLE
[Tasks] Add Apple M5 Pro and M5 Max to hardware specs

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -414,6 +414,14 @@ export const SKUS = {
 				tflops: 5.7,
 				memory: [16, 24, 32],
 			},
+			"Apple M5 Pro": {
+				tflops: 11.4,
+				memory: [24, 36, 48, 64],
+			},
+			"Apple M5 Max": {
+				tflops: 22.8,
+				memory: [36, 48, 64, 128],
+			},
 		},
 	},
 } satisfies Record<string, Record<string, Record<string, HardwareSpec>>>;


### PR DESCRIPTION
## Summary
- Add Apple M5 Pro (20-core GPU, up to 64GB unified memory) and M5 Max (40-core GPU, up to 128GB unified memory) to hardware SKU definitions
- TFLOPS values follow the established scaling pattern: M5 base (5.7) × 2 = M5 Pro (11.4), × 4 = M5 Max (22.8), consistent with M4 Pro/Max
- Memory configurations based on [Apple's official specs](https://support.apple.com/en-us/126318)

## Sources
- [Apple debuts M5 Pro and M5 Max](https://www.apple.com/newsroom/2026/03/apple-debuts-m5-pro-and-m5-max-to-supercharge-the-most-demanding-pro-workflows/)
- [MacBook Pro M5 Pro/Max Tech Specs](https://support.apple.com/en-us/126318)

## Test plan
- [ ] Verify TFLOPS values align with available benchmarks
- [ ] Confirm memory configurations match Apple's official specs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds static data entries to the hardware spec map with no behavioral or control-flow changes; main risk is incorrect spec values affecting sizing results.
> 
> **Overview**
> Updates the `SKUS` hardware definitions to include new Apple Silicon entries for `Apple M5 Pro` and `Apple M5 Max`.
> 
> Each new SKU adds TFLOPS values and supported unified memory configurations so downstream sizing/threshold logic can recognize these chips.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da456216866f496e2adc077ad227c40ae521a24b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->