### PR TITLE
Add MXFP4 quantization type for dense models (ftype 41)

### DIFF
--- a/packages/tasks/src/gguf.ts
+++ b/packages/tasks/src/gguf.ts
@@ -43,6 +43,7 @@ export enum GGMLFileQuantizationType {
 	MXFP4_MOE = 38,
 	NVFP4 = 39,
 	Q1_0 = 40,
+	MXFP4 = 41,
 
 	// custom quants used by unsloth
 	// they are not officially a scheme enum value in GGUF, but only here for naming
@@ -102,6 +103,7 @@ export const GGUF_QUANT_ORDER: GGMLFileQuantizationType[] = [
 	GGMLFileQuantizationType.Q4_3,
 	GGMLFileQuantizationType.MXFP4_MOE,
 	GGMLFileQuantizationType.NVFP4,
+	GGMLFileQuantizationType.MXFP4,
 
 	// 3-bit quantizations
 	GGMLFileQuantizationType.Q3_K_XL,


### PR DESCRIPTION
Adds MXFP4=41 to GGMLFileQuantizationType for dense MXFP4 GGUF models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new GGUF file quantization enum value and includes it in the ordering list, with minimal impact beyond recognizing the new label.
> 
> **Overview**
> Adds support for dense MXFP4 GGUF models by introducing `GGMLFileQuantizationType.MXFP4 = 41` and including it in `GGUF_QUANT_ORDER`, ensuring quant label parsing and quant ordering logic recognize the new ftype.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b1c5a94c051302b15edb2d66bc8328f1bfcf9a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->