### PR TITLE
add dgx spark to hardware spec

### DIFF
--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -68,6 +68,11 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		memory: [128],
 		computeCapability: 12.1,
 	},
+	"DGX Spark": {
+		tflops: 29.71,
+		memory: [128],
+		computeCapability: 12.1,
+	},
 	"RTX PRO 6000 WS": {
 		tflops: 126,
 		memory: [96],


### PR DESCRIPTION
I need to show off 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk data-only change that extends the `NVIDIA_SKUS` lookup with a new entry; impact is limited to any code paths that display or match GPU model names.
> 
> **Overview**
> Adds a new NVIDIA GPU SKU entry for `DGX Spark` in `packages/tasks/src/hardware-nvidia.ts`, including TFLOPS, memory, and compute capability values so it can be recognized anywhere `NVIDIA_SKUS` is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0327aa468f5ddd3d652cc9d30c546f6fa0f12b17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->