### PR TITLE
add HA and OC local apps

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -161,6 +161,82 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		expect(snippet[2].content).toContain("pi");
 	});
 
+	it("openclaw", async () => {
+		const { snippet: snippetFunc } = LOCAL_APPS.openclaw;
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			gguf: { total: 1, context_length: 4096, chat_template: "{% if tools %}" },
+			inference: "",
+		};
+		const snippet = snippetFunc(model);
+
+		expect(snippet[0].content).toContain(`llama-server -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}} --jinja`);
+		expect(snippet[1].content).toContain('--custom-base-url "http://127.0.0.1:8080/v1"');
+		expect(snippet[1].content).toContain('--custom-model-id "Llama-3.2-3B-Instruct-GGUF"');
+		expect(snippet[1].content).toContain('--custom-api-key "llama.cpp"');
+		expect(snippet[2].content).toContain("openclaw");
+	});
+
+	it("openclaw - mlx", async () => {
+		const { snippet: snippetFunc } = LOCAL_APPS.openclaw;
+		const model: ModelData = {
+			id: "mlx-community/Llama-3.2-3B-Instruct-mlx",
+			tags: ["mlx", "conversational"],
+			pipeline_tag: "text-generation",
+			config: {
+				tokenizer_config: {
+					chat_template: "{% if tools %}...{% endif %}",
+				},
+			},
+			inference: "",
+		};
+		const snippet = snippetFunc(model);
+
+		expect(snippet[0].setup).toContain("uv tool install mlx-lm");
+		expect(snippet[0].content).toContain('mlx_lm.server --model "mlx-community/Llama-3.2-3B-Instruct-mlx"');
+		expect(snippet[1].content).toContain('--custom-model-id "mlx-community/Llama-3.2-3B-Instruct-mlx"');
+		expect(snippet[1].content).toContain('--custom-api-key "none"');
+		expect(snippet[2].content).toContain("openclaw");
+	});
+
+	it("hermes-agent", async () => {
+		const { snippet: snippetFunc } = LOCAL_APPS["hermes-agent"];
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			gguf: { total: 1, context_length: 4096, chat_template: "{% if tools %}" },
+			inference: "",
+		};
+		const snippet = snippetFunc(model);
+
+		expect(snippet[0].content).toContain(`llama-server -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}} --jinja`);
+		expect(snippet[1].content).toContain("default: bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}");
+		expect(snippet[1].content).toContain("api_key: llama.cpp");
+		expect(snippet[2].content).toContain("hermes");
+	});
+
+	it("hermes-agent - mlx", async () => {
+		const { snippet: snippetFunc } = LOCAL_APPS["hermes-agent"];
+		const model: ModelData = {
+			id: "mlx-community/Llama-3.2-3B-Instruct-mlx",
+			tags: ["mlx", "conversational"],
+			pipeline_tag: "text-generation",
+			config: {
+				tokenizer_config: {
+					chat_template: "{% if tools %}...{% endif %}",
+				},
+			},
+			inference: "",
+		};
+		const snippet = snippetFunc(model);
+
+		expect(snippet[0].setup).toContain("uv tool install mlx-lm");
+		expect(snippet[1].content).toContain("default: mlx-community/Llama-3.2-3B-Instruct-mlx");
+		expect(snippet[1].content).toContain("api_key: none");
+		expect(snippet[2].content).toContain("hermes");
+	});
+
 	it("docker model runner", async () => {
 		const { snippet: snippetFunc } = LOCAL_APPS["docker-model-runner"];
 		const model: ModelData = {

--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -3,6 +3,11 @@ import { LOCAL_APPS } from "./local-apps.js";
 import type { ModelData } from "./model-data.js";
 
 describe("local-apps", () => {
+	it("shares the same model-page predicate for pi-based tool callers", async () => {
+		expect(LOCAL_APPS.pi.displayOnModelPage).toBe(LOCAL_APPS.openclaw.displayOnModelPage);
+		expect(LOCAL_APPS.pi.displayOnModelPage).toBe(LOCAL_APPS["hermes-agent"].displayOnModelPage);
+	});
+
 	it("llama.cpp conversational", async () => {
 		const { snippet: snippetFunc } = LOCAL_APPS["llama.cpp"];
 		const model: ModelData = {

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -506,6 +506,93 @@ const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 	];
 };
 
+const snippetOpenClaw = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
+	const isMLX = isMlxModel(model);
+	const modelName = model.id.split("/").pop() ?? model.id;
+	const serverBaseUrl = "http://127.0.0.1:8080/v1";
+
+	const serverStep: LocalAppSnippet = isMLX
+		? {
+				title: "Start the MLX server",
+				setup: "# Install MLX LM:\nuv tool install mlx-lm",
+				content: `# Start a local OpenAI-compatible server:\nmlx_lm.server --model "${model.id}"`,
+			}
+		: {
+				title: "Start the llama.cpp server",
+				setup: "# Install llama.cpp:\nbrew install llama.cpp",
+				content: `# Start a local OpenAI-compatible server:\nllama-server -hf ${model.id}${getQuantTag(filepath)} --jinja`,
+			};
+
+	return [
+		serverStep,
+		{
+			title: "Configure OpenClaw for the local server",
+			content: [
+				"# Install OpenClaw by running:",
+				"# npm install -g openclaw@latest",
+				"# Configure OpenClaw:",
+				"openclaw onboard --non-interactive \\",
+				"  --auth-choice custom-api-key \\",
+				`  --custom-base-url "${serverBaseUrl}" \\`,
+				`  --custom-model-id "${isMLX ? model.id : modelName}" \\`,
+				`  --custom-api-key "${isMLX ? "none" : "llama.cpp"}" \\`,
+				"  --secret-input-mode plaintext \\",
+				"  --custom-compatibility openai \\",
+				"  --accept-risk",
+			].join("\n"),
+		},
+		{
+			title: "Run OpenClaw",
+			content: "openclaw",
+		},
+	];
+};
+
+const snippetHermesAgent = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
+	const isMLX = isMlxModel(model);
+	const modelId = isMLX ? model.id : `${model.id}${getQuantTag(filepath)}`;
+
+	const serverStep: LocalAppSnippet = isMLX
+		? {
+				title: "Start the MLX server",
+				setup: "# Install MLX LM:\nuv tool install mlx-lm",
+				content: `# Start a local OpenAI-compatible server:\nmlx_lm.server --model "${model.id}"`,
+			}
+		: {
+				title: "Start the llama.cpp server",
+				setup: "# Install llama.cpp:\nbrew install llama.cpp",
+				content: `# Start a local OpenAI-compatible server:\nllama-server -hf ${model.id}${getQuantTag(filepath)} --jinja`,
+			};
+
+	return [
+		serverStep,
+		{
+			title: "Set Hermes default config",
+			content: [
+				"# Install Hermes by running:",
+				"# curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash",
+				"# hermes setup",
+				"# Add to your Hermes config file:",
+				"model:",
+				"  provider: custom",
+				`  default: ${modelId}`,
+				"  base_url: http://127.0.0.1:8080/v1",
+				`  api_key: ${isMLX ? "none" : "llama.cpp"}`,
+				"",
+				"custom_providers:",
+				"  - name: Local (127.0.0.1:8080)",
+				"    base_url: http://127.0.0.1:8080/v1",
+				`    api_key: ${isMLX ? "none" : "llama.cpp"}`,
+				`    model: ${modelId}`,
+			].join("\n"),
+		},
+		{
+			title: "Run Hermes",
+			content: "hermes",
+		},
+	];
+};
+
 const snippetDockerModelRunner = (model: ModelData, filepath?: string): string => {
 	// Only add quant tag for GGUF models, not safetensors
 	const quantTag = isLlamaCppGgufModel(model) ? getQuantTag(filepath) : "";
@@ -756,6 +843,26 @@ export const LOCAL_APPS = {
 			model.tags.includes("conversational") &&
 			!!getChatTemplate(model)?.includes("tools"),
 		snippet: snippetPi,
+	},
+	openclaw: {
+		prettyLabel: "OpenClaw",
+		docsUrl: "https://github.com/openclaw",
+		mainTask: "text-generation",
+		displayOnModelPage: (model) =>
+			(isLlamaCppGgufModel(model) || isMlxModel(model)) &&
+			model.tags.includes("conversational") &&
+			!!getChatTemplate(model)?.includes("tools"),
+		snippet: snippetOpenClaw,
+	},
+	"hermes-agent": {
+		prettyLabel: "Hermes",
+		docsUrl: "https://hermes-agent.nousresearch.com/",
+		mainTask: "text-generation",
+		displayOnModelPage: (model) =>
+			(isLlamaCppGgufModel(model) || isMlxModel(model)) &&
+			model.tags.includes("conversational") &&
+			!!getChatTemplate(model)?.includes("tools"),
+		snippet: snippetHermesAgent,
 	},
 } satisfies Record<string, LocalApp>;
 

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -135,6 +135,14 @@ function isUnslothModel(model: ModelData) {
 	return model.tags.includes("unsloth") || isLlamaCppGgufModel(model);
 }
 
+function isToolCallingLocalAgentModel(model: ModelData): boolean {
+	return (
+		(isLlamaCppGgufModel(model) || isMlxModel(model)) &&
+		model.tags.includes("conversational") &&
+		!!getChatTemplate(model)?.includes("tools")
+	);
+}
+
 function getQuantTag(filepath?: string): string {
 	const defaultTag = ":{{QUANT_TAG}}";
 
@@ -818,30 +826,21 @@ export const LOCAL_APPS = {
 		prettyLabel: "Pi",
 		docsUrl: "https://github.com/badlogic/pi-mono",
 		mainTask: "text-generation",
-		displayOnModelPage: (model) =>
-			(isLlamaCppGgufModel(model) || isMlxModel(model)) &&
-			model.tags.includes("conversational") &&
-			!!getChatTemplate(model)?.includes("tools"),
+		displayOnModelPage: isToolCallingLocalAgentModel,
 		snippet: snippetPi,
 	},
 	openclaw: {
 		prettyLabel: "OpenClaw",
 		docsUrl: "https://github.com/openclaw",
 		mainTask: "text-generation",
-		displayOnModelPage: (model) =>
-			(isLlamaCppGgufModel(model) || isMlxModel(model)) &&
-			model.tags.includes("conversational") &&
-			!!getChatTemplate(model)?.includes("tools"),
+		displayOnModelPage: isToolCallingLocalAgentModel,
 		snippet: snippetOpenClaw,
 	},
 	"hermes-agent": {
 		prettyLabel: "Hermes",
 		docsUrl: "https://hermes-agent.nousresearch.com/",
 		mainTask: "text-generation",
-		displayOnModelPage: (model) =>
-			(isLlamaCppGgufModel(model) || isMlxModel(model)) &&
-			model.tags.includes("conversational") &&
-			!!getChatTemplate(model)?.includes("tools"),
+		displayOnModelPage: isToolCallingLocalAgentModel,
 		snippet: snippetHermesAgent,
 	},
 } satisfies Record<string, LocalApp>;

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -486,7 +486,6 @@ const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 	const isMLX = isMlxModel(model);
 	const serverStep = getLocalServerStep(model, filepath);
 
-	// Step 2: Pi config — port and provider name differ
 	const modelsJson = JSON.stringify(
 		{
 			providers: {

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -525,9 +525,8 @@ const snippetOpenClaw = (model: ModelData, filepath?: string): LocalAppSnippet[]
 		serverStep,
 		{
 			title: "Configure OpenClaw for the local server",
+			setup: "# Install OpenClaw:\nnpm install -g openclaw@latest",
 			content: [
-				"# Install OpenClaw by running:",
-				"# npm install -g openclaw@latest",
 				"# Configure OpenClaw:",
 				"openclaw onboard --non-interactive \\",
 				"  --auth-choice custom-api-key \\",
@@ -555,10 +554,12 @@ const snippetHermesAgent = (model: ModelData, filepath?: string): LocalAppSnippe
 		serverStep,
 		{
 			title: "Set Hermes default config",
+			setup: [
+				"# Install Hermes:",
+				"curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash",
+				"hermes setup",
+			].join("\n"),
 			content: [
-				"# Install Hermes by running:",
-				"# curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash",
-				"# hermes setup",
 				"# Add to your Hermes config file:",
 				"model:",
 				"  provider: custom",

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -459,12 +459,8 @@ const snippetMlxLm = (model: ModelData): LocalAppSnippet[] => {
 	];
 };
 
-const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
-	const modelName = model.id.split("/").pop() ?? model.id;
-	const isMLX = isMlxModel(model);
-
-	// Step 1: Server — differs by backend
-	const serverStep: LocalAppSnippet = isMLX
+const getLocalServerStep = (model: ModelData, filepath?: string): LocalAppSnippet => {
+	return isMlxModel(model)
 		? {
 				title: "Start the MLX server",
 				setup: "# Install MLX LM:\nuv tool install mlx-lm",
@@ -475,6 +471,12 @@ const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 				setup: "# Install llama.cpp:\nbrew install llama.cpp",
 				content: `# Start a local OpenAI-compatible server:\nllama-server -hf ${model.id}${getQuantTag(filepath)} --jinja`,
 			};
+};
+
+const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
+	const modelName = model.id.split("/").pop() ?? model.id;
+	const isMLX = isMlxModel(model);
+	const serverStep = getLocalServerStep(model, filepath);
 
 	// Step 2: Pi config — port and provider name differ
 	const modelsJson = JSON.stringify(
@@ -510,18 +512,7 @@ const snippetOpenClaw = (model: ModelData, filepath?: string): LocalAppSnippet[]
 	const isMLX = isMlxModel(model);
 	const modelName = model.id.split("/").pop() ?? model.id;
 	const serverBaseUrl = "http://127.0.0.1:8080/v1";
-
-	const serverStep: LocalAppSnippet = isMLX
-		? {
-				title: "Start the MLX server",
-				setup: "# Install MLX LM:\nuv tool install mlx-lm",
-				content: `# Start a local OpenAI-compatible server:\nmlx_lm.server --model "${model.id}"`,
-			}
-		: {
-				title: "Start the llama.cpp server",
-				setup: "# Install llama.cpp:\nbrew install llama.cpp",
-				content: `# Start a local OpenAI-compatible server:\nllama-server -hf ${model.id}${getQuantTag(filepath)} --jinja`,
-			};
+	const serverStep = getLocalServerStep(model, filepath);
 
 	return [
 		serverStep,
@@ -551,18 +542,7 @@ const snippetOpenClaw = (model: ModelData, filepath?: string): LocalAppSnippet[]
 const snippetHermesAgent = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 	const isMLX = isMlxModel(model);
 	const modelId = isMLX ? model.id : `${model.id}${getQuantTag(filepath)}`;
-
-	const serverStep: LocalAppSnippet = isMLX
-		? {
-				title: "Start the MLX server",
-				setup: "# Install MLX LM:\nuv tool install mlx-lm",
-				content: `# Start a local OpenAI-compatible server:\nmlx_lm.server --model "${model.id}"`,
-			}
-		: {
-				title: "Start the llama.cpp server",
-				setup: "# Install llama.cpp:\nbrew install llama.cpp",
-				content: `# Start a local OpenAI-compatible server:\nllama-server -hf ${model.id}${getQuantTag(filepath)} --jinja`,
-			};
+	const serverStep = getLocalServerStep(model, filepath);
 
 	return [
 		serverStep,


### PR DESCRIPTION
adding logos to moon shortly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive snippet/predicate logic and test coverage for new local-app entries; low risk beyond potential UX gating/snippet formatting regressions.
> 
> **Overview**
> Adds two new local app integrations, **OpenClaw** and **Hermes** (keyed as `openclaw` and `hermes-agent`), including copy/paste setup snippets for running them against a local OpenAI-compatible server.
> 
> Refactors the existing Pi integration by extracting a shared `getLocalServerStep` (MLX vs `llama.cpp`) and centralizing the “tool-calling local agent” eligibility check into `isToolCallingLocalAgentModel`, which is now shared by Pi/OpenClaw/Hermes. Expands tests to cover the new apps (GGUF + MLX cases) and asserts all three apps share the same `displayOnModelPage` predicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66539fd86577d380ac1b85ce4d31501e8c2a92a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->