### PR TITLE
feat: add missing blackwell pro workstation cards to hardware list

### DIFF
--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -78,6 +78,31 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		memory: [96],
 		computeCapability: 12.0,
 	},
+	"RTX PRO 5000": {
+		tflops: 66.94,
+		memory: [48, 72],
+		computeCapability: 12.0,
+	},
+	"RTX PRO 4500 WS": {
+		tflops: 50.53,
+		memory: [32],
+		computeCapability: 12.0,
+	},
+	"RTX PRO 4000": {
+		tflops: 36.83,
+		memory: [24],
+		computeCapability: 12.0,
+	},
+	"RTX PRO 4000 SFF": {
+		tflops: 24.05,
+		memory: [24],
+		computeCapability: 12.0,
+	},
+	"RTX PRO 2000": {
+		tflops: 17.03,
+		memory: [16],
+		computeCapability: 12.0,
+	},
 	"RTX 6000 Ada": {
 		tflops: 91.1,
 		memory: [48],


### PR DESCRIPTION
Adding missing blackwell pro workstation cards, sources for
- RTX PRO 5000:
  - 48GB: https://www.techpowerup.com/gpu-specs/rtx-pro-5000-blackwell.c4276
  - 72GB: https://www.techpowerup.com/gpu-specs/rtx-pro-5000-72-gb-blackwell.c4357
- RTX PRO 4500 WS: https://www.techpowerup.com/gpu-specs/rtx-pro-4500-blackwell-workstation.c4278
- RTX PRO 4000: https://www.techpowerup.com/gpu-specs/rtx-pro-4000-blackwell.c4279
- RTX PRO 4000 SFF: https://www.techpowerup.com/gpu-specs/rtx-pro-4000-blackwell-sff.c4329
- RTX PRO 2000: https://www.techpowerup.com/gpu-specs/rtx-pro-2000-blackwell.c4330

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only extends the static `NVIDIA_SKUS` lookup table with additional GPU entries and does not change any logic or data flow.
> 
> **Overview**
> Adds missing Blackwell desktop workstation GPUs to the `NVIDIA_SKUS` catalog in `hardware-nvidia.ts`, including `RTX PRO 5000` (48/72GB), `RTX PRO 4500 WS`, `RTX PRO 4000`, `RTX PRO 4000 SFF`, and `RTX PRO 2000`, each with TFLOPs, memory options, and compute capability `12.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 856bfbf10438d81b3ef9b083723670a00411f444. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->