### PR TITLE
🐛 Fix parseGGUFQuantLabel for non-standard k-quant size variations (Q3_K_P, …)

### DIFF
--- a/packages/gguf/src/gguf.spec.ts
+++ b/packages/gguf/src/gguf.spec.ts
@@ -341,6 +341,14 @@ describe("gguf", () => {
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-IQ3_XS.gguf")).toEqual("IQ3_XS");
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-Q4_0_4_4.gguf")).toEqual("Q4_0"); // TODO: investigate Q4_0_4_4
 		expect(parseGGUFQuantLabel("Qwen3-4B-UD-Q2_K_XL.gguf")).toEqual("UD-Q2_K_XL"); // unsloth UD (Unsloth Dynamic) prefix
+		// issue #2107: non-standard "_K_P" size variations should all be recognized, not just Q2_K_P / Q6_K_P
+		expect(parseGGUFQuantLabel("Qwen3.6-35B-A3B-Q2_K_P.gguf")).toEqual("Q2_K_P");
+		expect(parseGGUFQuantLabel("Qwen3.6-35B-A3B-Q3_K_P.gguf")).toEqual("Q3_K_P");
+		expect(parseGGUFQuantLabel("Qwen3.6-35B-A3B-Q4_K_P.gguf")).toEqual("Q4_K_P");
+		expect(parseGGUFQuantLabel("Qwen3.6-35B-A3B-Q5_K_P.gguf")).toEqual("Q5_K_P");
+		expect(parseGGUFQuantLabel("Qwen3.6-35B-A3B-Q6_K_P.gguf")).toEqual("Q6_K_P");
+		expect(parseGGUFQuantLabel("Qwen3.6-35B-A3B-Q8_K_P.gguf")).toEqual("Q8_K_P");
+		expect(parseGGUFQuantLabel("Qwen3.6-35B-A3B-Q3_K_S.gguf")).toEqual("Q3_K_S"); // standard size variations still match exactly
 	});
 
 	it("calculate tensor data offset", async () => {

--- a/packages/tasks/src/gguf.ts
+++ b/packages/tasks/src/gguf.ts
@@ -55,8 +55,11 @@ export enum GGMLFileQuantizationType {
 }
 
 const ggufQuants = Object.values(GGMLFileQuantizationType).filter((v): v is string => typeof v === "string");
+// Fallback bare k-quant bases so non-standard size variations (e.g. Q3_K_P) are still
+// matched; the enum has no bare Q3_K/Q4_K/Q5_K/Q8_K, unlike Q2_K/Q6_K. See issue #2107.
+const bareKQuantsFallback = ["Q3_K", "Q4_K", "Q5_K", "Q8_K"];
 export const GGUF_QUANT_RE = new RegExp(
-	"(?<prefix>UD-)?" + `(?<quant>${ggufQuants.join("|")})` + "(_(?<sizeVariation>[A-Z]+))?",
+	"(?<prefix>UD-)?" + `(?<quant>${[...ggufQuants, ...bareKQuantsFallback].join("|")})` + "(_(?<sizeVariation>[A-Z]+))?",
 );
 export const GGUF_QUANT_RE_GLOBAL = new RegExp(GGUF_QUANT_RE, "g");
 


### PR DESCRIPTION
## Summary

`parseGGUFQuantLabel` / `GGUF_QUANT_RE` failed to recognize GGUF filenames ending in `Q3_K_P` / `Q4_K_P` / `Q5_K_P` / `Q8_K_P`, while `Q2_K_P` and `Q6_K_P` worked. This is the root cause of #2107 (the hardware compatibility widget shows some `_K_P` files but not others).

### Root cause

`GGUF_QUANT_RE` builds its `quant` alternation from the `GGMLFileQuantizationType` enum. That enum contains bare `Q2_K` and `Q6_K` entries, but for 3/4/5/8-bit k-quants it only has the specific file types (`Q3_K_S/M/L`, `Q4_K_S/M`, `Q5_K_S/M`, `Q8_0`, …) — there is no bare `Q3_K`/`Q4_K`/`Q5_K`/`Q8_K`.

So `Q2_K_P` matched as `quant=Q2_K` + `sizeVariation=P`, but `Q3_K_P` had no enum alternative to match against and parsed to `undefined`.

### Fix

Append bare `Q3_K` / `Q4_K` / `Q5_K` / `Q8_K` as fallback alternatives in the regex. Non-standard size variations now parse consistently through the existing `sizeVariation` group; standard file types still match their exact enum names first (the fallback bases are appended last).

## Test plan

- [x] Added assertions to the `parse quant label` test in `packages/gguf/src/gguf.spec.ts` covering `Q2_K_P`…`Q8_K_P` plus a standard `Q3_K_S` regression check
- [x] `pnpm --filter gguf test ./src/gguf.spec.ts -t "quant"` — passes (parse quant label, `GGUF_QUANT_ORDER` sync, nearest-quant)
- [x] `pnpm --filter tasks test` — 18 passed (incl. `local-apps`, which consumes `parseGGUFQuantLabel`)
- [x] `pnpm --filter tasks check` / `pnpm --filter gguf check` (tsc) — pass
- [x] eslint + oxfmt — pass

Fixes #2107

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly extends the quantization filename regex to recognize additional `Q*_K_<VAR>` patterns and adds targeted tests; potential impact is limited to quant-label parsing/matching behavior.
> 
> **Overview**
> Fixes `parseGGUFQuantLabel`/`GGUF_QUANT_RE` to recognize non-standard k-quant size variations like `Q3_K_P`, `Q4_K_P`, `Q5_K_P`, and `Q8_K_P` by adding fallback bare `Q*_K` bases to the regex alternation.
> 
> Extends the `parse quant label` spec to cover `Q2_K_P` through `Q8_K_P` and includes a regression assertion that standard variants (e.g. `Q3_K_S`) still match as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afe67fffb9aa7d26a0c191f905bd9a52bbedce87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->