### PR TITLE
Add glotocr-bench to evaluation frameworks

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -89,4 +89,9 @@ export const EVALUATION_FRAMEWORKS = {
 			"ParseBench is a benchmark for evaluating document parsing systems on real-world enterprise documents across tables, charts, content faithfulness, semantic formatting, and visual grounding.",
 		url: "https://github.com/run-llama/ParseBench",
 	},
+	"glotocr-bench": {
+		name: "glotocr-bench",
+		description: "GlotOCR Bench is a benchmark for evaluating OCR for different Unicode scripts.",
+		url: "https://github.com/cisnlp/glotocr-bench",
+	},
 } as const;


### PR DESCRIPTION
Hi @davanstrien, I’d appreciate it if you could check this pull request.

I’ve uploaded the paper to arXiv: https://arxiv.org/abs/2604.12978

I also saved the results here for reproducibility: https://huggingface.co/datasets/cis-lmu/GlotOCR-bench-v1.0-results

I made it an automatically gated dataset so it does not get contaminated.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a new entry to a static `EVALUATION_FRAMEWORKS` registry with no behavioral logic changes.
> 
> **Overview**
> Adds **GlotOCR Bench** as a supported entry in `EVALUATION_FRAMEWORKS`, including its `name`, `description`, and `url`, so it can be referenced from `eval.yaml` configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a63d8d270ca4e0f077e12e986dd8fcf42dbbc57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->