### PR TITLE
fix: support numeric member access in jinja parser (obj.0 -> obj[0])

### DIFF
--- a/packages/jinja/src/parser.ts
+++ b/packages/jinja/src/parser.ts
@@ -541,10 +541,17 @@ export function parse(tokens: Token[]): Program {
 				// computed (i.e., bracket notation: obj[expr])
 				property = parseMemberExpressionArgumentsList();
 				expect(TOKEN_TYPES.CloseSquareBracket, "Expected closing square bracket");
-			} else {
+				} else {
 				// non-computed (i.e., dot notation: obj.expr)
-				property = parsePrimaryExpression(); // should be an identifier
-				if (property.type !== "Identifier") {
+				// Python Jinja2 also allows numeric access like obj.0 (equivalent to obj[0])
+				property = parsePrimaryExpression();
+				if (property.type === "Identifier") {
+					// Standard dot access: obj.prop
+				} else if (property.type === "IntegerLiteral") {
+					// Numeric dot access: obj.0 -> obj[0] (computed)
+					object = new MemberExpression(object, property, true);
+					continue;
+				} else {
 					throw new SyntaxError(`Expected identifier following dot operator`);
 				}
 			}


### PR DESCRIPTION
Python Jinja2 supports numeric member access like obj.0 (equivalent to obj[0]), but the JS implementation only allowed Identifier after a dot. This fixes parsing of GLM-5.1 chat templates that use m.content.0.type.

https://huggingface.co/zai-org/GLM-5.1/blob/main/chat_template.jinja#L97

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core parsing of member expressions; while small, it can alter how dotted expressions are interpreted and could impact template parsing edge cases.
> 
> **Overview**
> Adds support for Jinja-style numeric member access in `parseMemberExpression`, allowing `obj.0` to parse as a computed member lookup equivalent to `obj[0]`.
> 
> Non-numeric dot access behavior remains the same, but dot access now accepts an `IntegerLiteral` after `.` and immediately emits a computed `MemberExpression` for that segment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b316c12a3f17dcae004f506d764d48a0640fb36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->