### PR TITLE
Add ToolPiper as a local app for GGUF models

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -246,4 +246,29 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 
 		expect(displayOnModelPage(model)).toBe(false);
 	});
+
+	it("toolpiper gguf model", async () => {
+		const { displayOnModelPage, snippet: snippetFunc } = LOCAL_APPS.toolpiper;
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			gguf: { total: 1, context_length: 4096 },
+			inference: "",
+		};
+
+		expect(displayOnModelPage(model)).toBe(true);
+		const snippet = snippetFunc(model);
+		expect(snippet.content).toBe("Download bartowski/Llama-3.2-3B-Instruct-GGUF");
+	});
+
+	it("toolpiper not shown for non-gguf model", async () => {
+		const { displayOnModelPage } = LOCAL_APPS.toolpiper;
+		const model: ModelData = {
+			id: "meta-llama/Llama-3.2-3B-Instruct",
+			tags: ["conversational"],
+			inference: "",
+		};
+
+		expect(displayOnModelPage(model)).toBe(false);
+	});
 });

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -213,6 +213,13 @@ const snippetOllama = (model: ModelData, filepath?: string): string => {
 	return `ollama run hf.co/${model.id}${getQuantTag(filepath)}`;
 };
 
+const snippetToolPiper = (model: ModelData): LocalAppSnippet => {
+	return {
+		title: "In ToolPiper chat, type",
+		content: `Download ${model.id}`,
+	};
+};
+
 const snippetUnsloth = (model: ModelData): LocalAppSnippet[] => {
 	const isGguf = isLlamaCppGgufModel(model);
 
@@ -753,6 +760,14 @@ export const LOCAL_APPS = {
 			model.tags.includes("conversational") &&
 			!!getChatTemplate(model)?.includes("tools"),
 		snippet: snippetPi,
+	},
+	toolpiper: {
+		prettyLabel: "ToolPiper",
+		docsUrl: "https://modelpiper.com",
+		mainTask: "text-generation",
+		macOSOnly: true,
+		displayOnModelPage: isLlamaCppGgufModel,
+		snippet: snippetToolPiper,
 	},
 } satisfies Record<string, LocalApp>;
 


### PR DESCRIPTION
## Summary

- Adds [ToolPiper](https://modelpiper.com) to the local apps dropdown on GGUF model pages
- ToolPiper is a macOS AI toolkit that runs inference locally on Apple Silicon (llama.cpp, CoreML, MLX)
- Users download and run models via natural language in the built-in chat — the snippet is simply `Download {model.id}`
- macOS-only, same GGUF model filter as Ollama

## Changes

- `packages/tasks/src/local-apps.ts` — snippet function + `LOCAL_APPS.toolpiper` entry
- `packages/tasks/src/local-apps.spec.ts` — 2 tests (GGUF shown, non-GGUF hidden)

## How it looks

The dropdown shows **ToolPiper** with a macOS pill on any GGUF model page:

```
In ToolPiper chat, type
Download bartowski/Llama-3.2-3B-Instruct-GGUF
```

## Links

- Website: https://modelpiper.com
- Mac App Store: https://apps.apple.com/app/toolpiper/id6741087040
- Example tagged model: [ModelPiper/PiperSR-2x](https://huggingface.co/ModelPiper/PiperSR-2x)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `LOCAL_APPS` entry and simple snippet output gated behind existing GGUF detection, plus tests; no changes to core inference or data handling.
> 
> **Overview**
> Adds **ToolPiper** to the local-apps list as a *macOS-only* option that appears on GGUF (llama.cpp-compatible) model pages.
> 
> Introduces a new snippet generator that instructs users to run `Download {model.id}` inside ToolPiper, and adds tests to verify ToolPiper is shown only for GGUF models and the snippet content is correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d702e370a38ef85d5276c90679118fde22536d2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->