### PR TITLE
Pi: emit "input": ["text", "image"] for vision-capable models

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -153,6 +153,7 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		expect(snippet[1].setup).toContain("npm install -g @mariozechner/pi-coding-agent");
 		expect(snippet[1].content).toContain(`"id": "Qwen3.6-35B-A3B-GGUF"`);
 		expect(snippet[1].content).toContain(`"input"`);
+		expect(snippet[1].content).toContain(`"text"`);
 		expect(snippet[1].content).toContain(`"image"`);
 		expect(snippet[2].content).toContain("pi");
 	});

--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -138,6 +138,25 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		expect(snippet[2].content).toContain("pi");
 	});
 
+	it("pi - vision", async () => {
+		const { snippet: snippetFunc } = LOCAL_APPS["pi"];
+		const model: ModelData = {
+			id: "unsloth/Qwen3.6-35B-A3B-GGUF",
+			pipeline_tag: "image-text-to-text",
+			tags: ["conversational"],
+			gguf: { total: 1, context_length: 4096, chat_template: "{% if tools %}" },
+			inference: "",
+		};
+		const snippet = snippetFunc(model);
+
+		expect(snippet[0].content).toContain(`llama-server -hf unsloth/Qwen3.6-35B-A3B-GGUF:{{QUANT_TAG}} --jinja`);
+		expect(snippet[1].setup).toContain("npm install -g @mariozechner/pi-coding-agent");
+		expect(snippet[1].content).toContain(`"id": "Qwen3.6-35B-A3B-GGUF"`);
+		expect(snippet[1].content).toContain(`"input"`);
+		expect(snippet[1].content).toContain(`"image"`);
+		expect(snippet[2].content).toContain("pi");
+	});
+
 	it("pi - mlx", async () => {
 		const { snippet: snippetFunc } = LOCAL_APPS["pi"];
 		const model: ModelData = {

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -466,6 +466,7 @@ const snippetMlxLm = (model: ModelData): LocalAppSnippet[] => {
 const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 	const modelName = model.id.split("/").pop() ?? model.id;
 	const isMLX = isMlxModel(model);
+	const isVision = model.pipeline_tag === "image-text-to-text";
 
 	// Step 1: Server — differs by backend
 	const serverStep: LocalAppSnippet = isMLX
@@ -481,6 +482,10 @@ const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 			};
 
 	// Step 2: Pi config — port and provider name differ
+	const modelEntry: Record<string, unknown> = { id: isMLX ? model.id : modelName };
+	if (isVision) {
+		modelEntry.input = ["text", "image"];
+	}
 	const modelsJson = JSON.stringify(
 		{
 			providers: {
@@ -488,7 +493,7 @@ const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 					baseUrl: "http://localhost:8080/v1",
 					api: "openai-completions",
 					apiKey: "none",
-					models: [{ id: isMLX ? model.id : modelName }],
+					models: [modelEntry],
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- For models with `pipeline_tag === "image-text-to-text"`, the Pi "Use this model" snippet now writes `"input": ["text", "image"]` into the generated `~/.pi/agent/models.json`. Without this field, Pi can't pass images to the model — so users had to discover the field manually from the docs to get vision working.
- Behavior for text-only models is unchanged (existing test extended; new `pi - vision` test added).
- Cross-ref: huggingface/hub-docs#2408 — the documentation PR that explains the same field. @gary149's review there suggested surfacing it directly in the snippet.

## Test plan
- [x] `pnpm test` in `packages/tasks` (17 tests pass, including new `pi - vision`)
- [x] `pnpm check`, `pnpm lint:check`, `pnpm format:check` all clean
- [x] Verified generated JSON output via local script: text models produce identical output to before; vision models gain the `input` field correctly nested

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Pi snippet JSON generation for models flagged as vision-capable and adds a focused unit test; no auth, persistence, or runtime execution paths change beyond emitted config text.
> 
> **Overview**
> Updates the Pi “Use this model” snippet to include `"input": ["text", "image"]` in the generated `models.json` entry when the selected model has `pipeline_tag === "image-text-to-text"`, enabling image inputs for vision-capable models.
> 
> Adds a new `pi - vision` test to assert the `input` field is emitted (and preserves existing behavior for text-only and MLX-backed Pi snippets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf73c012e6685a17449301fb86d2959e34ecd945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->