### PR TITLE
Add CollectorVision model library

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -156,6 +156,20 @@ pred_df = pipeline.predict_df(
 	return [installSnippet, exampleSnippet];
 };
 
+export const collectorvision = (model: ModelData): string[] => [
+	`pip install git+https://github.com/HanClinto/CollectorVision huggingface_hub`,
+	`from huggingface_hub import hf_hub_download
+import collector_vision as cvg
+
+checkpoint = hf_hub_download(repo_id="${model.id}", filename="model.onnx")
+
+# Detector models, such as Cornelius:
+detector = cvg.NeuralCornerDetector(checkpoint)
+
+# Embedder models, such as Milo:
+embedder = cvg.NeuralEmbedder(checkpoint)`,
+];
+
 export const colipri = (model: ModelData): string[] => {
 	const installSnippet = `pip install colipri`;
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -277,6 +277,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"setup.py"`,
 	},
+	collectorvision: {
+		prettyLabel: "CollectorVision",
+		repoName: "CollectorVision",
+		repoUrl: "https://github.com/HanClinto/CollectorVision",
+		snippets: snippets.collectorvision,
+		filter: false,
+		countDownloads: `path_extension:"onnx"`,
+	},
 	colipri: {
 		prettyLabel: "COLIPRI",
 		repoName: "COLIPRI",


### PR DESCRIPTION
## What

Adds CollectorVision as a Hub model library so CollectorVision model repos can display the library label, snippet, and custom download-count rule.

CollectorVision is a Python library for collectible-card identification. Given a camera photo of a trading card, it detects the card corners, dewarps the image, embeds the crop with an ONNX model, and searches a precomputed catalog of card embeddings. The first supported production catalog is Magic: The Gathering via Scryfall; other CCG catalogs are experimental.

This PR registers the lightweight Hub integration: library label metadata, a model-page usage snippet, and download metrics. A fuller Hub docs page, like the SetFit hub-docs PR, would be better as a separate follow-up once the library is published on PyPI and the API surface is a little more stable.

## How Users Use It

The typical end-to-end flow is:

```python
import cv2
import collector_vision as cvg

catalog = cvg.Catalog.load("hf://HanClinto/milo/scryfall-mtg")

image = cv2.imread("photo.jpg")
detection = cvg.NeuralCornerDetector().detect(image)
crop = detection.dewarp(image)
embedding = catalog.embedder.embed(crop)
hits = catalog.search(embedding, top_k=5)
```

The Hub model-page snippet added in this PR is intentionally lower-level: it downloads the current model page's `model.onnx` with `hf_hub_download(repo_id="${model.id}", ...)`, then shows how to pass that checkpoint to `NeuralCornerDetector` or `NeuralEmbedder`.

## Download Counting

The download-count rule counts ONNX files via `path_extension:"onnx"`, which covers both canonical `model.onnx` files and explicitly versioned ONNX model snapshots. It does not count Milo catalog `.npz` files.

## Models

The relevant model cards have been updated with `library_name: collectorvision` and are discoverable via the Hub API:

- https://huggingface.co/HanClinto/milo
- https://huggingface.co/HanClinto/cornelius

## Validation

- `pnpm --filter @huggingface/tasks format:check`
- `pnpm --filter @huggingface/tasks check`
