### PR TITLE
Add RTX 2050 Mobile 4GB to hardware-nvidia.ts

### DIFF
--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -448,6 +448,11 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		memory: [6],
 		computeCapability: 7.5,
 	},
+	"RTX 2050 Mobile": {
+		tflops: 5.1, // 30W = 735-1245 MHz - https://www.techpowerup.com/gpu-specs/geforce-rtx-2050-mobile.c3859
+		memory: [4],
+		computeCapability: 8.6, // Architecture AMPERE_RTX
+	},
 	"GTX 1080 Ti": {
 		tflops: 11.34, // float32 (GPU does not support native float16)
 		memory: [11],

--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -449,7 +449,7 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		computeCapability: 7.5,
 	},
 	"RTX 2050 Mobile": {
-		tflops: 5.1, // 30W = 735-1245 MHz - https://www.techpowerup.com/gpu-specs/geforce-rtx-2050-mobile.c3859
+		tflops: 10.2,
 		memory: [4],
 		computeCapability: 8.6, // Architecture AMPERE_RTX
 	},

--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -451,7 +451,7 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 	"RTX 2050 Mobile": {
 		tflops: 10.2,
 		memory: [4],
-		computeCapability: 8.6, // Architecture AMPERE_RTX
+		computeCapability: 8.6, // Ampere (outlier GPU in the 20xx series)
 	},
 	"GTX 1080 Ti": {
 		tflops: 11.34, // float32 (GPU does not support native float16)


### PR DESCRIPTION
**NVIDIA GeForce RTX 2050 - 4GB VRAM**
It is based on Ampere architecture.
On my laptop (Debian), the command `nvidia-smi --query-gpu=clocks.max.sm,clocks.sm` returns 2100 MHz, but the card is capped at 30-45W, so I based the TFLOPS on the **Theoretical Performance** obtained from https://www.techpowerup.com/gpu-specs/geforce-rtx-2050-mobile.c3859

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a data-only addition to the NVIDIA GPU SKU table (TFLOPS/VRAM/compute capability) with no changes to logic or interfaces.
> 
> **Overview**
> Adds an `RTX 2050 Mobile` entry to `packages/tasks/src/hardware-nvidia.ts` with `tflops: 10.2`, `memory: [4]`, and `computeCapability: 8.6` (Ampere) so hardware detection/selection can recognize and size this GPU.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2024db96301161793ece31b755d9ca052121d76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->