### PR TITLE
fix(inference): propagate abort signals across providers

### DIFF
--- a/packages/inference/src/providers/black-forest-labs.ts
+++ b/packages/inference/src/providers/black-forest-labs.ts
@@ -67,14 +67,15 @@ export class BlackForestLabsTextToImageTask extends TaskProviderHelper implement
 		url?: string,
 		headers?: HeadersInit,
 		outputType?: "url" | "blob" | "json",
+		signal?: AbortSignal,
 	): Promise<string | Blob | Record<string, unknown>> {
 		const logger = getLogger();
 		const urlObj = new URL(response.polling_url);
 		for (let step = 0; step < 5; step++) {
-			await delay(1000);
+			await delay(1000, signal);
 			logger.debug(`Polling Black Forest Labs API for the result... ${step + 1}/5`);
 			urlObj.searchParams.set("attempt", step.toString(10));
-			const resp = await fetch(urlObj, { headers: { "Content-Type": "application/json" } });
+			const resp = await fetch(urlObj, { headers: { "Content-Type": "application/json" }, signal });
 			if (!resp.ok) {
 				throw new InferenceClientProviderApiError(
 					"Failed to fetch result from black forest labs API",
@@ -101,7 +102,7 @@ export class BlackForestLabsTextToImageTask extends TaskProviderHelper implement
 				if (outputType === "url") {
 					return payload.result.sample;
 				}
-				const image = await fetch(payload.result.sample);
+				const image = await fetch(payload.result.sample, { signal });
 				return await image.blob();
 			}
 		}

--- a/packages/inference/src/providers/fal-ai.ts
+++ b/packages/inference/src/providers/fal-ai.ts
@@ -107,6 +107,7 @@ abstract class FalAiQueueTask extends FalAITask {
 		response: FalAiQueueOutput,
 		url?: string,
 		headers?: Record<string, string>,
+		signal?: AbortSignal,
 	): Promise<unknown> {
 		if (!url || !headers) {
 			throw new InferenceClientInputError(`URL and headers are required for ${this.task} task`);
@@ -133,8 +134,8 @@ abstract class FalAiQueueTask extends FalAITask {
 		const resultUrl = `${baseUrl}${modelId}${queryParams}`;
 
 		while (status !== "COMPLETED") {
-			await delay(500);
-			const statusResponse = await fetch(statusUrl, { headers });
+			await delay(500, signal);
+			const statusResponse = await fetch(statusUrl, { headers, signal });
 
 			if (!statusResponse.ok) {
 				throw new InferenceClientProviderApiError(
@@ -156,7 +157,7 @@ abstract class FalAiQueueTask extends FalAITask {
 			}
 		}
 
-		const resultResponse = await fetch(resultUrl, { headers });
+		const resultResponse = await fetch(resultUrl, { headers, signal });
 		let result: unknown;
 		try {
 			result = await resultResponse.json();
@@ -208,8 +209,9 @@ export class FalAITextToImageTask extends FalAiQueueTask implements TextToImageT
 		url?: string,
 		headers?: Record<string, string>,
 		outputType?: OutputType,
+		signal?: AbortSignal,
 	): Promise<string | Blob | Record<string, unknown>> {
-		const result = (await this.getResponseFromQueueApi(response, url, headers)) as FalAITextToImageOutput;
+		const result = (await this.getResponseFromQueueApi(response, url, headers, signal)) as FalAITextToImageOutput;
 		if (
 			typeof result === "object" &&
 			"images" in result &&
@@ -225,7 +227,7 @@ export class FalAITextToImageTask extends FalAiQueueTask implements TextToImageT
 			if (outputType === "url") {
 				return result.images[0].url;
 			}
-			const urlResponse = await fetch(result.images[0].url);
+			const urlResponse = await fetch(result.images[0].url, { signal });
 			const blob = await urlResponse.blob();
 			return outputType === "dataUrl" ? dataUrlFromBlob(blob) : blob;
 		}
@@ -277,8 +279,10 @@ export class FalAIImageToImageTask extends FalAiQueueTask implements ImageToImag
 		response: FalAiQueueOutput,
 		url?: string,
 		headers?: Record<string, string>,
+		_outputType?: undefined,
+		signal?: AbortSignal,
 	): Promise<Blob> {
-		const result = await this.getResponseFromQueueApi(response, url, headers);
+		const result = await this.getResponseFromQueueApi(response, url, headers, signal);
 
 		if (
 			typeof result === "object" &&
@@ -292,7 +296,7 @@ export class FalAIImageToImageTask extends FalAiQueueTask implements ImageToImag
 			typeof result.images[0].url === "string" &&
 			isUrl(result.images[0].url)
 		) {
-			const urlResponse = await fetch(result.images[0].url);
+			const urlResponse = await fetch(result.images[0].url, { signal });
 			return await urlResponse.blob();
 		} else {
 			throw new InferenceClientProviderOutputError(
@@ -347,8 +351,10 @@ export class FalAITextToVideoTask extends FalAiQueueTask implements TextToVideoT
 		response: FalAiQueueOutput,
 		url?: string,
 		headers?: Record<string, string>,
+		_outputType?: undefined,
+		signal?: AbortSignal,
 	): Promise<Blob> {
-		const result = await this.getResponseFromQueueApi(response, url, headers);
+		const result = await this.getResponseFromQueueApi(response, url, headers, signal);
 
 		if (
 			typeof result === "object" &&
@@ -360,7 +366,7 @@ export class FalAITextToVideoTask extends FalAiQueueTask implements TextToVideoT
 			typeof result.video.url === "string" &&
 			isUrl(result.video.url)
 		) {
-			const urlResponse = await fetch(result.video.url);
+			const urlResponse = await fetch(result.video.url, { signal });
 			return await urlResponse.blob();
 		} else {
 			throw new InferenceClientProviderOutputError(
@@ -408,8 +414,10 @@ export class FalAIImageToVideoTask extends FalAiQueueTask implements ImageToVide
 		response: FalAiQueueOutput,
 		url?: string,
 		headers?: Record<string, string>,
+		_outputType?: undefined,
+		signal?: AbortSignal,
 	): Promise<Blob> {
-		const result = await this.getResponseFromQueueApi(response, url, headers);
+		const result = await this.getResponseFromQueueApi(response, url, headers, signal);
 
 		if (
 			typeof result === "object" &&
@@ -422,7 +430,7 @@ export class FalAIImageToVideoTask extends FalAiQueueTask implements ImageToVide
 			"url" in result.video &&
 			isUrl(result.video.url)
 		) {
-			const urlResponse = await fetch(result.video.url);
+			const urlResponse = await fetch(result.video.url, { signal });
 			return await urlResponse.blob();
 		}
 
@@ -507,7 +515,13 @@ export class FalAITextToSpeechTask extends FalAITask {
 		};
 	}
 
-	override async getResponse(response: unknown): Promise<Blob> {
+	override async getResponse(
+		response: unknown,
+		_url?: string,
+		_headers?: HeadersInit,
+		_outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob> {
 		const res = response as FalAITextToSpeechOutput;
 		if (typeof res?.audio?.url !== "string") {
 			throw new InferenceClientProviderOutputError(
@@ -516,7 +530,7 @@ export class FalAITextToSpeechTask extends FalAITask {
 				)}`,
 			);
 		}
-		const urlResponse = await fetch(res.audio.url);
+		const urlResponse = await fetch(res.audio.url, { signal });
 		if (!urlResponse.ok) {
 			throw new InferenceClientProviderApiError(
 				`Failed to fetch audio from ${res.audio.url}: ${urlResponse.statusText}`,
@@ -577,8 +591,10 @@ export class FalAIImageSegmentationTask extends FalAiQueueTask implements ImageS
 		response: FalAiQueueOutput,
 		url?: string,
 		headers?: Record<string, string>,
+		_outputType?: undefined,
+		signal?: AbortSignal,
 	): Promise<ImageSegmentationOutput> {
-		const result = await this.getResponseFromQueueApi(response, url, headers);
+		const result = await this.getResponseFromQueueApi(response, url, headers, signal);
 		if (
 			typeof result === "object" &&
 			result !== null &&
@@ -588,7 +604,7 @@ export class FalAIImageSegmentationTask extends FalAiQueueTask implements ImageS
 			"url" in result.image &&
 			typeof result.image.url === "string"
 		) {
-			const maskResponse = await fetch(result.image.url);
+			const maskResponse = await fetch(result.image.url, { signal });
 			if (!maskResponse.ok) {
 				throw new InferenceClientProviderApiError(
 					`Failed to fetch segmentation mask from ${result.image.url}`,

--- a/packages/inference/src/providers/hf-inference.ts
+++ b/packages/inference/src/providers/hf-inference.ts
@@ -139,6 +139,7 @@ export class HFInferenceTextToImageTask extends HFInferenceTask implements TextT
 		url?: string,
 		headers?: HeadersInit,
 		outputType?: OutputType,
+		signal?: AbortSignal,
 	): Promise<string | Blob | Record<string, unknown>> {
 		if (!response) {
 			throw new InferenceClientProviderOutputError(
@@ -154,11 +155,11 @@ export class HFInferenceTextToImageTask extends HFInferenceTask implements TextT
 				if (outputType === "dataUrl") {
 					return `data:image/jpeg;base64,${base64Data}`;
 				}
-				const base64Response = await fetch(`data:image/jpeg;base64,${base64Data}`);
+				const base64Response = await fetch(`data:image/jpeg;base64,${base64Data}`, { signal });
 				return await base64Response.blob();
 			}
 			if ("output" in response && Array.isArray(response.output)) {
-				const urlResponse = await fetch(response.output[0]);
+				const urlResponse = await fetch(response.output[0], { signal });
 				const blob = await urlResponse.blob();
 				return outputType === "dataUrl" ? dataUrlFromBlob(blob) : blob;
 			}

--- a/packages/inference/src/providers/hyperbolic.ts
+++ b/packages/inference/src/providers/hyperbolic.ts
@@ -111,6 +111,7 @@ export class HyperbolicTextToImageTask extends TaskProviderHelper implements Tex
 		url?: string,
 		headers?: HeadersInit,
 		outputType?: OutputType,
+		signal?: AbortSignal,
 	): Promise<string | Blob | Record<string, unknown>> {
 		if (
 			typeof response === "object" &&
@@ -125,7 +126,7 @@ export class HyperbolicTextToImageTask extends TaskProviderHelper implements Tex
 			if (outputType === "dataUrl") {
 				return `data:image/jpeg;base64,${response.images[0].image}`;
 			}
-			return fetch(`data:image/jpeg;base64,${response.images[0].image}`).then((res) => res.blob());
+			return fetch(`data:image/jpeg;base64,${response.images[0].image}`, { signal }).then((res) => res.blob());
 		}
 
 		throw new InferenceClientProviderOutputError("Received malformed response from Hyperbolic text-to-image API");

--- a/packages/inference/src/providers/nebius.ts
+++ b/packages/inference/src/providers/nebius.ts
@@ -118,6 +118,7 @@ export class NebiusTextToImageTask extends TaskProviderHelper implements TextToI
 		url?: string,
 		headers?: HeadersInit,
 		outputType?: OutputType,
+		signal?: AbortSignal,
 	): Promise<string | Blob | Record<string, unknown>> {
 		if (
 			typeof response === "object" &&
@@ -138,7 +139,7 @@ export class NebiusTextToImageTask extends TaskProviderHelper implements TextToI
 				if (outputType === "dataUrl") {
 					return `data:image/jpeg;base64,${base64Data}`;
 				}
-				return fetch(`data:image/jpeg;base64,${base64Data}`).then((res) => res.blob());
+				return fetch(`data:image/jpeg;base64,${base64Data}`, { signal }).then((res) => res.blob());
 			}
 		}
 

--- a/packages/inference/src/providers/novita.ts
+++ b/packages/inference/src/providers/novita.ts
@@ -80,6 +80,8 @@ export class NovitaTextToVideoTask extends TaskProviderHelper implements TextToV
 		response: NovitaAsyncAPIOutput,
 		url?: string,
 		headers?: Record<string, string>,
+		_outputType?: undefined,
+		signal?: AbortSignal,
 	): Promise<Blob> {
 		if (!url || !headers) {
 			throw new InferenceClientInputError("URL and headers are required for text-to-video task");
@@ -101,8 +103,8 @@ export class NovitaTextToVideoTask extends TaskProviderHelper implements TextToV
 		let taskResult: unknown;
 
 		while (status !== "TASK_STATUS_SUCCEED" && status !== "TASK_STATUS_FAILED") {
-			await delay(500);
-			const resultResponse = await fetch(resultUrl, { headers });
+			await delay(500, signal);
+			const resultResponse = await fetch(resultUrl, { headers, signal });
 			if (!resultResponse.ok) {
 				throw new InferenceClientProviderApiError(
 					"Failed to fetch task result",
@@ -154,7 +156,7 @@ export class NovitaTextToVideoTask extends TaskProviderHelper implements TextToV
 			typeof taskResult.videos[0].video_url === "string" &&
 			isUrl(taskResult.videos[0].video_url)
 		) {
-			const urlResponse = await fetch(taskResult.videos[0].video_url);
+			const urlResponse = await fetch(taskResult.videos[0].video_url, { signal });
 			return await urlResponse.blob();
 		} else {
 			throw new InferenceClientProviderOutputError(

--- a/packages/inference/src/providers/nscale.ts
+++ b/packages/inference/src/providers/nscale.ts
@@ -63,6 +63,7 @@ export class NscaleTextToImageTask extends TaskProviderHelper implements TextToI
 		url?: string,
 		headers?: HeadersInit,
 		outputType?: OutputType,
+		signal?: AbortSignal,
 	): Promise<string | Blob | Record<string, unknown>> {
 		if (
 			typeof response === "object" &&
@@ -79,7 +80,7 @@ export class NscaleTextToImageTask extends TaskProviderHelper implements TextToI
 			if (outputType === "dataUrl") {
 				return `data:image/jpeg;base64,${base64Data}`;
 			}
-			return fetch(`data:image/jpeg;base64,${base64Data}`).then((res) => res.blob());
+			return fetch(`data:image/jpeg;base64,${base64Data}`, { signal }).then((res) => res.blob());
 		}
 
 		throw new InferenceClientProviderOutputError("Received malformed response from Nscale text-to-image API");

--- a/packages/inference/src/providers/providerHelper.ts
+++ b/packages/inference/src/providers/providerHelper.ts
@@ -244,7 +244,7 @@ export interface ObjectDetectionTaskHelper {
 export interface ImageToTextTaskHelper {
 	getResponse(response: unknown, url?: string, headers?: HeadersInit): Promise<ImageToTextOutput>;
 	preparePayload(params: BodyParams<ImageToTextInput & BaseArgs>): Record<string, unknown> | BodyInit;
-	preparePayloadAsync(args: ImageToTextArgs): Promise<RequestArgs>;
+	preparePayloadAsync(args: ImageToTextArgs, signal?: AbortSignal): Promise<RequestArgs>;
 }
 
 export interface ZeroShotImageClassificationTaskHelper {
@@ -332,7 +332,13 @@ export interface AudioToAudioTaskHelper {
 	): Record<string, unknown> | BodyInit;
 }
 export interface AutomaticSpeechRecognitionTaskHelper {
-	getResponse(response: unknown, url?: string, headers?: HeadersInit): Promise<AutomaticSpeechRecognitionOutput>;
+	getResponse(
+		response: unknown,
+		url?: string,
+		headers?: HeadersInit,
+		outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<AutomaticSpeechRecognitionOutput>;
 	preparePayload(params: BodyParams<AutomaticSpeechRecognitionInput & BaseArgs>): Record<string, unknown> | BodyInit;
 	preparePayloadAsync(args: AutomaticSpeechRecognitionArgs): Promise<RequestArgs>;
 }

--- a/packages/inference/src/providers/providerHelper.ts
+++ b/packages/inference/src/providers/providerHelper.ts
@@ -88,6 +88,7 @@ export abstract class TaskProviderHelper {
 		url?: string,
 		headers?: HeadersInit,
 		outputType?: OutputType,
+		signal?: AbortSignal,
 	): Promise<unknown>;
 
 	/**
@@ -154,41 +155,78 @@ export interface TextToImageTaskHelper {
 		url?: string,
 		headers?: HeadersInit,
 		outputType?: OutputType,
+		signal?: AbortSignal,
 	): Promise<string | Blob | Record<string, unknown>>;
 	preparePayload(params: BodyParams<TextToImageInput & BaseArgs>): Record<string, unknown>;
 }
 
 export interface TextToVideoTaskHelper {
-	getResponse(response: unknown, url?: string, headers?: Record<string, string>): Promise<Blob>;
+	getResponse(
+		response: unknown,
+		url?: string,
+		headers?: Record<string, string>,
+		outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob>;
 	preparePayload(params: BodyParams<TextToVideoInput & BaseArgs>): Record<string, unknown>;
 }
 
 export interface ImageToImageTaskHelper {
-	getResponse(response: unknown, url?: string, headers?: HeadersInit): Promise<Blob>;
+	getResponse(
+		response: unknown,
+		url?: string,
+		headers?: HeadersInit,
+		outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob>;
 	preparePayload(params: BodyParams<ImageToImageInput & BaseArgs>): Record<string, unknown>;
 	preparePayloadAsync(args: ImageToImageArgs): Promise<RequestArgs>;
 }
 
 export interface ImageToVideoTaskHelper {
-	getResponse(response: unknown, url?: string, headers?: HeadersInit): Promise<Blob>;
+	getResponse(
+		response: unknown,
+		url?: string,
+		headers?: HeadersInit,
+		outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob>;
 	preparePayload(params: BodyParams<ImageToVideoInput & BaseArgs>): Record<string, unknown>;
 	preparePayloadAsync(args: ImageToVideoArgs): Promise<RequestArgs>;
 }
 
 export interface ImageTextToImageTaskHelper {
-	getResponse(response: unknown, url?: string, headers?: HeadersInit): Promise<Blob>;
+	getResponse(
+		response: unknown,
+		url?: string,
+		headers?: HeadersInit,
+		outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob>;
 	preparePayload(params: BodyParams<ImageTextToImageInput & BaseArgs>): Record<string, unknown>;
 	preparePayloadAsync(args: ImageTextToImageArgs): Promise<RequestArgs>;
 }
 
 export interface ImageTextToVideoTaskHelper {
-	getResponse(response: unknown, url?: string, headers?: HeadersInit): Promise<Blob>;
+	getResponse(
+		response: unknown,
+		url?: string,
+		headers?: HeadersInit,
+		outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob>;
 	preparePayload(params: BodyParams<ImageTextToVideoInput & BaseArgs>): Record<string, unknown>;
 	preparePayloadAsync(args: ImageTextToVideoArgs): Promise<RequestArgs>;
 }
 
 export interface ImageSegmentationTaskHelper {
-	getResponse(response: unknown, url?: string, headers?: HeadersInit): Promise<ImageSegmentationOutput>;
+	getResponse(
+		response: unknown,
+		url?: string,
+		headers?: HeadersInit,
+		outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<ImageSegmentationOutput>;
 	preparePayload(params: BodyParams<ImageSegmentationInput & BaseArgs>): Record<string, unknown> | BodyInit;
 	preparePayloadAsync(args: ImageSegmentationArgs): Promise<RequestArgs>;
 }
@@ -272,7 +310,13 @@ export interface SummarizationTaskHelper {
 
 // Audio Tasks
 export interface TextToSpeechTaskHelper {
-	getResponse(response: unknown, url?: string, headers?: HeadersInit): Promise<Blob>;
+	getResponse(
+		response: unknown,
+		url?: string,
+		headers?: HeadersInit,
+		outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob>;
 	preparePayload(params: BodyParams<TextToSpeechInput & BaseArgs>): Record<string, unknown>;
 }
 

--- a/packages/inference/src/providers/replicate.ts
+++ b/packages/inference/src/providers/replicate.ts
@@ -93,6 +93,7 @@ export class ReplicateTextToImageTask extends ReplicateTask implements TextToIma
 		url?: string,
 		headers?: Record<string, string>,
 		outputType?: OutputType,
+		signal?: AbortSignal,
 	): Promise<string | Blob | Record<string, unknown>> {
 		void url;
 		void headers;
@@ -105,7 +106,7 @@ export class ReplicateTextToImageTask extends ReplicateTask implements TextToIma
 			if (outputType === "url") {
 				return res.output;
 			}
-			const urlResponse = await fetch(res.output);
+			const urlResponse = await fetch(res.output, { signal });
 			const blob = await urlResponse.blob();
 			return outputType === "dataUrl" ? dataUrlFromBlob(blob) : blob;
 		}
@@ -124,7 +125,7 @@ export class ReplicateTextToImageTask extends ReplicateTask implements TextToIma
 			if (outputType === "url") {
 				return res.output[0];
 			}
-			const urlResponse = await fetch(res.output[0]);
+			const urlResponse = await fetch(res.output[0], { signal });
 			const blob = await urlResponse.blob();
 			return outputType === "dataUrl" ? dataUrlFromBlob(blob) : blob;
 		}
@@ -147,17 +148,23 @@ export class ReplicateTextToSpeechTask extends ReplicateTask {
 		return payload;
 	}
 
-	override async getResponse(response: ReplicateOutput): Promise<Blob> {
+	override async getResponse(
+		response: ReplicateOutput,
+		_url?: string,
+		_headers?: HeadersInit,
+		_outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob> {
 		if (response instanceof Blob) {
 			return response;
 		}
 		if (response && typeof response === "object") {
 			if ("output" in response) {
 				if (typeof response.output === "string") {
-					const urlResponse = await fetch(response.output);
+					const urlResponse = await fetch(response.output, { signal });
 					return await urlResponse.blob();
 				} else if (Array.isArray(response.output)) {
-					const urlResponse = await fetch(response.output[0]);
+					const urlResponse = await fetch(response.output[0], { signal });
 					return await urlResponse.blob();
 				}
 			}
@@ -167,7 +174,13 @@ export class ReplicateTextToSpeechTask extends ReplicateTask {
 }
 
 export class ReplicateTextToVideoTask extends ReplicateTask implements TextToVideoTaskHelper {
-	override async getResponse(response: ReplicateOutput): Promise<Blob> {
+	override async getResponse(
+		response: ReplicateOutput,
+		_url?: string,
+		_headers?: HeadersInit,
+		_outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob> {
 		if (
 			typeof response === "object" &&
 			!!response &&
@@ -175,7 +188,7 @@ export class ReplicateTextToVideoTask extends ReplicateTask implements TextToVid
 			typeof response.output === "string" &&
 			isUrl(response.output)
 		) {
-			const urlResponse = await fetch(response.output);
+			const urlResponse = await fetch(response.output, { signal });
 			return await urlResponse.blob();
 		}
 
@@ -216,7 +229,13 @@ export class ReplicateAutomaticSpeechRecognitionTask
 		};
 	}
 
-	override async getResponse(response: ReplicateOutput): Promise<AutomaticSpeechRecognitionOutput> {
+	override async getResponse(
+		response: ReplicateOutput,
+		_url?: string,
+		_headers?: HeadersInit,
+		_outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<AutomaticSpeechRecognitionOutput> {
 		if (typeof response?.output === "string") return { text: response.output };
 		if (Array.isArray(response?.output) && typeof response.output[0] === "string") return { text: response.output[0] };
 
@@ -231,7 +250,7 @@ export class ReplicateAutomaticSpeechRecognitionTask
 			if (typeof out.transcription === "string") return { text: out.transcription };
 			if (typeof out.translation === "string") return { text: out.translation };
 			if (typeof out.txt_file === "string") {
-				const r = await fetch(out.txt_file);
+				const r = await fetch(out.txt_file, { signal });
 				return { text: await r.text() };
 			}
 		}
@@ -276,7 +295,13 @@ export class ReplicateImageToImageTask extends ReplicateTask implements ImageToI
 		};
 	}
 
-	override async getResponse(response: ReplicateOutput): Promise<Blob> {
+	override async getResponse(
+		response: ReplicateOutput,
+		_url?: string,
+		_headers?: HeadersInit,
+		_outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob> {
 		if (
 			typeof response === "object" &&
 			!!response &&
@@ -285,7 +310,7 @@ export class ReplicateImageToImageTask extends ReplicateTask implements ImageToI
 			response.output.length > 0 &&
 			typeof response.output[0] === "string"
 		) {
-			const urlResponse = await fetch(response.output[0]);
+			const urlResponse = await fetch(response.output[0], { signal });
 			return await urlResponse.blob();
 		}
 
@@ -296,7 +321,7 @@ export class ReplicateImageToImageTask extends ReplicateTask implements ImageToI
 			typeof response.output === "string" &&
 			isUrl(response.output)
 		) {
-			const urlResponse = await fetch(response.output);
+			const urlResponse = await fetch(response.output, { signal });
 			return await urlResponse.blob();
 		}
 

--- a/packages/inference/src/providers/together.ts
+++ b/packages/inference/src/providers/together.ts
@@ -120,6 +120,7 @@ export class TogetherTextToImageTask extends TaskProviderHelper implements TextT
 		url?: string,
 		headers?: HeadersInit,
 		outputType?: OutputType,
+		signal?: AbortSignal,
 	): Promise<string | Blob | Record<string, unknown>> {
 		if (
 			typeof response === "object" &&
@@ -140,7 +141,7 @@ export class TogetherTextToImageTask extends TaskProviderHelper implements TextT
 				if (outputType === "dataUrl") {
 					return `data:image/jpeg;base64,${base64Data}`;
 				}
-				return fetch(`data:image/jpeg;base64,${base64Data}`).then((res) => res.blob());
+				return fetch(`data:image/jpeg;base64,${base64Data}`, { signal }).then((res) => res.blob());
 			}
 		}
 

--- a/packages/inference/src/providers/wavespeed.ts
+++ b/packages/inference/src/providers/wavespeed.ts
@@ -129,6 +129,7 @@ abstract class WavespeedAITask extends TaskProviderHelper {
 		url?: string,
 		headers?: Record<string, string>,
 		outputType?: OutputType,
+		signal?: AbortSignal,
 	): Promise<string | Blob | Record<string, unknown>> {
 		if (!url || !headers) {
 			throw new InferenceClientInputError("Headers are required for WaveSpeed AI API calls");
@@ -144,7 +145,7 @@ abstract class WavespeedAITask extends TaskProviderHelper {
 
 		// Poll for results until completion
 		while (true) {
-			const resultResponse = await fetch(resultUrl, { headers });
+			const resultResponse = await fetch(resultUrl, { headers, signal });
 
 			if (!resultResponse.ok) {
 				throw new InferenceClientProviderApiError(
@@ -179,7 +180,7 @@ abstract class WavespeedAITask extends TaskProviderHelper {
 					}
 
 					// Default: fetch and return blob
-					const mediaResponse = await fetch(mediaUrl);
+					const mediaResponse = await fetch(mediaUrl, { signal });
 					if (!mediaResponse.ok) {
 						throw new InferenceClientProviderApiError(
 							"Failed to fetch generation output from WaveSpeed AI API",
@@ -200,7 +201,7 @@ abstract class WavespeedAITask extends TaskProviderHelper {
 
 				default: {
 					// Wait before polling again
-					await delay(500);
+					await delay(500, signal);
 					continue;
 				}
 			}
@@ -223,8 +224,10 @@ export class WavespeedAITextToVideoTask extends WavespeedAITask implements TextT
 		response: WaveSpeedAISubmitTaskResponse,
 		url?: string,
 		headers?: Record<string, string>,
+		_outputType?: undefined,
+		signal?: AbortSignal,
 	): Promise<Blob> {
-		return super.getResponse(response, url, headers) as Promise<Blob>;
+		return super.getResponse(response, url, headers, undefined, signal) as Promise<Blob>;
 	}
 }
 
@@ -244,8 +247,10 @@ export class WavespeedAIImageToImageTask extends WavespeedAITask implements Imag
 		response: WaveSpeedAISubmitTaskResponse,
 		url?: string,
 		headers?: Record<string, string>,
+		_outputType?: undefined,
+		signal?: AbortSignal,
 	): Promise<Blob> {
-		return super.getResponse(response, url, headers) as Promise<Blob>;
+		return super.getResponse(response, url, headers, undefined, signal) as Promise<Blob>;
 	}
 }
 
@@ -265,8 +270,10 @@ export class WavespeedAIImageToVideoTask extends WavespeedAITask implements Imag
 		response: WaveSpeedAISubmitTaskResponse,
 		url?: string,
 		headers?: Record<string, string>,
+		_outputType?: undefined,
+		signal?: AbortSignal,
 	): Promise<Blob> {
-		return super.getResponse(response, url, headers) as Promise<Blob>;
+		return super.getResponse(response, url, headers, undefined, signal) as Promise<Blob>;
 	}
 }
 

--- a/packages/inference/src/providers/zai-org.ts
+++ b/packages/inference/src/providers/zai-org.ts
@@ -103,6 +103,7 @@ export class ZaiTextToImageTask extends ZaiTask implements TextToImageTaskHelper
 		url?: string,
 		headers?: Record<string, string>,
 		outputType?: OutputType,
+		signal?: AbortSignal,
 	): Promise<string | Blob | Record<string, unknown>> {
 		if (!url || !headers) {
 			throw new InferenceClientInputError(`URL and headers are required for 'text-to-image' task`);
@@ -139,11 +140,12 @@ export class ZaiTextToImageTask extends ZaiTask implements TextToImageTaskHelper
 		};
 
 		for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
-			await delay(POLL_INTERVAL_MS);
+			await delay(POLL_INTERVAL_MS, signal);
 
 			const resp = await fetch(pollUrl, {
 				method: "GET",
 				headers: pollHeaders,
+				signal,
 			});
 
 			if (!resp.ok) {
@@ -184,7 +186,7 @@ export class ZaiTextToImageTask extends ZaiTask implements TextToImageTaskHelper
 					return imageUrl;
 				}
 
-				const imageResponse = await fetch(imageUrl);
+				const imageResponse = await fetch(imageUrl, { signal });
 				const blob = await imageResponse.blob();
 				return outputType === "dataUrl" ? dataUrlFromBlob(blob) : blob;
 			}
@@ -205,13 +207,13 @@ export class ZaiImageToTextTask extends ZaiTask implements ImageToTextTaskHelper
 		return "/api/paas/v4/layout_parsing";
 	}
 
-	async preparePayloadAsync(args: ImageToTextArgs): Promise<RequestArgs> {
+	async preparePayloadAsync(args: ImageToTextArgs, signal?: AbortSignal): Promise<RequestArgs> {
 		const blob =
 			"data" in args && args.data instanceof Blob
 				? args.data
 				: "inputs" in args
 					? typeof args.inputs === "string" && isUrl(args.inputs)
-						? await fetch(args.inputs).then((r) => r.blob())
+						? await fetch(args.inputs, { signal }).then((r) => r.blob())
 						: args.inputs instanceof Blob
 							? args.inputs
 							: undefined

--- a/packages/inference/src/tasks/audio/automaticSpeechRecognition.ts
+++ b/packages/inference/src/tasks/audio/automaticSpeechRecognition.ts
@@ -21,5 +21,5 @@ export async function automaticSpeechRecognition(
 		...options,
 		task: "automatic-speech-recognition",
 	});
-	return providerHelper.getResponse(res);
+	return providerHelper.getResponse(res, undefined, undefined, undefined, options?.signal);
 }

--- a/packages/inference/src/tasks/audio/textToSpeech.ts
+++ b/packages/inference/src/tasks/audio/textToSpeech.ts
@@ -19,5 +19,5 @@ export async function textToSpeech(args: TextToSpeechArgs, options?: Options): P
 		...options,
 		task: "text-to-speech",
 	});
-	return providerHelper.getResponse(res);
+	return providerHelper.getResponse(res, undefined, undefined, undefined, options?.signal);
 }

--- a/packages/inference/src/tasks/cv/imageSegmentation.ts
+++ b/packages/inference/src/tasks/cv/imageSegmentation.ts
@@ -23,5 +23,5 @@ export async function imageSegmentation(
 		task: "image-segmentation",
 	});
 	const { url, info } = await makeRequestOptions(args, providerHelper, { ...options, task: "image-segmentation" });
-	return providerHelper.getResponse(res, url, info.headers as Record<string, string>);
+	return providerHelper.getResponse(res, url, info.headers as Record<string, string>, undefined, options?.signal);
 }

--- a/packages/inference/src/tasks/cv/imageTextToImage.ts
+++ b/packages/inference/src/tasks/cv/imageTextToImage.ts
@@ -18,5 +18,11 @@ export async function imageTextToImage(args: ImageTextToImageArgs, options?: Opt
 		...options,
 		task: "image-text-to-image",
 	});
-	return providerHelper.getResponse(res, requestContext.url, requestContext.info.headers as Record<string, string>);
+	return providerHelper.getResponse(
+		res,
+		requestContext.url,
+		requestContext.info.headers as Record<string, string>,
+		undefined,
+		options?.signal,
+	);
 }

--- a/packages/inference/src/tasks/cv/imageTextToVideo.ts
+++ b/packages/inference/src/tasks/cv/imageTextToVideo.ts
@@ -18,5 +18,11 @@ export async function imageTextToVideo(args: ImageTextToVideoArgs, options?: Opt
 		...options,
 		task: "image-text-to-video",
 	});
-	return providerHelper.getResponse(res, requestContext.url, requestContext.info.headers as Record<string, string>);
+	return providerHelper.getResponse(
+		res,
+		requestContext.url,
+		requestContext.info.headers as Record<string, string>,
+		undefined,
+		options?.signal,
+	);
 }

--- a/packages/inference/src/tasks/cv/imageToImage.ts
+++ b/packages/inference/src/tasks/cv/imageToImage.ts
@@ -20,5 +20,5 @@ export async function imageToImage(args: ImageToImageArgs, options?: Options): P
 		task: "image-to-image",
 	});
 	const { url, info } = await makeRequestOptions(args, providerHelper, { ...options, task: "image-to-image" });
-	return providerHelper.getResponse(res, url, info.headers as Record<string, string>);
+	return providerHelper.getResponse(res, url, info.headers as Record<string, string>, undefined, options?.signal);
 }

--- a/packages/inference/src/tasks/cv/imageToText.ts
+++ b/packages/inference/src/tasks/cv/imageToText.ts
@@ -12,7 +12,7 @@ export type ImageToTextArgs = BaseArgs & (ImageToTextInput | LegacyImageInput);
 export async function imageToText(args: ImageToTextArgs, options?: Options): Promise<ImageToTextOutput> {
 	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
 	const providerHelper = getProviderHelper(provider, "image-to-text");
-	const payload = await providerHelper.preparePayloadAsync(args);
+	const payload = await providerHelper.preparePayloadAsync(args, options?.signal);
 	const { data: res } = await innerRequest<ImageToTextOutput>(payload, providerHelper, {
 		...options,
 		task: "image-to-text",

--- a/packages/inference/src/tasks/cv/imageToVideo.ts
+++ b/packages/inference/src/tasks/cv/imageToVideo.ts
@@ -20,5 +20,5 @@ export async function imageToVideo(args: ImageToVideoArgs, options?: Options): P
 		task: "image-to-video",
 	});
 	const { url, info } = await makeRequestOptions(args, providerHelper, { ...options, task: "image-to-video" });
-	return providerHelper.getResponse(res, url, info.headers as Record<string, string>);
+	return providerHelper.getResponse(res, url, info.headers as Record<string, string>, undefined, options?.signal);
 }

--- a/packages/inference/src/tasks/cv/textToImage.ts
+++ b/packages/inference/src/tasks/cv/textToImage.ts
@@ -43,5 +43,11 @@ export async function textToImage(
 	});
 
 	const { url, info } = await makeRequestOptions(args, providerHelper, { ...options, task: "text-to-image" });
-	return providerHelper.getResponse(res, url, info.headers as Record<string, string>, options?.outputType);
+	return providerHelper.getResponse(
+		res,
+		url,
+		info.headers as Record<string, string>,
+		options?.outputType,
+		options?.signal,
+	);
 }

--- a/packages/inference/src/tasks/cv/textToVideo.ts
+++ b/packages/inference/src/tasks/cv/textToVideo.ts
@@ -24,5 +24,5 @@ export async function textToVideo(args: TextToVideoArgs, options?: Options): Pro
 		},
 	);
 	const { url, info } = await makeRequestOptions(args, providerHelper, { ...options, task: "text-to-video" });
-	return providerHelper.getResponse(response, url, info.headers as Record<string, string>);
+	return providerHelper.getResponse(response, url, info.headers as Record<string, string>, undefined, options?.signal);
 }

--- a/packages/inference/src/utils/delay.ts
+++ b/packages/inference/src/utils/delay.ts
@@ -1,5 +1,33 @@
-export function delay(ms: number): Promise<void> {
-	return new Promise((resolve) => {
-		setTimeout(() => resolve(), ms);
+function createAbortError(signal: AbortSignal): Error {
+	return signal.reason instanceof Error ? signal.reason : new DOMException("The operation was aborted", "AbortError");
+}
+
+export function delay(ms: number, signal?: AbortSignal): Promise<void> {
+	if (signal?.aborted) {
+		return Promise.reject(createAbortError(signal));
+	}
+
+	return new Promise((resolve, reject) => {
+		const abortSignal = signal;
+		const cleanup = () => {
+			abortSignal?.removeEventListener("abort", onAbort);
+		};
+
+		const onAbort = () => {
+			clearTimeout(timeout);
+			cleanup();
+			if (!abortSignal) {
+				reject(new DOMException("The operation was aborted", "AbortError"));
+				return;
+			}
+			reject(createAbortError(abortSignal));
+		};
+
+		const timeout = setTimeout(() => {
+			cleanup();
+			resolve();
+		}, ms);
+		timeout.unref?.();
+		abortSignal?.addEventListener("abort", onAbort, { once: true });
 	});
 }

--- a/packages/inference/src/utils/delay.ts
+++ b/packages/inference/src/utils/delay.ts
@@ -8,26 +8,26 @@ export function delay(ms: number, signal?: AbortSignal): Promise<void> {
 	}
 
 	return new Promise((resolve, reject) => {
-		const abortSignal = signal;
-		const cleanup = () => {
-			abortSignal?.removeEventListener("abort", onAbort);
-		};
-
-		const onAbort = () => {
-			clearTimeout(timeout);
-			cleanup();
-			if (!abortSignal) {
-				reject(new DOMException("The operation was aborted", "AbortError"));
-				return;
-			}
-			reject(createAbortError(abortSignal));
-		};
-
+		let cleanup = () => {};
 		const timeout = setTimeout(() => {
 			cleanup();
 			resolve();
 		}, ms);
 		timeout.unref?.();
-		abortSignal?.addEventListener("abort", onAbort, { once: true });
+
+		if (!signal) {
+			return;
+		}
+
+		const onAbort = () => {
+			clearTimeout(timeout);
+			cleanup();
+			reject(createAbortError(signal));
+		};
+		cleanup = () => {
+			signal.removeEventListener("abort", onAbort);
+		};
+
+		signal.addEventListener("abort", onAbort, { once: true });
 	});
 }

--- a/packages/inference/test/fal-ai.spec.ts
+++ b/packages/inference/test/fal-ai.spec.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FalAITextToImageTask } from "../src/providers/fal-ai.js";
+
+describe("FalAI queue polling", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	it("aborts before the next polling request starts", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const task = new FalAITextToImageTask();
+		const controller = new AbortController();
+
+		const responsePromise = task.getResponse(
+			{
+				request_id: "request-id",
+				status: "IN_PROGRESS",
+				response_url: "https://queue.fal.run/fal-ai/flux/dev/requests/request-id",
+			},
+			"https://router.huggingface.co/fal-ai/fal-ai/flux/dev?_subdomain=queue",
+			{ Authorization: "Bearer token" },
+			"json",
+			controller.signal,
+		);
+
+		controller.abort();
+
+		await expect(responsePromise).rejects.toThrow(/aborted/i);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("passes the abort signal to fal-ai status polling fetches", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>((_url, init) => {
+			return new Promise<Response>((_resolve, reject) => {
+				const signal = init?.signal;
+				signal?.addEventListener(
+					"abort",
+					() => {
+						reject(new DOMException("The operation was aborted", "AbortError"));
+					},
+					{ once: true },
+				);
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const task = new FalAITextToImageTask();
+		const controller = new AbortController();
+
+		const responsePromise = task.getResponse(
+			{
+				request_id: "request-id",
+				status: "IN_PROGRESS",
+				response_url: "https://queue.fal.run/fal-ai/flux/dev/requests/request-id",
+			},
+			"https://router.huggingface.co/fal-ai/fal-ai/flux/dev?_subdomain=queue",
+			{ Authorization: "Bearer token" },
+			"json",
+			controller.signal,
+		);
+
+		await vi.advanceTimersByTimeAsync(500);
+		expect(fetchMock).toHaveBeenCalledWith(
+			expect.stringContaining("/status"),
+			expect.objectContaining({ headers: { Authorization: "Bearer token" }, signal: controller.signal }),
+		);
+
+		controller.abort();
+
+		await expect(responsePromise).rejects.toThrow(/aborted/i);
+	});
+});

--- a/packages/inference/test/provider-abort-signal.spec.ts
+++ b/packages/inference/test/provider-abort-signal.spec.ts
@@ -3,13 +3,15 @@ import { BlackForestLabsTextToImageTask } from "../src/providers/black-forest-la
 import { FalAITextToImageTask } from "../src/providers/fal-ai.js";
 import { ZaiImageToTextTask } from "../src/providers/zai-org.js";
 
+const itWithFakeTimers = typeof window !== "undefined" && typeof window.document !== "undefined" ? it.skip : it;
+
 describe("Provider abort signal propagation", () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
 		vi.useRealTimers();
 	});
 
-	it("aborts before the next fal-ai polling request starts", async () => {
+	itWithFakeTimers("aborts before the next fal-ai polling request starts", async () => {
 		vi.useFakeTimers();
 		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>();
 		vi.stubGlobal("fetch", fetchMock);
@@ -35,7 +37,7 @@ describe("Provider abort signal propagation", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
-	it("passes the abort signal to fal-ai status polling fetches", async () => {
+	itWithFakeTimers("passes the abort signal to fal-ai status polling fetches", async () => {
 		vi.useFakeTimers();
 		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>((_url, init) => {
 			return new Promise<Response>((_resolve, reject) => {
@@ -77,7 +79,7 @@ describe("Provider abort signal propagation", () => {
 		await expect(responsePromise).rejects.toThrow(/aborted/i);
 	});
 
-	it("passes the abort signal to black-forest-labs polling fetches", async () => {
+	itWithFakeTimers("passes the abort signal to black-forest-labs polling fetches", async () => {
 		vi.useFakeTimers();
 		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>((_url, init) => {
 			return new Promise<Response>((_resolve, reject) => {

--- a/packages/inference/test/provider-abort-signal.spec.ts
+++ b/packages/inference/test/provider-abort-signal.spec.ts
@@ -1,13 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { BlackForestLabsTextToImageTask } from "../src/providers/black-forest-labs.js";
 import { FalAITextToImageTask } from "../src/providers/fal-ai.js";
+import { ZaiImageToTextTask } from "../src/providers/zai-org.js";
 
-describe("FalAI queue polling", () => {
+describe("Provider abort signal propagation", () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
 		vi.useRealTimers();
 	});
 
-	it("aborts before the next polling request starts", async () => {
+	it("aborts before the next fal-ai polling request starts", async () => {
 		vi.useFakeTimers();
 		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>();
 		vi.stubGlobal("fetch", fetchMock);
@@ -73,5 +75,64 @@ describe("FalAI queue polling", () => {
 		controller.abort();
 
 		await expect(responsePromise).rejects.toThrow(/aborted/i);
+	});
+
+	it("passes the abort signal to black-forest-labs polling fetches", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>((_url, init) => {
+			return new Promise<Response>((_resolve, reject) => {
+				const signal = init?.signal;
+				signal?.addEventListener(
+					"abort",
+					() => {
+						reject(new DOMException("The operation was aborted", "AbortError"));
+					},
+					{ once: true },
+				);
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const task = new BlackForestLabsTextToImageTask();
+		const controller = new AbortController();
+
+		const responsePromise = task.getResponse(
+			{ id: "request-id", polling_url: "https://api.us1.bfl.ai/v1/get_result?id=request-id" },
+			undefined,
+			undefined,
+			"json",
+			controller.signal,
+		);
+
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(fetchMock).toHaveBeenCalledWith(
+			expect.any(URL),
+			expect.objectContaining({
+				headers: { "Content-Type": "application/json" },
+				signal: controller.signal,
+			}),
+		);
+
+		controller.abort();
+
+		await expect(responsePromise).rejects.toThrow(/aborted/i);
+	});
+
+	it("passes the abort signal to zai image input downloads", async () => {
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() =>
+			Promise.resolve(new Response(new Blob(["image"], { type: "image/png" }))),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const task = new ZaiImageToTextTask();
+		const controller = new AbortController();
+
+		const payload = await task.preparePayloadAsync(
+			{ inputs: "https://example.com/image.png" } as never,
+			controller.signal,
+		);
+
+		expect((payload as Record<string, unknown>).inputs).toMatch(/^data:image\/png;base64,/);
+		expect(fetchMock).toHaveBeenCalledWith("https://example.com/image.png", { signal: controller.signal });
 	});
 });


### PR DESCRIPTION
we had an internal cron (`inference-providers-validate-mappings`) stuck for 5 days due to it waiting indefinitely for a fetch to complete

according to codex, this wouldn't have happened if the abort signal was passed downstream properly - this is what this PR is trying to do

[traces (internal)](https://traces.com/s/jn7b42b1herx47tt7nkfcrpfex858ttk)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many provider `getResponse`/polling code paths and the shared `delay` utility to add abort support; changes are mostly additive but could affect request cancellation behavior and type signatures across providers.
> 
> **Overview**
> Adds end-to-end **AbortSignal propagation** across inference tasks so cancellations stop provider polling loops and downstream asset downloads.
> 
> This threads an optional `signal` through `TaskProviderHelper.getResponse` and relevant task helper interfaces, updates multiple providers (e.g. Fal.ai, Black Forest Labs, Replicate, WaveSpeed, Novita, ZAI, HF-Inference, etc.) to pass `signal` into `fetch` and polling `delay` calls, and makes `delay(ms, signal)` abort-aware.
> 
> Updates task entrypoints (e.g. `textToImage`, `textToVideo`, `imageToImage`, `textToSpeech`, `automaticSpeechRecognition`, `imageToText`) to forward `options.signal`, and adds a Vitest suite (`provider-abort-signal.spec.ts`) to verify aborts prevent/interrupt polling fetches and input downloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc4eb7d0e297477a6d5dc521834cc8690a2dde27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->