### PR TITLE
Add Q1_0 as new GGUF type

### DIFF
--- a/packages/gguf/src/quant-descriptions.ts
+++ b/packages/gguf/src/quant-descriptions.ts
@@ -140,6 +140,10 @@ export const GGUF_QUANT_DESCRIPTIONS: Record<GGMLQuantizationType, { txt: string
 		txt: "4-bit Microscaling Block Floating Point with global scale.",
 		src_url: "https://github.com/ggml-org/llama.cpp/pull/19769",
 	},
+	[GGMLQuantizationType.Q1_0]: {
+		txt: "1-bit quantization with fp16 block scale. Each block has 128 weights, where 0 represents -block_scale and 1 represents +block_scale.",
+		src_url: "https://github.com/ggml-org/llama.cpp/pull/21273",
+	},
 };
 
 const QK_K = 256;
@@ -183,4 +187,5 @@ export const GGML_QUANT_SIZES = {
 	[GGMLQuantizationType.TQ2_0]: calcBPW(256, 2 + 64),
 	[GGMLQuantizationType.MXFP4]: calcBPW(32, 1 + 16),
 	[GGMLQuantizationType.NVFP4]: calcBPW(64, 4 + 32),
+	[GGMLQuantizationType.Q1_0]: calcBPW(128, 2 + 16),
 };

--- a/packages/tasks/src/gguf.ts
+++ b/packages/tasks/src/gguf.ts
@@ -125,9 +125,9 @@ export const GGUF_QUANT_ORDER: GGMLFileQuantizationType[] = [
 	// 1-bit quantizations
 	GGMLFileQuantizationType.IQ1_S,
 	GGMLFileQuantizationType.IQ1_M,
-	GGMLFileQuantizationType.Q1_0,
 	GGMLFileQuantizationType.TQ1_0,
 	GGMLFileQuantizationType.TQ2_0,
+	GGMLFileQuantizationType.Q1_0,
 ];
 
 // This function finds the nearest quantization type that is less than or equal to the given quantization type.

--- a/packages/tasks/src/gguf.ts
+++ b/packages/tasks/src/gguf.ts
@@ -42,6 +42,7 @@ export enum GGMLFileQuantizationType {
 	TQ2_0 = 37,
 	MXFP4_MOE = 38,
 	NVFP4 = 39,
+	Q1_0 = 40,
 
 	// custom quants used by unsloth
 	// they are not officially a scheme enum value in GGUF, but only here for naming
@@ -124,6 +125,7 @@ export const GGUF_QUANT_ORDER: GGMLFileQuantizationType[] = [
 	// 1-bit quantizations
 	GGMLFileQuantizationType.IQ1_S,
 	GGMLFileQuantizationType.IQ1_M,
+	GGMLFileQuantizationType.Q1_0,
 	GGMLFileQuantizationType.TQ1_0,
 	GGMLFileQuantizationType.TQ2_0,
 ];
@@ -205,4 +207,5 @@ export enum GGMLQuantizationType {
 	TQ2_0 = 35,
 	MXFP4 = 39,
 	NVFP4 = 40,
+	Q1_0 = 41,
 }


### PR DESCRIPTION
This is to add support to Q1_0 newly added GGUF type. 
We just released 3 models in this format as 1-bit Bonsai ([see more info here](https://github.com/PrismML-Eng/Bonsai-demo/blob/main/1-bit-bonsai-8b-whitepaper.pdf))

And this PR is to show correct naming on the hugging-face gguf website tab:

https://huggingface.co/prism-ml/Bonsai-8B-gguf

<img width="675" height="332" alt="Screenshot 2026-04-06 at 14 16 31" src="https://github.com/user-attachments/assets/e5c44f6b-b69e-497f-974b-9c41b95bed7a" />


PR that merged Q1_0: https://github.com/ggml-org/llama.cpp/pull/21273

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new GGUF quantization enum/value mapping and updates ordering/regex inputs; main risk is mis-numbering or ordering causing incorrect quant label parsing or size calculations.
> 
> **Overview**
> Adds support for the newly introduced GGUF `Q1_0` 1-bit quantization.
> 
> This extends quant metadata to include a human-readable description/source link and a bits-per-weight size calculation, and updates the tasks-side GGUF quant enums and quant ordering lists so `Q1_0` is recognized when parsing/labeling and when selecting the nearest available quant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4007baa059eb64f2288ddb9efe5b4f0a999918a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->