### PR TITLE
Add llmpm to local apps

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -138,6 +138,23 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		expect(snippet[2].content).toContain("pi");
 	});
 
+	it("llmpm", async () => {
+		const { snippet: snippetFunc } = LOCAL_APPS["llmpm"];
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			inference: "",
+		};
+		const snippet = snippetFunc(model);
+
+		expect(snippet[0].content).toContain("pip install llmpm");
+		expect(snippet[0].content).toContain("llmpm run bartowski/Llama-3.2-3B-Instruct-GGUF");
+		expect(snippet[0].content).toContain(`llmpm run bartowski/Llama-3.2-3B-Instruct-GGUF --prompt "Surprise Me!"`);
+		expect(snippet[0].content).toContain("llmpm serve bartowski/Llama-3.2-3B-Instruct-GGUF");
+		expect(snippet[0].content).toContain("curl -X POST http://localhost:8080/v1/chat/completions");
+		expect(snippet[0].content).toContain(`"model": "bartowski/Llama-3.2-3B-Instruct-GGUF"`);
+	});
+
 	it("docker model runner", async () => {
 		const { snippet: snippetFunc } = LOCAL_APPS["docker-model-runner"];
 		const model: ModelData = {

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -698,7 +698,10 @@ export const LOCAL_APPS = {
 		prettyLabel: "Llmpm",
 		docsUrl: "https://www.llmpm.co/docs",
 		mainTask: "text-generation",
-		displayOnModelPage: isLlamaCppGgufModel || isTransformersModel,
+		displayOnModelPage: (model) =>
+			isLlamaCppGgufModel(model) ||
+			(isTransformersModel(model) &&
+				(model.pipeline_tag === "text-generation" || model.pipeline_tag === "text-to-image")),
 		snippet: snippetLlmpm,
 	},
 } satisfies Record<string, LocalApp>;

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -426,6 +426,36 @@ const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 	];
 };
 
+const snippetLlmpm = (model: ModelData): LocalAppSnippet[] => {
+	const modelId = model.id;
+	const openAICompatibleCurl = [
+		"# Invoking the OpenAI-compatible server with curl",
+		"curl -X POST http://localhost:8080/v1/chat/completions \\",
+		`  -H "Content-Type: application/json" \\`,
+		"  --data '{",
+		`    "model": "${modelId}",`,
+		`    "messages": [{"role": "user", "content": "Hello!"}]`,
+		"  }'",
+	];
+
+	return [
+		{
+			title: "Install & Start a New Chat",
+			content: [
+				"# Install Llmpm",
+				"pip install llmpm",
+				"# Run interactive chat in terminal",
+				`llmpm run ${modelId}`,
+				"# Run with a prompt",
+				`llmpm run ${modelId} --prompt "Surprise Me!"`,
+				"# Serve the model (OpenAI-compatible API)",
+				`llmpm serve ${modelId}`,
+				...openAICompatibleCurl,
+			].join("\n"),
+		},
+	];
+};
+
 const snippetDockerModelRunner = (model: ModelData, filepath?: string): string => {
 	// Only add quant tag for GGUF models, not safetensors
 	const quantTag = isLlamaCppGgufModel(model) ? getQuantTag(filepath) : "";
@@ -663,6 +693,13 @@ export const LOCAL_APPS = {
 		mainTask: "text-generation",
 		displayOnModelPage: (model) => isLlamaCppGgufModel(model) && !!model.gguf?.chat_template?.includes("tools"),
 		snippet: snippetPi,
+	},
+	llmpm: {
+		prettyLabel: "Llmpm",
+		docsUrl: "https://www.llmpm.co/docs",
+		mainTask: "text-generation",
+		displayOnModelPage: isLlamaCppGgufModel || isTransformersModel,
+		snippet: snippetLlmpm,
 	},
 } satisfies Record<string, LocalApp>;
 


### PR DESCRIPTION
# Summary

Add [LLMPM](https://llmpm.co/docs) as a local app

### What is llmpm?

LLMPM is a CLI tool that enables users to install, run, and manage open-source LLMs hosted on Hugging Face locally. It works similar to how package managers work for software. It simplifies working with models by making them portable, reproducible, and easy to execute across environments.

### Display condition

- `Llmpm` only displays for `GGUF` & `transformer` models with type `text-generation`
- The filter checks for `isLlamaCppGgufModel` or `isTransformersModel`
- This ensures the LLMPM app only surfaces for models which it can actually run

### Added the below snippet to the `local-apps.ts` to run & install llmpm

```sh
# Install Llmpm
pip install llmpm

# Run interactive chat in terminal
llmpm run ${modelId}

# Run with a prompt
llmpm run ${modelId} --prompt "Surprise Me!"

# Serve the model (OpenAI-compatible API)
llmpm serve ${modelId}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new local-app entry and associated snippets/tests without changing existing execution paths beyond an additional option in the model-page app list.
> 
> **Overview**
> Adds `llmpm` as a new option in `LOCAL_APPS`, including an install/run/serve snippet (with an OpenAI-compatible `curl` example) and display rules for GGUF models plus select Transformers `text-generation`/`text-to-image` models.
> 
> Extends `local-apps.spec.ts` with a new test to validate the generated `llmpm` snippet content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f63bba39ceba7d1604e6d758bb9e26a38b0c2ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->