### PR TITLE
feat: add mflux library for download tracking

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -850,6 +850,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/mit-nlp/MITIE",
 		countDownloads: `path_filename:"total_word_feature_extractor"`,
 	},
+	mflux: {
+		prettyLabel: "mflux",
+		repoName: "mflux",
+		repoUrl: "https://github.com/filipstrand/mflux",
+		filter: false,
+		countDownloads: `path:"config.json"`,
+	},
 	"ml-agents": {
 		prettyLabel: "ml-agents",
 		repoName: "ml-agents",


### PR DESCRIPTION
## Summary

- Adds [mflux](https://github.com/filipstrand/mflux) to `model-libraries.ts` so that download stats are tracked for models tagged with `library_name: mflux`
- Uses `config.json` as the `countDownloads` target, which mflux [explicitly requests](https://github.com/filipstrand/mflux/blob/main/src/mflux/models/common/weights/loading/weight_loader.py) via `snapshot_download(allow_patterns=[file_pattern, "config.json"])`

## Context

mflux is a line-by-line MLX port of image generation models (FLUX.1, FLUX.2, Z-Image, etc.) optimized for Apple Silicon. It has 4k+ GitHub stars and is actively maintained.

All models with `library_name: mflux` currently show **0 downloads** because the library isn't registered. Repos that happen to have `config.json` but *don't* set `library_name: mflux` get counted via the default fallback, confirming the fix is straightforward.

| Repo | `library_name` | Has `config.json` | Downloads |
|---|---|---|---|
| `madroid/flux.1-dev-mflux-4bit` | *(none)* | Yes | 40 |
| `dhairyashil/FLUX.1-schnell-mflux-4bit` | *(none)* | Yes | 155 |
| `filipstrand/FLUX.1-Krea-dev-mflux-4bit` | `mflux` | No | 0 |
| `Runpod/FLUX.2-klein-4B-mflux-4bit` | `mflux` | No | 0 |

Closes #2091

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new `MODEL_LIBRARIES_UI_ELEMENTS` entry to improve download counting for `library_name: mflux` models, with no changes to shared logic or security-sensitive code.
> 
> **Overview**
> Adds the `mflux` library to `MODEL_LIBRARIES_UI_ELEMENTS` so models tagged with `library_name: mflux` are recognized and have downloads counted.
> 
> Download counting for `mflux` is configured to use `path:"config.json"`, and the library is marked `filter: false` with repo metadata pointing to `filipstrand/mflux`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15918afe4caca5c8fbe372c3f661536f14a19904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->