### PR TITLE
feat: add ondeviceml.space — browser-based on-device AI inference

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -761,6 +761,20 @@ export const LOCAL_APPS = {
 			!!getChatTemplate(model)?.includes("tools"),
 		snippet: snippetPi,
 	},
+	"ondeviceml": {
+		prettyLabel: "ondeviceml.space",
+		docsUrl: "https://ondeviceml.space",
+		mainTask: "text-generation",
+		displayOnModelPage: (model) => {
+			const supportedModelTypes = ["gemma3n", "gemma4", "gemma3", "qwen2"];
+			return (
+				model.library_name === "transformers" &&
+				(model.pipeline_tag === "text-generation" || model.pipeline_tag === "image-text-to-text") &&
+				supportedModelTypes.some((t) => model.config?.model_type?.startsWith(t))
+			);
+		},
+		deeplink: (model) => new URL(`https://ondeviceml.space/?hf_model=${model.id}&task=${model.pipeline_tag ?? "text-generation"}`),
+	},
 } satisfies Record<string, LocalApp>;
 
 export type LocalAppKey = keyof typeof LOCAL_APPS;


### PR DESCRIPTION
## What this adds

Registers [ondeviceml.space](https://ondeviceml.space) as a local app for Gemma and Qwen2 transformer models.

`ondeviceml.space` is a client-side-only AI gallery: models run entirely in the browser via **WebGPU / WASM** (MediaPipe Tasks GenAI runtime). No server, no install, no account — the model weights download once to the browser cache and all inference stays on-device.

## Deep-link behavior

When a user clicks "Open in ondeviceml.space" from a model page, the URL

```
https://ondeviceml.space/?hf_model=google/gemma-3n-E2B-it&task=image-text-to-text
```

lands on the Gallery page, which:
1. Matches the `hf_model` param against the local catalog
2. Shows a confirmation banner: `[ Gemma 3n E2B → Chat ] [ Load & Open ] [ Dismiss ]`
3. Downloads the model weights (first visit only; cached via browser storage after)
4. Navigates to the matched feature

The deep-link intake is live on production — you can test it now:
```
https://ondeviceml.space/?hf_model=google/gemma-3n-E2B-it&task=image-text-to-text
https://ondeviceml.space/?hf_model=Qwen/Qwen2.5-1.5B-Instruct&task=text-generation
```

## `displayOnModelPage` logic

Shows only for `transformers`-library models with `text-generation` or `image-text-to-text` pipeline whose `model_type` is one of `gemma3n`, `gemma4`, `gemma3`, `qwen2` — the architectures validated to run via MediaPipe in-browser. Happy to expand or tighten the list based on your feedback.

## Catalog today

| Model | HF pipeline_tag | Browser runtime |
|---|---|---|
| Qwen/Qwen2.5-1.5B-Instruct | text-generation | WebGPU/WASM |
| google/gemma-3n-E2B-it | image-text-to-text | WebGPU/WASM |
| google/gemma-4-E2B-it | image-text-to-text | WebGPU/WASM |
| google/gemma-3n-E4B-it | image-text-to-text | WebGPU/WASM |

## Checklist

- [x] Deep-link is live and tested on production
- [x] `displayOnModelPage` targets only supported model types
- [x] No snippet needed — the deeplink opens a web URL directly
- [x] No macOS-only flag — works on any browser with WebGPU support (Chrome 113+, Edge)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `LOCAL_APPS` entry and display gating logic plus an external deeplink URL; no existing execution paths or core inference logic are modified.
> 
> **Overview**
> Adds `ondeviceml.space` to the `LOCAL_APPS` registry so supported Hugging Face model pages can show an **“Open in ondeviceml.space”** option.
> 
> The new entry is only shown for `transformers` models with `text-generation` or `image-text-to-text` pipelines whose `config.model_type` starts with one of `gemma3n`, `gemma4`, `gemma3`, or `qwen2`, and it deep-links to `https://ondeviceml.space/?hf_model=...&task=...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcba75d5c5c5ee8df4abaf390806acb73dc2d2d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->