### PR TITLE
Add Hermes Agent to local apps

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -3,6 +3,10 @@ import { LOCAL_APPS } from "./local-apps.js";
 import type { ModelData } from "./model-data.js";
 
 describe("local-apps", () => {
+	it("shares the same model-page predicate for tool-calling local agents", async () => {
+		expect(LOCAL_APPS.pi.displayOnModelPage).toBe(LOCAL_APPS["hermes-agent"].displayOnModelPage);
+	});
+
 	it("llama.cpp conversational", async () => {
 		const { snippet: snippetFunc } = LOCAL_APPS["llama.cpp"];
 		const model: ModelData = {
@@ -159,6 +163,46 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		expect(snippet[1].content).toContain('"baseUrl": "http://localhost:8080/v1"');
 		expect(snippet[1].content).toContain('"id": "mlx-community/Llama-3.2-3B-Instruct-mlx"');
 		expect(snippet[2].content).toContain("pi");
+	});
+
+	it("hermes-agent", async () => {
+		const { snippet: snippetFunc } = LOCAL_APPS["hermes-agent"];
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			gguf: { total: 1, context_length: 4096, chat_template: "{% if tools %}" },
+			inference: "",
+		};
+		const snippet = snippetFunc(model);
+
+		expect(snippet[0].content).toContain(`llama-server -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`);
+		expect(snippet[1].content).toContain("hermes config set model.provider custom");
+		expect(snippet[1].content).toContain("hermes config set model.base_url http://127.0.0.1:8080/v1");
+		expect(snippet[1].content).toContain(
+			"hermes config set model.default bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}"
+		);
+		expect(snippet[2].content).toContain("hermes");
+	});
+
+	it("hermes-agent - mlx", async () => {
+		const { snippet: snippetFunc } = LOCAL_APPS["hermes-agent"];
+		const model: ModelData = {
+			id: "mlx-community/Llama-3.2-3B-Instruct-mlx",
+			tags: ["mlx", "conversational"],
+			pipeline_tag: "text-generation",
+			config: {
+				tokenizer_config: {
+					chat_template: "{% if tools %}...{% endif %}",
+				},
+			},
+			inference: "",
+		};
+		const snippet = snippetFunc(model);
+
+		expect(snippet[0].setup).toContain("uv tool install mlx-lm");
+		expect(snippet[1].content).toContain("hermes config set model.provider custom");
+		expect(snippet[1].content).toContain("hermes config set model.default mlx-community/Llama-3.2-3B-Instruct-mlx");
+		expect(snippet[2].content).toContain("hermes");
 	});
 
 	it("docker model runner", async () => {

--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -179,7 +179,7 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		expect(snippet[1].content).toContain("hermes config set model.provider custom");
 		expect(snippet[1].content).toContain("hermes config set model.base_url http://127.0.0.1:8080/v1");
 		expect(snippet[1].content).toContain(
-			"hermes config set model.default bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}"
+			"hermes config set model.default bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}",
 		);
 		expect(snippet[2].content).toContain("hermes");
 	});

--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -3,10 +3,6 @@ import { LOCAL_APPS } from "./local-apps.js";
 import type { ModelData } from "./model-data.js";
 
 describe("local-apps", () => {
-	it("shares the same model-page predicate for tool-calling local agents", async () => {
-		expect(LOCAL_APPS.pi.displayOnModelPage).toBe(LOCAL_APPS["hermes-agent"].displayOnModelPage);
-	});
-
 	it("llama.cpp conversational", async () => {
 		const { snippet: snippetFunc } = LOCAL_APPS["llama.cpp"];
 		const model: ModelData = {

--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -138,7 +138,7 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 
 		expect(snippet[0].content).toContain(`llama-server -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`);
 		expect(snippet[1].setup).toContain("npm install -g @mariozechner/pi-coding-agent");
-		expect(snippet[1].content).toContain(`"id": "Llama-3.2-3B-Instruct-GGUF"`);
+		expect(snippet[1].content).toContain(`"id": "bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}"`);
 		expect(snippet[2].content).toContain("pi");
 	});
 

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -486,8 +486,8 @@ const getLocalServerStep = (model: ModelData, filepath?: string): LocalAppSnippe
 };
 
 const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
-	const modelName = model.id.split("/").pop() ?? model.id;
 	const isMLX = isMlxModel(model);
+	const modelId = isMLX ? model.id : `${model.id}${getQuantTag(filepath)}`;
 	const serverStep = getLocalServerStep(model, filepath);
 
 	const modelsJson = JSON.stringify(
@@ -497,7 +497,7 @@ const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 					baseUrl: "http://localhost:8080/v1",
 					api: "openai-completions",
 					apiKey: "none",
-					models: [{ id: isMLX ? model.id : modelName }],
+					models: [{ id: modelId }],
 				},
 			},
 		},

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -139,6 +139,14 @@ function isUnslothModel(model: ModelData) {
 	return model.tags.includes("unsloth") || isLlamaCppGgufModel(model);
 }
 
+function isToolCallingLocalAgentModel(model: ModelData): boolean {
+	return (
+		(isLlamaCppGgufModel(model) || isMlxModel(model)) &&
+		model.tags.includes("conversational") &&
+		!!getChatTemplate(model)?.includes("tools")
+	);
+}
+
 function getQuantTag(filepath?: string): string {
 	const defaultTag = ":{{QUANT_TAG}}";
 
@@ -463,12 +471,8 @@ const snippetMlxLm = (model: ModelData): LocalAppSnippet[] => {
 	];
 };
 
-const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
-	const modelName = model.id.split("/").pop() ?? model.id;
-	const isMLX = isMlxModel(model);
-
-	// Step 1: Server — differs by backend
-	const serverStep: LocalAppSnippet = isMLX
+const getLocalServerStep = (model: ModelData, filepath?: string): LocalAppSnippet => {
+	return isMlxModel(model)
 		? {
 				title: "Start the MLX server",
 				setup: "# Install MLX LM:\nuv tool install mlx-lm",
@@ -479,8 +483,13 @@ const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 				setup: "# Install llama.cpp:\nbrew install llama.cpp",
 				content: `# Start a local OpenAI-compatible server:\nllama-server -hf ${model.id}${getQuantTag(filepath)}`,
 			};
+};
 
-	// Step 2: Pi config — port and provider name differ
+const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
+	const modelName = model.id.split("/").pop() ?? model.id;
+	const isMLX = isMlxModel(model);
+	const serverStep = getLocalServerStep(model, filepath);
+
 	const modelsJson = JSON.stringify(
 		{
 			providers: {
@@ -506,6 +515,33 @@ const snippetPi = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 		{
 			title: "Run Pi",
 			content: "# Start Pi in your project directory:\npi",
+		},
+	];
+};
+
+const snippetHermesAgent = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
+	const modelId = isMlxModel(model) ? model.id : `${model.id}${getQuantTag(filepath)}`;
+	const serverStep = getLocalServerStep(model, filepath);
+
+	return [
+		serverStep,
+		{
+			title: "Configure Hermes",
+			setup: [
+				"# Install Hermes:",
+				"curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash",
+				"hermes setup",
+			].join("\n"),
+			content: [
+				"# Point Hermes at the local server:",
+				"hermes config set model.provider custom",
+				"hermes config set model.base_url http://127.0.0.1:8080/v1",
+				`hermes config set model.default ${modelId}`,
+			].join("\n"),
+		},
+		{
+			title: "Run Hermes",
+			content: "hermes",
 		},
 	];
 };
@@ -755,11 +791,15 @@ export const LOCAL_APPS = {
 		prettyLabel: "Pi",
 		docsUrl: "https://github.com/badlogic/pi-mono",
 		mainTask: "text-generation",
-		displayOnModelPage: (model) =>
-			(isLlamaCppGgufModel(model) || isMlxModel(model)) &&
-			model.tags.includes("conversational") &&
-			!!getChatTemplate(model)?.includes("tools"),
+		displayOnModelPage: isToolCallingLocalAgentModel,
 		snippet: snippetPi,
+	},
+	"hermes-agent": {
+		prettyLabel: "Hermes Agent",
+		docsUrl: "https://hermes-agent.nousresearch.com/",
+		mainTask: "text-generation",
+		displayOnModelPage: isToolCallingLocalAgentModel,
+		snippet: snippetHermesAgent,
 	},
 } satisfies Record<string, LocalApp>;
 


### PR DESCRIPTION

<img width="2174" height="1482" alt="image" src="https://github.com/user-attachments/assets/1e2b670c-614c-46a7-9d08-070a9be93122" />


## Summary
- Add [Hermes Agent](https://hermes-agent.nousresearch.com/) as a local app for tool-calling models served via llama.cpp or MLX (same eligibility as Pi: GGUF or MLX, `conversational`, chat template references `tools`)
- Snippet uses `hermes config set` CLI commands (verified to work) instead of editing `~/.hermes/config.yaml` by hand
- Refactor: extract `isToolCallingLocalAgentModel` and `getLocalServerStep` so Pi and Hermes share the predicate and the server-start step (Pi behavior unchanged byte-for-byte)

## Test plan
- [x] `pnpm --filter @huggingface/tasks test` — 19/19 pass
- [x] Verified end-to-end with `unsloth/Qwen3.6-27B-GGUF:UD-Q6_K_XL` running on llama.cpp


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the generated Pi configuration `model.id` for GGUF models (now includes the quant tag) and adds new snippet logic that affects what users run/configure, though it’s isolated to local-app guidance.
> 
> **Overview**
> Adds **Hermes Agent** as a new entry in `LOCAL_APPS`, available for the same tool-calling GGUF/MLX conversational models as Pi, and provides an install/config/run snippet using `hermes config set ...` against a local OpenAI-compatible server.
> 
> Refactors the Pi/Hermes flow by extracting a shared `isToolCallingLocalAgentModel` predicate and `getLocalServerStep` snippet generator, and updates Pi’s generated `models.json` to use the full GGUF model id including `:{{QUANT_TAG}}` (instead of the repo basename). Tests are expanded to cover Hermes (GGUF + MLX) and updated for the Pi id change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9c409d41d8a337ef25c68b276b702c59794d15b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->