### PR TITLE
Add Skala to download stats

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1268,6 +1268,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path:"cvlm_llama2_tokenizer/tokenizer.model"`,
 		snippets: snippets.seed_story,
 	},
+	"skala": {
+		prettyLabel: "Skala",
+		repoName: "Skala",
+		repoUrl: "https://github.com/microsoft/skala",
+		filter: false,
+		countDownloads: `path_extension:"fun"`,
+	},
 	soloaudio: {
 		prettyLabel: "SoloAudio",
 		repoName: "SoloAudio",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1268,7 +1268,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path:"cvlm_llama2_tokenizer/tokenizer.model"`,
 		snippets: snippets.seed_story,
 	},
-	"skala": {
+	skala: {
 		prettyLabel: "Skala",
 		repoName: "Skala",
 		repoUrl: "https://github.com/microsoft/skala",


### PR DESCRIPTION
Add download stats for https://hf.co/microsoft/skala-1.0

Following https://huggingface.co/docs/hub/models-download-stats


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new model-library entry and an associated download-count query, with no changes to core logic or data handling.
> 
> **Overview**
> Adds a new `skala` entry to `MODEL_LIBRARIES_UI_ELEMENTS`, enabling Hub download statistics and UI metadata for Microsoft’s Skala models.
> 
> Download counting for Skala is configured via an Elastic query targeting `*.fun` files (`path_extension:"fun"`), and the library is not exposed as a models-page filter (`filter: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee429a8d73deb4437cce5391bb63f841d6cd462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->