### PR TITLE
Add Intel Core Ultra 9 275HX to hardware.ts

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -109,6 +109,9 @@ export const SKUS = {
 			"Intel Core Ultra 7 265KF": {
 				tflops: 1.53,
 			},
+			"Intel Core Ultra 9 275HX": {
+				tflops: 1.89,
+			},
 			"Intel Core 14th Generation (i7)": {
 				tflops: 0.8,
 			},

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -106,11 +106,11 @@ export const SKUS = {
 			"Xeon E5v2 (Ivy Bridge)": {
 				tflops: 0.15,
 			},
-			"Intel Core Ultra 7 265KF": {
-				tflops: 1.53,
-			},
 			"Intel Core Ultra 9 275HX": {
 				tflops: 1.89,
+			},
+			"Intel Core Ultra 7 265KF": {
+				tflops: 1.53,
 			},
 			"Intel Core 14th Generation (i7)": {
 				tflops: 0.8,


### PR DESCRIPTION
Sources for TFLOPS value: 
- https://www.cpu-monkey.com/en/cpu-intel_core_ultra_9_275hx (1.89)
- https://nanoreview.net/en/cpu/intel-core-ultra-9-275hx (1.9)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new CPU SKU entry with a TFLOPS value, with no logic changes or data flow impacts.
> 
> **Overview**
> Adds a new `CPU.Intel` SKU entry for `Intel Core Ultra 9 275HX` in `packages/tasks/src/hardware.ts`, including its `tflops` value, so it can be selected/estimated alongside existing hardware specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e164c52543129683e09b262f93e8229c536d3ac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->