### PR TITLE
Fix chained dot integer accesses (obj.0 -> obj[0])

### DIFF
--- a/packages/jinja/src/format.ts
+++ b/packages/jinja/src/format.ts
@@ -261,7 +261,7 @@ function formatExpression(node: Expression, parentPrec: number = -1): string {
 				obj = `(${obj})`;
 			}
 			let prop = formatExpression(n.property);
-			if (!n.computed && n.property.type !== "Identifier") {
+			if (!n.computed && n.property.type !== "Identifier" && n.property.type !== "IntegerLiteral") {
 				prop = `(${prop})`;
 			}
 			return n.computed ? `${obj}[${prop}]` : `${obj}.${prop}`;

--- a/packages/jinja/src/lexer.ts
+++ b/packages/jinja/src/lexer.ts
@@ -377,7 +377,11 @@ export function tokenize(source: string, options: PreprocessOptions = {}): Token
 			// Consume integer part
 			let num = consumeWhile(isInteger);
 			// Possibly, consume fractional part
-			if (src[cursorPosition] === "." && isInteger(src[cursorPosition + 1])) {
+			if (
+				tokens.at(-1)?.type !== TOKEN_TYPES.Dot &&
+				src[cursorPosition] === "." &&
+				isInteger(src[cursorPosition + 1])
+			) {
 				++cursorPosition; // consume '.'
 				const frac = consumeWhile(isInteger);
 				num = `${num}.${frac}`;

--- a/packages/jinja/src/parser.ts
+++ b/packages/jinja/src/parser.ts
@@ -543,9 +543,9 @@ export function parse(tokens: Token[]): Program {
 				expect(TOKEN_TYPES.CloseSquareBracket, "Expected closing square bracket");
 			} else {
 				// non-computed (i.e., dot notation: obj.expr)
-				property = parsePrimaryExpression(); // should be an identifier
-				if (property.type !== "Identifier") {
-					throw new SyntaxError(`Expected identifier following dot operator`);
+				property = parsePrimaryExpression(); // should be an identifier or integer
+				if (property.type !== "Identifier" && property.type !== "IntegerLiteral") {
+					throw new SyntaxError(`Expected identifier or integer following dot operator`);
 				}
 			}
 			object = new MemberExpression(object, property, computed);

--- a/packages/jinja/src/runtime.ts
+++ b/packages/jinja/src/runtime.ts
@@ -1523,6 +1523,8 @@ export class Interpreter {
 			} else {
 				property = this.evaluate(expr.property, environment);
 			}
+		} else if (expr.property.type === "IntegerLiteral") {
+			property = new IntegerValue((expr.property as IntegerLiteral).value);
 		} else {
 			property = new StringValue((expr.property as Identifier).value);
 		}

--- a/packages/jinja/test/e2e.test.js
+++ b/packages/jinja/test/e2e.test.js
@@ -1059,6 +1059,104 @@ const TEST_CUSTOM_TEMPLATES = Object.freeze({
 		},
 		target: "<|startoftext|><|im_start|>user\n<image>What is in this image?<|im_end|>\n<|im_start|>assistant\n",
 	},
+	"zai-org/GLM-5.1": {
+		chat_template:
+			"[gMASK]<sop>\n{%- if tools -%}\n{%- macro tool_to_json(tool) -%}\n    {%- set ns_tool = namespace(first=true) -%}\n    {{ '{' -}}\n    {%- for k, v in tool.items() -%}\n        {%- if k != 'defer_loading' and k != 'strict' -%}\n            {%- if not ns_tool.first -%}{{- ', ' -}}{%- endif -%}\n            {%- set ns_tool.first = false -%}\n            \"{{ k }}\": {{ v | tojson(ensure_ascii=False) }}\n        {%- endif -%}\n    {%- endfor -%}\n    {{- '}' -}}\n{%- endmacro -%}\n<|system|>\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>\n{% for tool in tools %}\n{%- if 'function' in tool -%}\n    {%- set tool = tool['function'] -%}\n{%- endif -%}\n{% if tool.defer_loading is not defined or not tool.defer_loading %}\n{{ tool_to_json(tool) }}\n{% endif %}\n{% endfor %}\n</tools>\n\nFor each function call, output the function name and arguments within the following XML format:\n<tool_call>{function-name}<arg_key>{arg-key-1}</arg_key><arg_value>{arg-value-1}</arg_value><arg_key>{arg-key-2}</arg_key><arg_value>{arg-value-2}</arg_value>...</tool_call>{%- endif -%}\n{%- macro visible_text(content) -%}\n    {%- if content is string -%}\n        {{- content }}\n    {%- elif content is iterable and content is not mapping -%}\n        {%- for item in content -%}\n            {%- if item is mapping and item.type == 'text' -%}\n                {{- item.text }}\n            {%- elif item is string -%}\n                {{- item }}\n            {%- endif -%}\n        {%- endfor -%}\n    {%- else -%}\n        {{- content }}\n    {%- endif -%}\n{%- endmacro -%}\n{%- set ns = namespace(last_user_index=-1, thinking_indices='') -%}\n{%- for m in messages %}\n    {%- if m.role == 'user' %}\n        {%- set ns.last_user_index = loop.index0 -%}\n    {%- elif m.role == 'assistant' %}\n        {%- if m.reasoning_content is string %}\n            {%- set ns.thinking_indices = ns.thinking_indices ~ ',' ~ ns.last_user_index ~ ',' -%}\n        {%- endif %}\n    {%- endif %}\n{%- endfor %}\n{%- set ns.has_thinking = false -%}\n{%- for m in messages -%}\n{%- if m.role == 'user' -%}<|user|>{{ visible_text(m.content) }}{% set ns.has_thinking = (',' ~ loop.index0 ~ ',') in ns.thinking_indices -%}\n{%- elif m.role == 'assistant' -%}\n<|assistant|>\n{%- set content = visible_text(m.content) %}\n{%- if m.reasoning_content is string %}\n    {%- set reasoning_content = m.reasoning_content %}\n{%- elif '</think>' in content %}\n    {%- set reasoning_content = content.split('</think>')[0].split('<think>')[-1] %}\n    {%- set content = content.split('</think>')[-1] %}\n{%- elif loop.index0 > ns.last_user_index and not (enable_thinking is defined and not enable_thinking) %}\n    {%- set reasoning_content = '' %}\n{%- elif loop.index0 < ns.last_user_index and ns.has_thinking %}\n    {%- set reasoning_content = '' %}\n{%- endif %}\n{%- if ((clear_thinking is defined and not clear_thinking) or loop.index0 > ns.last_user_index) and reasoning_content is defined -%}\n{{ '<think>' + reasoning_content +  '</think>'}}\n{%- else -%}\n{{ '</think>' }}\n{%- endif -%}\n{%- if content.strip() -%}\n{{ content.strip() }}\n{%- endif -%}\n{% if m.tool_calls %}\n{% for tc in m.tool_calls %}\n{%- if tc.function %}\n    {%- set tc = tc.function %}\n{%- endif %}\n{{- '<tool_call>' + tc.name -}}\n{% set _args = tc.arguments %}{% for k, v in _args.items() %}<arg_key>{{ k }}</arg_key><arg_value>{{ v | tojson(ensure_ascii=False) if v is not string else v }}</arg_value>{% endfor %}</tool_call>{% endfor %}\n{% endif %}\n{%- elif m.role == 'tool' -%}\n{%- if loop.first or (messages[loop.index0 - 1].role != \"tool\") %}\n    {{- '<|observation|>' -}}\n{%- endif %}\n{%- if m.content is string -%}\n    {{- '<tool_response>' + m.content + '</tool_response>' -}}\n{%- elif m.content is iterable and m.content is not mapping and m.content and m.content.0.type == \"tool_reference\" -%}\n    {{- '<tool_response><tools>\\n' -}}\n    {% for tr in m.content %}\n        {%- for tool in tools -%}\n            {%- if 'function' in tool -%}\n                {%- set tool = tool['function'] -%}\n            {%- endif -%}\n            {%- if tool.name == tr.name -%}\n                {{- tool_to_json(tool) + '\\n' -}}\n            {%- endif -%}\n        {%- endfor -%}\n    {%- endfor -%}\n    {{- '</tools></tool_response>' -}}\n{%- else -%}\n    {{- '<tool_response>' + visible_text(m.content) + '</tool_response>' -}}\n{% endif -%}\n{%- elif m.role == 'system' -%}\n<|system|>{{ visible_text(m.content) }}\n{%- endif -%}\n{%- endfor -%}\n{%- if add_generation_prompt -%}\n    <|assistant|>{{- '</think>' if (enable_thinking is defined and not enable_thinking) else '<think>' -}}\n{%- endif -%}",
+		data: {
+			messages: [
+				{
+					role: "user",
+					content: "Load the referenced tools.",
+				},
+				{
+					role: "assistant",
+					content: "",
+					tool_calls: [
+						{
+							function: {
+								name: "load_tools",
+								arguments: {
+									names: ["get_weather", "get_time"],
+								},
+							},
+						},
+					],
+				},
+				{
+					role: "tool",
+					tool_call_id: "call_load_tools_1",
+					content: [
+						{
+							type: "tool_reference",
+							name: "get_weather",
+						},
+						{
+							type: "tool_reference",
+							name: "get_time",
+						},
+					],
+				},
+			],
+			tools: [
+				{
+					type: "function",
+					function: {
+						name: "load_tools",
+						description: "Load one or more deferred tools by name.",
+						parameters: {
+							type: "object",
+							properties: {
+								names: {
+									type: "array",
+									items: { type: "string" },
+									description: "Tool names to load.",
+								},
+							},
+							required: ["names"],
+						},
+					},
+				},
+				{
+					type: "function",
+					function: {
+						name: "get_weather",
+						description: "Get the weather for a location.",
+						defer_loading: true,
+						parameters: {
+							type: "object",
+							properties: {
+								location: {
+									type: "string",
+									description: "City or location name.",
+								},
+							},
+							required: ["location"],
+						},
+					},
+				},
+				{
+					type: "function",
+					function: {
+						name: "get_time",
+						description: "Get the local time for a location.",
+						defer_loading: true,
+						parameters: {
+							type: "object",
+							properties: {
+								location: {
+									type: "string",
+									description: "City or location name.",
+								},
+							},
+							required: ["location"],
+						},
+					},
+				},
+			],
+		},
+		target:
+			'[gMASK]<sop><|system|>\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>\n{"name": "load_tools", "description": "Load one or more deferred tools by name.", "parameters": {"type": "object", "properties": {"names": {"type": "array", "items": {"type": "string"}, "description": "Tool names to load."}}, "required": ["names"]}}\n</tools>\n\nFor each function call, output the function name and arguments within the following XML format:\n<tool_call>{function-name}<arg_key>{arg-key-1}</arg_key><arg_value>{arg-value-1}</arg_value><arg_key>{arg-key-2}</arg_key><arg_value>{arg-value-2}</arg_value>...</tool_call><|user|>Load the referenced tools.<|assistant|><think></think><tool_call>load_tools<arg_key>names</arg_key><arg_value>["get_weather", "get_time"]</arg_value></tool_call><|observation|><tool_response><tools>\n{"name": "get_weather", "description": "Get the weather for a location.", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "City or location name."}}, "required": ["location"]}}\n{"name": "get_time", "description": "Get the local time for a location.", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "City or location name."}}, "required": ["location"]}}\n</tools></tool_response>',
+	},
 });
 
 /**

--- a/packages/jinja/test/templates.test.js
+++ b/packages/jinja/test/templates.test.js
@@ -65,6 +65,7 @@ const TEST_STRINGS = {
 
 	// Object properties
 	PROPERTIES: `{{ obj.x + obj.y }}{{ obj['x'] + obj.y }}`,
+	PROPERTIES_1: `|{{ matrix.0 }}|{{ matrix.0.1 }}|{{ matrix.0.1.1 }}|{{ object.0.apple.banana.1.2[3]['cherry'] }}|`,
 
 	// Object methods
 	OBJ_METHODS: `{{ obj.x(x, y) }}{{ ' ' + obj.x() + ' ' }}{{ obj.z[x](x, y) }}`,
@@ -1220,6 +1221,53 @@ const TEST_PARSED = {
 		{ value: ".", type: "Dot" },
 		{ value: "y", type: "Identifier" },
 		{ value: "}}", type: "CloseExpression" },
+	],
+	PROPERTIES_1: [
+		{ value: "|", type: "Text" },
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "matrix", type: "Identifier" },
+		{ value: ".", type: "Dot" },
+		{ value: "0", type: "NumericLiteral" },
+		{ value: "}}", type: "CloseExpression" },
+		{ value: "|", type: "Text" },
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "matrix", type: "Identifier" },
+		{ value: ".", type: "Dot" },
+		{ value: "0", type: "NumericLiteral" },
+		{ value: ".", type: "Dot" },
+		{ value: "1", type: "NumericLiteral" },
+		{ value: "}}", type: "CloseExpression" },
+		{ value: "|", type: "Text" },
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "matrix", type: "Identifier" },
+		{ value: ".", type: "Dot" },
+		{ value: "0", type: "NumericLiteral" },
+		{ value: ".", type: "Dot" },
+		{ value: "1", type: "NumericLiteral" },
+		{ value: ".", type: "Dot" },
+		{ value: "1", type: "NumericLiteral" },
+		{ value: "}}", type: "CloseExpression" },
+		{ value: "|", type: "Text" },
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "object", type: "Identifier" },
+		{ value: ".", type: "Dot" },
+		{ value: "0", type: "NumericLiteral" },
+		{ value: ".", type: "Dot" },
+		{ value: "apple", type: "Identifier" },
+		{ value: ".", type: "Dot" },
+		{ value: "banana", type: "Identifier" },
+		{ value: ".", type: "Dot" },
+		{ value: "1", type: "NumericLiteral" },
+		{ value: ".", type: "Dot" },
+		{ value: "2", type: "NumericLiteral" },
+		{ value: "[", type: "OpenSquareBracket" },
+		{ value: "3", type: "NumericLiteral" },
+		{ value: "]", type: "CloseSquareBracket" },
+		{ value: "[", type: "OpenSquareBracket" },
+		{ value: "cherry", type: "StringLiteral" },
+		{ value: "]", type: "CloseSquareBracket" },
+		{ value: "}}", type: "CloseExpression" },
+		{ value: "|", type: "Text" },
 	],
 
 	// Object methods
@@ -4715,6 +4763,24 @@ const TEST_CONTEXT = {
 	PROPERTIES: {
 		obj: { x: 10, y: 20 },
 	},
+	PROPERTIES_1: {
+		matrix: [
+			[
+				["zero-zero-zero", "zero-zero-one"],
+				["zero-one-zero", "zero-one-one"],
+			],
+		],
+		object: [
+			{
+				apple: {
+					banana: [
+						"unused",
+						["zero", "one", ["unused-zero", "unused-one", "unused-two", { cherry: "mixed-indexing" }]],
+					],
+				},
+			},
+		],
+	},
 
 	// Object methods
 	OBJ_METHODS: {
@@ -5125,6 +5191,7 @@ const EXPECTED_OUTPUTS = {
 
 	// Object properties
 	PROPERTIES: "3030",
+	PROPERTIES_1: `|[["zero-zero-zero", "zero-zero-one"], ["zero-one-zero", "zero-one-one"]]|["zero-one-zero", "zero-one-one"]|zero-one-one|mixed-indexing|`,
 
 	// Object methods
 	OBJ_METHODS: "AB  A_B",


### PR DESCRIPTION
Supersedes https://github.com/huggingface/huggingface.js/pull/2140; with repeated and interleaved access support.

https://huggingface.co/zai-org/GLM-5.1 now works as intended

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches lexer/parser/runtime/formatter behavior for member access and numeric literals, which can subtly change how templates are tokenized and evaluated (especially around `.` and decimals). Scope is still localized to Jinja expression handling and covered by new tests.
> 
> **Overview**
> Fixes Jinja member-access handling so numeric indices can be used with dot notation (e.g. `matrix.0.1`) and chained/interleaved with bracket notation, treating `obj.0` as an index access rather than a float literal.
> 
> This updates the lexer to avoid lexing `.<digit>` as a fractional part when the `.` is a member-access operator, extends the parser/runtime to accept `IntegerLiteral` after `.` and evaluate it as an integer index, and adjusts the formatter to emit dot accesses for integer properties without extra parentheses. Adds regression tests for deep/chained mixed indexing and a new `zai-org/GLM-5.1` e2e template case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6cc8637f1e3d41f1d43b983eb7b0df2537f1a19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->