### PR TITLE
gguf: parser for percentage-mixed GGUF filenames

### DIFF
--- a/packages/gguf/src/gguf.spec.ts
+++ b/packages/gguf/src/gguf.spec.ts
@@ -8,6 +8,7 @@ import {
 	ggufAllShards,
 	parseGgufShardFilename,
 	parseGGUFQuantLabel,
+	parseGGUFQuantMix,
 	GGUF_QUANT_ORDER,
 	findNearestQuantType,
 	serializeGgufMetadata,
@@ -341,6 +342,64 @@ describe("gguf", () => {
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-IQ3_XS.gguf")).toEqual("IQ3_XS");
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-Q4_0_4_4.gguf")).toEqual("Q4_0"); // TODO: investigate Q4_0_4_4
 		expect(parseGGUFQuantLabel("Qwen3-4B-UD-Q2_K_XL.gguf")).toEqual("UD-Q2_K_XL"); // unsloth UD (Unsloth Dynamic) prefix
+		// percentage-mixed filenames — should return the dominant (largest-%) component,
+		// not the last one (which would be the smallest tail)
+		expect(parseGGUFQuantLabel("DeepSeek-V4-Flash-55IQ2_XXS-34Q2_K-07Q8_0-03F16.gguf")).toEqual("IQ2_XXS");
+		expect(parseGGUFQuantLabel("DeepSeek-V4-Flash-95Q4_K-04Q8_0-imatrix.gguf")).toEqual("Q4_K");
+	});
+
+	it("parse percentage-mixed quant filename", async () => {
+		// DeepSeek V4 Flash q2 recipe (antirez/deepseek-v4-gguf)
+		expect(parseGGUFQuantMix("DeepSeek-V4-Flash-55IQ2_XXS-34Q2_K-07Q8_0-03F16.gguf")).toEqual({
+			components: [
+				{ pct: 55, quant: "IQ2_XXS" },
+				{ pct: 34, quant: "Q2_K" },
+				{ pct: 7, quant: "Q8_0" },
+				{ pct: 3, quant: "F16" },
+			],
+			dominant: { pct: 55, quant: "IQ2_XXS" },
+		});
+
+		// trailing `-imatrix` suffix doesn't disturb the parse
+		expect(parseGGUFQuantMix("DeepSeek-V4-Flash-55IQ2_XXS-34Q2_K-07Q8_0-03F16-imatrix.gguf")?.dominant).toEqual({
+			pct: 55,
+			quant: "IQ2_XXS",
+		});
+
+		// q4 recipe (2 components is still a mix)
+		expect(parseGGUFQuantMix("DeepSeek-V4-Flash-95Q4_K-04Q8_0.gguf")).toEqual({
+			components: [
+				{ pct: 95, quant: "Q4_K" },
+				{ pct: 4, quant: "Q8_0" },
+			],
+			dominant: { pct: 95, quant: "Q4_K" },
+		});
+
+		// MTP type slot does not interfere (per ggml-org/ggml#1488)
+		expect(parseGGUFQuantMix("DeepSeek-V4-Flash-95Q4_K-04Q8_0-MTP.gguf")?.dominant).toEqual({
+			pct: 95,
+			quant: "Q4_K",
+		});
+
+		// Path prefix is stripped before parsing
+		expect(parseGGUFQuantMix("subdir/DeepSeek-V4-Flash-95Q4_K-04Q8_0.gguf")?.components.length).toBe(2);
+
+		// Plain single-quant filenames are not mixes → undefined
+		expect(parseGGUFQuantMix("Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf")).toBeUndefined();
+		expect(parseGGUFQuantMix("Codestral-22B-v0.1-Q2_K.gguf")).toBeUndefined();
+		expect(parseGGUFQuantMix("Codestral-22B-v0.1.gguf")).toBeUndefined();
+
+		// Model size labels like "7B" or "8B" should not be misread as components
+		expect(parseGGUFQuantMix("Llama-7B-8B-Q4_0.gguf")).toBeUndefined();
+
+		// Dominant is the largest pct even if input order is different
+		expect(parseGGUFQuantMix("Model-03F16-55IQ2_XXS-34Q2_K-07Q8_0.gguf")?.dominant).toEqual({
+			pct: 55,
+			quant: "IQ2_XXS",
+		});
+
+		// IQ2_XXS must win over its prefix IQ2_XS (length-sorted alternation)
+		expect(parseGGUFQuantMix("Model-55IQ2_XXS-34Q2_K.gguf")?.components[0].quant).toBe("IQ2_XXS");
 	});
 
 	it("calculate tensor data offset", async () => {

--- a/packages/gguf/src/gguf.spec.ts
+++ b/packages/gguf/src/gguf.spec.ts
@@ -400,6 +400,14 @@ describe("gguf", () => {
 
 		// IQ2_XXS must win over its prefix IQ2_XS (length-sorted alternation)
 		expect(parseGGUFQuantMix("Model-55IQ2_XXS-34Q2_K.gguf")?.components[0].quant).toBe("IQ2_XXS");
+
+		// Non-quant storage types (I8/I16/I32/I64/F64) must not be recognized as components
+		expect(parseGGUFQuantMix("Model-32I32-16I16.gguf")).toBeUndefined();
+		// F64 dropped; F32 + Q8_0 remain → still a mix, F32 dominant
+		expect(parseGGUFQuantMix("Model-50F64-30F32-20Q8_0.gguf")?.components).toEqual([
+			{ pct: 30, quant: "F32" },
+			{ pct: 20, quant: "Q8_0" },
+		]);
 	});
 
 	it("calculate tensor data offset", async () => {

--- a/packages/gguf/src/gguf.ts
+++ b/packages/gguf/src/gguf.ts
@@ -17,12 +17,15 @@ export { GGUFValueType, GGMLQuantizationType, Architecture } from "./types";
 export { GGUF_QUANT_DESCRIPTIONS } from "./quant-descriptions";
 export {
 	parseGGUFQuantLabel,
+	parseGGUFQuantMix,
 	GGUF_QUANT_RE,
 	GGUF_QUANT_RE_GLOBAL,
+	GGUF_QUANT_MIX_COMPONENT_RE,
 	GGUF_QUANT_ORDER,
 	findNearestQuantType,
 	GGMLFileQuantizationType,
 } from "@huggingface/tasks";
+export type { GGUFQuantMix, GGUFQuantMixComponent } from "@huggingface/tasks";
 
 export const RE_GGUF_FILE = /\.gguf$/;
 export const RE_GGUF_SHARD_FILE = /^(?<prefix>.*?)-(?<shard>\d{5})-of-(?<total>\d{5})\.gguf$/;

--- a/packages/tasks/src/gguf.ts
+++ b/packages/tasks/src/gguf.ts
@@ -221,8 +221,12 @@ export enum GGMLQuantizationType {
 // (e.g. "55IQ2_XXS", "07Q8_0"). Lookbehind/lookahead require the token to be
 // delimited by `^`, `-`, `.`, or `$` so we don't accidentally chew through
 // model size labels like "7B" or other tokens.
+// I8/I16/I32/I64/F64 are integer/float storage types for metadata tensors,
+// not quantization methods — exclude so a hypothetical "-32I32-16I16-" pair
+// isn't misread as a mix recipe.
+const _GGUF_QUANT_MIX_NON_QUANT_NAMES = new Set(["I8", "I16", "I32", "I64", "F64"]);
 const _ggmlQuantNames = Object.values(GGMLQuantizationType)
-	.filter((v): v is string => typeof v === "string")
+	.filter((v): v is string => typeof v === "string" && !_GGUF_QUANT_MIX_NON_QUANT_NAMES.has(v))
 	// Sort by length descending so "IQ2_XXS" wins over the shorter prefix "IQ2_XS".
 	.sort((a, b) => b.length - a.length);
 

--- a/packages/tasks/src/gguf.ts
+++ b/packages/tasks/src/gguf.ts
@@ -61,6 +61,13 @@ export const GGUF_QUANT_RE = new RegExp(
 export const GGUF_QUANT_RE_GLOBAL = new RegExp(GGUF_QUANT_RE, "g");
 
 export function parseGGUFQuantLabel(fname: string): string | undefined {
+	// Percentage-mixed filenames (e.g. "Model-55IQ2_XXS-34Q2_K-07Q8_0-03F16.gguf")
+	// encode a per-tensor-class recipe; for those we return the dominant (largest-%)
+	// component rather than picking by file-order, which would surface the smallest tail.
+	const mix = parseGGUFQuantMix(fname);
+	if (mix) {
+		return mix.dominant.quant;
+	}
 	const quantLabel = fname.toUpperCase().match(GGUF_QUANT_RE_GLOBAL)?.at(-1); // if there is multiple quant substrings in a name, we prefer the last one
 	return quantLabel;
 }
@@ -208,4 +215,50 @@ export enum GGMLQuantizationType {
 	MXFP4 = 39,
 	NVFP4 = 40,
 	Q1_0 = 41,
+}
+
+// Match one "<pct><quant>" component of a percentage-mixed GGUF filename
+// (e.g. "55IQ2_XXS", "07Q8_0"). Lookbehind/lookahead require the token to be
+// delimited by `^`, `-`, `.`, or `$` so we don't accidentally chew through
+// model size labels like "7B" or other tokens.
+const _ggmlQuantNames = Object.values(GGMLQuantizationType)
+	.filter((v): v is string => typeof v === "string")
+	// Sort by length descending so "IQ2_XXS" wins over the shorter prefix "IQ2_XS".
+	.sort((a, b) => b.length - a.length);
+
+export const GGUF_QUANT_MIX_COMPONENT_RE = new RegExp(
+	`(?<=^|-)(?<pct>\\d{1,3})(?<quant>${_ggmlQuantNames.join("|")})(?=$|[-.])`,
+	"g",
+);
+
+export interface GGUFQuantMixComponent {
+	/** Percentage of bytes this component contributes to the file (0-100). */
+	pct: number;
+	/** Tensor-level quantization type name (matches `GGMLQuantizationType` keys). */
+	quant: keyof typeof GGMLQuantizationType;
+}
+
+export interface GGUFQuantMix {
+	/** All "<pct><quant>" components found in the filename, in file order. */
+	components: GGUFQuantMixComponent[];
+	/** Component with the largest percentage share. */
+	dominant: GGUFQuantMixComponent;
+}
+
+/** Parse a percentage-mixed GGUF filename (e.g. `Model-55IQ2_XXS-34Q2_K.gguf`). */
+export function parseGGUFQuantMix(fname: string): GGUFQuantMix | undefined {
+	const base = (fname.split("/").pop() ?? fname).toUpperCase();
+	const stem = base.replace(/\.GGUF$/, "");
+	// Re-create the regex per call so we don't share lastIndex across callers.
+	const re = new RegExp(GGUF_QUANT_MIX_COMPONENT_RE.source, "g");
+	const matches = [...stem.matchAll(re)];
+	if (matches.length < 2) {
+		return undefined;
+	}
+	const components: GGUFQuantMixComponent[] = matches.map((m) => ({
+		pct: Number(m.groups?.pct ?? 0),
+		quant: m.groups?.quant as keyof typeof GGMLQuantizationType,
+	}));
+	const dominant = components.reduce((a, b) => (b.pct > a.pct ? b : a));
+	return { components, dominant };
 }


### PR DESCRIPTION
Adds a parser for percentage-mixed GGUF filenames — files that ship a single artifact with tensors quantized to multiple ggml types and encode the per-type byte share in the name as `<pct><quant>` tokens.

Example: `DeepSeek-V4-Flash-55IQ2_XXS-34Q2_K-07Q8_0-03F16.gguf` ([antirez/deepseek-v4-gguf](https://huggingface.co/antirez/deepseek-v4-gguf)).

### API

```ts
parseGGUFQuantMix("DeepSeek-V4-Flash-55IQ2_XXS-34Q2_K-07Q8_0-03F16.gguf")
// {
//   components: [{pct:55,quant:'IQ2_XXS'}, {pct:34,quant:'Q2_K'}, {pct:7,quant:'Q8_0'}, {pct:3,quant:'F16'}],
//   dominant:   {pct:55, quant:'IQ2_XXS'},
// }
```

Also exports `GGUF_QUANT_MIX_COMPONENT_RE` and `GGUFQuantMix` / `GGUFQuantMixComponent` types.

### `parseGGUFQuantLabel` delegates to it

When the filename looks like a mix, `parseGGUFQuantLabel` now returns the **dominant** component instead of the file-order last match (which today surfaces the smallest tail — `F16` in the example above). Plain single-quant filenames are unchanged.

```ts
parseGGUFQuantLabel("DeepSeek-V4-Flash-55IQ2_XXS-34Q2_K-07Q8_0-03F16.gguf") // → "IQ2_XXS"
parseGGUFQuantLabel("Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf")               // → "Q4_K_M"  (unchanged)
parseGGUFQuantLabel("Qwen3-4B-UD-Q2_K_XL.gguf")                             // → "UD-Q2_K_XL"  (unchanged)
```

### Notes

- Returns `undefined` for plain single-quant filenames so it composes cleanly with the existing fallback.
- Delimited lookbehind / lookahead avoids false positives on size labels like `7B`.
- Quant alternation is length-sorted so `IQ2_XXS` wins over the prefix `IQ2_XS`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new filename parser and adjusts `parseGGUFQuantLabel` output only for percentage-mixed names, with extensive unit test coverage; no GGUF binary parsing or data handling logic is changed.
> 
> **Overview**
> Adds support for **percentage-mixed GGUF filenames** (e.g. `Model-55IQ2_XXS-34Q2_K-07Q8_0-03F16.gguf`) by introducing `parseGGUFQuantMix`, `GGUF_QUANT_MIX_COMPONENT_RE`, and the `GGUFQuantMix*` types in `@huggingface/tasks`, and re-exporting them from `packages/gguf`.
> 
> Updates `parseGGUFQuantLabel` to detect these mixed names and return the **dominant (largest %) quant** instead of the last match, and adds comprehensive tests covering suffixes like `-imatrix`/`-MTP`, path prefixes, size-label false positives, and non-quant storage types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4a6f7552744f3cafa6613a9ac5450d5803a2bad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->