### PR TITLE
feat: Add Arc Pro B70 32 GB to hardware.ts

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -113,8 +113,8 @@ export const SKUS = {
 				releaseYear: 2025,
 			},
 			"Arc B70": {
-				tflops: 22.94,
-				memory: [32, 64],
+				tflops: 45.88,
+				memory: [32],
 				msrp: 949,
 				power: 230,
 				releaseYear: 2026,

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -112,6 +112,13 @@ export const SKUS = {
 				power: 200,
 				releaseYear: 2025,
 			},
+			"Arc B70": {
+				tflops: 22.94,
+				memory: [32, 64],
+				msrp: 949,
+				power: 230,
+				releaseYear: 2026,
+			},
 		},
 		QUALCOMM: {
 			"Snapdragon X Elite X1E-00-1DE": {

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -112,7 +112,7 @@ export const SKUS = {
 				power: 200,
 				releaseYear: 2025,
 			},
-			"Arc B70": {
+			"Arc Pro B70": {
 				tflops: 45.88,
 				memory: [32],
 				msrp: 949,


### PR DESCRIPTION
Add Intel Arc Pro B70 to the list of available hardware.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a data-only addition of a new GPU SKU entry and does not change any logic or control flow.
> 
> **Overview**
> Adds a new Intel GPU entry, `Arc Pro B70`, to `packages/tasks/src/hardware.ts` under `SKUS.GPU.INTEL`, including TFLOPS, 32GB memory, MSRP, power, and release year metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d40bb4b7e7af10260021a331241e8ed34e72e49a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->