### PR TITLE
Patch vulnerable transitive deps in doc-internal

### DIFF
--- a/packages/doc-internal/package.json
+++ b/packages/doc-internal/package.json
@@ -31,5 +31,13 @@
 		"typedoc": "^0.25.12",
 		"typedoc-plugin-markdown": "^3.17.1"
 	},
+	"pnpm": {
+		"overrides": {
+			"handlebars": "^4.7.9",
+			"yaml": "^2.8.3",
+			"minimatch": "^9.0.7",
+			"brace-expansion": "^2.0.3"
+		}
+	},
 	"packageManager": "pnpm@10.10.0"
 }

--- a/packages/doc-internal/pnpm-lock.yaml
+++ b/packages/doc-internal/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  handlebars: ^4.7.9
+  yaml: ^2.8.3
+  minimatch: ^9.0.7
+  brace-expansion: ^2.0.3
+
 importers:
 
   .:
@@ -12,8 +18,8 @@ importers:
         specifier: ^9.2.1
         version: 9.2.1
       yaml:
-        specifier: ^2.2.2
-        version: 2.2.2
+        specifier: ^2.8.3
+        version: 2.9.0
     devDependencies:
       '@types/node':
         specifier: ^18.14.5
@@ -36,8 +42,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -46,8 +52,8 @@ packages:
     resolution: {integrity: sha512-Pxxgq3W0HyA3XUvSXcFhRSs+43Jsx0ddxcFrbjxNGkL2Ak5BAUBxLqI5G6ADDeCHLfzzXFhe0b1yYcctGmytMA==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  handlebars@4.7.7:
-    resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -66,12 +72,8 @@ packages:
     engines: {node: '>= 12'}
     hasBin: true
 
-  minimatch@7.4.2:
-    resolution: {integrity: sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==}
-    engines: {node: '>=10'}
-
-  minimatch@9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
@@ -126,9 +128,10 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
-  yaml@2.2.2:
-    resolution: {integrity: sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==}
-    engines: {node: '>= 14'}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
 snapshots:
 
@@ -138,7 +141,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  brace-expansion@2.0.1:
+  brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
 
@@ -147,11 +150,11 @@ snapshots:
   glob@9.2.1:
     dependencies:
       fs.realpath: 1.0.0
-      minimatch: 7.4.2
+      minimatch: 9.0.9
       minipass: 4.2.4
       path-scurry: 1.6.1
 
-  handlebars@4.7.7:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -168,13 +171,9 @@ snapshots:
 
   marked@4.3.0: {}
 
-  minimatch@7.4.2:
+  minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.1
-
-  minimatch@9.0.3:
-    dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.1.0
 
   minimist@1.2.8: {}
 
@@ -198,14 +197,14 @@ snapshots:
 
   typedoc-plugin-markdown@3.17.1(typedoc@0.25.12(typescript@5.8.3)):
     dependencies:
-      handlebars: 4.7.7
+      handlebars: 4.7.9
       typedoc: 0.25.12(typescript@5.8.3)
 
   typedoc@0.25.12(typescript@5.8.3):
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0
-      minimatch: 9.0.3
+      minimatch: 9.0.9
       shiki: 0.14.7
       typescript: 5.8.3
 
@@ -220,4 +219,4 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  yaml@2.2.2: {}
+  yaml@2.9.0: {}


### PR DESCRIPTION
## Summary
- add targeted `pnpm.overrides` in `packages/doc-internal/package.json`
- refresh `packages/doc-internal/pnpm-lock.yaml` to resolve patched transitive versions for `handlebars`, `yaml`, `minimatch`, and `brace-expansion`
- keep the change scoped to dependency metadata and lockfile only

## Validation
- `pnpm install --ignore-scripts` (from `packages/doc-internal`)
- verified vulnerable lock entries are replaced with patched versions in `packages/doc-internal/pnpm-lock.yaml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only dependency metadata/lockfile updates to force patched transitive versions; potential impact is limited to doc generation build/runtime if the newer resolutions behave differently.
> 
> **Overview**
> Adds `pnpm.overrides` to `packages/doc-internal/package.json` to force patched versions of vulnerable transitive dependencies (`handlebars`, `yaml`, `minimatch`, `brace-expansion`).
> 
> Refreshes `packages/doc-internal/pnpm-lock.yaml` to apply those overrides, updating resolved versions (notably bumping `yaml` to `2.9.0` and aligning `typedoc`/`glob` transitive trees on newer `handlebars`/`minimatch`/`brace-expansion`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b179c6f8149e3c97fa1fd579f1e19718454df1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->