### PR TITLE
Add WildDet3D to model libraries

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1538,7 +1538,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	wilddet3d: {
 		prettyLabel: "WildDet3D",
 		repoName: "WildDet3D",
-		repoUrl: "https://github.com/weikaih04/WildDet3D",
+		repoUrl: "https://github.com/allenai/WildDet3D",
 		filter: false,
 		countDownloads: `path_extension:"pt"`,
 	},

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1535,6 +1535,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		docsUrl: "https://huggingface.co/microsoft/wham/blob/main/README.md",
 		countDownloads: `path_extension:"ckpt"`,
 	},
+	wilddet3d: {
+		prettyLabel: "WildDet3D",
+		repoName: "WildDet3D",
+		repoUrl: "https://github.com/weikaih04/WildDet3D",
+		filter: false,
+		countDownloads: `path_extension:"pt"`,
+	},
 	whisperkit: {
 		prettyLabel: "WhisperKit",
 		repoName: "WhisperKit",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1535,13 +1535,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		docsUrl: "https://huggingface.co/microsoft/wham/blob/main/README.md",
 		countDownloads: `path_extension:"ckpt"`,
 	},
-	wilddet3d: {
-		prettyLabel: "WildDet3D",
-		repoName: "WildDet3D",
-		repoUrl: "https://github.com/allenai/WildDet3D",
-		filter: false,
-		countDownloads: `path_extension:"pt"`,
-	},
 	whisperkit: {
 		prettyLabel: "WhisperKit",
 		repoName: "WhisperKit",
@@ -1549,6 +1542,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		docsUrl: "https://github.com/argmaxinc/WhisperKit?tab=readme-ov-file#homebrew",
 		snippets: snippets.whisperkit,
 		countDownloads: `path_filename:"model" AND path_extension:"mil" AND _exists_:"path_prefix"`,
+	},
+	wilddet3d: {
+		prettyLabel: "WildDet3D",
+		repoName: "WildDet3D",
+		repoUrl: "https://github.com/allenai/WildDet3D",
+		filter: false,
+		countDownloads: `path_extension:"pt"`,
 	},
 	yolov10: {
 		// YOLOv10 is a fork of ultraLytics. Code snippets and download count are the same but the repo is different.


### PR DESCRIPTION
## Summary

Add [WildDet3D](https://github.com/weikaih04/WildDet3D) to the model libraries for download tracking.

- **Library**: `wilddet3d`
- **Download tracking**: `.pt` files
- **Model repo**: [allenai/WildDet3D](https://huggingface.co/allenai/WildDet3D) (already tagged with `library_name: wilddet3d`)

WildDet3D is a promptable monocular 3D object detection model from Allen Institute for AI (Ai2).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new `MODEL_LIBRARIES_UI_ELEMENTS` entry with a simple `.pt` download-count query and no changes to existing logic.
> 
> **Overview**
> Adds the `wilddet3d` model library to `MODEL_LIBRARIES_UI_ELEMENTS`, including repo metadata and a `countDownloads` Elastic query to track downloads for `.pt` files (kept out of the UI library filter list via `filter: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ddbf9d7d34d2d84640b9d0754b039509121ada2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->