### PR TITLE
feat: add Radeon Pro V620 to hardware list

### DIFF
--- a/packages/tasks/src/hardware-amd.ts
+++ b/packages/tasks/src/hardware-amd.ts
@@ -130,6 +130,11 @@ export const AMD_GPU_SKUS: Record<string, AmdGpuHardwareSpec> = {
 		memory: [4, 8],
 		gfxVersion: "gfx1012",
 	},
+	"Radeon Pro V620": {
+		tflops: 40.55,
+		memory: [32],
+		gfxVersion: "gfx1030",
+	},
 	"Radeon Pro VII": {
 		tflops: 26.11,
 		memory: [16, 32],


### PR DESCRIPTION
Sources for tflops and memory values : https://www.techpowerup.com/gpu-specs/radeon-pro-v620.c3846

amd-smi output:
```shell
+------------------------------------------------------------------------------+
| AMD-SMI 26.2.2+671d39a71e    amdgpu version: Linuxver ROCm version: 7.2.2    |
| VBIOS version: 606253                                                        |
| Platform: Linux Baremetal                                                    |
|-------------------------------------+----------------------------------------|
| BDF                        GPU-Name | Mem-Uti   Temp   UEC       Power-Usage |
| GPU  HIP-ID  OAM-ID  Partition-Mode | GFX-Uti    Fan               Mem-Usage |
|=====================================+========================================|
| 0000:03:00.0    AMD Radeon Pro V620 | 0 %      37 °C   0            11/250 W |
|   0       3     N/A             N/A | 0 %        N/A             16/30704 MB |
|-------------------------------------+----------------------------------------|
```
rocminfo:
```shell
rocminfo | awk '/Vendor Name:/ { vendor=$NF } /Name:[[:space:]]+gfx[0-9]/ && vendor != "CPU" { print $NF }' | sort -u
gfx1030
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new AMD GPU entry to the static SKU metadata table with no behavioral or security-sensitive logic changes.
> 
> **Overview**
> Adds the `Radeon Pro V620` to the AMD GPU SKU registry (`hardware-amd.ts`), including its `tflops`, supported `memory` size, and `gfxVersion` (`gfx1030`) so it can be selected/recognized wherever `AMD_GPU_SKUS` is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 189d13aad532c311599e6aba58e58d67b102f8ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->