### PR TITLE
Register mdpbench as an evaluation framework

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -81,6 +81,6 @@ export const EVALUATION_FRAMEWORKS = {
   name: "mdpbench",
   description:
     "MDPBench is a benchmark for evaluating multilingual document parsing across digital, photographed, Latin, and non-Latin document subsets.",
-  url: "https://huggingface.co/datasets/Delores-Lin/MDPBench",
+  url: "https://github.com/Yuliang-Liu/MultimodalOCR",
 	},
 } as const;

--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -79,7 +79,8 @@ export const EVALUATION_FRAMEWORKS = {
 	},
 	mdpbench: {
 		name: "mdpbench",
-		description: "MDPBench is a benchmark for evaluating multilingual document parsing across digital, photographed, Latin, and non-Latin document subsets.",
+		description:
+			"MDPBench is a benchmark for evaluating multilingual document parsing across digital, photographed, Latin, and non-Latin document subsets.",
 		url: "https://github.com/Yuliang-Liu/MultimodalOCR",
 	},
 } as const;

--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -78,9 +78,8 @@ export const EVALUATION_FRAMEWORKS = {
 		url: "https://github.com/huggingface/open_asr_leaderboard",
 	},
 	mdpbench: {
-  name: "mdpbench",
-  description:
-    "MDPBench is a benchmark for evaluating multilingual document parsing across digital, photographed, Latin, and non-Latin document subsets.",
-  url: "https://github.com/Yuliang-Liu/MultimodalOCR",
+		name: "mdpbench",
+		description: "MDPBench is a benchmark for evaluating multilingual document parsing across digital, photographed, Latin, and non-Latin document subsets.",
+		url: "https://github.com/Yuliang-Liu/MultimodalOCR",
 	},
 } as const;

--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -77,4 +77,10 @@ export const EVALUATION_FRAMEWORKS = {
 		description: "The Open ASR Leaderboard ranks and evaluates speech recognition models.",
 		url: "https://github.com/huggingface/open_asr_leaderboard",
 	},
+	mdpbench: {
+  name: "mdpbench",
+  description:
+    "MDPBench is a benchmark for evaluating multilingual document parsing across digital, photographed, Latin, and non-Latin document subsets.",
+  url: "https://huggingface.co/datasets/Delores-Lin/MDPBench",
+	},
 } as const;


### PR DESCRIPTION
This PR registers `mdpbench` as an evaluation framework in `packages/tasks/src/eval.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new static entry to the `EVALUATION_FRAMEWORKS` registry with no behavioral or logic changes beyond allowing `mdpbench` to be referenced.
> 
> **Overview**
> Registers **`mdpbench`** in `packages/tasks/src/eval.ts` by adding its name, description, and URL to the exported `EVALUATION_FRAMEWORKS` map so it can be referenced from `eval.yaml` configurations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db00a647f22706b45c345b59d33b74793b996316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->