### PR TITLE
Add ParseBench evaluation framework

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -71,4 +71,10 @@ export const EVALUATION_FRAMEWORKS = {
 		description: "The Open ASR Leaderboard ranks and evaluates speech recognition models.",
 		url: "https://github.com/huggingface/open_asr_leaderboard",
 	},
+	parsebench: {
+		name: "parsebench",
+		description:
+			"ParseBench is a benchmark for evaluating how well document parsing tools convert PDFs into structured output that AI agents can reliably act on.",
+		url: "https://github.com/run-llama/ParseBench",
+	},
 } as const;

--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -82,7 +82,7 @@ export const EVALUATION_FRAMEWORKS = {
 		description:
 			"ParseBench is a benchmark for evaluating how well document parsing tools convert PDFs into structured output that AI agents can reliably act on.",
 		url: "https://github.com/run-llama/ParseBench",
-    },
+	},
 	mdpbench: {
 		name: "mdpbench",
 		description:

--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -82,6 +82,7 @@ export const EVALUATION_FRAMEWORKS = {
 		description:
 			"ParseBench is a benchmark for evaluating how well document parsing tools convert PDFs into structured output that AI agents can reliably act on.",
 		url: "https://github.com/run-llama/ParseBench",
+    },
 	mdpbench: {
 		name: "mdpbench",
 		description:


### PR DESCRIPTION
## Summary

- Adds `parsebench` to the `EVALUATION_FRAMEWORKS` list in `packages/tasks/src/eval.ts`
- ParseBench is a benchmark by LlamaIndex for evaluating how well document parsing tools convert PDFs into structured output for AI agents
- Covers ~2,000 human-verified pages from real enterprise documents across five capability dimensions

## Links

- GitHub: https://github.com/run-llama/ParseBench
- HuggingFace dataset: https://huggingface.co/datasets/llamaindex/ParseBench
- Paper: https://arxiv.org/abs/2604.08538

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only extends a static `EVALUATION_FRAMEWORKS` registry entry used for `eval.yaml` validation/metadata, with no behavioral logic changes beyond recognizing a new key.
> 
> **Overview**
> Adds `parsebench` to the `EVALUATION_FRAMEWORKS` registry in `packages/tasks/src/eval.ts`, including its name/description and GitHub URL so it can be referenced as a supported evaluation framework in benchmark `eval.yaml` configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eba84cc70a0184b99bf41203a3dc6993b888a2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->