### PR TITLE
Add KokoClone library integration 

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -951,7 +951,9 @@ sf.write('output.wav', audio, 24000)`,
 export const kokoclone = (model: ModelData): string[] => [
 	`from core.cloner import KokoClone
 	
-cloner = KokoClone()
+# Initialize cloner with this specific model repository
+cloner = KokoClone(hf_repo="${model.id}")
+
 cloner.generate(
     text="Hello world!",
     lang="en",

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -950,7 +950,7 @@ sf.write('output.wav', audio, 24000)`,
 
 export const kokoclone = (model: ModelData): string[] => [
 	`from core.cloner import KokoClone
-	
+
 # Initialize cloner with this specific model repository
 cloner = KokoClone(hf_repo="${model.id}")
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -948,6 +948,18 @@ import soundfile as sf
 sf.write('output.wav', audio, 24000)`,
 ];
 
+export const kokoclone = (model: ModelData): string[] => [
+	`from core.cloner import KokoClone
+	
+cloner = KokoClone()
+cloner.generate(
+    text="Hello world!",
+    lang="en",
+    reference_audio="reference.wav",
+    output_path="output.wav"
+)`
+];
+
 export const lightning_ir = (model: ModelData): string[] => {
 	if (model.tags.includes("bi-encoder")) {
 		return [

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -959,7 +959,7 @@ cloner.generate(
     lang="en",
     reference_audio="reference.wav",
     output_path="output.wav",
-)`
+)`,
 ];
 
 export const lightning_ir = (model: ModelData): string[] => {

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -958,7 +958,7 @@ cloner.generate(
     text="Hello world!",
     lang="en",
     reference_audio="reference.wav",
-    output_path="output.wav"
+    output_path="output.wav",
 )`
 ];
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -704,7 +704,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_extension:"pt"`,
 	},
-
 	k2: {
 		prettyLabel: "K2",
 		repoName: "k2",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -701,7 +701,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "KokoClone",
 		repoName: "kokoclone",
 		repoUrl: "https://github.com/Ashish-Patnaik/kokoclone",
-		countDownloads: { path_extension: "onnx" },
+		countDownloads: ` path_extension: "onnx" `,
 		snippets: snippets.kokoclone,
 	},
 	k2: {

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -697,6 +697,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_extension:"pt"`,
 	},
+	kokoclone: {
+		prettyLabel: "KokoClone",
+		repoName: "kokoclone",
+		repoUrl: "https://github.com/Ashish-Patnaik/kokoclone",
+		countDownloads: { path_extension: "onnx" },
+		snippets: snippets.kokoclone,
+	},
 	k2: {
 		prettyLabel: "K2",
 		repoName: "k2",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -692,7 +692,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	},
 	kokoclone: {
 		prettyLabel: "KokoClone",
-		repoName: "kokoclone",
+		repoName: "KokoClone",
 		repoUrl: "https://github.com/Ashish-Patnaik/kokoclone",
 		countDownloads: `path_extension: "onnx"`,
 		snippets: snippets.kokoclone,

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -690,6 +690,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/KittenML/KittenTTS",
 		snippets: snippets.kittentts,
 	},
+		kokoclone: {
+		prettyLabel: "KokoClone",
+		repoName: "kokoclone",
+		repoUrl: "https://github.com/Ashish-Patnaik/kokoclone",
+		countDownloads: `path_extension: "onnx"`,
+		snippets: snippets.kokoclone,
+	},
 	kronos: {
 		prettyLabel: "KRONOS",
 		repoName: "KRONOS",
@@ -697,13 +704,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_extension:"pt"`,
 	},
-	kokoclone: {
-		prettyLabel: "KokoClone",
-		repoName: "kokoclone",
-		repoUrl: "https://github.com/Ashish-Patnaik/kokoclone",
-		countDownloads: ` path_extension: "onnx" `,
-		snippets: snippets.kokoclone,
-	},
+
 	k2: {
 		prettyLabel: "K2",
 		repoName: "k2",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -690,7 +690,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/KittenML/KittenTTS",
 		snippets: snippets.kittentts,
 	},
-		kokoclone: {
+	kokoclone: {
 		prettyLabel: "KokoClone",
 		repoName: "kokoclone",
 		repoUrl: "https://github.com/Ashish-Patnaik/kokoclone",


### PR DESCRIPTION
This PR adds support for KokoClone, an ONNX-based voice cloning library built on top of kokoro model, to the Hugging Face Hub.

It includes:

- Library registration (kokoclone)
- Custom download tracking for .onnx files
- Usage snippet for easy model loading and inference

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only extends the library registry and adds a new example snippet plus a download-count query, without affecting core model execution or auth/data paths.
> 
> **Overview**
> Adds **KokoClone** to the model library registry (`MODEL_LIBRARIES_UI_ELEMENTS`) so Hub models tagged `kokoclone` show the correct label/repo link, a usage snippet, and custom download counting for `.onnx` artifacts.
> 
> Introduces a new `snippets.kokoclone` Python example demonstrating initializing `KokoClone` from `hf_repo` and generating audio from text with a reference clip.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3077f4c385278509560852ced1f083407e0e93e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->