### PR TITLE
Add ResearchClawBench eval framework

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -101,6 +101,12 @@ export const EVALUATION_FRAMEWORKS = {
 			"CLAW-Eval is an evaluation framework for assessing LLMs as autonomous agents across 300 human-verified tasks covering communication, finance, and productivity domains.",
 		url: "https://github.com/claw-eval/claw-eval",
 	},
+	researchclawbench: {
+		name: "researchclawbench",
+		description:
+			"ResearchClawBench is a benchmark for evaluating AI agents on end-to-end scientific research tasks, from reading data and related work to producing code, figures, and publication-style reports.",
+		url: "https://github.com/InternScience/ResearchClawBench",
+	},
 	pbench: {
 		name: "pbench",
 		description:


### PR DESCRIPTION
## Summary

Adds `researchclawbench` to the supported evaluation frameworks for benchmark dataset `eval.yaml` files.

ResearchClawBench is an end-to-end scientific research benchmark for AI agents and standalone LLMs, covering workflows from reading raw data and related work to producing code, figures, and publication-style reports.

Dataset prepared for the Hub Evaluation Results feature:
https://huggingface.co/datasets/InternScience/ResearchClawBench

The dataset repo already includes:
- `eval.yaml` with `evaluation_framework: researchclawbench`
- `.eval_results/*.yaml` entries following the benchmark result format

Reference similar benchmark setup:
https://huggingface.co/datasets/claw-eval/Claw-Eval

## Change

- Add `researchclawbench` to `EVALUATION_FRAMEWORKS` in `packages/tasks/src/eval.ts`.

## Notes

This is intended to allow the ResearchClawBench dataset to be recognized as a Benchmark dataset and display the benchmark leaderboard/tag on the Hub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new entry to a static `EVALUATION_FRAMEWORKS` registry with no changes to execution flow or data handling.
> 
> **Overview**
> Adds **ResearchClawBench** to the `EVALUATION_FRAMEWORKS` map in `packages/tasks/src/eval.ts`, enabling benchmark datasets to declare `evaluation_framework: researchclawbench` and be recognized accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36c6e24641cb04cc04f204228177504a06829710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->