### PR TITLE
add sapiens2 as library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1202,6 +1202,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_extension:"pt2" OR path_extension:"pth" OR path_extension:"onnx"`,
 	},
+	sapiens2: {
+		prettyLabel: "sapiens2",
+		repoName: "sapiens2",
+		repoUrl: "https://github.com/facebookresearch/sapiens2",
+		filter: false,
+		countDownloads: `path_extension:"safetensors"`,
+	},
 	seedvr: {
 		prettyLabel: "SeedVR",
 		repoName: "SeedVR",


### PR DESCRIPTION
@pcuenca 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new entry to the model libraries UI mapping, with no changes to control flow or data handling.
> 
> **Overview**
> Adds a new `sapiens2` model library entry in `model-libraries.ts`, including repo metadata (`facebookresearch/sapiens2`) and a `countDownloads` Elastic query that counts `*.safetensors` artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a99c6435fc981534d7c733030e344ef0ea4110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->