### PR TITLE
Add wildclawbench to EVALUATION_FRAMEWORKS

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -101,4 +101,10 @@ export const EVALUATION_FRAMEWORKS = {
 			"CLAW-Eval is an evaluation framework for assessing LLMs as autonomous agents across 300 human-verified tasks covering communication, finance, and productivity domains.",
 		url: "https://github.com/claw-eval/claw-eval",
 	},
+	wildclawbench: {
+		name: "wildclawbench",
+		description:
+			"WildClawBench is an end-to-end agent benchmark that runs inside a live OpenClaw environment with 60 practical tasks across productivity, code intelligence, multimodal synthesis, search, social interaction, and safety.",
+		url: "https://github.com/internlm/WildClawBench",
+	},
 } as const;


### PR DESCRIPTION
Adds wildclawbench to EVALUATION_FRAMEWORKS in packages/tasks/src/eval.ts so the [WildClawBench](https://huggingface.co/datasets/internlm/WildClawBench) dataset can use evaluation_framework: wildclawbench in eval.yaml and display the benchmark badge on the Hub.

Project: https://github.com/internlm/WildClawBench
Dataset: https://huggingface.co/datasets/internlm/WildClawBench

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new entry to a static `EVALUATION_FRAMEWORKS` mapping with no behavioral or data-handling logic changes.
> 
> **Overview**
> Adds `wildclawbench` to the `EVALUATION_FRAMEWORKS` registry in `packages/tasks/src/eval.ts`, including name/description/URL metadata so datasets can reference `evaluation_framework: wildclawbench` and surface the corresponding benchmark badge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f0c66bbdf659c79f6a247d79ecbde4404185c18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->