### PR TITLE
Add model download stats for encoderfile

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -434,6 +434,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_filename:"slicex_elm_config" AND path_extension:"json"`,
 	},
+	encoderfile: {
+		prettyLabel: "encoderfile",
+		repoName: "encoderfile",
+		repoUrl: "https://github.com/mozilla-ai/encoderfile",
+		filter: false,
+		countDownloads: `path_extension: "encoderfile"`,
+	},
 	espnet: {
 		prettyLabel: "ESPnet",
 		repoName: "ESPnet",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -439,7 +439,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "encoderfile",
 		repoUrl: "https://github.com/mozilla-ai/encoderfile",
 		filter: false,
-		countDownloads: `path_extension: "encoderfile"`,
+		countDownloads: `path_extension:"encoderfile"`,
 	},
 	espnet: {
 		prettyLabel: "ESPnet",


### PR DESCRIPTION
This PR adds download stats tracking for encoderfile, a framework that packages encoder transformers into single binary executables. Hoping I added everything I needed to! You can learn more about the project here: https://github.com/mozilla-ai/encoderfile.

Thanks from Mozilla.ai! ❤️🤗

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new model-library entry and an ElasticSearch query for download counting, with no changes to core logic or security-sensitive code.
> 
> **Overview**
> Adds `encoderfile` to `MODEL_LIBRARIES_UI_ELEMENTS`, including repo metadata and a `countDownloads` ElasticSearch query (`path_extension:"encoderfile"`) so Hub download stats can be tracked for encoderfile-packaged models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acb532c87f8afcdc468d692d73ac8dc4f2a95398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->