### PR TITLE
Add NVIDIA Titan GPU series to hardware-nvidia SKUs

### DIFF
--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -24,7 +24,9 @@ export enum NvidiaComputeCapabilities {
 	PASCAL_TEGRA = 6.2,
 	PASCAL = 6.1,
 	PASCAL_DATACENTER = 6.0,
-	MAXWELL = 5.3,
+	MAXWELL_TEGRA = 5.3,
+	MAXWELL = 5.2,
+	KEPLER = 3.5,
 }
 
 export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
@@ -502,6 +504,41 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		tflops: 32.62,
 		memory: [24],
 		computeCapability: 7.5,
+	},
+	"Titan RTX": {
+		tflops: 16.31,
+		memory: [24],
+		computeCapability: 7.5,
+	},
+	"Titan V": {
+		tflops: 14.9,
+		memory: [12],
+		computeCapability: 7.0,
+	},
+	"Titan Xp": {
+		tflops: 12.15, // float32 (GPU does not support native float16)
+		memory: [12],
+		computeCapability: 6.1,
+	},
+	"Titan X (Pascal)": {
+		tflops: 10.97, // float32 (GPU does not support native float16)
+		memory: [12],
+		computeCapability: 6.1,
+	},
+	"GTX Titan X": {
+		tflops: 6.605, // float32 (GPU does not support native float16)
+		memory: [12],
+		computeCapability: 5.2,
+	},
+	"GTX Titan Black": {
+		tflops: 5.645, // float32 (GPU does not support native float16)
+		memory: [6],
+		computeCapability: 3.5,
+	},
+	"GTX Titan": {
+		tflops: 4.709, // float32 (GPU does not support native float16)
+		memory: [6],
+		computeCapability: 3.5,
 	},
 	"GTX 1660": {
 		tflops: 10.05,


### PR DESCRIPTION
## Summary

Adds all 7 consumer Titan-class NVIDIA GPUs to \`packages/tasks/src/hardware-nvidia.ts\`, covering the full Titan lineage from Kepler (2013) to Turing (2018).

## New SKUs

| Key | Architecture | VRAM | FP32 TFLOPS | Compute Cap. |
|-----|-------------|------|-------------|---------|
| \`GTX Titan\` | Kepler GK110 (2013) | 6 GB | 4.709 | 3.5 |
| \`GTX Titan Black\` | Kepler GK110B (2014) | 6 GB | 5.645 | 3.5 |
| \`GTX Titan X\` | Maxwell GM200 (2015) | 12 GB | 6.605 | 5.2 |
| \`Titan X (Pascal)\` | Pascal GP102 (2016) | 12 GB | 10.97 | 6.1 |
| \`Titan Xp\` | Pascal GP102 (2017) | 12 GB | 12.15 | 6.1 |
| \`Titan V\` | Volta GV100 (2017) | 12 GB | 14.9 | 7.0 |
| \`Titan RTX\` | Turing TU102 (2018) | 24 GB | 16.31 | 7.5 |

TFLOPS values are **FP32** (pre-Volta Titan cards lack native FP16 support), calculated from \`(CUDA cores × boost clock MHz × 2) / 1,000,000\` using core counts and clocks sourced from [Wikipedia GeForce 700 series](https://en.wikipedia.org/wiki/GeForce_700_series), [Wikipedia GeForce 10 series](https://en.wikipedia.org/wiki/GeForce_10_series), [Wikipedia Volta microarchitecture](https://en.wikipedia.org/wiki/Volta_(microarchitecture)), and official NVIDIA product pages.

## Enum fix

The existing \`MAXWELL = 5.3\` in \`NvidiaComputeCapabilities\` was the Tegra/mobile Maxwell variant (Jetson TX2 etc.). Renamed to \`MAXWELL_TEGRA = 5.3\` and added:
- \`MAXWELL = 5.2\` — desktop Maxwell (GTX 980 Ti, GTX Titan X, etc.)
- \`KEPLER = 3.5\` — Kepler desktop (GTX Titan, GTX Titan Black, GTX 780 Ti, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive SKU data, but the rename/split of the `MAXWELL` compute capability constant could break any downstream code that referenced the old enum value or relied on its numeric mapping.
> 
> **Overview**
> Adds the full consumer NVIDIA Titan GPU lineup to `NVIDIA_SKUS` (Kepler through Turing), including TFLOPS, VRAM, and compute capability entries.
> 
> Refines `NvidiaComputeCapabilities` by renaming the existing `MAXWELL` value to `MAXWELL_TEGRA` and introducing distinct `MAXWELL` (5.2) and `KEPLER` (3.5) constants to better match desktop vs Tegra compute capability versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a634089d6f5ebbeb219cc2650bb07cd67e3cd889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->