### PR TITLE
feat: add Atomic Chat local app integration

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -174,6 +174,19 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		expect(snippet).toEqual(`docker model run hf.co/bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`);
 	});
 
+	it("atomic chat deeplink", async () => {
+		const { displayOnModelPage, deeplink } = LOCAL_APPS["atomic-chat"];
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			gguf: { total: 1, context_length: 4096 },
+			inference: "",
+		};
+
+		expect(displayOnModelPage(model)).toBe(true);
+		expect(deeplink(model).href).toBe("atomic-chat://models/huggingface/bartowski/Llama-3.2-3B-Instruct-GGUF");
+	});
+
 	it("unsloth tagged model", async () => {
 		const { displayOnModelPage, snippet: snippetFunc } = LOCAL_APPS.unsloth;
 		const model: ModelData = {

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -636,6 +636,13 @@ export const LOCAL_APPS = {
 		displayOnModelPage: isLlamaCppGgufModel,
 		deeplink: (model) => new URL(`jan://models/huggingface/${model.id}`),
 	},
+	"atomic-chat": {
+		prettyLabel: "Atomic Chat",
+		docsUrl: "https://atomic.chat",
+		mainTask: "text-generation",
+		displayOnModelPage: isLlamaCppGgufModel,
+		deeplink: (model) => new URL(`atomic-chat://models/huggingface/${model.id}`),
+	},
 	backyard: {
 		prettyLabel: "Backyard AI",
 		docsUrl: "https://backyard.ai",


### PR DESCRIPTION
## Summary
- add `Atomic Chat` to `LOCAL_APPS` as a GGUF-compatible local app with an `atomic-chat://models/huggingface/<repo>` deeplink
- add a focused test covering visibility and deeplink generation for the new local app entry
- keep the change scoped to `@huggingface/tasks` without extra dependencies or unrelated refactors

## Test plan
- [x] `corepack pnpm exec vitest run "packages/tasks/src/local-apps.spec.ts"`
- [x] `corepack pnpm --filter @huggingface/tasks test`
- [x] `corepack pnpm --filter @huggingface/tasks check`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `LOCAL_APPS` entry and a small test, without changing shared selection logic or existing app behavior.
> 
> **Overview**
> Adds **Atomic Chat** as a new local-app integration in `@huggingface/tasks`, surfaced for GGUF/llama.cpp-compatible models and providing an `atomic-chat://models/huggingface/<repo>` deeplink.
> 
> Extends `local-apps.spec.ts` with a focused test to verify the app is shown for a GGUF model and that the generated deeplink URL matches the expected scheme and path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a79c530148b89c10bea94bdc61d10148764494ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->