### PR TITLE
Add BioNeMo and NV-Medtech libraries

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -899,7 +899,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: true,
 		countDownloads: `path_extension:"nemo" OR path:"model_config.yaml" OR path_extension:"json"`,
 	},
-	nv-medtech: {
+	"nv-medtech": {
 		prettyLabel: "NV-MedTech",
 		repoName: "NV-MedTech",
 		filter: false,


### PR DESCRIPTION
This PR is to add two new libraries to enable download count for the model repos.

Librares:
- BioNeMo
- NV-Medtech

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds two new entries to the model library UI/download-count mapping, with no changes to runtime logic beyond additional keys and Elastic download queries.
> 
> **Overview**
> Adds support for two additional model libraries in `MODEL_LIBRARIES_UI_ELEMENTS`: **`bionemo`** (BioNeMo) and **`nv-medtech`** (NV-MedTech).
> 
> Each entry includes repo metadata and a `countDownloads` Elastic query so models tagged with these library names can have download counts computed (without enabling the models page filter for either).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 892838399c0210cf2f92f629b38b36242b5ed441. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->