### PR TITLE
Add TRELLIS.2 as a library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1476,6 +1476,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/microsoft/TRELLIS",
 		countDownloads: `path_extension:"safetensors"`,
 	},
+	trellis2: {
+		prettyLabel: "TRELLIS.2",
+		repoName: "TRELLIS.2",
+		repoUrl: "https://github.com/microsoft/TRELLIS.2",
+		countDownloads: `path_extension:"safetensors"`,
+	},
 	ultralytics: {
 		prettyLabel: "ultralytics",
 		repoName: "ultralytics",


### PR DESCRIPTION
## Summary
- Add `trellis2` to the model library UI metadata so models tagged with `library_name: trellis2` can report library download stats: https://huggingface.co/models?other=trellis2
- Count downloads using `path_extension:"safetensors"`, matching the checkpoint files under `ckpts/` in `microsoft/TRELLIS.2-4B`.

## Test plan
- `pnpm --filter @huggingface/tasks format:check`
- `pnpm --filter @huggingface/tasks lint:check`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new entry to the model library UI metadata and download-count query without touching core logic or security-sensitive code.
> 
> **Overview**
> Adds a new `trellis2` entry to `MODEL_LIBRARIES_UI_ELEMENTS` so models tagged with `library_name: trellis2` display the TRELLIS.2 library metadata and have downloads counted via the `path_extension:"safetensors"` query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e6ebd4c8384e6c4835b021bd894878bb8a9b77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->