### PR TITLE
[Hub] Add `kernel` to `RepoType`

### DIFF
--- a/packages/hub/src/lib/cache-management.ts
+++ b/packages/hub/src/lib/cache-management.ts
@@ -261,6 +261,8 @@ export function parseRepoType(type: string): RepoType {
 			return "space";
 		case "buckets":
 			return "bucket";
+		case "kernels":
+			return "kernel";
 		default:
 			throw new TypeError(`Invalid repo type: ${type}`);
 	}

--- a/packages/hub/src/types/public.ts
+++ b/packages/hub/src/types/public.ts
@@ -1,13 +1,18 @@
 import type { PipelineType } from "@huggingface/tasks";
 
-export type RepoType = "space" | "dataset" | "model" | "bucket";
+export type RepoType = "space" | "dataset" | "model" | "bucket" | "kernel";
 
 export interface RepoId {
 	name: string;
 	type: RepoType;
 }
 
-export type RepoFullName = string | `spaces/${string}` | `datasets/${string}` | `buckets/${string}`;
+export type RepoFullName =
+	| string
+	| `spaces/${string}`
+	| `datasets/${string}`
+	| `buckets/${string}`
+	| `kernels/${string}`;
 
 export type RepoDesignation = RepoId | RepoFullName;
 

--- a/packages/hub/src/utils/toRepoId.ts
+++ b/packages/hub/src/utils/toRepoId.ts
@@ -23,6 +23,10 @@ export function toRepoId(repo: RepoDesignation): RepoId {
 		throw new TypeError("Buckets should start with 'buckets/', plural, not 'bucket/'");
 	}
 
+	if (repo.startsWith("kernel/")) {
+		throw new TypeError("Kernels should start with 'kernels/', plural, not 'kernel/'");
+	}
+
 	const slashes = repo.split("/").length - 1;
 
 	if (repo.startsWith("spaces/")) {
@@ -55,6 +59,17 @@ export function toRepoId(repo: RepoDesignation): RepoId {
 		return {
 			type: "bucket",
 			name: repo.slice("buckets/".length),
+		};
+	}
+
+	if (repo.startsWith("kernels/")) {
+		if (slashes !== 2) {
+			throw new TypeError("Kernel Id must include namespace and name of the kernel");
+		}
+
+		return {
+			type: "kernel",
+			name: repo.slice("kernels/".length),
 		};
 	}
 


### PR DESCRIPTION
## Summary

to keep the types consistent with moon

- Add `"kernel"` to the `RepoType` union and `kernels/${string}` to `RepoFullName` to keep types consistent with moon
- Add `kernels/` parsing in `toRepoId` (with singular `kernel/` typo guard)
- Add `"kernels" → "kernel"` mapping in `parseRepoType` (cache management)


Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type/utility extension; main risk is missed call sites that assume repo types are limited to the previous set, which could cause compile errors or unhandled cases at runtime.
> 
> **Overview**
> Adds **`kernel` as a supported repository type** by extending `RepoType`/`RepoFullName` to include `kernel` and `kernels/...`.
> 
> Updates parsing utilities to recognize `kernels/` designations in `toRepoId` (including a singular `kernel/` typo guard) and to map cache folder prefixes `kernels` to `kernel` in `parseRepoType`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b86c526faafe50cb5cf8fb85852a251d2486bc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->