### PR TITLE
Add RX 9060 XT in hardware-amd.ts

### DIFF
--- a/packages/tasks/src/hardware-amd.ts
+++ b/packages/tasks/src/hardware-amd.ts
@@ -54,7 +54,7 @@ export const AMD_GPU_SKUS: Record<string, AmdGpuHardwareSpec> = {
 		tflops: 72.25,
 		memory: [16],
 		gfxVersion: "gfx1201",
-	},	
+	},
 	"RX 9060 XT": {
 		tflops: 51.28,
 		memory: [8, 16],

--- a/packages/tasks/src/hardware-amd.ts
+++ b/packages/tasks/src/hardware-amd.ts
@@ -56,7 +56,7 @@ export const AMD_GPU_SKUS: Record<string, AmdGpuHardwareSpec> = {
 		gfxVersion: "gfx1201",
 	},	
 	"RX 9060 XT": {
-		tflops: 51,28,
+		tflops: 51.28,
 		memory: [8, 16],
 		gfxVersion: "gfx1200",
 	},

--- a/packages/tasks/src/hardware-amd.ts
+++ b/packages/tasks/src/hardware-amd.ts
@@ -54,6 +54,11 @@ export const AMD_GPU_SKUS: Record<string, AmdGpuHardwareSpec> = {
 		tflops: 72.25,
 		memory: [16],
 		gfxVersion: "gfx1201",
+	},	
+	"RX 9060 XT": {
+		tflops: 51,28,
+		memory: [8, 16],
+		gfxVersion: "gfx1200",
 	},
 	"RX 7900 XTX": {
 		tflops: 122.8,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a single new AMD GPU SKU entry used for hardware lookup/estimation; no behavioral logic changes beyond recognizing the new model.
> 
> **Overview**
> Adds the AMD `RX 9060 XT` to `AMD_GPU_SKUS` in `hardware-amd.ts`, including its TFLOPS, supported memory sizes (8/16GB), and `gfxVersion` (`gfx1200`) so it can be recognized alongside other AMD GPUs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f0b1418249bf6a77519edf4b77e21b7c53266a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->