### PR TITLE
🩹fix: Update code example

### DIFF
--- a/packages/ollama-utils/README.md
+++ b/packages/ollama-utils/README.md
@@ -7,7 +7,7 @@ For now, we are exposing chat template conversion to the Go format used by Ollam
 ## Chat template converter
 
 ```ts
-import { convertJinjaToGoTemplate } from "@huggingface/ollama-utils";
+import { convertGGUFTemplateToOllama } from "@huggingface/ollama-utils";
 
 const MODEL_INFO_URL = "https://huggingface.co/api/models/bartowski/Llama-3.2-3B-Instruct-GGUF?expand[]=gguf";
 const modelInfo = await (await fetch(MODEL_INFO_URL)).json();
@@ -22,7 +22,7 @@ console.log(modelInfo);
  *   }
  * }
  */
-const convertedTemplate = convertJinjaToGoTemplate(modelInfo.gguf);
+const convertedTemplate = convertGGUFTemplateToOllama(modelInfo.gguf);
 if (convertedTemplate) {
   console.log(convertedTemplate.ollama);
   /**


### PR DESCRIPTION
Replaced `convertJinjaToGoTemplate` with `convertGGUFTemplateToOllama`. The latter is exported resulting in valid code execution, while the former is not resulting in an error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that fixes the README snippet to call an exported API, avoiding runtime import errors for users following the example.
> 
> **Overview**
> Updates the `@huggingface/ollama-utils` README code example to use `convertGGUFTemplateToOllama` instead of the non-exported `convertJinjaToGoTemplate`, so the documented import and usage are valid when copied into real code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d38e5fa82c5a03b938bda28bc1d87d1118f72fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->