### PR TITLE
feat: add workstation gfx1100 cards to hardware list

### DIFF
--- a/packages/tasks/src/hardware-amd.ts
+++ b/packages/tasks/src/hardware-amd.ts
@@ -60,12 +60,12 @@ export const AMD_GPU_SKUS: Record<string, AmdGpuHardwareSpec> = {
 		memory: [8, 16],
 		gfxVersion: "gfx1200",
 	},
-	"W7900": {
+	"PRO W7900": {
 		tflops: 122.6,
 		memory: [48],
 		gfxVersion: "gfx1100",
 	},
-	"W7800": {
+	"PRO W7800": {
 		tflops: 90.50,
 		memory: [32, 48],
 		gfxVersion: "gfx1100",

--- a/packages/tasks/src/hardware-amd.ts
+++ b/packages/tasks/src/hardware-amd.ts
@@ -66,7 +66,7 @@ export const AMD_GPU_SKUS: Record<string, AmdGpuHardwareSpec> = {
 		gfxVersion: "gfx1100",
 	},
 	"PRO W7800": {
-		tflops: 90.50,
+		tflops: 90.5,
 		memory: [32, 48],
 		gfxVersion: "gfx1100",
 	},

--- a/packages/tasks/src/hardware-amd.ts
+++ b/packages/tasks/src/hardware-amd.ts
@@ -60,6 +60,16 @@ export const AMD_GPU_SKUS: Record<string, AmdGpuHardwareSpec> = {
 		memory: [8, 16],
 		gfxVersion: "gfx1200",
 	},
+	"W7900": {
+		tflops: 122.6,
+		memory: [48],
+		gfxVersion: "gfx1100",
+	},
+	"W7800": {
+		tflops: 90.50,
+		memory: [32, 48],
+		gfxVersion: "gfx1100",
+	},
 	"RX 7900 XTX": {
 		tflops: 122.8,
 		memory: [24],


### PR DESCRIPTION
Adding missing gfx1100 workstation cards,  for consistency maybe all workstation cards should be PRO xxxx (ex: Radeon Pro VII becomes Pro VII and R9700 PRO becomes PRO R9700 or AI PRO R9700).

Sources: https://www.amd.com/en/products/graphics/workstations.html#tabs-33767a92d0-item-a59d3a42f3-tab

- PRO W7900: https://www.techpowerup.com/gpu-specs/radeon-pro-w7900.c4147
- PRO w7800:
  - 32GB: https://www.techpowerup.com/gpu-specs/radeon-pro-w7800.c4148
  - 48GB: https://www.techpowerup.com/gpu-specs/radeon-pro-w7800-48-gb.c4252

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only extends the static `AMD_GPU_SKUS` catalog with two new entries and doesn’t change any selection or computation logic.
> 
> **Overview**
> Adds AMD workstation GPUs `PRO W7900` and `PRO W7800` (both `gfx1100`) to `AMD_GPU_SKUS`, including their TFLOPS values and supported VRAM options, so downstream hardware lookups recognize these cards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f226d9ce056a2c367b7964c5df6b7e6b46e00f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->