### PR TITLE
[Tasks] local apps can define additional links

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -259,4 +259,20 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 
 		expect(displayOnModelPage(model)).toBe(false);
 	});
+
+	it("links as a function", async () => {
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			inference: "",
+		};
+		const appWithFnLinks = {
+			...LOCAL_APPS["llama.cpp"],
+			links: (m: ModelData) => [{ label: "Releases", url: `https://github.com/${m.id}/releases` }],
+		};
+
+		expect(appWithFnLinks.links(model)).toEqual([
+			{ label: "Releases", url: "https://github.com/bartowski/Llama-3.2-3B-Instruct-GGUF/releases" },
+		]);
+	});
 });

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -33,6 +33,10 @@ export type LocalApp = {
 	 */
 	docsUrl: string;
 	/**
+	 * Additional links to display (max 2)
+	 */
+	links?: { label: string; url: string }[] | ((model: ModelData) => { label: string; url: string }[]);
+	/**
 	 * main category of app
 	 */
 	mainTask: PipelineType;


### PR DESCRIPTION
to be displayed at the bottom of the modal, after the main documentation link 

<img width="946" height="307" alt="Screenshot 2026-04-22 at 10 36 56" src="https://github.com/user-attachments/assets/daaf7009-6f17-4e67-970b-7ff38ebc4da7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only change plus a small test addition; no runtime logic changes in app selection or snippet/deeplink generation.
> 
> **Overview**
> Extends the `LocalApp` type to optionally include `links`, allowing each local app to provide up to two extra links either as a static list or computed from the current `ModelData`.
> 
> Adds a unit test covering the function-based `links` variant to ensure URLs can be generated dynamically per model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d7f5c37a5ea580e1e75265020b2f2ca71a05f5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->