### PR TITLE
Add EUPE as library

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -720,6 +720,15 @@ export const espnet = (model: ModelData): string[] => {
 	return espnetUnknown();
 };
 
+export const eupe = (model: ModelData): string[] => [
+	`import torch
+
+REPO_DIR = <PATH/TO/A/LOCAL/DIRECTORY/WHERE/THE/EUPE/REPO/WAS/CLONED>
+
+model = torch.hub.load(REPO_DIR, "${model.id}", source="local", weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
+`,
+];
+
 export const fairseq = (model: ModelData): string[] => [
 	`from fairseq.checkpoint_utils import load_model_ensemble_and_task_from_hf_hub
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -720,23 +720,6 @@ export const espnet = (model: ModelData): string[] => {
 	return espnetUnknown();
 };
 
-export const eupe = (): string[] => [
-	`import torch
-
-REPO_DIR = <PATH/TO/A/LOCAL/DIRECTORY/WHERE/THE/EUPE/REPO/WAS/CLONED>
-
-# EUPE ViT models pretrained on web images
-eupe_vitt16 = torch.hub.load(REPO_DIR, 'eupe_vitt16', source='local', weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
-eupe_vits16 = torch.hub.load(REPO_DIR, 'eupe_vits16', source='local', weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
-eupe_vitb16 = torch.hub.load(REPO_DIR, 'eupe_vitb16', source='local', weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
-
-# EUPE ConvNeXt models pretrained on web images
-eupe_convnext_tiny = torch.hub.load(REPO_DIR, 'eupe_convnext_tiny', source='local', weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
-eupe_convnext_small = torch.hub.load(REPO_DIR, 'eupe_convnext_small', source='local', weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
-eupe_convnext_base = torch.hub.load(REPO_DIR, 'eupe_convnext_base', source='local', weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
-`,
-];
-
 export const fairseq = (model: ModelData): string[] => [
 	`from fairseq.checkpoint_utils import load_model_ensemble_and_task_from_hf_hub
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -720,12 +720,20 @@ export const espnet = (model: ModelData): string[] => {
 	return espnetUnknown();
 };
 
-export const eupe = (model: ModelData): string[] => [
+export const eupe = (): string[] => [
 	`import torch
 
 REPO_DIR = <PATH/TO/A/LOCAL/DIRECTORY/WHERE/THE/EUPE/REPO/WAS/CLONED>
 
-model = torch.hub.load(REPO_DIR, "${model.id}", source="local", weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
+# EUPE ViT models pretrained on web images
+eupe_vitt16 = torch.hub.load(REPO_DIR, 'eupe_vitt16', source='local', weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
+eupe_vits16 = torch.hub.load(REPO_DIR, 'eupe_vits16', source='local', weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
+eupe_vitb16 = torch.hub.load(REPO_DIR, 'eupe_vitb16', source='local', weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
+
+# EUPE ConvNeXt models pretrained on web images
+eupe_convnext_tiny = torch.hub.load(REPO_DIR, 'eupe_convnext_tiny', source='local', weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
+eupe_convnext_small = torch.hub.load(REPO_DIR, 'eupe_convnext_small', source='local', weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
+eupe_convnext_base = torch.hub.load(REPO_DIR, 'eupe_convnext_base', source='local', weights=<PATH/TO/THE/LOCAL/CHECKPOINT>)
 `,
 ];
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -443,7 +443,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: true,
 	},
 	eupe: {
-		prettyLabel: "eupe",
+		prettyLabel: "EUPE",
 		repoName: "EUPE",
 		repoUrl: "https://github.com/facebookresearch/EUPE",
 		filter: false,

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -442,6 +442,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.espnet,
 		filter: true,
 	},
+	eupe: {
+		prettyLabel: "eupe",
+		repoName: "EUPE",
+		repoUrl: "https://github.com/facebookresearch/EUPE",
+		filter: false,
+		snippets: snippets.eupe,
+		countDownloads: `path_extension:"pt"`,
+	},
 	fairseq: {
 		prettyLabel: "Fairseq",
 		repoName: "fairseq",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -447,7 +447,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "EUPE",
 		repoUrl: "https://github.com/facebookresearch/EUPE",
 		filter: false,
-		snippets: snippets.eupe,
 		countDownloads: `path_extension:"pt"`,
 	},
 	fairseq: {


### PR DESCRIPTION
Following Niels's suggestion (https://github.com/facebookresearch/EUPE/issues/2) to add models from https://huggingface.co/collections/facebook/eupe as library, enabling downloads stats.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new static entry in the model library registry, affecting only labeling and download-count query behavior for `library_name=eupe` models.
> 
> **Overview**
> Adds **EUPE** to `MODEL_LIBRARIES_UI_ELEMENTS`, including repo metadata and an Elastic download-count query (`path_extension:"pt"`).
> 
> EUPE is marked `filter: false`, so it won’t appear in the main library filter list but will enable download stats attribution for EUPE-tagged models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63c7b22daeaf024eec6b1e423a37391c1991b28e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->