### PR TITLE
feat(hub): add `copyFiles` API for remote file copy between buckets and repositories

### DIFF
--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -86,7 +86,28 @@ type CommitBlob = Omit<CommitFile, "content"> & { content: Blob };
 // 	content?:  ContentSource;
 // };
 
-export type CommitOperation = CommitDeletedEntry | CommitFile | CommitEditFile /* | CommitRenameFile */;
+/**
+ * Server-side copy of a file from a source repo/bucket to the destination repo.
+ *
+ * Only supported when the destination repo is a bucket. The source file must be xet-backed,
+ * so the caller is responsible for resolving the source path to its {@link sourceXetHash}
+ * (typically via {@link pathsInfo} or {@link listFiles}).
+ *
+ * For higher-level helpers that perform the resolution and handle non-xet source files,
+ * see {@link copyFile}, {@link copyFiles} and {@link copyFolder}.
+ */
+export interface CommitCopyFile {
+	operation: "copy";
+	path: string;
+	sourceXetHash: string;
+	sourceRepo: RepoDesignation;
+}
+
+export type CommitOperation =
+	| CommitDeletedEntry
+	| CommitFile
+	| CommitEditFile
+	| CommitCopyFile /* | CommitRenameFile */;
 type CommitBlobOperation = Exclude<CommitOperation, CommitFile> | CommitBlob;
 
 export type CommitParams = {
@@ -175,6 +196,10 @@ export async function* commitIter(params: CommitParams): AsyncGenerator<CommitPr
 
 	if (repoId.type === "bucket") {
 		return yield* commitIterBucket(params);
+	}
+
+	if (params.operations.some((op) => op.operation === "copy")) {
+		throw new Error("'copy' operations are only supported when the destination repo is a bucket");
 	}
 
 	yield { event: "phase", phase: "preuploading" };
@@ -855,6 +880,55 @@ export async function* commitIterBucket(params: CommitParams): AsyncGenerator<Co
 								xetHash,
 							}),
 						)
+						.join("\n"),
+					signal: abortSignal,
+				},
+			);
+
+			if (!resp.ok && resp.status !== 422) {
+				throw await createApiError(resp);
+			}
+
+			const json = (await resp.json()) as ApiBucketBatchResponse;
+
+			for (const failed of json.failed) {
+				yield {
+					event: "fileProgress",
+					path: failed.path,
+					progress: 0,
+					state: "error",
+				};
+			}
+		}
+
+		abortSignal?.throwIfAborted();
+
+		const copyOperations = allOperations.filter(
+			(operation): operation is CommitCopyFile => operation.operation === "copy",
+		);
+
+		for (const copyChunk of chunk(copyOperations, 100)) {
+			abortSignal?.throwIfAborted();
+
+			const resp = await (params.fetch ?? fetch)(
+				`${params.hubUrl ?? HUB_URL}/api/${repoId.type}s/${repoId.name}/batch`,
+				{
+					method: "POST",
+					headers: {
+						...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+						"Content-Type": "application/x-ndjson",
+					},
+					body: copyChunk
+						.map((op) => {
+							const sourceRepoId = toRepoId(op.sourceRepo);
+							return JSON.stringify({
+								type: "copyFile",
+								path: op.path,
+								xetHash: op.sourceXetHash,
+								sourceRepoType: sourceRepoId.type,
+								sourceRepoId: sourceRepoId.name,
+							});
+						})
 						.join("\n"),
 					signal: abortSignal,
 				},

--- a/packages/hub/src/lib/copy-files.spec.ts
+++ b/packages/hub/src/lib/copy-files.spec.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from "vitest";
+import { TEST_HUB_URL, TEST_ACCESS_TOKEN, TEST_USER } from "../test/consts";
+import { insecureRandomString } from "../utils/insecureRandomString";
+import { createRepo } from "./create-repo";
+import { deleteRepo } from "./delete-repo";
+import { copyFiles, parseHfCopyHandle } from "./copy-files";
+import { listFiles } from "./list-files";
+import { commit } from "./commit";
+
+describe("parseHfCopyHandle", () => {
+	it("should parse a bucket handle", () => {
+		const handle = parseHfCopyHandle("hf://buckets/namespace/bucket-name/path/to/file");
+		expect(handle).toEqual({
+			type: "bucket",
+			bucketId: "namespace/bucket-name",
+			path: "path/to/file",
+		});
+	});
+
+	it("should parse a bucket handle without path", () => {
+		const handle = parseHfCopyHandle("hf://buckets/namespace/bucket-name");
+		expect(handle).toEqual({
+			type: "bucket",
+			bucketId: "namespace/bucket-name",
+			path: "",
+		});
+	});
+
+	it("should parse a model repo handle (implicit)", () => {
+		const handle = parseHfCopyHandle("hf://username/my-model/weights.bin");
+		expect(handle).toEqual({
+			type: "repo",
+			repoType: "model",
+			repoId: "username/my-model",
+			revision: "main",
+			path: "weights.bin",
+		});
+	});
+
+	it("should parse a model repo handle (explicit)", () => {
+		const handle = parseHfCopyHandle("hf://models/username/my-model/weights.bin");
+		expect(handle).toEqual({
+			type: "repo",
+			repoType: "model",
+			repoId: "username/my-model",
+			revision: "main",
+			path: "weights.bin",
+		});
+	});
+
+	it("should parse a dataset repo handle", () => {
+		const handle = parseHfCopyHandle("hf://datasets/username/my-dataset/data/train.parquet");
+		expect(handle).toEqual({
+			type: "repo",
+			repoType: "dataset",
+			repoId: "username/my-dataset",
+			revision: "main",
+			path: "data/train.parquet",
+		});
+	});
+
+	it("should parse a space repo handle", () => {
+		const handle = parseHfCopyHandle("hf://spaces/username/my-space/app.py");
+		expect(handle).toEqual({
+			type: "repo",
+			repoType: "space",
+			repoId: "username/my-space",
+			revision: "main",
+			path: "app.py",
+		});
+	});
+
+	it("should parse a handle with revision", () => {
+		const handle = parseHfCopyHandle("hf://username/my-model@dev/weights.bin");
+		expect(handle).toEqual({
+			type: "repo",
+			repoType: "model",
+			repoId: "username/my-model",
+			revision: "dev",
+			path: "weights.bin",
+		});
+	});
+
+	it("should parse a handle with no subpath", () => {
+		const handle = parseHfCopyHandle("hf://datasets/username/my-dataset");
+		expect(handle).toEqual({
+			type: "repo",
+			repoType: "dataset",
+			repoId: "username/my-dataset",
+			revision: "main",
+			path: "",
+		});
+	});
+
+	it("should throw for invalid handle", () => {
+		expect(() => parseHfCopyHandle("not-a-hf-handle")).toThrow("Expected a path starting with 'hf://'");
+	});
+
+	it("should throw for empty handle", () => {
+		expect(() => parseHfCopyHandle("hf://")).toThrow("Invalid HF handle");
+	});
+
+	it("should throw for handle with only repo type", () => {
+		expect(() => parseHfCopyHandle("hf://models/alone")).toThrow("Invalid repo HF handle");
+	});
+});
+
+describe("copyFiles", () => {
+	it("should reject non-bucket destinations", async () => {
+		await expect(
+			copyFiles({
+				source: "hf://buckets/ns/bucket/file.bin",
+				destination: "hf://models/ns/repo/file.bin",
+				accessToken: TEST_ACCESS_TOKEN,
+				hubUrl: TEST_HUB_URL,
+			}),
+		).rejects.toThrow("Destination must be a bucket");
+	});
+
+	it("should copy files from one bucket to another", async () => {
+		const srcBucketName = `${TEST_USER}/TEST-src-${insecureRandomString()}`;
+		const dstBucketName = `${TEST_USER}/TEST-dst-${insecureRandomString()}`;
+
+		try {
+			await createRepo({
+				accessToken: TEST_ACCESS_TOKEN,
+				repo: { name: srcBucketName, type: "bucket" },
+				hubUrl: TEST_HUB_URL,
+			});
+
+			await createRepo({
+				accessToken: TEST_ACCESS_TOKEN,
+				repo: { name: dstBucketName, type: "bucket" },
+				hubUrl: TEST_HUB_URL,
+			});
+
+			await commit({
+				repo: { type: "bucket", name: srcBucketName },
+				operations: [
+					{
+						operation: "addOrUpdate",
+						path: "test-file.txt",
+						content: new Blob(["hello world"]),
+					},
+				],
+				title: "Add test file",
+				accessToken: TEST_ACCESS_TOKEN,
+				hubUrl: TEST_HUB_URL,
+			});
+
+			await copyFiles({
+				source: `hf://buckets/${srcBucketName}/test-file.txt`,
+				destination: `hf://buckets/${dstBucketName}/`,
+				accessToken: TEST_ACCESS_TOKEN,
+				hubUrl: TEST_HUB_URL,
+			});
+
+			const files: string[] = [];
+			for await (const file of listFiles({
+				repo: { type: "bucket", name: dstBucketName },
+				recursive: true,
+				accessToken: TEST_ACCESS_TOKEN,
+				hubUrl: TEST_HUB_URL,
+			})) {
+				if (file.type === "file") {
+					files.push(file.path);
+				}
+			}
+
+			expect(files).toContain("test-file.txt");
+		} finally {
+			await deleteRepo({
+				repo: { name: srcBucketName, type: "bucket" },
+				credentials: { accessToken: TEST_ACCESS_TOKEN },
+				hubUrl: TEST_HUB_URL,
+			}).catch(() => {});
+
+			await deleteRepo({
+				repo: { name: dstBucketName, type: "bucket" },
+				credentials: { accessToken: TEST_ACCESS_TOKEN },
+				hubUrl: TEST_HUB_URL,
+			}).catch(() => {});
+		}
+	});
+
+	it("should copy files from a repo to a bucket", async () => {
+		const srcRepoName = `${TEST_USER}/TEST-repo-${insecureRandomString()}`;
+		const dstBucketName = `${TEST_USER}/TEST-dst-${insecureRandomString()}`;
+
+		try {
+			await createRepo({
+				accessToken: TEST_ACCESS_TOKEN,
+				repo: { name: srcRepoName, type: "model" },
+				hubUrl: TEST_HUB_URL,
+			});
+
+			await createRepo({
+				accessToken: TEST_ACCESS_TOKEN,
+				repo: { name: dstBucketName, type: "bucket" },
+				hubUrl: TEST_HUB_URL,
+			});
+
+			await commit({
+				repo: { type: "model", name: srcRepoName },
+				operations: [
+					{
+						operation: "addOrUpdate",
+						path: "config.json",
+						content: new Blob(['{"model_type": "test"}']),
+					},
+				],
+				title: "Add config",
+				accessToken: TEST_ACCESS_TOKEN,
+				hubUrl: TEST_HUB_URL,
+			});
+
+			await copyFiles({
+				source: `hf://models/${srcRepoName}`,
+				destination: `hf://buckets/${dstBucketName}/models/test/`,
+				accessToken: TEST_ACCESS_TOKEN,
+				hubUrl: TEST_HUB_URL,
+			});
+
+			const files: string[] = [];
+			for await (const file of listFiles({
+				repo: { type: "bucket", name: dstBucketName },
+				recursive: true,
+				accessToken: TEST_ACCESS_TOKEN,
+				hubUrl: TEST_HUB_URL,
+			})) {
+				if (file.type === "file") {
+					files.push(file.path);
+				}
+			}
+
+			expect(files.some((f) => f.includes("config.json"))).toBe(true);
+		} finally {
+			await deleteRepo({
+				repo: { name: srcRepoName, type: "model" },
+				credentials: { accessToken: TEST_ACCESS_TOKEN },
+				hubUrl: TEST_HUB_URL,
+			}).catch(() => {});
+
+			await deleteRepo({
+				repo: { name: dstBucketName, type: "bucket" },
+				credentials: { accessToken: TEST_ACCESS_TOKEN },
+				hubUrl: TEST_HUB_URL,
+			}).catch(() => {});
+		}
+	});
+});

--- a/packages/hub/src/lib/copy-files.spec.ts
+++ b/packages/hub/src/lib/copy-files.spec.ts
@@ -3,121 +3,121 @@ import { TEST_HUB_URL, TEST_ACCESS_TOKEN, TEST_USER } from "../test/consts";
 import { insecureRandomString } from "../utils/insecureRandomString";
 import { createRepo } from "./create-repo";
 import { deleteRepo } from "./delete-repo";
-import { copyFiles, parseHfCopyHandle } from "./copy-files";
+import { copyFile, copyFiles, copyFolder, relativeUnderFolder } from "./copy-files";
 import { listFiles } from "./list-files";
 import { commit } from "./commit";
 
-describe("parseHfCopyHandle", () => {
-	it("should parse a bucket handle", () => {
-		const handle = parseHfCopyHandle("hf://buckets/namespace/bucket-name/path/to/file");
-		expect(handle).toEqual({
-			type: "bucket",
-			bucketId: "namespace/bucket-name",
-			path: "path/to/file",
-		});
+describe("relativeUnderFolder", () => {
+	it("returns the basename when filePath equals folderPath (single-file folder)", () => {
+		expect(relativeUnderFolder("data/train.parquet", "data/train.parquet")).toBe("train.parquet");
 	});
 
-	it("should parse a bucket handle without path", () => {
-		const handle = parseHfCopyHandle("hf://buckets/namespace/bucket-name");
-		expect(handle).toEqual({
-			type: "bucket",
-			bucketId: "namespace/bucket-name",
-			path: "",
-		});
+	it("returns the path relative to the folder", () => {
+		expect(relativeUnderFolder("data/2024/train.parquet", "data")).toBe("2024/train.parquet");
 	});
 
-	it("should parse a model repo handle (implicit)", () => {
-		const handle = parseHfCopyHandle("hf://username/my-model/weights.bin");
-		expect(handle).toEqual({
-			type: "repo",
-			repoType: "model",
-			repoId: "username/my-model",
-			revision: "main",
-			path: "weights.bin",
-		});
+	it("returns the filePath unchanged when folderPath is empty", () => {
+		expect(relativeUnderFolder("a/b/c.txt", "")).toBe("a/b/c.txt");
 	});
 
-	it("should parse a model repo handle (explicit)", () => {
-		const handle = parseHfCopyHandle("hf://models/username/my-model/weights.bin");
-		expect(handle).toEqual({
-			type: "repo",
-			repoType: "model",
-			repoId: "username/my-model",
-			revision: "main",
-			path: "weights.bin",
-		});
-	});
-
-	it("should parse a dataset repo handle", () => {
-		const handle = parseHfCopyHandle("hf://datasets/username/my-dataset/data/train.parquet");
-		expect(handle).toEqual({
-			type: "repo",
-			repoType: "dataset",
-			repoId: "username/my-dataset",
-			revision: "main",
-			path: "data/train.parquet",
-		});
-	});
-
-	it("should parse a space repo handle", () => {
-		const handle = parseHfCopyHandle("hf://spaces/username/my-space/app.py");
-		expect(handle).toEqual({
-			type: "repo",
-			repoType: "space",
-			repoId: "username/my-space",
-			revision: "main",
-			path: "app.py",
-		});
-	});
-
-	it("should parse a handle with revision", () => {
-		const handle = parseHfCopyHandle("hf://username/my-model@dev/weights.bin");
-		expect(handle).toEqual({
-			type: "repo",
-			repoType: "model",
-			repoId: "username/my-model",
-			revision: "dev",
-			path: "weights.bin",
-		});
-	});
-
-	it("should parse a handle with no subpath", () => {
-		const handle = parseHfCopyHandle("hf://datasets/username/my-dataset");
-		expect(handle).toEqual({
-			type: "repo",
-			repoType: "dataset",
-			repoId: "username/my-dataset",
-			revision: "main",
-			path: "",
-		});
-	});
-
-	it("should throw for invalid handle", () => {
-		expect(() => parseHfCopyHandle("not-a-hf-handle")).toThrow("Expected a path starting with 'hf://'");
-	});
-
-	it("should throw for empty handle", () => {
-		expect(() => parseHfCopyHandle("hf://")).toThrow("Invalid HF handle");
-	});
-
-	it("should throw for handle with only repo type", () => {
-		expect(() => parseHfCopyHandle("hf://models/alone")).toThrow("Invalid repo HF handle");
+	it("throws when filePath is not under folderPath", () => {
+		expect(() => relativeUnderFolder("foo/bar", "baz")).toThrow("not inside folder");
 	});
 });
 
-describe("copyFiles", () => {
-	it("should reject non-bucket destinations", async () => {
+describe("copyFiles (mocked)", () => {
+	it("rejects copy ops on a non-bucket destination", async () => {
 		await expect(
 			copyFiles({
-				source: "hf://buckets/ns/bucket/file.bin",
-				destination: "hf://models/ns/repo/file.bin",
+				destination: { type: "model", name: "ns/repo" } as never,
+				files: [
+					{
+						source: { type: "bucket", name: "ns/bucket" },
+						sourcePath: "file.bin",
+						destinationPath: "file.bin",
+					},
+				],
 				accessToken: TEST_ACCESS_TOKEN,
-				hubUrl: TEST_HUB_URL,
+				hubUrl: "https://example.invalid",
+				fetch: mockFetch({
+					"/api/buckets/ns/bucket/paths-info": () =>
+						jsonResponse([{ path: "file.bin", type: "file", size: 5, xetHash: "abc123" }]),
+				}),
 			}),
-		).rejects.toThrow("Destination must be a bucket");
+		).rejects.toThrow("'copy' operations are only supported when the destination repo is a bucket");
 	});
 
-	it("should copy files from one bucket to another", async () => {
+	it("throws when the source path is a folder", async () => {
+		await expect(
+			copyFiles({
+				destination: { type: "bucket", name: "ns/dst" },
+				files: [
+					{
+						source: { type: "model", name: "ns/model" },
+						sourcePath: "data",
+						destinationPath: "data",
+					},
+				],
+				accessToken: TEST_ACCESS_TOKEN,
+				hubUrl: "https://example.invalid",
+				fetch: mockFetch({
+					"/api/models/ns/model/paths-info": () => jsonResponse([{ path: "data", type: "directory", size: 0 }]),
+				}),
+			}),
+		).rejects.toThrow("is a folder; use copyFolder()");
+	});
+
+	it("throws a clear error when the source file is missing", async () => {
+		await expect(
+			copyFiles({
+				destination: { type: "bucket", name: "ns/dst" },
+				files: [
+					{
+						source: { type: "model", name: "ns/model" },
+						sourcePath: "missing.txt",
+						destinationPath: "missing.txt",
+					},
+				],
+				accessToken: TEST_ACCESS_TOKEN,
+				hubUrl: "https://example.invalid",
+				fetch: mockFetch({
+					"/api/models/ns/model/paths-info": () => jsonResponse([]),
+				}),
+			}),
+		).rejects.toThrow("Source file not found");
+	});
+
+	it("refuses to copy unmigrated LFS files and reports their size", async () => {
+		await expect(
+			copyFiles({
+				destination: { type: "bucket", name: "ns/dst" },
+				files: [
+					{
+						source: { type: "model", name: "ns/model" },
+						sourcePath: "model.safetensors",
+						destinationPath: "model.safetensors",
+					},
+				],
+				accessToken: TEST_ACCESS_TOKEN,
+				hubUrl: "https://example.invalid",
+				fetch: mockFetch({
+					"/api/models/ns/model/paths-info": () =>
+						jsonResponse([
+							{
+								path: "model.safetensors",
+								type: "file",
+								size: 5_300_000_000,
+								lfs: { oid: "deadbeef", size: 5_300_000_000, pointerSize: 134 },
+							},
+						]),
+				}),
+			}),
+		).rejects.toThrow(/LFS file\(s\).*'model\.safetensors' \(5\.30 GB\).*Migrate these files to xet/s);
+	});
+});
+
+describe("copyFile / copyFiles / copyFolder (integration)", () => {
+	it("copies a single file from one bucket to another", async () => {
 		const srcBucketName = `${TEST_USER}/TEST-src-${insecureRandomString()}`;
 		const dstBucketName = `${TEST_USER}/TEST-dst-${insecureRandomString()}`;
 
@@ -148,9 +148,11 @@ describe("copyFiles", () => {
 				hubUrl: TEST_HUB_URL,
 			});
 
-			await copyFiles({
-				source: `hf://buckets/${srcBucketName}/test-file.txt`,
-				destination: `hf://buckets/${dstBucketName}/`,
+			await copyFile({
+				source: { type: "bucket", name: srcBucketName },
+				sourcePath: "test-file.txt",
+				destination: { type: "bucket", name: dstBucketName },
+				destinationPath: "test-file.txt",
 				accessToken: TEST_ACCESS_TOKEN,
 				hubUrl: TEST_HUB_URL,
 			});
@@ -183,7 +185,7 @@ describe("copyFiles", () => {
 		}
 	});
 
-	it("should copy files from a repo to a bucket", async () => {
+	it("copies a folder from a model repo to a bucket", async () => {
 		const srcRepoName = `${TEST_USER}/TEST-repo-${insecureRandomString()}`;
 		const dstBucketName = `${TEST_USER}/TEST-dst-${insecureRandomString()}`;
 
@@ -214,9 +216,10 @@ describe("copyFiles", () => {
 				hubUrl: TEST_HUB_URL,
 			});
 
-			await copyFiles({
-				source: `hf://models/${srcRepoName}`,
-				destination: `hf://buckets/${dstBucketName}/models/test/`,
+			await copyFolder({
+				source: { type: "model", name: srcRepoName },
+				destination: { type: "bucket", name: dstBucketName },
+				destinationPath: "models/test/",
 				accessToken: TEST_ACCESS_TOKEN,
 				hubUrl: TEST_HUB_URL,
 			});
@@ -233,7 +236,7 @@ describe("copyFiles", () => {
 				}
 			}
 
-			expect(files.some((f) => f.includes("config.json"))).toBe(true);
+			expect(files).toContain("models/test/config.json");
 		} finally {
 			await deleteRepo({
 				repo: { name: srcRepoName, type: "model" },
@@ -249,3 +252,24 @@ describe("copyFiles", () => {
 		}
 	});
 });
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+	return new Response(JSON.stringify(body), {
+		status: init.status ?? 200,
+		headers: { "Content-Type": "application/json", ...(init.headers ?? {}) },
+	});
+}
+
+type MockHandler = (req: Request) => Response | Promise<Response>;
+
+function mockFetch(routes: Record<string, MockHandler>): typeof fetch {
+	return async (input, init) => {
+		const req = new Request(input as RequestInfo, init);
+		const url = new URL(req.url);
+		const matched = Object.entries(routes).find(([prefix]) => url.pathname.startsWith(prefix));
+		if (!matched) {
+			throw new Error(`Unexpected request to ${req.method} ${url.pathname}`);
+		}
+		return matched[1](req);
+	};
+}

--- a/packages/hub/src/lib/copy-files.spec.ts
+++ b/packages/hub/src/lib/copy-files.spec.ts
@@ -32,8 +32,7 @@ describe("copyFiles (mocked)", () => {
 				destination: { type: "model", name: "ns/repo" } as never,
 				files: [
 					{
-						source: { type: "bucket", name: "ns/bucket" },
-						sourcePath: "file.bin",
+						source: { repo: { type: "bucket", name: "ns/bucket" }, path: "file.bin" },
 						destinationPath: "file.bin",
 					},
 				],
@@ -53,8 +52,7 @@ describe("copyFiles (mocked)", () => {
 				destination: { type: "bucket", name: "ns/dst" },
 				files: [
 					{
-						source: { type: "model", name: "ns/model" },
-						sourcePath: "data",
+						source: { repo: { type: "model", name: "ns/model" }, path: "data" },
 						destinationPath: "data",
 					},
 				],
@@ -73,8 +71,7 @@ describe("copyFiles (mocked)", () => {
 				destination: { type: "bucket", name: "ns/dst" },
 				files: [
 					{
-						source: { type: "model", name: "ns/model" },
-						sourcePath: "missing.txt",
+						source: { repo: { type: "model", name: "ns/model" }, path: "missing.txt" },
 						destinationPath: "missing.txt",
 					},
 				],
@@ -93,8 +90,7 @@ describe("copyFiles (mocked)", () => {
 				destination: { type: "bucket", name: "ns/dst" },
 				files: [
 					{
-						source: { type: "model", name: "ns/model" },
-						sourcePath: "model.safetensors",
+						source: { repo: { type: "model", name: "ns/model" }, path: "model.safetensors" },
 						destinationPath: "model.safetensors",
 					},
 				],
@@ -149,10 +145,8 @@ describe("copyFile / copyFiles / copyFolder (integration)", () => {
 			});
 
 			await copyFile({
-				source: { type: "bucket", name: srcBucketName },
-				sourcePath: "test-file.txt",
-				destination: { type: "bucket", name: dstBucketName },
-				destinationPath: "test-file.txt",
+				source: { repo: { type: "bucket", name: srcBucketName }, path: "test-file.txt" },
+				destination: { repo: { type: "bucket", name: dstBucketName }, path: "test-file.txt" },
 				accessToken: TEST_ACCESS_TOKEN,
 				hubUrl: TEST_HUB_URL,
 			});
@@ -217,9 +211,11 @@ describe("copyFile / copyFiles / copyFolder (integration)", () => {
 			});
 
 			await copyFolder({
-				source: { type: "model", name: srcRepoName },
-				destination: { type: "bucket", name: dstBucketName },
-				destinationPath: "models/test/",
+				source: { repo: { type: "model", name: srcRepoName } },
+				destination: {
+					repo: { type: "bucket", name: dstBucketName },
+					path: "models/test/",
+				},
 				accessToken: TEST_ACCESS_TOKEN,
 				hubUrl: TEST_HUB_URL,
 			});

--- a/packages/hub/src/lib/copy-files.ts
+++ b/packages/hub/src/lib/copy-files.ts
@@ -1,0 +1,443 @@
+import { HUB_URL } from "../consts";
+import { createApiError } from "../error";
+import type { ApiBucketBatchResponse } from "../types/api/api-commit";
+import type { CredentialsParams, RepoType } from "../types/public";
+import { checkCredentials } from "../utils/checkCredentials";
+import { chunk } from "../utils/chunk";
+import { downloadFile } from "./download-file";
+import type { ListFileEntry } from "./list-files";
+import { listFiles } from "./list-files";
+import type { PathInfo } from "./paths-info";
+import { pathsInfo } from "./paths-info";
+import { commit } from "./commit";
+
+const BATCH_CHUNK_SIZE = 1000;
+
+interface BucketCopyHandle {
+	type: "bucket";
+	bucketId: string;
+	path: string;
+}
+
+interface RepoCopyHandle {
+	type: "repo";
+	repoType: RepoType;
+	repoId: string;
+	revision: string;
+	path: string;
+}
+
+type CopyHandle = BucketCopyHandle | RepoCopyHandle;
+
+/**
+ * Parse an `hf://` handle into a structured representation.
+ *
+ * Supports:
+ * - `hf://buckets/namespace/bucket-name/optional/path`
+ * - `hf://models/namespace/repo-name/path`  (or `hf://namespace/repo-name/path` defaults to model)
+ * - `hf://datasets/namespace/repo-name/path`
+ * - `hf://spaces/namespace/repo-name/path`
+ * - Revisions via `@revision`: `hf://namespace/repo-name@rev/path`
+ */
+export function parseHfCopyHandle(hfHandle: string): CopyHandle {
+	if (!hfHandle.startsWith("hf://")) {
+		throw new Error(`Invalid HF handle: '${hfHandle}'. Expected a path starting with 'hf://'.`);
+	}
+
+	const path = hfHandle.slice("hf://".length);
+
+	if (path.startsWith("buckets/")) {
+		const rest = path.slice("buckets/".length);
+		const parts = rest.split("/");
+		if (parts.length < 2 || !parts[0] || !parts[1]) {
+			throw new Error(`Invalid bucket path: '${hfHandle}'. Expected format: hf://buckets/namespace/bucket_name`);
+		}
+		const bucketId = `${parts[0]}/${parts[1]}`;
+		const bucketPath = parts.slice(2).join("/");
+		return {
+			type: "bucket",
+			bucketId,
+			path: bucketPath,
+		};
+	}
+
+	const trimmed = path.replace(/^\/+|\/+$/g, "");
+	if (!trimmed) {
+		throw new Error(`Invalid HF handle: '${hfHandle}'.`);
+	}
+
+	const parts = trimmed.split("/");
+
+	const repoTypeMapping: Record<string, RepoType> = {
+		models: "model",
+		datasets: "dataset",
+		spaces: "space",
+	};
+
+	let repoType: RepoType = "model";
+	let restParts = parts;
+	if (parts[0] in repoTypeMapping) {
+		repoType = repoTypeMapping[parts[0]];
+		restParts = parts.slice(1);
+	}
+
+	if (restParts.length < 2) {
+		throw new Error(
+			`Invalid repo HF handle: '${hfHandle}'. Expected format 'hf://namespace/repo/path' or with explicit repo type prefix.`,
+		);
+	}
+
+	const namespace = restParts[0];
+	const repoNameWithRevision = restParts[1];
+	const remainingParts = restParts.slice(2);
+
+	let repoName: string;
+	let revision: string;
+
+	if (repoNameWithRevision.includes("@")) {
+		const atIdx = repoNameWithRevision.indexOf("@");
+		repoName = repoNameWithRevision.slice(0, atIdx);
+		revision = decodeURIComponent(repoNameWithRevision.slice(atIdx + 1));
+	} else {
+		repoName = repoNameWithRevision;
+		revision = "main";
+	}
+
+	const repoPath = remainingParts.join("/");
+
+	return {
+		type: "repo",
+		repoType,
+		repoId: `${namespace}/${repoName}`,
+		revision,
+		path: repoPath,
+	};
+}
+
+interface CopyFileOp {
+	path: string;
+	xetHash: string;
+	sourceRepoType: string;
+	sourceRepoId: string;
+}
+
+/**
+ * Copy files between locations on the Hub.
+ *
+ * Copies files from a bucket or repository (model, dataset, space) to a bucket.
+ * Both individual files and entire folders are supported.
+ *
+ * Currently, only bucket destinations are supported. Copying to a repository is not supported.
+ *
+ * For xet-backed files (most files on the Hub), the copy is performed server-side
+ * with no data transfer. For small non-xet files in repositories, the files are
+ * downloaded and re-uploaded to the destination bucket.
+ *
+ * @example
+ * ```ts
+ * import { copyFiles } from "@huggingface/hub";
+ *
+ * // Copy a single file between buckets
+ * await copyFiles({
+ *   source: "hf://buckets/my-bucket/data.bin",
+ *   destination: "hf://buckets/other-bucket/data.bin",
+ *   accessToken: "hf_...",
+ * });
+ *
+ * // Copy a folder from a bucket to another bucket
+ * await copyFiles({
+ *   source: "hf://buckets/my-bucket/models/",
+ *   destination: "hf://buckets/other-bucket/backup/",
+ *   accessToken: "hf_...",
+ * });
+ *
+ * // Copy from a model repo to a bucket
+ * await copyFiles({
+ *   source: "hf://models/username/my-model/model.safetensors",
+ *   destination: "hf://buckets/my-bucket/",
+ *   accessToken: "hf_...",
+ * });
+ *
+ * // Copy an entire dataset to a bucket
+ * await copyFiles({
+ *   source: "hf://datasets/username/my-dataset/",
+ *   destination: "hf://buckets/my-bucket/datasets/",
+ *   accessToken: "hf_...",
+ * });
+ * ```
+ */
+export async function copyFiles(
+	params: {
+		/**
+		 * Source location as an `hf://` handle.
+		 * Can be a bucket path (e.g. `"hf://buckets/my-bucket/path/to/file"`)
+		 * or a repo path (e.g. `"hf://models/username/my-model/weights.bin"`,
+		 * `"hf://datasets/username/my-dataset/data/"`).
+		 */
+		source: string;
+		/**
+		 * Destination location as an `hf://` handle pointing to a bucket
+		 * (e.g. `"hf://buckets/my-bucket/target/path"`).
+		 */
+		destination: string;
+		hubUrl?: string;
+		/**
+		 * Custom fetch function to use instead of the default one, for example to use a proxy or edit headers.
+		 */
+		fetch?: typeof fetch;
+	} & Partial<CredentialsParams>,
+): Promise<void> {
+	const accessToken = checkCredentials(params);
+	const hubUrl = params.hubUrl ?? HUB_URL;
+	const fetchFn = params.fetch ?? fetch;
+
+	const sourceHandle = parseHfCopyHandle(params.source);
+	const destinationHandle = parseHfCopyHandle(params.destination);
+
+	if (destinationHandle.type !== "bucket") {
+		throw new Error("Bucket-to-repo and repo-to-repo copy are not supported. Destination must be a bucket.");
+	}
+
+	const destinationBucketId = destinationHandle.bucketId;
+	const destinationPath = destinationHandle.path;
+
+	let destinationIsDirectory: boolean;
+	if (destinationPath === "" || params.destination.endsWith("/")) {
+		destinationIsDirectory = true;
+	} else {
+		const destInfo = await pathsInfo({
+			repo: { type: "bucket", name: destinationBucketId },
+			paths: [destinationPath],
+			accessToken,
+			hubUrl,
+			fetch: fetchFn,
+		});
+
+		if (destInfo.length > 0) {
+			destinationIsDirectory = false;
+		} else {
+			let hasChildren = false;
+			for await (const _ of listFiles({
+				repo: { type: "bucket", name: destinationBucketId },
+				path: destinationPath,
+				recursive: false,
+				accessToken,
+				hubUrl,
+				fetch: fetchFn,
+			})) {
+				hasChildren = true;
+				break;
+			}
+			destinationIsDirectory = hasChildren;
+		}
+	}
+
+	function resolveTargetPath(srcFilePath: string, srcRootPath: string | null, isSingleFile: boolean): string {
+		const basename = srcFilePath.split("/").pop() ?? srcFilePath;
+		if (isSingleFile) {
+			if (destinationPath === "") {
+				return basename;
+			}
+			if (destinationIsDirectory) {
+				return `${destinationPath.replace(/\/+$/, "")}/${basename}`;
+			}
+			return destinationPath;
+		}
+
+		let relPath: string;
+		if (srcRootPath === null) {
+			relPath = srcFilePath;
+		} else if (srcFilePath.startsWith(srcRootPath + "/")) {
+			relPath = srcFilePath.slice(srcRootPath.length + 1);
+		} else if (srcFilePath === srcRootPath) {
+			relPath = srcFilePath.split("/").pop() ?? srcFilePath;
+		} else {
+			throw new Error(`Unexpected source path while copying folder: '${srcFilePath}'.`);
+		}
+
+		if (relPath === "") {
+			throw new Error("Cannot copy an empty relative path.");
+		}
+		if (destinationPath === "") {
+			return relPath;
+		}
+		return `${destinationPath.replace(/\/+$/, "")}/${relPath}`;
+	}
+
+	const allCopies: CopyFileOp[] = [];
+	const pendingDownloads: Array<{ filePath: string; targetPath: string }> = [];
+
+	if (sourceHandle.type === "bucket") {
+		const sourcePath = sourceHandle.path;
+
+		let sourcePathInfo: PathInfo[] = [];
+		if (sourcePath) {
+			sourcePathInfo = await pathsInfo({
+				repo: { type: "bucket", name: sourceHandle.bucketId },
+				paths: [sourcePath],
+				accessToken,
+				hubUrl,
+				fetch: fetchFn,
+			});
+		}
+
+		if (sourcePathInfo.length === 1 && sourcePathInfo[0].type === "file") {
+			const sourceFile = sourcePathInfo[0];
+			const targetPath = resolveTargetPath(sourceFile.path, null, true);
+			allCopies.push({
+				path: targetPath,
+				xetHash: sourceFile.xetHash!,
+				sourceRepoType: "bucket",
+				sourceRepoId: sourceHandle.bucketId,
+			});
+		} else {
+			destinationIsDirectory = true;
+			for await (const item of listFiles({
+				repo: { type: "bucket", name: sourceHandle.bucketId },
+				path: sourcePath || undefined,
+				recursive: true,
+				accessToken,
+				hubUrl,
+				fetch: fetchFn,
+			})) {
+				if (item.type !== "file") {
+					continue;
+				}
+				if (sourcePath && !(item.path === sourcePath || item.path.startsWith(sourcePath + "/"))) {
+					continue;
+				}
+				const targetPath = resolveTargetPath(item.path, sourcePath || null, false);
+				allCopies.push({
+					path: targetPath,
+					xetHash: item.xetHash!,
+					sourceRepoType: "bucket",
+					sourceRepoId: sourceHandle.bucketId,
+				});
+			}
+		}
+	} else {
+		const sourcePath = sourceHandle.path;
+		const repoDesignation = { type: sourceHandle.repoType, name: sourceHandle.repoId } as const;
+
+		function addRepoFile(file: ListFileEntry | PathInfo, targetPath: string): void {
+			if (file.xetHash && sourceHandle.type === "repo") {
+				allCopies.push({
+					path: targetPath,
+					xetHash: file.xetHash,
+					sourceRepoType: sourceHandle.repoType,
+					sourceRepoId: sourceHandle.repoId,
+				});
+			} else {
+				pendingDownloads.push({ filePath: file.path, targetPath });
+			}
+		}
+
+		let sourceRepoPathInfo: PathInfo[] = [];
+		if (sourcePath !== "") {
+			sourceRepoPathInfo = await pathsInfo({
+				repo: repoDesignation,
+				paths: [sourcePath],
+				revision: sourceHandle.revision,
+				accessToken,
+				hubUrl,
+				fetch: fetchFn,
+			});
+		}
+
+		if (sourceRepoPathInfo.length === 1 && sourceRepoPathInfo[0].type === "file") {
+			const targetPath = resolveTargetPath(sourceRepoPathInfo[0].path, null, true);
+			addRepoFile(sourceRepoPathInfo[0], targetPath);
+		} else {
+			destinationIsDirectory = true;
+			for await (const repoItem of listFiles({
+				repo: repoDesignation,
+				path: sourcePath || undefined,
+				recursive: true,
+				revision: sourceHandle.revision,
+				accessToken,
+				hubUrl,
+				fetch: fetchFn,
+			})) {
+				if (repoItem.type !== "file") {
+					continue;
+				}
+				const targetPath = resolveTargetPath(repoItem.path, sourcePath || null, false);
+				addRepoFile(repoItem, targetPath);
+			}
+		}
+	}
+
+	// Download non-xet files from repos and re-upload them to the destination bucket.
+	// These are typically small git-stored files (config.json, tokenizer files, etc.).
+	if (pendingDownloads.length > 0 && sourceHandle.type === "repo") {
+		const repoDesignation = { type: sourceHandle.repoType, name: sourceHandle.repoId } as const;
+		const bucketDesignation = { type: "bucket" as const, name: destinationBucketId };
+
+		for (const { filePath, targetPath } of pendingDownloads) {
+			const blob = await downloadFile({
+				repo: repoDesignation,
+				path: filePath,
+				revision: sourceHandle.revision,
+				accessToken,
+				hubUrl,
+				fetch: fetchFn,
+			});
+			if (!blob) {
+				throw new Error(`Failed to download file '${filePath}' from repo '${sourceHandle.repoId}'.`);
+			}
+			await commit({
+				repo: bucketDesignation,
+				operations: [
+					{
+						operation: "addOrUpdate",
+						path: targetPath,
+						content: blob,
+					},
+				],
+				title: `Copy ${filePath}`,
+				accessToken,
+				hubUrl,
+				fetch: fetchFn,
+			});
+		}
+	}
+
+	// Send server-side copy operations in batches
+	for (const copyChunk of chunk(allCopies, BATCH_CHUNK_SIZE)) {
+		const ndjsonBody = copyChunk
+			.map((op) =>
+				JSON.stringify({
+					type: "copyFile",
+					path: op.path,
+					xetHash: op.xetHash,
+					sourceRepoType: op.sourceRepoType,
+					sourceRepoId: op.sourceRepoId,
+				}),
+			)
+			.join("\n");
+
+		const resp = await fetchFn(`${hubUrl}/api/buckets/${destinationBucketId}/batch`, {
+			method: "POST",
+			headers: {
+				...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+				"Content-Type": "application/x-ndjson",
+			},
+			body: ndjsonBody,
+		});
+
+		if (!resp.ok) {
+			throw await createApiError(resp);
+		}
+
+		const result = (await resp.json()) as ApiBucketBatchResponse;
+		if (result.failed.length > 0) {
+			const failedPaths = result.failed
+				.slice(0, 5)
+				.map((f) => `${f.path}: ${f.error}`)
+				.join(", ");
+			throw new Error(
+				`Failed to copy ${result.failed.length} file(s): ${failedPaths}${result.failed.length > 5 ? "..." : ""}`,
+			);
+		}
+	}
+}

--- a/packages/hub/src/lib/copy-files.ts
+++ b/packages/hub/src/lib/copy-files.ts
@@ -1,446 +1,478 @@
-import { HUB_URL } from "../consts";
-import { createApiError } from "../error";
-import type { ApiBucketBatchResponse } from "../types/api/api-commit";
-import type { CredentialsParams, RepoType } from "../types/public";
+import type { BucketDesignation, CredentialsParams, RepoDesignation, RepoId } from "../types/public";
 import { checkCredentials } from "../utils/checkCredentials";
-import { chunk } from "../utils/chunk";
+import { promisesQueue } from "../utils/promisesQueue";
+import { toRepoId } from "../utils/toRepoId";
+import type { CommitOperation, CommitParams } from "./commit";
+import { commit } from "./commit";
 import { downloadFile } from "./download-file";
 import type { ListFileEntry } from "./list-files";
 import { listFiles } from "./list-files";
 import type { PathInfo } from "./paths-info";
 import { pathsInfo } from "./paths-info";
-import { commit } from "./commit";
 
-const BATCH_CHUNK_SIZE = 1000;
-
-interface BucketCopyHandle {
-	type: "bucket";
-	bucketId: string;
-	path: string;
-}
-
-interface RepoCopyHandle {
-	type: "repo";
-	repoType: RepoType;
-	repoId: string;
-	revision: string;
-	path: string;
-}
-
-type CopyHandle = BucketCopyHandle | RepoCopyHandle;
+const DOWNLOAD_CONCURRENCY = 5;
+const PATHS_INFO_BATCH_SIZE = 100;
+const MAX_REPORTED_LFS_PATHS = 5;
 
 /**
- * Parse an `hf://` handle into a structured representation.
- *
- * Supports:
- * - `hf://buckets/namespace/bucket-name/optional/path`
- * - `hf://models/namespace/repo-name/path`  (or `hf://namespace/repo-name/path` defaults to model)
- * - `hf://datasets/namespace/repo-name/path`
- * - `hf://spaces/namespace/repo-name/path`
- * - Revisions via `@revision`: `hf://namespace/repo-name@rev/path`
+ * One file to copy in a {@link copyFiles} call.
  */
-export function parseHfCopyHandle(hfHandle: string): CopyHandle {
-	if (!hfHandle.startsWith("hf://")) {
-		throw new Error(`Invalid HF handle: '${hfHandle}'. Expected a path starting with 'hf://'.`);
-	}
-
-	const path = hfHandle.slice("hf://".length);
-
-	if (path.startsWith("buckets/")) {
-		const rest = path.slice("buckets/".length);
-		const parts = rest.split("/");
-		if (parts.length < 2 || !parts[0] || !parts[1]) {
-			throw new Error(`Invalid bucket path: '${hfHandle}'. Expected format: hf://buckets/namespace/bucket_name`);
-		}
-		const bucketId = `${parts[0]}/${parts[1]}`;
-		const bucketPath = parts.slice(2).join("/");
-		return {
-			type: "bucket",
-			bucketId,
-			path: bucketPath,
-		};
-	}
-
-	const trimmed = path.replace(/^\/+|\/+$/g, "");
-	if (!trimmed) {
-		throw new Error(`Invalid HF handle: '${hfHandle}'.`);
-	}
-
-	const parts = trimmed.split("/");
-
-	const repoTypeMapping: Record<string, RepoType> = {
-		models: "model",
-		datasets: "dataset",
-		spaces: "space",
-	};
-
-	let repoType: RepoType = "model";
-	let restParts = parts;
-	if (parts[0] in repoTypeMapping) {
-		repoType = repoTypeMapping[parts[0]];
-		restParts = parts.slice(1);
-	}
-
-	if (restParts.length < 2) {
-		throw new Error(
-			`Invalid repo HF handle: '${hfHandle}'. Expected format 'hf://namespace/repo/path' or with explicit repo type prefix.`,
-		);
-	}
-
-	const namespace = restParts[0];
-	const repoNameWithRevision = restParts[1];
-	const remainingParts = restParts.slice(2);
-
-	let repoName: string;
-	let revision: string;
-
-	if (repoNameWithRevision.includes("@")) {
-		const atIdx = repoNameWithRevision.indexOf("@");
-		repoName = repoNameWithRevision.slice(0, atIdx);
-		revision = decodeURIComponent(repoNameWithRevision.slice(atIdx + 1));
-	} else {
-		repoName = repoNameWithRevision;
-		revision = "main";
-	}
-
-	const repoPath = remainingParts.join("/");
-
-	return {
-		type: "repo",
-		repoType,
-		repoId: `${namespace}/${repoName}`,
-		revision,
-		path: repoPath,
-	};
+export interface CopyFile {
+	source: RepoDesignation;
+	sourcePath: string;
+	/**
+	 * Git revision to read the source from. Ignored for bucket sources.
+	 *
+	 * @default "main"
+	 */
+	sourceRevision?: string;
+	/**
+	 * Exact destination path within the destination bucket.
+	 */
+	destinationPath: string;
 }
 
-interface CopyFileOp {
-	path: string;
-	xetHash: string;
-	sourceRepoType: string;
-	sourceRepoId: string;
-}
+type SharedParams = {
+	destination: BucketDesignation;
+	hubUrl?: CommitParams["hubUrl"];
+	fetch?: CommitParams["fetch"];
+	abortSignal?: CommitParams["abortSignal"];
+} & Partial<CredentialsParams>;
 
 /**
- * Copy files between locations on the Hub.
+ * Copy a single file from a source repo/bucket to the destination bucket.
  *
- * Copies files from a bucket or repository (model, dataset, space) to a bucket.
- * Both individual files and entire folders are supported.
- *
- * Currently, only bucket destinations are supported. Copying to a repository is not supported.
- *
- * For xet-backed files (most files on the Hub), the copy is performed server-side
- * with no data transfer. For small non-xet files in repositories, the files are
- * downloaded and re-uploaded to the destination bucket.
+ * The copy is server-side (no data transfer) when the source file is xet-backed.
+ * For small non-xet repo files (e.g. `config.json`) the file is downloaded and
+ * re-uploaded to the destination bucket in the same commit.
  *
  * @example
  * ```ts
- * import { copyFiles } from "@huggingface/hub";
- *
- * // Copy a single file between buckets
- * await copyFiles({
- *   source: "hf://buckets/my-bucket/data.bin",
- *   destination: "hf://buckets/other-bucket/data.bin",
+ * await copyFile({
+ *   source: { type: "model", name: "username/my-model" },
+ *   sourcePath: "model.safetensors",
+ *   destination: { type: "bucket", name: "username/my-bucket" },
+ *   destinationPath: "models/my-model/model.safetensors",
  *   accessToken: "hf_...",
  * });
+ * ```
+ */
+export function copyFile(params: CopyFile & SharedParams): Promise<undefined> {
+	return copyFiles({
+		...(params.accessToken ? { accessToken: params.accessToken } : { credentials: params.credentials }),
+		destination: params.destination,
+		files: [
+			{
+				source: params.source,
+				sourcePath: params.sourcePath,
+				sourceRevision: params.sourceRevision,
+				destinationPath: params.destinationPath,
+			},
+		],
+		hubUrl: params.hubUrl,
+		fetch: params.fetch,
+		abortSignal: params.abortSignal,
+	});
+}
+
+/**
+ * Copy multiple files (potentially from different source repos/buckets) to the destination
+ * bucket in a single commit.
  *
- * // Copy a folder from a bucket to another bucket
- * await copyFiles({
- *   source: "hf://buckets/my-bucket/models/",
- *   destination: "hf://buckets/other-bucket/backup/",
- *   accessToken: "hf_...",
- * });
+ * For xet-backed source files, the copy is performed server-side with no data transfer.
+ * For non-xet source files (typically small git-stored repo files), the file is
+ * downloaded and re-uploaded as part of the same commit.
  *
- * // Copy from a model repo to a bucket
+ * @example
+ * ```ts
  * await copyFiles({
- *   source: "hf://models/username/my-model/model.safetensors",
- *   destination: "hf://buckets/my-bucket/",
- *   accessToken: "hf_...",
- * });
- *
- * // Copy an entire dataset to a bucket
- * await copyFiles({
- *   source: "hf://datasets/username/my-dataset/",
- *   destination: "hf://buckets/my-bucket/datasets/",
+ *   destination: { type: "bucket", name: "username/my-bucket" },
+ *   files: [
+ *     {
+ *       source: { type: "bucket", name: "username/other-bucket" },
+ *       sourcePath: "data.bin",
+ *       destinationPath: "data.bin",
+ *     },
+ *     {
+ *       source: { type: "model", name: "username/my-model" },
+ *       sourcePath: "model.safetensors",
+ *       destinationPath: "models/my-model/model.safetensors",
+ *     },
+ *   ],
  *   accessToken: "hf_...",
  * });
  * ```
  */
 export async function copyFiles(
 	params: {
+		files: CopyFile[];
+	} & SharedParams,
+): Promise<undefined> {
+	if (params.files.length === 0) {
+		return undefined;
+	}
+
+	const operations = await resolveCopyOperations(params, params.files);
+
+	await commit({
+		...(params.accessToken ? { accessToken: params.accessToken } : { credentials: params.credentials }),
+		repo: params.destination,
+		operations,
+		title: "",
+		hubUrl: params.hubUrl,
+		fetch: params.fetch,
+		abortSignal: params.abortSignal,
+	});
+	return undefined;
+}
+
+/**
+ * Copy a folder (recursively) from a source repo/bucket to the destination bucket
+ * in a single commit.
+ *
+ * Per-file paths are resolved relative to {@link sourcePath}; the source folder
+ * itself is not preserved in the destination unless {@link destinationPath} keeps it.
+ *
+ * @example
+ * ```ts
+ * // Copy an entire dataset under "datasets/my-dataset/" in the bucket
+ * await copyFolder({
+ *   source: { type: "dataset", name: "username/my-dataset" },
+ *   destination: { type: "bucket", name: "username/my-bucket" },
+ *   destinationPath: "datasets/my-dataset/",
+ *   accessToken: "hf_...",
+ * });
+ *
+ * // Copy a subfolder
+ * await copyFolder({
+ *   source: { type: "bucket", name: "username/src-bucket" },
+ *   sourcePath: "models/",
+ *   destination: { type: "bucket", name: "username/dst-bucket" },
+ *   destinationPath: "backup/",
+ *   accessToken: "hf_...",
+ * });
+ * ```
+ */
+export async function copyFolder(
+	params: {
+		source: RepoDesignation;
 		/**
-		 * Source location as an `hf://` handle.
-		 * Can be a bucket path (e.g. `"hf://buckets/my-bucket/path/to/file"`)
-		 * or a repo path (e.g. `"hf://models/username/my-model/weights.bin"`,
-		 * `"hf://datasets/username/my-dataset/data/"`).
+		 * Path of the folder inside the source repo. Leave empty to copy the whole repo.
 		 */
-		source: string;
+		sourcePath?: string;
 		/**
-		 * Destination location as an `hf://` handle pointing to a bucket
-		 * (e.g. `"hf://buckets/my-bucket/target/path"`).
+		 * Git revision to read the source from. Ignored for bucket sources.
+		 *
+		 * @default "main"
 		 */
-		destination: string;
-		hubUrl?: string;
+		sourceRevision?: string;
 		/**
-		 * Custom fetch function to use instead of the default one, for example to use a proxy or edit headers.
+		 * Prefix in the destination bucket where the folder will be copied.
+		 * Leave empty to copy under the bucket root.
 		 */
-		fetch?: typeof fetch;
-	} & Partial<CredentialsParams>,
-): Promise<void> {
+		destinationPath?: string;
+	} & SharedParams,
+): Promise<undefined> {
 	const accessToken = checkCredentials(params);
-	const hubUrl = params.hubUrl ?? HUB_URL;
-	const fetchFn = params.fetch ?? fetch;
+	const sourceRepoId = toRepoId(params.source);
+	const sourcePath = (params.sourcePath ?? "").replace(/\/+$/, "");
+	const destinationPrefix = (params.destinationPath ?? "").replace(/\/+$/, "");
+	const sourceRevision = sourceRepoId.type === "bucket" ? undefined : (params.sourceRevision ?? "main");
 
-	const allCopies: CopyFileOp[] = [];
-	const pendingDownloads: Array<{ filePath: string; targetPath: string }> = [];
+	const operations: CommitOperation[] = [];
+	const pendingDownloads: Array<{ index: number; sourcePath: string }> = [];
+	const lfsOffenders: Array<{ path: string; size: number }> = [];
 
-	const sourceHandle = parseHfCopyHandle(params.source);
-	const destinationHandle = parseHfCopyHandle(params.destination);
-
-	if (destinationHandle.type !== "bucket") {
-		throw new Error("Bucket-to-repo and repo-to-repo copy are not supported. Destination must be a bucket.");
-	}
-
-	const destinationBucketId = destinationHandle.bucketId;
-	const destinationPath = destinationHandle.path;
-
-	let destinationIsDirectory: boolean;
-	if (destinationPath === "" || params.destination.endsWith("/")) {
-		destinationIsDirectory = true;
-	} else {
-		const destInfo = await pathsInfo({
-			repo: { type: "bucket", name: destinationBucketId },
-			paths: [destinationPath],
-			accessToken,
-			hubUrl,
-			fetch: fetchFn,
-		});
-
-		if (destInfo.length > 0) {
-			destinationIsDirectory = false;
-		} else {
-			const listFilesIter = listFiles({
-				repo: { type: "bucket", name: destinationBucketId },
-				path: destinationPath,
-				recursive: false,
-				accessToken,
-				hubUrl,
-				fetch: fetchFn,
-			});
-			const firstResult = await listFilesIter.next();
-			destinationIsDirectory = !firstResult.done;
-		}
-	}
-
-	function resolveTargetPath(srcFilePath: string, srcRootPath: string | null, isSingleFile: boolean): string {
-		const basename = srcFilePath.split("/").pop() ?? srcFilePath;
-		if (isSingleFile) {
-			if (destinationPath === "") {
-				return basename;
-			}
-			if (destinationIsDirectory) {
-				return `${destinationPath.replace(/\/+$/, "")}/${basename}`;
-			}
-			return destinationPath;
+	for await (const item of listFiles({
+		repo: sourceRepoId,
+		path: sourcePath || undefined,
+		recursive: true,
+		revision: sourceRevision,
+		accessToken,
+		hubUrl: params.hubUrl,
+		fetch: params.fetch,
+	})) {
+		if (item.type !== "file") {
+			continue;
 		}
 
-		let relPath: string;
-		if (srcRootPath === null) {
-			relPath = srcFilePath;
-		} else if (srcFilePath.startsWith(srcRootPath + "/")) {
-			relPath = srcFilePath.slice(srcRootPath.length + 1);
-		} else if (srcFilePath === srcRootPath) {
-			relPath = srcFilePath.split("/").pop() ?? srcFilePath;
-		} else {
-			throw new Error(`Unexpected source path while copying folder: '${srcFilePath}'.`);
-		}
+		const relPath = relativeUnderFolder(item.path, sourcePath);
+		const destPath = destinationPrefix ? `${destinationPrefix}/${relPath}` : relPath;
 
-		if (relPath === "") {
-			throw new Error("Cannot copy an empty relative path.");
-		}
-		if (destinationPath === "") {
-			return relPath;
-		}
-		return `${destinationPath.replace(/\/+$/, "")}/${relPath}`;
-	}
-
-	function addRepoFile(file: ListFileEntry | PathInfo, targetPath: string): void {
-		if (file.xetHash && sourceHandle.type === "repo") {
-			allCopies.push({
-				path: targetPath,
-				xetHash: file.xetHash,
-				sourceRepoType: sourceHandle.repoType,
-				sourceRepoId: sourceHandle.repoId,
-			});
-		} else {
-			pendingDownloads.push({ filePath: file.path, targetPath });
-		}
-	}
-
-	if (sourceHandle.type === "bucket") {
-		const sourcePath = sourceHandle.path;
-
-		let sourcePathInfo: PathInfo[] = [];
-		if (sourcePath) {
-			sourcePathInfo = await pathsInfo({
-				repo: { type: "bucket", name: sourceHandle.bucketId },
-				paths: [sourcePath],
-				accessToken,
-				hubUrl,
-				fetch: fetchFn,
-			});
-		}
-
-		if (sourcePathInfo.length === 1 && sourcePathInfo[0].type === "file") {
-			const sourceFile = sourcePathInfo[0];
-			if (!sourceFile.xetHash) {
-				throw new Error(`Source file '${sourceFile.path}' does not have a xetHash, cannot copy.`);
-			}
-			const targetPath = resolveTargetPath(sourceFile.path, null, true);
-			allCopies.push({
-				path: targetPath,
-				xetHash: sourceFile.xetHash,
-				sourceRepoType: "bucket",
-				sourceRepoId: sourceHandle.bucketId,
-			});
-		} else {
-			destinationIsDirectory = true;
-			for await (const item of listFiles({
-				repo: { type: "bucket", name: sourceHandle.bucketId },
-				path: sourcePath || undefined,
-				recursive: true,
-				accessToken,
-				hubUrl,
-				fetch: fetchFn,
-			})) {
-				if (item.type !== "file") {
-					continue;
-				}
-				if (!item.xetHash) {
-					continue;
-				}
-				if (sourcePath && !(item.path === sourcePath || item.path.startsWith(sourcePath + "/"))) {
-					continue;
-				}
-				const targetPath = resolveTargetPath(item.path, sourcePath || null, false);
-				allCopies.push({
-					path: targetPath,
-					xetHash: item.xetHash,
-					sourceRepoType: "bucket",
-					sourceRepoId: sourceHandle.bucketId,
+		switch (classifySourceFile(item)) {
+			case "copy":
+				operations.push({
+					operation: "copy",
+					path: destPath,
+					sourceXetHash: item.xetHash as string,
+					sourceRepo: sourceRepoId,
 				});
-			}
-		}
-	} else {
-		const sourcePath = sourceHandle.path;
-		const repoDesignation = { type: sourceHandle.repoType, name: sourceHandle.repoId } as const;
-
-		let sourceRepoPathInfo: PathInfo[] = [];
-		if (sourcePath !== "") {
-			sourceRepoPathInfo = await pathsInfo({
-				repo: repoDesignation,
-				paths: [sourcePath],
-				revision: sourceHandle.revision,
-				accessToken,
-				hubUrl,
-				fetch: fetchFn,
-			});
-		}
-
-		if (sourceRepoPathInfo.length === 1 && sourceRepoPathInfo[0].type === "file") {
-			const targetPath = resolveTargetPath(sourceRepoPathInfo[0].path, null, true);
-			addRepoFile(sourceRepoPathInfo[0], targetPath);
-		} else {
-			destinationIsDirectory = true;
-			for await (const repoItem of listFiles({
-				repo: repoDesignation,
-				path: sourcePath || undefined,
-				recursive: true,
-				revision: sourceHandle.revision,
-				accessToken,
-				hubUrl,
-				fetch: fetchFn,
-			})) {
-				if (repoItem.type !== "file") {
-					continue;
-				}
-				const targetPath = resolveTargetPath(repoItem.path, sourcePath || null, false);
-				addRepoFile(repoItem, targetPath);
-			}
+				continue;
+			case "lfs":
+				lfsOffenders.push({ path: item.path, size: item.lfs?.size ?? item.size });
+				continue;
+			case "download":
+				// Regular git-stored file (small): download + re-upload in the same commit.
+				pendingDownloads.push({ index: operations.length, sourcePath: item.path });
+				operations.push({
+					operation: "addOrUpdate",
+					path: destPath,
+					content: new Blob([]),
+				});
+				continue;
 		}
 	}
 
-	// Download non-xet files from repos and re-upload them to the destination bucket.
-	// These are typically small git-stored files (config.json, tokenizer files, etc.).
-	if (pendingDownloads.length > 0 && sourceHandle.type === "repo") {
-		const repoDesignation = { type: sourceHandle.repoType, name: sourceHandle.repoId } as const;
-		const bucketDesignation = { type: "bucket" as const, name: destinationBucketId };
+	if (lfsOffenders.length > 0) {
+		throwUnmigratedLfsError(sourceRepoId, lfsOffenders);
+	}
 
-		for (const { filePath, targetPath } of pendingDownloads) {
-			const blob = await downloadFile({
-				repo: repoDesignation,
-				path: filePath,
-				revision: sourceHandle.revision,
+	if (operations.length === 0) {
+		return undefined;
+	}
+
+	if (pendingDownloads.length > 0) {
+		await downloadAndFillBlobs({
+			pendingDownloads,
+			operations,
+			sourceRepoId,
+			sourceRevision,
+			accessToken,
+			hubUrl: params.hubUrl,
+			fetch: params.fetch,
+		});
+	}
+
+	await commit({
+		...(params.accessToken ? { accessToken: params.accessToken } : { credentials: params.credentials }),
+		repo: params.destination,
+		operations,
+		title: "",
+		hubUrl: params.hubUrl,
+		fetch: params.fetch,
+		abortSignal: params.abortSignal,
+	});
+	return undefined;
+}
+
+/**
+ * Resolve a list of {@link CopyFile} entries into `CommitOperation`s, batching `pathsInfo`
+ * calls per source repo and parallelizing downloads for non-xet files.
+ */
+async function resolveCopyOperations(shared: SharedParams, files: CopyFile[]): Promise<CommitOperation[]> {
+	const accessToken = checkCredentials(shared);
+
+	// Group files by (source repo, source revision) so we can batch pathsInfo calls.
+	const groups = new Map<
+		string,
+		{
+			repoId: RepoId;
+			revision: string | undefined;
+			entries: Array<{ index: number; file: CopyFile }>;
+		}
+	>();
+
+	for (let i = 0; i < files.length; i++) {
+		const file = files[i];
+		const repoId = toRepoId(file.source);
+		const revision = repoId.type === "bucket" ? undefined : (file.sourceRevision ?? "main");
+		const key = `${repoId.type}\0${repoId.name}\0${revision ?? ""}`;
+
+		let group = groups.get(key);
+		if (!group) {
+			group = { repoId, revision, entries: [] };
+			groups.set(key, group);
+		}
+		group.entries.push({ index: i, file });
+	}
+
+	const operations: CommitOperation[] = new Array(files.length);
+	const pendingDownloads: Array<{ index: number; repoId: RepoId; revision: string | undefined; sourcePath: string }> =
+		[];
+
+	for (const group of groups.values()) {
+		const paths = group.entries.map((e) => e.file.sourcePath);
+
+		const infos: Awaited<ReturnType<typeof pathsInfo>> = [];
+		for (let offset = 0; offset < paths.length; offset += PATHS_INFO_BATCH_SIZE) {
+			const slice = paths.slice(offset, offset + PATHS_INFO_BATCH_SIZE);
+			const res = await pathsInfo({
+				repo: group.repoId,
+				paths: slice,
+				revision: group.revision,
 				accessToken,
-				hubUrl,
-				fetch: fetchFn,
+				hubUrl: shared.hubUrl,
+				fetch: shared.fetch,
+			});
+			infos.push(...res);
+		}
+
+		const infoByPath = new Map(infos.map((i) => [i.path, i]));
+		const lfsOffenders: Array<{ path: string; size: number }> = [];
+
+		for (const { index, file } of group.entries) {
+			const info = infoByPath.get(file.sourcePath);
+			if (!info) {
+				throw new Error(`Source file not found: '${file.sourcePath}' in ${group.repoId.type}s/${group.repoId.name}`);
+			}
+			if (info.type !== "file") {
+				throw new Error(
+					`Source path '${file.sourcePath}' in ${group.repoId.type}s/${group.repoId.name} is a folder; use copyFolder() instead.`,
+				);
+			}
+
+			switch (classifySourceFile(info)) {
+				case "copy":
+					operations[index] = {
+						operation: "copy",
+						path: file.destinationPath,
+						sourceXetHash: info.xetHash as string,
+						sourceRepo: group.repoId,
+					};
+					continue;
+				case "lfs":
+					lfsOffenders.push({ path: file.sourcePath, size: info.lfs?.size ?? info.size });
+					continue;
+				case "download":
+					pendingDownloads.push({
+						index,
+						repoId: group.repoId,
+						revision: group.revision,
+						sourcePath: file.sourcePath,
+					});
+					operations[index] = {
+						operation: "addOrUpdate",
+						path: file.destinationPath,
+						content: new Blob([]),
+					};
+					continue;
+			}
+		}
+
+		if (lfsOffenders.length > 0) {
+			throwUnmigratedLfsError(group.repoId, lfsOffenders);
+		}
+	}
+
+	if (pendingDownloads.length > 0) {
+		await promisesQueue(
+			pendingDownloads.map(({ index, repoId, revision, sourcePath }) => async () => {
+				const blob = await downloadFile({
+					repo: repoId,
+					path: sourcePath,
+					revision,
+					accessToken,
+					hubUrl: shared.hubUrl,
+					fetch: shared.fetch,
+				});
+				if (!blob) {
+					throw new Error(`Failed to download '${sourcePath}' from ${repoId.type}s/${repoId.name}`);
+				}
+				const op = operations[index];
+				if (op.operation !== "addOrUpdate") {
+					throw new Error("Internal: expected addOrUpdate placeholder operation");
+				}
+				op.content = blob;
+			}),
+			DOWNLOAD_CONCURRENCY,
+		);
+	}
+
+	return operations;
+}
+
+async function downloadAndFillBlobs(args: {
+	pendingDownloads: Array<{ index: number; sourcePath: string }>;
+	operations: CommitOperation[];
+	sourceRepoId: RepoId;
+	sourceRevision: string | undefined;
+	accessToken: string | undefined;
+	hubUrl: string | undefined;
+	fetch: typeof fetch | undefined;
+}): Promise<void> {
+	await promisesQueue(
+		args.pendingDownloads.map(({ index, sourcePath }) => async () => {
+			const blob = await downloadFile({
+				repo: args.sourceRepoId,
+				path: sourcePath,
+				revision: args.sourceRevision,
+				accessToken: args.accessToken,
+				hubUrl: args.hubUrl,
+				fetch: args.fetch,
 			});
 			if (!blob) {
-				throw new Error(`Failed to download file '${filePath}' from repo '${sourceHandle.repoId}'.`);
+				throw new Error(`Failed to download '${sourcePath}' from ${args.sourceRepoId.type}s/${args.sourceRepoId.name}`);
 			}
-			await commit({
-				repo: bucketDesignation,
-				operations: [
-					{
-						operation: "addOrUpdate",
-						path: targetPath,
-						content: blob,
-					},
-				],
-				title: `Copy ${filePath}`,
-				accessToken,
-				hubUrl,
-				fetch: fetchFn,
-			});
-		}
+			const op = args.operations[index];
+			if (op.operation !== "addOrUpdate") {
+				throw new Error("Internal: expected addOrUpdate placeholder operation");
+			}
+			op.content = blob;
+		}),
+		DOWNLOAD_CONCURRENCY,
+	);
+}
+
+/**
+ * Compute the path of `filePath` relative to `folderPath`. Used to map source paths
+ * under a folder being copied to destination paths under the new prefix.
+ */
+export function relativeUnderFolder(filePath: string, folderPath: string): string {
+	if (!folderPath) {
+		return filePath;
 	}
-
-	// Send server-side copy operations in batches
-	for (const copyChunk of chunk(allCopies, BATCH_CHUNK_SIZE)) {
-		const ndjsonBody = copyChunk
-			.map((op) =>
-				JSON.stringify({
-					type: "copyFile",
-					path: op.path,
-					xetHash: op.xetHash,
-					sourceRepoType: op.sourceRepoType,
-					sourceRepoId: op.sourceRepoId,
-				}),
-			)
-			.join("\n");
-
-		const resp = await fetchFn(`${hubUrl}/api/buckets/${destinationBucketId}/batch`, {
-			method: "POST",
-			headers: {
-				...(accessToken && { Authorization: `Bearer ${accessToken}` }),
-				"Content-Type": "application/x-ndjson",
-			},
-			body: ndjsonBody,
-		});
-
-		if (!resp.ok) {
-			throw await createApiError(resp);
-		}
-
-		const result = (await resp.json()) as ApiBucketBatchResponse;
-		if (result.failed.length > 0) {
-			const failedPaths = result.failed
-				.slice(0, 5)
-				.map((f) => `${f.path}: ${f.error}`)
-				.join(", ");
-			throw new Error(
-				`Failed to copy ${result.failed.length} file(s): ${failedPaths}${result.failed.length > 5 ? "..." : ""}`,
-			);
-		}
+	if (filePath === folderPath) {
+		return filePath.split("/").pop() ?? filePath;
 	}
+	if (filePath.startsWith(folderPath + "/")) {
+		return filePath.slice(folderPath.length + 1);
+	}
+	throw new Error(`Path '${filePath}' is not inside folder '${folderPath}'`);
+}
+
+/**
+ * Decide how to handle a source file in the copy pipeline:
+ * - `"copy"`: xet-backed, can be copied server-side.
+ * - `"download"`: regular git-stored file, safe to download + re-upload.
+ * - `"lfs"`: LFS pointer file that has not been migrated to xet. We refuse to copy these
+ *   because they can be arbitrarily large; the caller should migrate them to xet first.
+ */
+function classifySourceFile(file: ListFileEntry | PathInfo): "copy" | "download" | "lfs" {
+	if (file.xetHash) {
+		return "copy";
+	}
+	if (file.lfs) {
+		return "lfs";
+	}
+	return "download";
+}
+
+/**
+ * Format a byte count using SI units (multiples of 1000, e.g. `1.2 GB`).
+ */
+function formatBytes(bytes: number): string {
+	if (!Number.isFinite(bytes) || bytes < 0) {
+		return `${bytes} B`;
+	}
+	const units = ["B", "kB", "MB", "GB", "TB", "PB"];
+	let value = bytes;
+	let i = 0;
+	while (value >= 1000 && i < units.length - 1) {
+		value /= 1000;
+		i++;
+	}
+	const formatted = i === 0 ? value.toString() : value.toFixed(value >= 100 ? 0 : value >= 10 ? 1 : 2);
+	return `${formatted} ${units[i]}`;
+}
+
+function throwUnmigratedLfsError(repoId: RepoId, entries: Array<{ path: string; size: number }>): never {
+	const head = entries
+		.slice(0, MAX_REPORTED_LFS_PATHS)
+		.map((e) => `'${e.path}' (${formatBytes(e.size)})`)
+		.join(", ");
+	const more = entries.length > MAX_REPORTED_LFS_PATHS ? ` (and ${entries.length - MAX_REPORTED_LFS_PATHS} more)` : "";
+	throw new Error(
+		`Cannot copy ${entries.length} LFS file(s) from ${repoId.type}s/${repoId.name} that have not been migrated to xet: ${head}${more}. ` +
+			`Migrate these files to xet before copying.`,
+	);
 }

--- a/packages/hub/src/lib/copy-files.ts
+++ b/packages/hub/src/lib/copy-files.ts
@@ -1,5 +1,6 @@
 import type { BucketDesignation, CredentialsParams, RepoDesignation, RepoId } from "../types/public";
 import { checkCredentials } from "../utils/checkCredentials";
+import { formatBytes } from "../utils/formatBytes";
 import { promisesQueue } from "../utils/promisesQueue";
 import { toRepoId } from "../utils/toRepoId";
 import type { CommitOperation, CommitParams } from "./commit";
@@ -445,24 +446,6 @@ function classifySourceFile(file: ListFileEntry | PathInfo): "copy" | "download"
 		return "lfs";
 	}
 	return "download";
-}
-
-/**
- * Format a byte count using SI units (multiples of 1000, e.g. `1.2 GB`).
- */
-function formatBytes(bytes: number): string {
-	if (!Number.isFinite(bytes) || bytes < 0) {
-		return `${bytes} B`;
-	}
-	const units = ["B", "kB", "MB", "GB", "TB", "PB"];
-	let value = bytes;
-	let i = 0;
-	while (value >= 1000 && i < units.length - 1) {
-		value /= 1000;
-		i++;
-	}
-	const formatted = i === 0 ? value.toString() : value.toFixed(value >= 100 ? 0 : value >= 10 ? 1 : 2);
-	return `${formatted} ${units[i]}`;
 }
 
 function throwUnmigratedLfsError(repoId: RepoId, entries: Array<{ path: string; size: number }>): never {

--- a/packages/hub/src/lib/copy-files.ts
+++ b/packages/hub/src/lib/copy-files.ts
@@ -191,6 +191,9 @@ export async function copyFiles(
 	const hubUrl = params.hubUrl ?? HUB_URL;
 	const fetchFn = params.fetch ?? fetch;
 
+	const allCopies: CopyFileOp[] = [];
+	const pendingDownloads: Array<{ filePath: string; targetPath: string }> = [];
+
 	const sourceHandle = parseHfCopyHandle(params.source);
 	const destinationHandle = parseHfCopyHandle(params.destination);
 
@@ -216,19 +219,16 @@ export async function copyFiles(
 		if (destInfo.length > 0) {
 			destinationIsDirectory = false;
 		} else {
-			let hasChildren = false;
-			for await (const _ of listFiles({
+			const listFilesIter = listFiles({
 				repo: { type: "bucket", name: destinationBucketId },
 				path: destinationPath,
 				recursive: false,
 				accessToken,
 				hubUrl,
 				fetch: fetchFn,
-			})) {
-				hasChildren = true;
-				break;
-			}
-			destinationIsDirectory = hasChildren;
+			});
+			const firstResult = await listFilesIter.next();
+			destinationIsDirectory = !firstResult.done;
 		}
 	}
 
@@ -264,8 +264,18 @@ export async function copyFiles(
 		return `${destinationPath.replace(/\/+$/, "")}/${relPath}`;
 	}
 
-	const allCopies: CopyFileOp[] = [];
-	const pendingDownloads: Array<{ filePath: string; targetPath: string }> = [];
+	function addRepoFile(file: ListFileEntry | PathInfo, targetPath: string): void {
+		if (file.xetHash && sourceHandle.type === "repo") {
+			allCopies.push({
+				path: targetPath,
+				xetHash: file.xetHash,
+				sourceRepoType: sourceHandle.repoType,
+				sourceRepoId: sourceHandle.repoId,
+			});
+		} else {
+			pendingDownloads.push({ filePath: file.path, targetPath });
+		}
+	}
 
 	if (sourceHandle.type === "bucket") {
 		const sourcePath = sourceHandle.path;
@@ -283,10 +293,13 @@ export async function copyFiles(
 
 		if (sourcePathInfo.length === 1 && sourcePathInfo[0].type === "file") {
 			const sourceFile = sourcePathInfo[0];
+			if (!sourceFile.xetHash) {
+				throw new Error(`Source file '${sourceFile.path}' does not have a xetHash, cannot copy.`);
+			}
 			const targetPath = resolveTargetPath(sourceFile.path, null, true);
 			allCopies.push({
 				path: targetPath,
-				xetHash: sourceFile.xetHash!,
+				xetHash: sourceFile.xetHash,
 				sourceRepoType: "bucket",
 				sourceRepoId: sourceHandle.bucketId,
 			});
@@ -303,13 +316,16 @@ export async function copyFiles(
 				if (item.type !== "file") {
 					continue;
 				}
+				if (!item.xetHash) {
+					continue;
+				}
 				if (sourcePath && !(item.path === sourcePath || item.path.startsWith(sourcePath + "/"))) {
 					continue;
 				}
 				const targetPath = resolveTargetPath(item.path, sourcePath || null, false);
 				allCopies.push({
 					path: targetPath,
-					xetHash: item.xetHash!,
+					xetHash: item.xetHash,
 					sourceRepoType: "bucket",
 					sourceRepoId: sourceHandle.bucketId,
 				});
@@ -318,19 +334,6 @@ export async function copyFiles(
 	} else {
 		const sourcePath = sourceHandle.path;
 		const repoDesignation = { type: sourceHandle.repoType, name: sourceHandle.repoId } as const;
-
-		function addRepoFile(file: ListFileEntry | PathInfo, targetPath: string): void {
-			if (file.xetHash && sourceHandle.type === "repo") {
-				allCopies.push({
-					path: targetPath,
-					xetHash: file.xetHash,
-					sourceRepoType: sourceHandle.repoType,
-					sourceRepoId: sourceHandle.repoId,
-				});
-			} else {
-				pendingDownloads.push({ filePath: file.path, targetPath });
-			}
-		}
 
 		let sourceRepoPathInfo: PathInfo[] = [];
 		if (sourcePath !== "") {

--- a/packages/hub/src/lib/copy-files.ts
+++ b/packages/hub/src/lib/copy-files.ts
@@ -16,25 +16,51 @@ const PATHS_INFO_BATCH_SIZE = 100;
 const MAX_REPORTED_LFS_PATHS = 5;
 
 /**
- * One file to copy in a {@link copyFiles} call.
+ * Source location of a file in {@link copyFile} / {@link copyFiles} / {@link copyFolder}.
  */
-export interface CopyFile {
-	source: RepoDesignation;
-	sourcePath: string;
+export interface CopySource {
+	repo: RepoDesignation;
+	/**
+	 * Path of the file (or folder, for {@link copyFolder}) inside the source repo.
+	 * Leave empty in {@link copyFolder} to copy the whole repo.
+	 */
+	path: string;
 	/**
 	 * Git revision to read the source from. Ignored for bucket sources.
 	 *
 	 * @default "main"
 	 */
-	sourceRevision?: string;
+	revision?: string;
+}
+
+/**
+ * Destination location for {@link copyFile} / {@link copyFolder}.
+ *
+ * The destination repo must be a bucket — server-side copy is currently only supported
+ * towards buckets.
+ */
+export interface CopyDestination {
+	repo: BucketDesignation;
 	/**
-	 * Exact destination path within the destination bucket.
+	 * Exact destination path within the destination bucket. For {@link copyFolder},
+	 * acts as a prefix; leave empty to copy under the bucket root.
+	 */
+	path: string;
+}
+
+/**
+ * One file to copy in a {@link copyFiles} call.
+ */
+export interface CopyFilesEntry {
+	source: CopySource;
+	/**
+	 * Exact path within the destination bucket. The bucket itself is shared with the
+	 * other entries via the top-level {@link copyFiles} `destination` parameter.
 	 */
 	destinationPath: string;
 }
 
 type SharedParams = {
-	destination: BucketDesignation;
 	hubUrl?: CommitParams["hubUrl"];
 	fetch?: CommitParams["fetch"];
 	abortSignal?: CommitParams["abortSignal"];
@@ -47,27 +73,37 @@ type SharedParams = {
  * For small non-xet repo files (e.g. `config.json`) the file is downloaded and
  * re-uploaded to the destination bucket in the same commit.
  *
+ * LFS pointer files that have not been migrated to xet are rejected up front
+ * (they would otherwise require downloading the full LFS blob).
+ *
  * @example
  * ```ts
  * await copyFile({
- *   source: { type: "model", name: "username/my-model" },
- *   sourcePath: "model.safetensors",
- *   destination: { type: "bucket", name: "username/my-bucket" },
- *   destinationPath: "models/my-model/model.safetensors",
+ *   source: {
+ *     repo: { type: "model", name: "username/my-model" },
+ *     path: "model.safetensors",
+ *   },
+ *   destination: {
+ *     repo: { type: "bucket", name: "username/my-bucket" },
+ *     path: "models/my-model/model.safetensors",
+ *   },
  *   accessToken: "hf_...",
  * });
  * ```
  */
-export function copyFile(params: CopyFile & SharedParams): Promise<undefined> {
+export function copyFile(
+	params: {
+		source: CopySource;
+		destination: CopyDestination;
+	} & SharedParams,
+): Promise<undefined> {
 	return copyFiles({
 		...(params.accessToken ? { accessToken: params.accessToken } : { credentials: params.credentials }),
-		destination: params.destination,
+		destination: params.destination.repo,
 		files: [
 			{
 				source: params.source,
-				sourcePath: params.sourcePath,
-				sourceRevision: params.sourceRevision,
-				destinationPath: params.destinationPath,
+				destinationPath: params.destination.path,
 			},
 		],
 		hubUrl: params.hubUrl,
@@ -84,19 +120,25 @@ export function copyFile(params: CopyFile & SharedParams): Promise<undefined> {
  * For non-xet source files (typically small git-stored repo files), the file is
  * downloaded and re-uploaded as part of the same commit.
  *
+ * LFS pointer files that have not been migrated to xet are rejected up front.
+ *
  * @example
  * ```ts
  * await copyFiles({
  *   destination: { type: "bucket", name: "username/my-bucket" },
  *   files: [
  *     {
- *       source: { type: "bucket", name: "username/other-bucket" },
- *       sourcePath: "data.bin",
+ *       source: {
+ *         repo: { type: "bucket", name: "username/other-bucket" },
+ *         path: "data.bin",
+ *       },
  *       destinationPath: "data.bin",
  *     },
  *     {
- *       source: { type: "model", name: "username/my-model" },
- *       sourcePath: "model.safetensors",
+ *       source: {
+ *         repo: { type: "model", name: "username/my-model" },
+ *         path: "model.safetensors",
+ *       },
  *       destinationPath: "models/my-model/model.safetensors",
  *     },
  *   ],
@@ -106,7 +148,8 @@ export function copyFile(params: CopyFile & SharedParams): Promise<undefined> {
  */
 export async function copyFiles(
 	params: {
-		files: CopyFile[];
+		destination: BucketDesignation;
+		files: CopyFilesEntry[];
 	} & SharedParams,
 ): Promise<undefined> {
 	if (params.files.length === 0) {
@@ -131,54 +174,47 @@ export async function copyFiles(
  * Copy a folder (recursively) from a source repo/bucket to the destination bucket
  * in a single commit.
  *
- * Per-file paths are resolved relative to {@link sourcePath}; the source folder
- * itself is not preserved in the destination unless {@link destinationPath} keeps it.
+ * Per-file paths are resolved relative to {@link CopySource.path}; the source folder
+ * itself is not preserved in the destination unless {@link CopyDestination.path}
+ * keeps it.
  *
  * @example
  * ```ts
  * // Copy an entire dataset under "datasets/my-dataset/" in the bucket
  * await copyFolder({
- *   source: { type: "dataset", name: "username/my-dataset" },
- *   destination: { type: "bucket", name: "username/my-bucket" },
- *   destinationPath: "datasets/my-dataset/",
+ *   source: { repo: { type: "dataset", name: "username/my-dataset" } },
+ *   destination: {
+ *     repo: { type: "bucket", name: "username/my-bucket" },
+ *     path: "datasets/my-dataset/",
+ *   },
  *   accessToken: "hf_...",
  * });
  *
  * // Copy a subfolder
  * await copyFolder({
- *   source: { type: "bucket", name: "username/src-bucket" },
- *   sourcePath: "models/",
- *   destination: { type: "bucket", name: "username/dst-bucket" },
- *   destinationPath: "backup/",
+ *   source: {
+ *     repo: { type: "bucket", name: "username/src-bucket" },
+ *     path: "models/",
+ *   },
+ *   destination: {
+ *     repo: { type: "bucket", name: "username/dst-bucket" },
+ *     path: "backup/",
+ *   },
  *   accessToken: "hf_...",
  * });
  * ```
  */
 export async function copyFolder(
 	params: {
-		source: RepoDesignation;
-		/**
-		 * Path of the folder inside the source repo. Leave empty to copy the whole repo.
-		 */
-		sourcePath?: string;
-		/**
-		 * Git revision to read the source from. Ignored for bucket sources.
-		 *
-		 * @default "main"
-		 */
-		sourceRevision?: string;
-		/**
-		 * Prefix in the destination bucket where the folder will be copied.
-		 * Leave empty to copy under the bucket root.
-		 */
-		destinationPath?: string;
+		source: Omit<CopySource, "path"> & { path?: string };
+		destination: Omit<CopyDestination, "path"> & { path?: string };
 	} & SharedParams,
 ): Promise<undefined> {
 	const accessToken = checkCredentials(params);
-	const sourceRepoId = toRepoId(params.source);
-	const sourcePath = (params.sourcePath ?? "").replace(/\/+$/, "");
-	const destinationPrefix = (params.destinationPath ?? "").replace(/\/+$/, "");
-	const sourceRevision = sourceRepoId.type === "bucket" ? undefined : (params.sourceRevision ?? "main");
+	const sourceRepoId = toRepoId(params.source.repo);
+	const sourcePath = (params.source.path ?? "").replace(/\/+$/, "");
+	const destinationPrefix = (params.destination.path ?? "").replace(/\/+$/, "");
+	const sourceRevision = sourceRepoId.type === "bucket" ? undefined : (params.source.revision ?? "main");
 
 	const operations: CommitOperation[] = [];
 	const pendingDownloads: Array<{ index: number; sourcePath: string }> = [];
@@ -246,7 +282,7 @@ export async function copyFolder(
 
 	await commit({
 		...(params.accessToken ? { accessToken: params.accessToken } : { credentials: params.credentials }),
-		repo: params.destination,
+		repo: params.destination.repo,
 		operations,
 		title: "",
 		hubUrl: params.hubUrl,
@@ -257,10 +293,10 @@ export async function copyFolder(
 }
 
 /**
- * Resolve a list of {@link CopyFile} entries into `CommitOperation`s, batching `pathsInfo`
- * calls per source repo and parallelizing downloads for non-xet files.
+ * Resolve a list of {@link CopyFilesEntry} entries into `CommitOperation`s, batching
+ * `pathsInfo` calls per source repo and parallelizing downloads for non-xet files.
  */
-async function resolveCopyOperations(shared: SharedParams, files: CopyFile[]): Promise<CommitOperation[]> {
+async function resolveCopyOperations(shared: SharedParams, files: CopyFilesEntry[]): Promise<CommitOperation[]> {
 	const accessToken = checkCredentials(shared);
 
 	// Group files by (source repo, source revision) so we can batch pathsInfo calls.
@@ -269,14 +305,14 @@ async function resolveCopyOperations(shared: SharedParams, files: CopyFile[]): P
 		{
 			repoId: RepoId;
 			revision: string | undefined;
-			entries: Array<{ index: number; file: CopyFile }>;
+			entries: Array<{ index: number; file: CopyFilesEntry }>;
 		}
 	>();
 
 	for (let i = 0; i < files.length; i++) {
 		const file = files[i];
-		const repoId = toRepoId(file.source);
-		const revision = repoId.type === "bucket" ? undefined : (file.sourceRevision ?? "main");
+		const repoId = toRepoId(file.source.repo);
+		const revision = repoId.type === "bucket" ? undefined : (file.source.revision ?? "main");
 		const key = `${repoId.type}\0${repoId.name}\0${revision ?? ""}`;
 
 		let group = groups.get(key);
@@ -292,7 +328,7 @@ async function resolveCopyOperations(shared: SharedParams, files: CopyFile[]): P
 		[];
 
 	for (const group of groups.values()) {
-		const paths = group.entries.map((e) => e.file.sourcePath);
+		const paths = group.entries.map((e) => e.file.source.path);
 
 		const infos: Awaited<ReturnType<typeof pathsInfo>> = [];
 		for (let offset = 0; offset < paths.length; offset += PATHS_INFO_BATCH_SIZE) {
@@ -312,13 +348,13 @@ async function resolveCopyOperations(shared: SharedParams, files: CopyFile[]): P
 		const lfsOffenders: Array<{ path: string; size: number }> = [];
 
 		for (const { index, file } of group.entries) {
-			const info = infoByPath.get(file.sourcePath);
+			const info = infoByPath.get(file.source.path);
 			if (!info) {
-				throw new Error(`Source file not found: '${file.sourcePath}' in ${group.repoId.type}s/${group.repoId.name}`);
+				throw new Error(`Source file not found: '${file.source.path}' in ${group.repoId.type}s/${group.repoId.name}`);
 			}
 			if (info.type !== "file") {
 				throw new Error(
-					`Source path '${file.sourcePath}' in ${group.repoId.type}s/${group.repoId.name} is a folder; use copyFolder() instead.`,
+					`Source path '${file.source.path}' in ${group.repoId.type}s/${group.repoId.name} is a folder; use copyFolder() instead.`,
 				);
 			}
 
@@ -332,14 +368,14 @@ async function resolveCopyOperations(shared: SharedParams, files: CopyFile[]): P
 					};
 					continue;
 				case "lfs":
-					lfsOffenders.push({ path: file.sourcePath, size: info.lfs?.size ?? info.size });
+					lfsOffenders.push({ path: file.source.path, size: info.lfs?.size ?? info.size });
 					continue;
 				case "download":
 					pendingDownloads.push({
 						index,
 						repoId: group.repoId,
 						revision: group.revision,
-						sourcePath: file.sourcePath,
+						sourcePath: file.source.path,
 					});
 					operations[index] = {
 						operation: "addOrUpdate",

--- a/packages/hub/src/lib/copy-files.ts
+++ b/packages/hub/src/lib/copy-files.ts
@@ -217,7 +217,7 @@ export async function copyFolder(
 	const sourceRevision = sourceRepoId.type === "bucket" ? undefined : (params.source.revision ?? "main");
 
 	const operations: CommitOperation[] = [];
-	const pendingDownloads: Array<{ index: number; sourcePath: string }> = [];
+	const pendingDownloads: PendingDownload[] = [];
 	const lfsOffenders: Array<{ path: string; size: number }> = [];
 
 	for await (const item of listFiles({
@@ -250,7 +250,12 @@ export async function copyFolder(
 				continue;
 			case "download":
 				// Regular git-stored file (small): download + re-upload in the same commit.
-				pendingDownloads.push({ index: operations.length, sourcePath: item.path });
+				pendingDownloads.push({
+					index: operations.length,
+					repoId: sourceRepoId,
+					revision: sourceRevision,
+					sourcePath: item.path,
+				});
 				operations.push({
 					operation: "addOrUpdate",
 					path: destPath,
@@ -268,17 +273,13 @@ export async function copyFolder(
 		return undefined;
 	}
 
-	if (pendingDownloads.length > 0) {
-		await downloadAndFillBlobs({
-			pendingDownloads,
-			operations,
-			sourceRepoId,
-			sourceRevision,
-			accessToken,
-			hubUrl: params.hubUrl,
-			fetch: params.fetch,
-		});
-	}
+	await downloadAndFillBlobs({
+		pendingDownloads,
+		operations,
+		accessToken,
+		hubUrl: params.hubUrl,
+		fetch: params.fetch,
+	});
 
 	await commit({
 		...(params.accessToken ? { accessToken: params.accessToken } : { credentials: params.credentials }),
@@ -324,8 +325,7 @@ async function resolveCopyOperations(shared: SharedParams, files: CopyFilesEntry
 	}
 
 	const operations: CommitOperation[] = new Array(files.length);
-	const pendingDownloads: Array<{ index: number; repoId: RepoId; revision: string | undefined; sourcePath: string }> =
-		[];
+	const pendingDownloads: PendingDownload[] = [];
 
 	for (const group of groups.values()) {
 		const paths = group.entries.map((e) => e.file.source.path);
@@ -391,54 +391,50 @@ async function resolveCopyOperations(shared: SharedParams, files: CopyFilesEntry
 		}
 	}
 
-	if (pendingDownloads.length > 0) {
-		await promisesQueue(
-			pendingDownloads.map(({ index, repoId, revision, sourcePath }) => async () => {
-				const blob = await downloadFile({
-					repo: repoId,
-					path: sourcePath,
-					revision,
-					accessToken,
-					hubUrl: shared.hubUrl,
-					fetch: shared.fetch,
-				});
-				if (!blob) {
-					throw new Error(`Failed to download '${sourcePath}' from ${repoId.type}s/${repoId.name}`);
-				}
-				const op = operations[index];
-				if (op.operation !== "addOrUpdate") {
-					throw new Error("Internal: expected addOrUpdate placeholder operation");
-				}
-				op.content = blob;
-			}),
-			DOWNLOAD_CONCURRENCY,
-		);
-	}
+	await downloadAndFillBlobs({
+		pendingDownloads,
+		operations,
+		accessToken,
+		hubUrl: shared.hubUrl,
+		fetch: shared.fetch,
+	});
 
 	return operations;
 }
 
+interface PendingDownload {
+	index: number;
+	repoId: RepoId;
+	revision: string | undefined;
+	sourcePath: string;
+}
+
+/**
+ * Download all `pendingDownloads` in parallel and fill the matching `addOrUpdate`
+ * placeholder ops in `operations` with the downloaded blob. No-op if the list is empty.
+ */
 async function downloadAndFillBlobs(args: {
-	pendingDownloads: Array<{ index: number; sourcePath: string }>;
+	pendingDownloads: PendingDownload[];
 	operations: CommitOperation[];
-	sourceRepoId: RepoId;
-	sourceRevision: string | undefined;
 	accessToken: string | undefined;
 	hubUrl: string | undefined;
 	fetch: typeof fetch | undefined;
 }): Promise<void> {
+	if (args.pendingDownloads.length === 0) {
+		return;
+	}
 	await promisesQueue(
-		args.pendingDownloads.map(({ index, sourcePath }) => async () => {
+		args.pendingDownloads.map(({ index, repoId, revision, sourcePath }) => async () => {
 			const blob = await downloadFile({
-				repo: args.sourceRepoId,
+				repo: repoId,
 				path: sourcePath,
-				revision: args.sourceRevision,
+				revision,
 				accessToken: args.accessToken,
 				hubUrl: args.hubUrl,
 				fetch: args.fetch,
 			});
 			if (!blob) {
-				throw new Error(`Failed to download '${sourcePath}' from ${args.sourceRepoId.type}s/${args.sourceRepoId.name}`);
+				throw new Error(`Failed to download '${sourcePath}' from ${repoId.type}s/${repoId.name}`);
 			}
 			const op = args.operations[index];
 			if (op.operation !== "addOrUpdate") {

--- a/packages/hub/src/lib/index.ts
+++ b/packages/hub/src/lib/index.ts
@@ -1,6 +1,7 @@
 export * from "./cache-management";
 export * from "./check-repo-access";
 export * from "./commit";
+export * from "./copy-files";
 export * from "./count-commits";
 export * from "./create-repo";
 export * from "./create-branch";

--- a/packages/hub/src/types/api/api-index-tree.ts
+++ b/packages/hub/src/types/api/api-index-tree.ts
@@ -9,6 +9,11 @@ export interface ApiIndexTreeEntry {
 		/** Size of the raw pointer file, 100~200 bytes */
 		pointerSize: number;
 	};
+	/**
+	 * Xet content hash. Set for bucket file entries (always) and for repo LFS entries
+	 * that have been migrated to xet.
+	 */
+	xetHash?: string;
 	lastCommit?: {
 		date: string;
 		id: string;

--- a/packages/hub/src/types/public.ts
+++ b/packages/hub/src/types/public.ts
@@ -16,6 +16,14 @@ export type RepoFullName =
 
 export type RepoDesignation = RepoId | RepoFullName;
 
+/**
+ * A {@link RepoDesignation} narrowed to bucket repos.
+ *
+ * Used by APIs that only operate on buckets (e.g. {@link copyFile}, {@link copyFiles},
+ * {@link copyFolder}).
+ */
+export type BucketDesignation = { type: "bucket"; name: string } | `buckets/${string}`;
+
 /** Actually `hf_${string}`, but for convenience, using the string type */
 export type AccessToken = string;
 

--- a/packages/hub/src/utils/formatBytes.spec.ts
+++ b/packages/hub/src/utils/formatBytes.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { formatBytes } from "./formatBytes";
+
+describe("formatBytes", () => {
+	it("uses SI units (multiples of 1000)", () => {
+		expect(formatBytes(0)).toBe("0 B");
+		expect(formatBytes(999)).toBe("999 B");
+		expect(formatBytes(1000)).toBe("1.00 kB");
+		expect(formatBytes(1_500)).toBe("1.50 kB");
+		expect(formatBytes(1_000_000)).toBe("1.00 MB");
+		expect(formatBytes(5_300_000_000)).toBe("5.30 GB");
+	});
+
+	it("adjusts precision based on magnitude", () => {
+		expect(formatBytes(12_300)).toBe("12.3 kB");
+		expect(formatBytes(123_000)).toBe("123 kB");
+	});
+
+	it("handles invalid inputs gracefully", () => {
+		expect(formatBytes(NaN)).toBe("NaN B");
+		expect(formatBytes(-1)).toBe("-1 B");
+	});
+});

--- a/packages/hub/src/utils/formatBytes.ts
+++ b/packages/hub/src/utils/formatBytes.ts
@@ -1,0 +1,19 @@
+/**
+ * Format a byte count using SI units (multiples of 1000, e.g. `1.2 GB`).
+ *
+ * Negative or non-finite inputs are returned as `"<value> B"` without unit conversion.
+ */
+export function formatBytes(bytes: number): string {
+	if (!Number.isFinite(bytes) || bytes < 0) {
+		return `${bytes} B`;
+	}
+	const units = ["B", "kB", "MB", "GB", "TB", "PB"];
+	let value = bytes;
+	let i = 0;
+	while (value >= 1000 && i < units.length - 1) {
+		value /= 1000;
+		i++;
+	}
+	const formatted = i === 0 ? value.toString() : value.toFixed(value >= 100 ? 0 : value >= 10 ? 1 : 2);
+	return `${formatted} ${units[i]}`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the **"copy files remotely"** API in `@huggingface/hub`, porting the Python [`HfApi.copy_files`](https://github.com/huggingface/huggingface_hub/pull/3874) functionality to TypeScript/JS.

This enables the **"Copy to Bucket"** feature on the Hub UI, allowing instant server-side file copy between buckets and from repositories to buckets.

### Supported operations

| Source | Destination | Mechanism |
|--------|------------|-----------|
| Bucket | Bucket | Server-side copy by xet hash (no data transfer) |
| Repo (model/dataset/space) with xet files | Bucket | Server-side copy by xet hash (no data transfer) |
| Repo with non-xet files (small git files) | Bucket | Download + re-upload via `commit()` |

### Not supported (yet)

- Bucket → Repo copy
- Repo → Repo copy

### Features

- **`copyFiles()`** — main function, exported from `@huggingface/hub`
- **`parseHfCopyHandle()`** — parses `hf://` handles (buckets, models, datasets, spaces, with `@revision` support)
- Single file and recursive folder copy
- Automatic destination path resolution (file vs directory target)
- Batched server-side copy via `POST /api/buckets/{id}/batch` with NDJSON `copyFile` operations
- Fallback download+upload path for non-xet repo files using existing `commit()` infrastructure

### Usage

```ts
import { copyFiles } from "@huggingface/hub";

// Copy a single file between buckets
await copyFiles({
  source: "hf://buckets/my-bucket/data.bin",
  destination: "hf://buckets/other-bucket/data.bin",
  accessToken: "hf_...",
});

// Copy a folder from a bucket to another bucket
await copyFiles({
  source: "hf://buckets/my-bucket/models/",
  destination: "hf://buckets/other-bucket/backup/",
  accessToken: "hf_...",
});

// Copy from a model repo to a bucket
await copyFiles({
  source: "hf://models/username/my-model/model.safetensors",
  destination: "hf://buckets/my-bucket/",
  accessToken: "hf_...",
});

// Copy an entire dataset to a bucket
await copyFiles({
  source: "hf://datasets/username/my-dataset/",
  destination: "hf://buckets/my-bucket/datasets/",
  accessToken: "hf_...",
});
```

## Reference

Python implementation: https://github.com/huggingface/huggingface_hub/pull/3874

## How to test locally

### Unit tests (handle parsing)

```bash
cd packages/hub
pnpm test -- --testPathPattern copy-files
```

The `parseHfCopyHandle` unit tests run without any network access.

### Integration tests (require CI Hub access)

The integration tests (`copyFiles` describe block) run against the CI Hub at `https://hub-ci.huggingface.co`. They:

1. Create temporary source/destination repos (bucket and/or model)
2. Upload test files
3. Run `copyFiles`
4. Verify files appear in the destination
5. Clean up repos

To run them:

```bash
cd packages/hub

# Set up test credentials (the tests use TEST_ACCESS_TOKEN from src/test/consts.ts)
pnpm test -- --testPathPattern copy-files
```

### Manual testing

You can also test manually against the production Hub:

```ts
import { copyFiles } from "@huggingface/hub";

// Copy a public model's files to your bucket
await copyFiles({
  source: "hf://models/openai-community/gpt2",
  destination: "hf://buckets/your-username/your-bucket/models/gpt2/",
  accessToken: "hf_YOUR_TOKEN",
});
```

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://huggingface.slack.com/archives/C04PJ0H35UM/p1775835738303639?thread_ts=1775835738.303639&cid=C04PJ0H35UM)

<div><a href="https://cursor.com/agents/bc-07f08a58-0a3f-58dd-9f50-0c39ca664d0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07f08a58-0a3f-58dd-9f50-0c39ca664d0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

