### PR TITLE
Add MultiMolecule

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1094,6 +1094,58 @@ from MeshAnything.models.meshanything import MeshAnything
 model = MeshAnything(args)`,
 ];
 
+export const multimolecule = (model: ModelData): string[] => {
+	const widgetExample = model.widgetData?.[0] as WidgetExampleTextInput | undefined;
+	const exampleText = widgetExample?.text;
+	const maskToken = model.mask_token ?? "<mask>";
+	const sequence = exampleText?.replace(maskToken, "A");
+
+	const snippets = [
+		`pip install multimolecule`,
+	];
+
+	if (sequence) {
+		snippets.push(
+			`from multimolecule import AutoModel, AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained("${model.id}")
+model = AutoModel.from_pretrained("${model.id}")
+
+inputs = tokenizer("${sequence}", return_tensors="pt")
+outputs = model(**inputs)
+embeddings = outputs.last_hidden_state`,
+		);
+	} else {
+		snippets.push(
+			`from multimolecule import AutoModel, AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained("${model.id}")
+model = AutoModel.from_pretrained("${model.id}")`,
+		);
+	}
+
+	if (model.tags.includes("rna-secondary-structure") && exampleText) {
+		snippets.push(
+			`import multimolecule
+from transformers import pipeline
+
+predictor = pipeline("rna-secondary-structure", model="${model.id}")
+output = predictor("${exampleText}")
+print(output["secondary_structure"])`,
+		);
+	} else if (model.pipeline_tag === "fill-mask" && exampleText) {
+		snippets.push(
+			`import multimolecule
+from transformers import pipeline
+
+predictor = pipeline("fill-mask", model="${model.id}")
+output = predictor("${exampleText}")`,
+		);
+	}
+
+	return snippets;
+};
+
 export const open_clip = (model: ModelData): string[] => [
 	`import open_clip
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1100,9 +1100,7 @@ export const multimolecule = (model: ModelData): string[] => {
 	const maskToken = model.mask_token ?? "<mask>";
 	const sequence = exampleText?.replace(maskToken, "A");
 
-	const snippets = [
-		`pip install multimolecule`,
-	];
+	const snippets = [`pip install multimolecule`];
 
 	if (sequence) {
 		snippets.push(

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -940,6 +940,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"vae/3d-vae.pt"`,
 	},
+	multimolecule: {
+	  prettyLabel: "MultiMolecule",
+	  repoName: "MultiMolecule",
+	  repoUrl: "https://github.com/MultiMolecule/multimolecule",
+	  docsUrl: "https://multimolecule.danling.org",
+	  snippets: snippets.multimolecule,
+	  filter: false,
+	},
 	nemo: {
 		prettyLabel: "NeMo",
 		repoName: "NeMo",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -941,12 +941,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path:"vae/3d-vae.pt"`,
 	},
 	multimolecule: {
-	  prettyLabel: "MultiMolecule",
-	  repoName: "MultiMolecule",
-	  repoUrl: "https://github.com/MultiMolecule/multimolecule",
-	  docsUrl: "https://multimolecule.danling.org",
-	  snippets: snippets.multimolecule,
-	  filter: false,
+		prettyLabel: "MultiMolecule",
+		repoName: "MultiMolecule",
+		repoUrl: "https://github.com/MultiMolecule/multimolecule",
+		docsUrl: "https://multimolecule.danling.org",
+		snippets: snippets.multimolecule,
+		filter: false,
 	},
 	nemo: {
 		prettyLabel: "NeMo",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new model library entry and display snippets without changing existing library behavior or any security/data-handling paths.
> 
> **Overview**
> Adds **MultiMolecule** as a supported model library in `MODEL_LIBRARIES_UI_ELEMENTS`, including repo/docs metadata and wiring to a new `snippets.multimolecule` generator.
> 
> Introduces `multimolecule(model)` code snippets that show `pip install multimolecule`, basic `AutoModel`/`AutoTokenizer` loading, and (when widget examples/tags indicate) optional examples for `fill-mask` and `rna-secondary-structure` pipelines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6da49b90f0088c9b636c2c6c27d0f5cc8d3192db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->