### PR TITLE
Add wildclawbench to EVALUATION_FRAMEWORKS

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -101,7 +101,7 @@ export const EVALUATION_FRAMEWORKS = {
 			"CLAW-Eval is an evaluation framework for assessing LLMs as autonomous agents across 300 human-verified tasks covering communication, finance, and productivity domains.",
 		url: "https://github.com/claw-eval/claw-eval",
 	},
-	"wildclawbench": {
+	wildclawbench: {
 		name: "wildclawbench",
 		description:
 			"WildClawBench is an in-the-wild benchmark for evaluating AI agents in the OpenClaw environment across 60 hand-built, end-to-end tasks spanning productivity, code intelligence, social interaction, search, creative synthesis, and safety domains.",

--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -101,4 +101,10 @@ export const EVALUATION_FRAMEWORKS = {
 			"CLAW-Eval is an evaluation framework for assessing LLMs as autonomous agents across 300 human-verified tasks covering communication, finance, and productivity domains.",
 		url: "https://github.com/claw-eval/claw-eval",
 	},
+	"wildclawbench": {
+		name: "wildclawbench",
+		description:
+			"WildClawBench is an in-the-wild benchmark for evaluating AI agents in the OpenClaw environment across 60 hand-built, end-to-end tasks spanning productivity, code intelligence, social interaction, search, creative synthesis, and safety domains.",
+		url: "https://github.com/InternLM/WildClawBench",
+	},
 } as const;


### PR DESCRIPTION
## Summary

Add [WildClawBench](https://github.com/InternLM/WildClawBench) as a supported evaluation framework in the `EVALUATION_FRAMEWORKS` list, enabling benchmark datasets on the Hub to use `evaluation_framework: wildclawbench` in their `eval.yaml` files.

## What is WildClawBench?

WildClawBench is an in-the-wild benchmark for evaluating AI agents end-to-end inside a live [OpenClaw](https://github.com/openclaw/openclaw) environment. Rather than testing isolated capabilities (single function call, single instruction), it drops agents into a real workspace and grades whether they can complete practical, multi-step jobs without hand-holding.

- **60 hand-built, original tasks** across 6 categories: Productivity Flow, Code Intelligence, Social Interaction, Search & Retrieval, Creative Synthesis, and Safety Alignment
- **Real environment, not mocks** — tasks run inside live OpenClaw instances with browser, bash, file system, email, and calendar tools
- **Reproducible & isolated** — each task runs in its own Docker container; ground-truth and grading scripts are injected only *after* the agent finishes, eliminating data leakage and making scores reproducible across machines
- **Stresses long-horizon agency** — 10–60+ tool calls per task, multimodal inputs (video, image), 10–20 min wall-clock workflows, undocumented-codebase comprehension, and adversarial safety scenarios (prompt injection, credential leaks)
- **Bilingual** — English and Chinese tasks
- **Hard enough to matter** — every frontier model today scores below 0.6 overall

GitHub: <https://github.com/InternLM/WildClawBench>  
Leaderboard: <https://internlm.github.io/WildClawBench/>  
Dataset: <https://huggingface.co/datasets/internlm/WildClawBench>

## Motivation

WildClawBench complements existing entries in `EVALUATION_FRAMEWORKS` by targeting **agentic, end-to-end** capability rather than single-turn QA or pure code generation. The dataset (including Docker image, task workspaces, and grading scripts) is already hosted on the Hub at [`internlm/WildClawBench`](https://huggingface.co/datasets/internlm/WildClawBench). Registering the framework identifier lets the benchmark publish a leaderboard through the Hub's standard evaluation-results pipeline and lets community submissions reference `evaluation_framework: wildclawbench` in their `eval.yaml` files.

## Changes

- Added `wildclawbench` entry to `EVALUATION_FRAMEWORKS` in `packages/tasks/src/eval.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new static entry to the `EVALUATION_FRAMEWORKS` registry with no behavioral or security-sensitive logic changes.
> 
> **Overview**
> Adds **`wildclawbench`** to the `EVALUATION_FRAMEWORKS` list in `packages/tasks/src/eval.ts`, including its display name, description, and repository URL so datasets can reference `evaluation_framework: wildclawbench` in `eval.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817877a4f070968e074e85d16525e417371a0632. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->