### PR TITLE
Add parsebench to evaluation frameworks

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -83,4 +83,10 @@ export const EVALUATION_FRAMEWORKS = {
 			"MDPBench is a benchmark for evaluating multilingual document parsing across digital, photographed, Latin, and non-Latin document subsets.",
 		url: "https://github.com/Yuliang-Liu/MultimodalOCR",
 	},
+	parsebench: {
+		name: "parsebench",
+		description:
+			"ParseBench is a benchmark for evaluating document parsing systems on real-world enterprise documents across tables, charts, content faithfulness, semantic formatting, and visual grounding.",
+		url: "https://github.com/run-llama/ParseBench",
+	},
 } as const;


### PR DESCRIPTION
Adds `parsebench` to the `EVALUATION_FRAMEWORKS` enum so the [ParseBench dataset](https://huggingface.co/datasets/llamaindex/ParseBench) can register its `eval.yaml` without a validation error.

Currently the ParseBench `eval.yaml` fails validation with:

> ✖ Invalid input → at evaluation_framework

Framework details:
- **Name**: parsebench
- **Repo**: https://github.com/run-llama/ParseBench (Apache 2.0)
- **Description**: A benchmark for evaluating document parsing systems on real-world enterprise documents across tables, charts, content faithfulness, semantic formatting, and visual grounding (~2,000 human-verified enterprise document pages).

cc @NathanHB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new `EVALUATION_FRAMEWORKS` entry used for `eval.yaml` validation, with no behavioral changes beyond allowing the new framework value.
> 
> **Overview**
> Adds `parsebench` to `EVALUATION_FRAMEWORKS` (name/description/URL) so datasets can reference `evaluation_framework: parsebench` in `eval.yaml` without failing validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bb6986154066acd12624f506aff299032adae63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->