### PR TITLE
gguf: parser for GGUF filename variants (LoRA / vocab / MTP / imatrix)

### DIFF
--- a/packages/gguf/src/gguf.spec.ts
+++ b/packages/gguf/src/gguf.spec.ts
@@ -8,6 +8,7 @@ import {
 	ggufAllShards,
 	parseGgufShardFilename,
 	parseGGUFQuantLabel,
+	parseGGUFFileVariant,
 	GGUF_QUANT_ORDER,
 	findNearestQuantType,
 	serializeGgufMetadata,
@@ -341,6 +342,47 @@ describe("gguf", () => {
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-IQ3_XS.gguf")).toEqual("IQ3_XS");
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-Q4_0_4_4.gguf")).toEqual("Q4_0"); // TODO: investigate Q4_0_4_4
 		expect(parseGGUFQuantLabel("Qwen3-4B-UD-Q2_K_XL.gguf")).toEqual("UD-Q2_K_XL"); // unsloth UD (Unsloth Dynamic) prefix
+	});
+
+	it("parse file variant", async () => {
+		// Plain model files → empty array
+		expect(parseGGUFFileVariant("Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf")).toEqual([]);
+		expect(parseGGUFFileVariant("Codestral-22B-v0.1.gguf")).toEqual([]);
+
+		// Spec <Type> slot values
+		expect(parseGGUFFileVariant("Model-Q4_K_M-LoRA.gguf")).toEqual(["LoRA"]);
+		expect(parseGGUFFileVariant("Model-Q4_K_M-vocab.gguf")).toEqual(["vocab"]);
+		expect(parseGGUFFileVariant("Qwen3.6-27B-MTP-Q8_0.gguf")).toEqual(["MTP"]); // MTP before encoding (am17an/RDson style)
+
+		// imatrix community marker
+		expect(parseGGUFFileVariant("Model-IQ2_XXS-imatrix.gguf")).toEqual(["imatrix"]);
+		expect(parseGGUFFileVariant("Model-imatrix-Q4_K_M.gguf")).toEqual(["imatrix"]); // prefix position
+
+		// Multiple distinct tokens preserved in first-occurrence order
+		expect(parseGGUFFileVariant("Model-MTP-imatrix-Q4_K_M.gguf")).toEqual(["MTP", "imatrix"]);
+		expect(parseGGUFFileVariant("Model-imatrix-MTP-Q4_K_M.gguf")).toEqual(["imatrix", "MTP"]);
+		expect(parseGGUFFileVariant("Model-LoRA-MTP-Q4_K_M.gguf")).toEqual(["LoRA", "MTP"]);
+
+		// Exact duplicates deduped
+		expect(parseGGUFFileVariant("Model-imatrix-Q4_K_M-imatrix.gguf")).toEqual(["imatrix"]);
+		expect(parseGGUFFileVariant("Model-MTP-MTP-Q4_K_M.gguf")).toEqual(["MTP"]);
+
+		// Case-insensitive match, canonical case returned
+		expect(parseGGUFFileVariant("Model-q4_k_m-lora.gguf")).toEqual(["LoRA"]);
+		expect(parseGGUFFileVariant("Model-LORA-mtp.gguf")).toEqual(["LoRA", "MTP"]);
+
+		// `.` separator works (mradermacher-style stems)
+		expect(parseGGUFFileVariant("Model.imatrix.Q4_K_M.gguf")).toEqual(["imatrix"]);
+
+		// `i1-` prefix is NOT a recognized marker on its own
+		expect(parseGGUFFileVariant("DeepSeek-V3.i1-Q4_K_M.gguf")).toEqual([]);
+
+		// Path prefix is stripped before parsing
+		expect(parseGGUFFileVariant("subdir/Model-Q4_K_M-LoRA.gguf")).toEqual(["LoRA"]);
+
+		// Substrings inside other tokens must NOT match (delimited only)
+		expect(parseGGUFFileVariant("Llama-imatrixed-Q4_K_M.gguf")).toEqual([]);
+		expect(parseGGUFFileVariant("MTPiston-Q4_K_M.gguf")).toEqual([]);
 	});
 
 	it("calculate tensor data offset", async () => {

--- a/packages/gguf/src/gguf.ts
+++ b/packages/gguf/src/gguf.ts
@@ -17,12 +17,14 @@ export { GGUFValueType, GGMLQuantizationType, Architecture } from "./types";
 export { GGUF_QUANT_DESCRIPTIONS } from "./quant-descriptions";
 export {
 	parseGGUFQuantLabel,
+	parseGGUFFileVariant,
 	GGUF_QUANT_RE,
 	GGUF_QUANT_RE_GLOBAL,
 	GGUF_QUANT_ORDER,
 	findNearestQuantType,
 	GGMLFileQuantizationType,
 } from "@huggingface/tasks";
+export type { GGUFFileVariant } from "@huggingface/tasks";
 
 export const RE_GGUF_FILE = /\.gguf$/;
 export const RE_GGUF_SHARD_FILE = /^(?<prefix>.*?)-(?<shard>\d{5})-of-(?<total>\d{5})\.gguf$/;

--- a/packages/tasks/src/gguf.ts
+++ b/packages/tasks/src/gguf.ts
@@ -209,3 +209,42 @@ export enum GGMLQuantizationType {
 	NVFP4 = 40,
 	Q1_0 = 41,
 }
+
+/**
+ * Filename-level GGUF variants. `LoRA` / `vocab` / `MTP` come from the GGUF
+ * naming spec's `<Type>` slot (see `ggml-org/ggml#1488` for MTP). `imatrix`
+ * is a community marker that the file was quantized with an importance
+ * matrix; it is not part of the spec `<Type>` slot but appears widely in
+ * filenames and is reported here for convenience.
+ */
+export type GGUFFileVariant = "LoRA" | "vocab" | "MTP" | "imatrix";
+
+const GGUF_FILE_VARIANTS: readonly GGUFFileVariant[] = ["LoRA", "vocab", "MTP", "imatrix"];
+
+// Match any variant token as a delimited token (`^`, `-`, or `.` on each side),
+// case-insensitive. Capture group is the matched token in whatever case appeared.
+const GGUF_FILE_VARIANT_RE = new RegExp(`(?<=^|[-.])(?<v>${GGUF_FILE_VARIANTS.join("|")})(?=$|[-.])`, "gi");
+
+/**
+ * Parse the variant tokens out of a GGUF filename, returning them in
+ * first-occurrence order with exact duplicates removed. Returns `[]` for
+ * plain model files.
+ */
+export function parseGGUFFileVariant(fname: string): GGUFFileVariant[] {
+	const base = fname.split("/").pop() ?? fname;
+	const stem = base.replace(/\.gguf$/i, "");
+	const canonical = new Map(GGUF_FILE_VARIANTS.map((v) => [v.toLowerCase(), v] as const));
+	// Re-create the regex per call so we don't share lastIndex across callers.
+	const re = new RegExp(GGUF_FILE_VARIANT_RE.source, "gi");
+	const out: GGUFFileVariant[] = [];
+	const seen = new Set<GGUFFileVariant>();
+	for (const m of stem.matchAll(re)) {
+		const token = m.groups?.v;
+		if (!token) continue;
+		const variant = canonical.get(token.toLowerCase());
+		if (!variant || seen.has(variant)) continue;
+		seen.add(variant);
+		out.push(variant);
+	}
+	return out;
+}


### PR DESCRIPTION
Adds `parseGGUFFileVariant` for filename-level GGUF variants. Today nothing in the SDK parses the `<Type>` slot at all — there are parsers for `<Encoding>` (`parseGGUFQuantLabel`) and `<Shard>` (`parseGgufShardFilename`) but not for the rest.

### API

```ts
export type GGUFFileVariant = "LoRA" | "vocab" | "MTP" | "imatrix";
export function parseGGUFFileVariant(fname: string): GGUFFileVariant[];
```

Returns variants in first-occurrence order, with exact duplicates deduped. `[]` for plain model files.

| Filename | Returns |
|---|---|
| `Model-Q4_K_M.gguf` | `[]` |
| `Model-Q4_K_M-LoRA.gguf` | `["LoRA"]` |
| `Qwen3.6-27B-MTP-Q8_0.gguf` | `["MTP"]` |
| `Model-IQ2_XXS-imatrix.gguf` | `["imatrix"]` |
| `Model-MTP-imatrix-Q4_K_M.gguf` | `["MTP", "imatrix"]` |
| `Model-imatrix-Q4_K_M-imatrix.gguf` | `["imatrix"]` *(dedup)* |
| `DeepSeek-V3.i1-Q4_K_M.gguf` | `[]` *(`i1-` not recognized)* |
| `Llama-imatrixed-Q4_K_M.gguf` | `[]` *(substring inside another token)* |

### Design choices

- **Array, not single value.** A file can legitimately carry both a spec `<Type>` token *and* an `imatrix` marker (e.g., `Model-MTP-imatrix-Q4_K_M.gguf`). An array preserves that without collapsing axes.
- **`imatrix` included alongside spec values** even though it's not part of the spec `<Type>` slot. It's a widespread community marker (e.g., antirez/deepseek-v4-gguf uses `-imatrix` suffix) and consumers usually want both surfaced from one call.
- **`i1-` prefix NOT recognized.** mradermacher's `i1-` is the only filename heuristic for imatrix that uses a different shape; IQ-quants don't actually imply imatrix and Q-quants can use it too, so we deliberately don't expand the matcher to cover heuristic markers — only explicit `imatrix` tokens.
- **Delimited token match** (`^`, `-`, `.` on each side, case-insensitive) so substrings like `imatrixed` or `MTPiston` don't false-match.
- **`MTP` is anticipated** by [ggml-org/ggml#1488](https://github.com/ggml-org/ggml/pull/1488), which is still in flight. `LoRA` and `vocab` are long-established in the spec.

### Tests

Covers: empty array for plain models, all four variant values, multi-token preservation, dedup, case-insensitive match with canonical-case return, `.` separator, path prefix stripping, explicit non-match for `i1-`, and substring false-positive guards (`imatrixed`, `MTPiston`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new filename parsing logic (regex with lookbehind and global matching) and re-exports it as part of the public `gguf` API, which could have runtime compatibility or edge-case parsing impacts.
> 
> **Overview**
> Adds `parseGGUFFileVariant` (and `GGUFFileVariant`) to extract filename-level GGUF variant tokens like `LoRA`, `vocab`, `MTP`, and `imatrix`, returning a deduped list in first-occurrence order with delimiter- and case-insensitive matching.
> 
> Re-exports the new parser/type via `packages/gguf/src/gguf.ts`, and expands `gguf.spec.ts` with coverage for ordering, deduping, delimiter handling (`-`/`.`), path stripping, and false-positive guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47ad4c3e5e5329f1881123eb63696d7912795e43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->