### PR TITLE
Add Radeon 610M hardware SKU

### DIFF
--- a/packages/tasks/src/hardware-amd.ts
+++ b/packages/tasks/src/hardware-amd.ts
@@ -234,6 +234,14 @@ export const AMD_GPU_SKUS: Record<string, AmdGpuHardwareSpec> = {
 		power: 250,
 		releaseYear: 2020,
 	},
+	"Radeon 610M": {
+		tflops: 0.97,
+		memory: [16, 24, 32, 48, 64, 96],
+		gfxVersion: "gfx1037",
+		msrp: 300,
+		power: 15,
+		releaseYear: 2022,
+	},
 	"Ryzen AI Max+ 395": {
 		tflops: 59.4,
 		memory: [64, 96, 128],


### PR DESCRIPTION
## Summary

- add Radeon 610M to the AMD GPU hardware compatibility list
- model it as an RDNA2 iGPU with shared-memory options for llama.cpp/Vulkan-style reporting

Refs #2145

## Tests

- pnpm --filter tasks check
- pnpm --filter tasks format:check
- pnpm --filter tasks lint:check
- pnpm --filter tasks test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new static AMD GPU/iGPU SKU entry with no behavioral or algorithmic changes.
> 
> **Overview**
> Adds **Radeon 610M** to the `AMD_GPU_SKUS` compatibility list in `hardware-amd.ts`, including TFLOPS, shared-memory size options, `gfxVersion` (`gfx1037`), MSRP, power, and release year so it can be recognized in hardware lookups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c445d1b5b10b7cc072249ff766659db02092fa1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->