### PR TITLE
Refactoring Hardware database

### DIFF
--- a/packages/tasks/src/hardware-apple.ts
+++ b/packages/tasks/src/hardware-apple.ts
@@ -1,0 +1,80 @@
+import type { HardwareSpec } from "./hardware.js";
+
+export const APPLE_SKUS: Record<string, HardwareSpec> = {
+	"Apple MacBook Neo": {
+		tflops: 1.9,
+		memory: [8],
+	},
+	"Apple M1": {
+		tflops: 2.6,
+		memory: [8, 16],
+	},
+	"Apple M1 Pro": {
+		tflops: 5.2,
+		memory: [16, 24, 32],
+	},
+	"Apple M1 Max": {
+		tflops: 10.4,
+		memory: [16, 24, 32, 64],
+	},
+	"Apple M1 Ultra": {
+		tflops: 21,
+		memory: [16, 24, 32, 64, 96, 128],
+	},
+	"Apple M2": {
+		tflops: 3.6,
+		memory: [8, 16, 24],
+	},
+	"Apple M2 Pro": {
+		tflops: 6.8,
+		memory: [16, 24, 32],
+	},
+	"Apple M2 Max": {
+		tflops: 13.49,
+		memory: [32, 64, 96],
+	},
+	"Apple M2 Ultra": {
+		tflops: 27.2,
+		memory: [64, 96, 128, 192],
+	},
+	"Apple M3": {
+		tflops: 4.1,
+		memory: [8, 16, 24],
+	},
+	"Apple M3 Pro": {
+		tflops: 7.4,
+		memory: [18, 36],
+	},
+	"Apple M3 Max": {
+		tflops: 14.2,
+		memory: [36, 48, 64, 96, 128],
+	},
+	"Apple M3 Ultra": {
+		tflops: 28.4,
+		memory: [96, 256, 512],
+	},
+	"Apple M4": {
+		tflops: 4.6,
+		memory: [16, 24, 32],
+	},
+	"Apple M4 Pro": {
+		tflops: 9.2,
+		memory: [24, 48, 64],
+	},
+	"Apple M4 Max": {
+		tflops: 18.4,
+		memory: [36, 48, 64, 96, 128, 256, 512],
+	},
+	"Apple M5": {
+		tflops: 5.7,
+		memory: [16, 24, 32],
+	},
+	"Apple M5 Pro": {
+		tflops: 11.4,
+		memory: [24, 36, 48, 64],
+	},
+	"Apple M5 Max": {
+		tflops: 22.8,
+		memory: [36, 48, 64, 128],
+	},
+};

--- a/packages/tasks/src/hardware-cpu-amd.ts
+++ b/packages/tasks/src/hardware-cpu-amd.ts
@@ -1,0 +1,88 @@
+import type { HardwareSpec } from "./hardware.js";
+
+export const CPU_AMD_SKUS: Record<string, HardwareSpec> = {
+	"EPYC 5th Generation Zen 5 (Turin)": {
+		tflops: 13.8,
+	},
+	"EPYC 4th Generation Zen 4 (Genoa)": {
+		tflops: 5,
+	},
+	"EPYC 3th Generation Zen 3 (Milan)": {
+		tflops: 2.4,
+	},
+	"EPYC 2th Generation Zen 2 (Rome)": {
+		tflops: 0.6,
+	},
+	"EPYC 1st Generation Zen (Naples)": {
+		tflops: 0.6,
+	},
+	"Ryzen Threadripper Zen 5 9000 (Shimada Peak)": {
+		tflops: 14.0,
+	},
+	"Ryzen Threadripper Zen 4 7000 (Storm Peak)": {
+		tflops: 10.0,
+	},
+	"Ryzen Threadripper Zen 3 5000 (Chagall)": {
+		tflops: 4.6,
+	},
+	"Ryzen Threadripper Zen 2 3000 (Castle Peak)": {
+		tflops: 3.2,
+	},
+	"Ryzen Threadripper Zen 1000 (Whitehaven)": {
+		tflops: 0.6,
+	},
+	"Ryzen 7 3800X (16)": {
+		tflops: 1.73,
+	},
+	"Ryzen Zen 5 9000 (Ryzen 9)": {
+		tflops: 0.56,
+	},
+	"Ryzen Zen 5 9000 (Ryzen 7)": {
+		tflops: 0.56,
+	},
+	"Ryzen Zen 5 9000 (Ryzen 5)": {
+		tflops: 0.56,
+	},
+	"Ryzen Zen 4 7000 (Ryzen 9)": {
+		tflops: 0.56,
+	},
+	"Ryzen Zen 4 7000 (Ryzen 7)": {
+		tflops: 0.56,
+	},
+	"Ryzen Zen 4 7000 (Ryzen 5)": {
+		tflops: 0.56,
+	},
+	"Ryzen Zen 3 5000 (Ryzen 9)": {
+		tflops: 1.33,
+	},
+	"Ryzen Zen 3 5000 (Ryzen 7)": {
+		tflops: 1.33,
+	},
+	"Ryzen Zen 3 5000 (Ryzen 5)": {
+		tflops: 0.72,
+	},
+	"Ryzen Zen 2 3000 (Ryzen 9)": {
+		tflops: 0.72,
+	},
+	"Ryzen Zen 2 3000 (Ryzen 7)": {
+		tflops: 0.72,
+	},
+	"Ryzen Zen 2 3000 (Ryzen 5)": {
+		tflops: 0.72,
+	},
+	"Ryzen Zen 2 3000 (Ryzen 3)": {
+		tflops: 0.72,
+	},
+	"Ryzen AI 300 (Ryzen AI 9 HX)": {
+		tflops: 5.52,
+	},
+	"Ryzen AI 300 (Ryzen AI 9)": {
+		tflops: 5.2,
+	},
+	"Ryzen AI 300 (Ryzen AI 7)": {
+		tflops: 4.34,
+	},
+	"Ryzen AI 300 (Ryzen AI 5)": {
+		tflops: 1.57,
+	},
+};

--- a/packages/tasks/src/hardware-cpu-intel.ts
+++ b/packages/tasks/src/hardware-cpu-intel.ts
@@ -1,0 +1,76 @@
+import type { HardwareSpec } from "./hardware.js";
+
+export const CPU_INTEL_SKUS: Record<string, HardwareSpec> = {
+	"Xeon 4th Generation (Sapphire Rapids)": {
+		tflops: 1.3,
+	},
+	"Xeon 3th Generation (Ice Lake)": {
+		tflops: 0.8,
+	},
+	"Xeon 2th Generation (Cascade Lake)": {
+		tflops: 0.55,
+	},
+	"Xeon E5v4 (Broadwell)": {
+		tflops: 0.25,
+	},
+	"Xeon E5v3 (Haswell)": {
+		tflops: 0.2,
+	},
+	"Xeon E5v2 (Ivy Bridge)": {
+		tflops: 0.15,
+	},
+	"Intel Core Ultra 7 265KF": {
+		tflops: 1.53,
+	},
+	"Intel Core 14th Generation (i7)": {
+		tflops: 0.8,
+	},
+	"Intel Core 13th Generation (i9)": {
+		tflops: 0.85,
+	},
+	"Intel Core 13th Generation (i7)": {
+		tflops: 0.82,
+	},
+	"Intel Core 13th Generation (i5)": {
+		tflops: 0.68,
+	},
+	"Intel Core 13th Generation (i3)": {
+		tflops: 0.57,
+	},
+	"Intel Core 12th Generation (i9)": {
+		tflops: 0.79,
+	},
+	"Intel Core 12th Generation (i7)": {
+		tflops: 0.77,
+	},
+	"Intel Core 12th Generation (i5)": {
+		tflops: 0.65,
+	},
+	"Intel Core 12th Generation (i3)": {
+		tflops: 0.53,
+	},
+	"Intel Core 11th Generation (i9)": {
+		tflops: 0.7,
+	},
+	"Intel Core 11th Generation (i7)": {
+		tflops: 0.6,
+	},
+	"Intel Core 11th Generation (i5)": {
+		tflops: 0.5,
+	},
+	"Intel Core 11th Generation (i3)": {
+		tflops: 0.35,
+	},
+	"Intel Core 10th Generation (i9)": {
+		tflops: 0.46,
+	},
+	"Intel Core 10th Generation (i7)": {
+		tflops: 0.46,
+	},
+	"Intel Core 10th Generation (i5)": {
+		tflops: 0.46,
+	},
+	"Intel Core 10th Generation (i3)": {
+		tflops: 0.44,
+	},
+};

--- a/packages/tasks/src/hardware-gpu-amd.ts
+++ b/packages/tasks/src/hardware-gpu-amd.ts
@@ -1,6 +1,6 @@
 import type { HardwareSpec } from "./hardware.js";
 
-export interface AmdGpuHardwareSpec extends HardwareSpec {
+export interface HardwareSpecGpuAmd extends HardwareSpec {
 	/**
 	 * GFX version / LLVM ISA target (AMD GPUs only), e.g. "gfx1100"
 	 *
@@ -9,7 +9,7 @@ export interface AmdGpuHardwareSpec extends HardwareSpec {
 	gfxVersion: string;
 }
 
-export const AMD_GPU_SKUS: Record<string, AmdGpuHardwareSpec> = {
+export const GPU_AMD_SKUS: Record<string, HardwareSpecGpuAmd> = {
 	MI300: {
 		tflops: 383.0,
 		memory: [192],

--- a/packages/tasks/src/hardware-gpu-intel.ts
+++ b/packages/tasks/src/hardware-gpu-intel.ts
@@ -1,0 +1,28 @@
+import type { HardwareSpec } from "./hardware.js";
+
+export const GPU_INTEL_SKUS: Record<string, HardwareSpec> = {
+	"Arc A750": {
+		tflops: 34.41,
+		memory: [8],
+	},
+	"Arc A770": {
+		tflops: 39.32,
+		memory: [8, 16],
+	},
+	"Arc B570": {
+		tflops: 23.04,
+		memory: [10],
+	},
+	"Arc B580": {
+		tflops: 27.34,
+		memory: [12],
+	},
+	"Arc B50": {
+		tflops: 21.3,
+		memory: [16],
+	},
+	"Arc B60": {
+		tflops: 24.58,
+		memory: [24, 48],
+	},
+};

--- a/packages/tasks/src/hardware-gpu-nvidia.ts
+++ b/packages/tasks/src/hardware-gpu-nvidia.ts
@@ -1,6 +1,6 @@
 import type { HardwareSpec } from "./hardware.js";
 
-export interface NvidiaHardwareSpec extends HardwareSpec {
+export interface HardwareSpecGpuNvidia extends HardwareSpec {
 	/**
 	 * CUDA Compute Capability (NVIDIA GPUs only)
 	 *
@@ -27,7 +27,7 @@ export enum NvidiaComputeCapabilities {
 	MAXWELL = 5.3,
 }
 
-export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
+export const GPU_NVIDIA_SKUS: Record<string, HardwareSpecGpuNvidia> = {
 	B200: {
 		tflops: 496.6,
 		memory: [192],

--- a/packages/tasks/src/hardware-gpu-qualcomm.ts
+++ b/packages/tasks/src/hardware-gpu-qualcomm.ts
@@ -1,0 +1,19 @@
+import type { HardwareSpec } from "./hardware.js";
+
+export const GPU_QUALCOMM_SKUS: Record<string, HardwareSpec> = {
+	"Snapdragon X Elite X1E-00-1DE": {
+		tflops: 4.6,
+	},
+	"Snapdragon X Elite X1E-84-100": {
+		tflops: 4.6,
+	},
+	"Snapdragon X Elite X1E-80-100": {
+		tflops: 3.8,
+	},
+	"Snapdragon X Elite X1E-78-100": {
+		tflops: 3.8,
+	},
+	"Snapdragon X Plus X1P-64-100": {
+		tflops: 3.8,
+	},
+};

--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -448,6 +448,11 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		memory: [6],
 		computeCapability: 7.5,
 	},
+	"RTX 2050 Mobile": {
+		tflops: 5.1, // 30W = 735-1245 MHz - https://www.techpowerup.com/gpu-specs/geforce-rtx-2050-mobile.c3859
+		memory: [4],
+		computeCapability: 8.6, // Architecture AMPERE_RTX
+	},
 	"GTX 1080 Ti": {
 		tflops: 11.34, // float32 (GPU does not support native float16)
 		memory: [11],

--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -449,7 +449,7 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		computeCapability: 7.5,
 	},
 	"RTX 2050 Mobile": {
-		tflops: 5.1, // 30W = 735-1245 MHz - https://www.techpowerup.com/gpu-specs/geforce-rtx-2050-mobile.c3859
+		tflops: 10.2,
 		memory: [4],
 		computeCapability: 8.6, // Architecture AMPERE_RTX
 	},

--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -451,7 +451,7 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 	"RTX 2050 Mobile": {
 		tflops: 10.2,
 		memory: [4],
-		computeCapability: 8.6, // Architecture AMPERE_RTX
+		computeCapability: 8.6, // Ampere (outlier GPU in the 20xx series)
 	},
 	"GTX 1080 Ti": {
 		tflops: 11.34, // float32 (GPU does not support native float16)

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -3,6 +3,7 @@ import { GPU_NVIDIA_SKUS } from "./hardware-gpu-nvidia.js";
 import { GPU_INTEL_SKUS } from "./hardware-gpu-intel.js";
 import { GPU_QUALCOMM_SKUS } from "./hardware-gpu-qualcomm.js";
 import { CPU_INTEL_SKUS } from "./hardware-cpu-intel.js";
+import { CPU_AMD_SKUS } from "./hardware-cpu-amd.js";
 
 /**
  * Biden AI Executive Order (since revoked by President Trump):
@@ -50,92 +51,7 @@ export const SKUS = {
 	},
 	CPU: {
 		Intel: CPU_INTEL_SKUS,
-		AMD: {
-			"EPYC 5th Generation Zen 5 (Turin)": {
-				tflops: 13.8,
-			},
-			"EPYC 4th Generation Zen 4 (Genoa)": {
-				tflops: 5,
-			},
-			"EPYC 3th Generation Zen 3 (Milan)": {
-				tflops: 2.4,
-			},
-			"EPYC 2th Generation Zen 2 (Rome)": {
-				tflops: 0.6,
-			},
-			"EPYC 1st Generation Zen (Naples)": {
-				tflops: 0.6,
-			},
-			"Ryzen Threadripper Zen 5 9000 (Shimada Peak)": {
-				tflops: 14.0,
-			},
-			"Ryzen Threadripper Zen 4 7000 (Storm Peak)": {
-				tflops: 10.0,
-			},
-			"Ryzen Threadripper Zen 3 5000 (Chagall)": {
-				tflops: 4.6,
-			},
-			"Ryzen Threadripper Zen 2 3000 (Castle Peak)": {
-				tflops: 3.2,
-			},
-			"Ryzen Threadripper Zen 1000 (Whitehaven)": {
-				tflops: 0.6,
-			},
-			"Ryzen 7 3800X (16)": {
-				tflops: 1.73,
-			},
-			"Ryzen Zen 5 9000 (Ryzen 9)": {
-				tflops: 0.56,
-			},
-			"Ryzen Zen 5 9000 (Ryzen 7)": {
-				tflops: 0.56,
-			},
-			"Ryzen Zen 5 9000 (Ryzen 5)": {
-				tflops: 0.56,
-			},
-			"Ryzen Zen 4 7000 (Ryzen 9)": {
-				tflops: 0.56,
-			},
-			"Ryzen Zen 4 7000 (Ryzen 7)": {
-				tflops: 0.56,
-			},
-			"Ryzen Zen 4 7000 (Ryzen 5)": {
-				tflops: 0.56,
-			},
-			"Ryzen Zen 3 5000 (Ryzen 9)": {
-				tflops: 1.33,
-			},
-			"Ryzen Zen 3 5000 (Ryzen 7)": {
-				tflops: 1.33,
-			},
-			"Ryzen Zen 3 5000 (Ryzen 5)": {
-				tflops: 0.72,
-			},
-			"Ryzen Zen 2 3000 (Ryzen 9)": {
-				tflops: 0.72,
-			},
-			"Ryzen Zen 2 3000 (Ryzen 7)": {
-				tflops: 0.72,
-			},
-			"Ryzen Zen 2 3000 (Ryzen 5)": {
-				tflops: 0.72,
-			},
-			"Ryzen Zen 2 3000 (Ryzen 3)": {
-				tflops: 0.72,
-			},
-			"Ryzen AI 300 (Ryzen AI 9 HX)": {
-				tflops: 5.52,
-			},
-			"Ryzen AI 300 (Ryzen AI 9)": {
-				tflops: 5.2,
-			},
-			"Ryzen AI 300 (Ryzen AI 7)": {
-				tflops: 4.34,
-			},
-			"Ryzen AI 300 (Ryzen AI 5)": {
-				tflops: 1.57,
-			},
-		},
+		AMD: CPU_AMD_SKUS,
 	},
 	"Apple Silicon": {
 		"-": {

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -4,6 +4,7 @@ import { GPU_INTEL_SKUS } from "./hardware-gpu-intel.js";
 import { GPU_QUALCOMM_SKUS } from "./hardware-gpu-qualcomm.js";
 import { CPU_INTEL_SKUS } from "./hardware-cpu-intel.js";
 import { CPU_AMD_SKUS } from "./hardware-cpu-amd.js";
+import { APPLE_SKUS } from "./hardware-apple.js";
 
 /**
  * Biden AI Executive Order (since revoked by President Trump):
@@ -54,84 +55,7 @@ export const SKUS = {
 		AMD: CPU_AMD_SKUS,
 	},
 	"Apple Silicon": {
-		"-": {
-			"Apple MacBook Neo": {
-				tflops: 1.9,
-				memory: [8],
-			},
-			"Apple M1": {
-				tflops: 2.6,
-				memory: [8, 16],
-			},
-			"Apple M1 Pro": {
-				tflops: 5.2,
-				memory: [16, 24, 32],
-			},
-			"Apple M1 Max": {
-				tflops: 10.4,
-				memory: [16, 24, 32, 64],
-			},
-			"Apple M1 Ultra": {
-				tflops: 21,
-				memory: [16, 24, 32, 64, 96, 128],
-			},
-			"Apple M2": {
-				tflops: 3.6,
-				memory: [8, 16, 24],
-			},
-			"Apple M2 Pro": {
-				tflops: 6.8,
-				memory: [16, 24, 32],
-			},
-			"Apple M2 Max": {
-				tflops: 13.49,
-				memory: [32, 64, 96],
-			},
-			"Apple M2 Ultra": {
-				tflops: 27.2,
-				memory: [64, 96, 128, 192],
-			},
-			"Apple M3": {
-				tflops: 4.1,
-				memory: [8, 16, 24],
-			},
-			"Apple M3 Pro": {
-				tflops: 7.4,
-				memory: [18, 36],
-			},
-			"Apple M3 Max": {
-				tflops: 14.2,
-				memory: [36, 48, 64, 96, 128],
-			},
-			"Apple M3 Ultra": {
-				tflops: 28.4,
-				memory: [96, 256, 512],
-			},
-			"Apple M4": {
-				tflops: 4.6,
-				memory: [16, 24, 32],
-			},
-			"Apple M4 Pro": {
-				tflops: 9.2,
-				memory: [24, 48, 64],
-			},
-			"Apple M4 Max": {
-				tflops: 18.4,
-				memory: [36, 48, 64, 96, 128, 256, 512],
-			},
-			"Apple M5": {
-				tflops: 5.7,
-				memory: [16, 24, 32],
-			},
-			"Apple M5 Pro": {
-				tflops: 11.4,
-				memory: [24, 36, 48, 64],
-			},
-			"Apple M5 Max": {
-				tflops: 22.8,
-				memory: [36, 48, 64, 128],
-			},
-		},
+		"-": APPLE_SKUS,
 	},
 } satisfies Record<string, Record<string, Record<string, HardwareSpec>>>;
 

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -1,5 +1,6 @@
 import { GPU_AMD_SKUS } from "./hardware-gpu-amd.js";
 import { GPU_NVIDIA_SKUS } from "./hardware-gpu-nvidia.js";
+import { GPU_INTEL_SKUS } from "./hardware-gpu-intel.js";
 
 /**
  * Biden AI Executive Order (since revoked by President Trump):
@@ -42,32 +43,7 @@ export const SKUS = {
 	GPU: {
 		NVIDIA: GPU_NVIDIA_SKUS,
 		AMD: GPU_AMD_SKUS,
-		INTEL: {
-			"Arc A750": {
-				tflops: 34.41,
-				memory: [8],
-			},
-			"Arc A770": {
-				tflops: 39.32,
-				memory: [8, 16],
-			},
-			"Arc B570": {
-				tflops: 23.04,
-				memory: [10],
-			},
-			"Arc B580": {
-				tflops: 27.34,
-				memory: [12],
-			},
-			"Arc B50": {
-				tflops: 21.3,
-				memory: [16],
-			},
-			"Arc B60": {
-				tflops: 24.58,
-				memory: [24, 48],
-			},
-		},
+		INTEL: GPU_INTEL_SKUS,
 		QUALCOMM: {
 			"Snapdragon X Elite X1E-00-1DE": {
 				tflops: 4.6,

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -1,6 +1,7 @@
 import { GPU_AMD_SKUS } from "./hardware-gpu-amd.js";
 import { GPU_NVIDIA_SKUS } from "./hardware-gpu-nvidia.js";
 import { GPU_INTEL_SKUS } from "./hardware-gpu-intel.js";
+import { GPU_QUALCOMM_SKUS } from "./hardware-gpu-qualcomm.js";
 
 /**
  * Biden AI Executive Order (since revoked by President Trump):
@@ -44,23 +45,7 @@ export const SKUS = {
 		NVIDIA: GPU_NVIDIA_SKUS,
 		AMD: GPU_AMD_SKUS,
 		INTEL: GPU_INTEL_SKUS,
-		QUALCOMM: {
-			"Snapdragon X Elite X1E-00-1DE": {
-				tflops: 4.6,
-			},
-			"Snapdragon X Elite X1E-84-100": {
-				tflops: 4.6,
-			},
-			"Snapdragon X Elite X1E-80-100": {
-				tflops: 3.8,
-			},
-			"Snapdragon X Elite X1E-78-100": {
-				tflops: 3.8,
-			},
-			"Snapdragon X Plus X1P-64-100": {
-				tflops: 3.8,
-			},
-		},
+		QUALCOMM: GPU_QUALCOMM_SKUS,
 	},
 	CPU: {
 		Intel: {

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -2,6 +2,7 @@ import { GPU_AMD_SKUS } from "./hardware-gpu-amd.js";
 import { GPU_NVIDIA_SKUS } from "./hardware-gpu-nvidia.js";
 import { GPU_INTEL_SKUS } from "./hardware-gpu-intel.js";
 import { GPU_QUALCOMM_SKUS } from "./hardware-gpu-qualcomm.js";
+import { CPU_INTEL_SKUS } from "./hardware-cpu-intel.js";
 
 /**
  * Biden AI Executive Order (since revoked by President Trump):
@@ -48,80 +49,7 @@ export const SKUS = {
 		QUALCOMM: GPU_QUALCOMM_SKUS,
 	},
 	CPU: {
-		Intel: {
-			"Xeon 4th Generation (Sapphire Rapids)": {
-				tflops: 1.3,
-			},
-			"Xeon 3th Generation (Ice Lake)": {
-				tflops: 0.8,
-			},
-			"Xeon 2th Generation (Cascade Lake)": {
-				tflops: 0.55,
-			},
-			"Xeon E5v4 (Broadwell)": {
-				tflops: 0.25,
-			},
-			"Xeon E5v3 (Haswell)": {
-				tflops: 0.2,
-			},
-			"Xeon E5v2 (Ivy Bridge)": {
-				tflops: 0.15,
-			},
-			"Intel Core Ultra 7 265KF": {
-				tflops: 1.53,
-			},
-			"Intel Core 14th Generation (i7)": {
-				tflops: 0.8,
-			},
-			"Intel Core 13th Generation (i9)": {
-				tflops: 0.85,
-			},
-			"Intel Core 13th Generation (i7)": {
-				tflops: 0.82,
-			},
-			"Intel Core 13th Generation (i5)": {
-				tflops: 0.68,
-			},
-			"Intel Core 13th Generation (i3)": {
-				tflops: 0.57,
-			},
-			"Intel Core 12th Generation (i9)": {
-				tflops: 0.79,
-			},
-			"Intel Core 12th Generation (i7)": {
-				tflops: 0.77,
-			},
-			"Intel Core 12th Generation (i5)": {
-				tflops: 0.65,
-			},
-			"Intel Core 12th Generation (i3)": {
-				tflops: 0.53,
-			},
-			"Intel Core 11th Generation (i9)": {
-				tflops: 0.7,
-			},
-			"Intel Core 11th Generation (i7)": {
-				tflops: 0.6,
-			},
-			"Intel Core 11th Generation (i5)": {
-				tflops: 0.5,
-			},
-			"Intel Core 11th Generation (i3)": {
-				tflops: 0.35,
-			},
-			"Intel Core 10th Generation (i9)": {
-				tflops: 0.46,
-			},
-			"Intel Core 10th Generation (i7)": {
-				tflops: 0.46,
-			},
-			"Intel Core 10th Generation (i5)": {
-				tflops: 0.46,
-			},
-			"Intel Core 10th Generation (i3)": {
-				tflops: 0.44,
-			},
-		},
+		Intel: CPU_INTEL_SKUS,
 		AMD: {
 			"EPYC 5th Generation Zen 5 (Turin)": {
 				tflops: 13.8,

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -1,5 +1,5 @@
-import { AMD_GPU_SKUS } from "./hardware-amd.js";
-import { NVIDIA_SKUS } from "./hardware-nvidia.js";
+import { GPU_AMD_SKUS } from "./hardware-gpu-amd.js";
+import { GPU_NVIDIA_SKUS } from "./hardware-gpu-nvidia.js";
 
 /**
  * Biden AI Executive Order (since revoked by President Trump):
@@ -40,8 +40,8 @@ export const DEFAULT_MEMORY_OPTIONS = [
 
 export const SKUS = {
 	GPU: {
-		NVIDIA: NVIDIA_SKUS,
-		AMD: AMD_GPU_SKUS,
+		NVIDIA: GPU_NVIDIA_SKUS,
+		AMD: GPU_AMD_SKUS,
 		INTEL: {
 			"Arc A750": {
 				tflops: 34.41,

--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -59,8 +59,8 @@ export {
 
 export { SKUS, DEFAULT_MEMORY_OPTIONS } from "./hardware.js";
 export type { HardwareSpec, SkuType } from "./hardware.js";
-export type { AmdGpuHardwareSpec } from "./hardware-amd.js";
-export type { NvidiaHardwareSpec } from "./hardware-nvidia.js";
+export type { HardwareSpecGpuAmd } from "./hardware-gpu-amd.js";
+export type { HardwareSpecGpuNvidia } from "./hardware-gpu-nvidia.js";
 export { LOCAL_APPS } from "./local-apps.js";
 export type { LocalApp, LocalAppKey, LocalAppSnippet } from "./local-apps.js";
 


### PR DESCRIPTION
With #2131 I found that it’s really simple to add Nvidia GPU, so I decided to replicate the same structure for all the others, providing some order and verifying that those variables weren’t used in other files.

I have reorganized the hardware database and begun cleaning up and standardizing file names, the variables used and their internal references. I created variables and files for each database, specifically (in ./packages/tasks/src/):
- files: from `hardware-[manufacturer].ts` to `hardware-[gpu/cpu]-[manufacturer].ts` (with the exception of `apple`)
- variables: from `[VARIABLE]_SKUS` to `[GPU/CPU]_[MANUFACTURER]_SKUS` (exception for `APPLE`)
- variables: from `[*]HardwareSpec` to `HardwareSpec[Gpu/Cpu][Manufacturer]` (currently only `Amd` and `Nvidia`)

I’m not very experienced with JS, but I did my best; I hope this turns out to be an useful refactor.

ALSO: after the exchange of comments with @pcuenca about the `computeCapability` of my card, in the `./packages/tasks/src/hardware-gpu-nvidia.ts` file, I would suggest using variables like `NvidiaComputeCapabilities.BLACKWELL` for `computeCapability` instead of numbers, but my skills didn’t allow me to implement the change; I wasn’t sure if it would be possible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a data/organization refactor, but it changes exported symbol names and module paths, which can break downstream imports if any consumers referenced the old identifiers.
> 
> **Overview**
> Refactors the hardware SKU database by extracting GPU/CPU/Apple SKU tables into dedicated modules (e.g. `hardware-gpu-intel.ts`, `hardware-cpu-amd.ts`, `hardware-apple.ts`) and wiring `hardware.ts` to import and compose them instead of embedding large inline objects.
> 
> Standardizes naming across the public API by renaming GPU spec interfaces and SKU constants (e.g. `AMD_GPU_SKUS` -> `GPU_AMD_SKUS`, `NVIDIA_SKUS` -> `GPU_NVIDIA_SKUS`, and `AmdGpuHardwareSpec`/`NvidiaHardwareSpec` -> `HardwareSpecGpuAmd`/`HardwareSpecGpuNvidia`), and updates `packages/tasks/src/index.ts` exports accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a16ed5cf2bb74f9806eddfe4f03f0a5f9f190b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->