### PR TITLE
Unsloth Update Install Commands

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -184,7 +184,9 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 
 		expect(displayOnModelPage(model)).toBe(true);
 		const snippet = snippetFunc(model);
-		expect(snippet[0].setup).toBe("pip install unsloth\nunsloth studio setup");
+		expect(snippet[0].setup).toBe(
+			"# MacOS, Linux, WSL\ncurl -fsSL https://unsloth.ai/install.sh | sh\n# Windows\nirm https://unsloth.ai/install.ps1 | iex\nunsloth studio setup",
+		);
 		expect(snippet[0].content).toBe(
 			"# Run unsloth studio\nunsloth studio -H 0.0.0.0 -p 8000\n# Then open http://localhost:8000/chat in your browser\n# Search for some-user/my-unsloth-finetune to start chatting",
 		);
@@ -192,7 +194,9 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		expect(snippet[1].content).toBe(
 			"# Open https://huggingface.co/spaces/unsloth/studio in your browser\n# Search for some-user/my-unsloth-finetune to start chatting",
 		);
-		expect(snippet[2].setup).toBe("pip install unsloth");
+		expect(snippet[2].setup).toBe(
+			"# MacOS, Linux, WSL\ncurl -fsSL https://unsloth.ai/install.sh | sh\n# Windows\nirm https://unsloth.ai/install.ps1 | iex",
+		);
 		expect(snippet[2].content).toBe(
 			'from unsloth import FastModel\nmodel, tokenizer = FastModel.from_pretrained(\n    model_name="some-user/my-unsloth-finetune",\n    max_seq_length=2048,\n)',
 		);
@@ -209,7 +213,9 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 
 		expect(displayOnModelPage(model)).toBe(true);
 		const snippet = snippetFunc(model);
-		expect(snippet[0].setup).toBe("pip install unsloth\nunsloth studio setup");
+		expect(snippet[0].setup).toBe(
+			"# MacOS, Linux, WSL\ncurl -fsSL https://unsloth.ai/install.sh | sh\n# Windows\nirm https://unsloth.ai/install.ps1 | iex\nunsloth studio setup",
+		);
 		expect(snippet[0].content).toBe(
 			"# Run unsloth studio\nunsloth studio -H 0.0.0.0 -p 8000\n# Then open http://localhost:8000/chat in your browser\n# Search for unsloth/Llama-3.2-3B-Instruct-GGUF to start chatting",
 		);


### PR DESCRIPTION
Updated Unsloth install commands to not use pip but curl for smoother installs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to updating test assertions for Unsloth snippet setup strings, with no production logic modified.
> 
> **Overview**
> Updates `local-apps.spec.ts` to expect **new Unsloth installation instructions** in generated snippets, switching setup text from `pip install unsloth` to OS-specific `curl`/PowerShell install commands (and keeping `unsloth studio setup` where applicable).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09ae42a3f0cc5817ef03cbc438f988f74706e735. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->