### PR TITLE
Add MSRP to remaining hardware + make typing non-optional

### DIFF
--- a/packages/tasks/src/hardware-amd.ts
+++ b/packages/tasks/src/hardware-amd.ts
@@ -1,6 +1,6 @@
-import type { HardwareSpec, WithRequired } from "./hardware.js";
+import type { HardwareSpec } from "./hardware.js";
 
-export interface AmdGpuHardwareSpec extends WithRequired<HardwareSpec, "msrp"> {
+export interface AmdGpuHardwareSpec extends HardwareSpec {
 	/**
 	 * GFX version / LLVM ISA target (AMD GPUs only), e.g. "gfx1100"
 	 *

--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -1,6 +1,6 @@
-import type { HardwareSpec, WithRequired } from "./hardware.js";
+import type { HardwareSpec } from "./hardware.js";
 
-export interface NvidiaHardwareSpec extends WithRequired<HardwareSpec, "msrp"> {
+export interface NvidiaHardwareSpec extends HardwareSpec {
 	/**
 	 * CUDA Compute Capability (NVIDIA GPUs only)
 	 *

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -91,18 +91,23 @@ export const SKUS = {
 		QUALCOMM: {
 			"Snapdragon X Elite X1E-00-1DE": {
 				tflops: 4.6,
+				msrp: 900,
 			},
 			"Snapdragon X Elite X1E-84-100": {
 				tflops: 4.6,
+				msrp: 1_700,
 			},
 			"Snapdragon X Elite X1E-80-100": {
 				tflops: 3.8,
+				msrp: 1_300,
 			},
 			"Snapdragon X Elite X1E-78-100": {
 				tflops: 3.8,
+				msrp: 1_200,
 			},
 			"Snapdragon X Plus X1P-64-100": {
 				tflops: 3.8,
+				msrp: 1_000,
 			},
 		},
 	},

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -15,8 +15,6 @@ export const TFLOPS_THRESHOLD_WHITE_HOUSE_CLUSTER = 10 ** 8;
  */
 export const TFLOPS_THRESHOLD_EU_AI_ACT_MODEL_TRAINING_TOTAL = 10 ** 13;
 
-export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
-
 export interface HardwareSpec {
 	/**
 	 * Approximate value, in FP16 whenever possible for GPUs and FP32 for CPUs.
@@ -45,7 +43,7 @@ export interface HardwareSpec {
 	 * "Ryzen Zen 4 7000 (Ryzen 9)"), this is the tray/box price of a
 	 * representative flagship SKU at launch.
 	 */
-	msrp?: number;
+	msrp: number;
 }
 
 export const DEFAULT_MEMORY_OPTIONS = [


### PR DESCRIPTION
## Summary
Final stacked PR in the MSRP series — on top of #2158 (which is on #2157, on #2156).

Two changes:
1. **Adds an \`msrp\` field to the 5 Qualcomm Snapdragon X Elite / X Plus entries** — the only hardware items remaining in \`hardware*.ts\` that did not yet have an \`msrp\`. These SoCs aren't sold standalone, so values reflect a typical Copilot+ PC configured with that chip; the \`X1E-00-1DE\` entry uses the \$899 Snapdragon Dev Kit for Windows price.
2. **Tightens the typing: \`HardwareSpec.msrp\` is now required (\`msrp: number\`)**. The previously-introduced \`WithRequired<HardwareSpec, "msrp">\` helper is no longer needed and is removed; \`NvidiaHardwareSpec\` and \`AmdGpuHardwareSpec\` simply \`extends HardwareSpec\` again.

## Test plan
- [x] \`npx tsc --noEmit\` in \`packages/tasks\` passes
- [x] No \`tflops\` entry without a corresponding \`msrp\` remains across \`hardware.ts\`, \`hardware-nvidia.ts\`, \`hardware-amd.ts\`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Makes `HardwareSpec.msrp` mandatory, which can break any code or data relying on it being optional, but changes are confined to static hardware spec typing/data.
> 
> **Overview**
> All hardware specs now require an `msrp` value: `HardwareSpec.msrp` is changed from optional to required, and the temporary `WithRequired<HardwareSpec, "msrp">` helper is removed, with AMD/NVIDIA spec interfaces reverting to `extends HardwareSpec`.
> 
> The remaining Qualcomm Snapdragon X Elite/X Plus GPU entries are updated to include `msrp`, bringing the hardware SKU data into alignment with the stricter type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf6e9e626b3713e20d5a231bb98bbc217f6562ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->