### PR TITLE
✨ Add fount to local apps

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -504,6 +504,36 @@ const snippetDockerModelRunner = (model: ModelData, filepath?: string): string =
 	return `docker model run hf.co/${model.id}${quantTag}`;
 };
 
+const snippetFount = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
+	const fountModelName = `hf:${model.id}${getQuantTag(filepath)}`;
+	return [
+		{
+			title: "Open in fount (browser)",
+			setup: [
+				"# Install fount:",
+				"# https://steve02081504.github.io/fount/readme/#installation",
+			].join("\n"),
+			content: `https://steve02081504.github.io/fount/protocol?url=${encodeURIComponent(`fount://run/serviceGenerators:AI:local/install;${fountModelName}`)}`.replaceAll("%7B%7BQUANT_TAG%7D%7D", "{{QUANT_TAG}}"),
+		},
+		{
+			title: "Use CLI (*nix)",
+			setup: [
+				"# Install fount:",
+				"bash <(curl -fsSL https://steve02081504.github.io/fount/install.sh)",
+			].join("\n"),
+			content: `fount run \${FOUNT_USERNAME:-$USER} serviceGenerators/AI/local install ${fountModelName}`,
+		},
+		{
+			title: "Use CLI (PowerShell)",
+			setup: [
+				"# Install fount:",
+				"irm https://steve02081504.github.io/fount/install.ps1 | iex",
+			].join("\n"),
+			content: `fount run $(if ($env:FOUNT_USERNAME) { $env:FOUNT_USERNAME } else { $env:USERNAME }) serviceGenerators/AI/local install ${fountModelName}`,
+		},
+	];
+};
+
 const snippetLemonade = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 	const tagName = getQuantTag(filepath);
 	const modelName = model.id.includes("/") ? model.id.split("/")[1] : model.id;
@@ -745,6 +775,13 @@ export const LOCAL_APPS = {
 			model.tags.includes("conversational") &&
 			!!getChatTemplate(model)?.includes("tools"),
 		snippet: snippetPi,
+	},
+	fount: {
+		prettyLabel: "𝓯𝓸𝓾𝓷𝓽",
+		docsUrl: "https://github.com/steve02081504/fount",
+		mainTask: "text-generation",
+		displayOnModelPage: isLlamaCppGgufModel,
+		snippet: snippetFount,
 	},
 } satisfies Record<string, LocalApp>;
 


### PR DESCRIPTION
### What is fount?

[fount](https://github.com/steve02081504/fount) is an open-source, programmable AI agent runtime platform with 10k+ active users. It runs GGUF models locally via a built-in `serviceGenerators/AI/local` module (backed by llama.cpp), and exposes them as a standardised AI source for use across all fount shells (chat UI, Discord, Telegram, browser extension, terminal, etc.).

fount runs on Windows, macOS, Linux, and Android, and can be installed with a single command or via Docker.

### What does this PR add?

Adds a `fount` entry to `LOCAL_APPS` in `local-apps.ts`, displayed on GGUF model pages (`isLlamaCppGgufModel`).

The snippet offers three options:

| Option | Description |
|---|---|
| **Open in fount (browser)** | A one-click `https://steve02081504.github.io/fount/protocol?url=fount://…` deep-link that authenticates through the brower instance and triggers the install |
| **Use CLI (\*nix)** | Shell command using `${FOUNT_USERNAME:-$USER}` |
| **Use CLI (PowerShell)** | PowerShell command using `$(if ($env:FOUNT_USERNAME) { $env:FOUNT_USERNAME } else { $env:USERNAME })`, compatible with both Windows PowerShell 5.x and PowerShell Core 7+ |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new `LOCAL_APPS` entry and snippet generation for `fount` on GGUF model pages; changes are isolated to UI/snippet output with no impact on inference logic or data handling.
> 
> **Overview**
> Adds **`fount`** as a new local app option for **GGUF (`isLlamaCppGgufModel`) model pages**.
> 
> Introduces a `snippetFount` generator that provides a browser deep-link installer plus cross-platform CLI install commands (*nix and PowerShell), including quant tag handling via `getQuantTag`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b49dd8cb01ba9b3f065e32ef0fc3d6efe16a9102. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->