### PR TITLE
fix(mcp-client): prevent HF_TOKEN leak to lookalike domains

### DIFF
--- a/packages/mcp-client/src/utils.ts
+++ b/packages/mcp-client/src/utils.ts
@@ -37,7 +37,8 @@ export function urlToServerConfig(urlStr: string, authToken?: string): ServerCon
 	const shouldIncludeToken =
 		!!authToken &&
 		(hostname.endsWith(".hf.space") ||
-			hostname.endsWith("huggingface.co") ||
+			hostname === "huggingface.co" ||
+			hostname.endsWith(".huggingface.co") ||
 			hostname === "localhost" ||
 			hostname === "127.0.0.1");
 

--- a/packages/mcp-client/test/UrlConversion.spec.ts
+++ b/packages/mcp-client/test/UrlConversion.spec.ts
@@ -76,6 +76,22 @@ describe("urlToServerConfig", () => {
 			}
 		});
 
+		it("should NOT include token for lookalike domains", () => {
+			const urls = [
+				"https://evilhuggingface.co/mcp",
+				"https://nothuggingface.co/mcp",
+				"https://evilhuggingface.co/sse",
+				"https://nothuggingface.co/sse",
+			];
+
+			for (const url of urls) {
+				const config = urlToServerConfig(url, TOKEN);
+				if (config.type === "http" || config.type === "sse") {
+					expect(config.config.options).toBeUndefined();
+				}
+			}
+		});
+
 		it("should NOT include token for non-HF/non-local domains regardless of transport type", () => {
 			const urls = [
 				"https://example.com/api/mcp", // StreamableHTTP


### PR DESCRIPTION
## Summary

- Fixes a hostname validation bug in `@huggingface/mcp-client` where `hostname.endsWith("huggingface.co")` matches attacker-registered lookalike domains (e.g. `evilhuggingface.co`, `nothuggingface.co`), leaking the user's `HF_TOKEN` as a Bearer credential
- Replaces the suffix check with an exact match for the apex domain (`huggingface.co`) plus a dotted suffix for subdomains (`.huggingface.co`), consistent with the existing `.hf.space` check on the adjacent line
- Adds test coverage for lookalike domain rejection

## Details

In `packages/mcp-client/src/utils.ts`, the token inclusion check was:

```ts
hostname.endsWith("huggingface.co")
```

This is missing a leading dot, so any domain *ending in* `huggingface.co` passes — including `evilhuggingface.co`. The adjacent `.hf.space` check correctly uses a leading dot.

The fix:

```ts
hostname === "huggingface.co" || hostname.endsWith(".huggingface.co")
```

## Test plan

- [x] Existing `UrlConversion.spec.ts` tests pass (legitimate HF domains, localhost, non-HF domains)
- [x] New test verifies `evilhuggingface.co` and `nothuggingface.co` do NOT receive the token