### PR TITLE
[inference] Use /v1/completions for hf-inference text-generation

### DIFF
--- a/packages/inference/src/providers/hf-inference.ts
+++ b/packages/inference/src/providers/hf-inference.ts
@@ -27,6 +27,7 @@ import type {
 	SummarizationOutput,
 	TableQuestionAnsweringOutput,
 	TextClassificationOutput,
+	TextGenerationInput,
 	TextGenerationOutput,
 	TokenClassificationOutput,
 	TranslationOutput,
@@ -39,7 +40,6 @@ import { HF_ROUTER_URL } from "../config.js";
 import { InferenceClientInputError, InferenceClientProviderOutputError } from "../errors.js";
 import type { TabularClassificationOutput } from "../tasks/tabular/tabularClassification.js";
 import type { BodyParams, OutputType, RequestArgs, UrlParams } from "../types.js";
-import { toArray } from "../utils/toArray.js";
 import type {
 	AudioClassificationTaskHelper,
 	AudioToAudioTaskHelper,
@@ -210,14 +210,54 @@ export class HFInferenceConversationalTask extends HFInferenceTask implements Co
 	}
 }
 
+interface HFInferenceTextCompletionOutput {
+	choices: Array<{ text: string }>;
+}
+
 export class HFInferenceTextGenerationTask extends HFInferenceTask implements TextGenerationTaskHelper {
-	override async getResponse(response: TextGenerationOutput | TextGenerationOutput[]): Promise<TextGenerationOutput> {
-		const res = toArray(response);
-		if (Array.isArray(res) && res.every((x) => "generated_text" in x && typeof x?.generated_text === "string")) {
-			return (res as TextGenerationOutput[])?.[0];
+	override makeUrl(params: UrlParams): string {
+		let url: string;
+		if (params.model.startsWith("http://") || params.model.startsWith("https://")) {
+			url = params.model.trim();
+		} else {
+			url = `${this.makeBaseUrl(params)}/models/${params.model}`;
+		}
+
+		url = url.replace(/\/+$/, "");
+		if (url.endsWith("/v1")) {
+			url += "/completions";
+		} else if (!url.endsWith("/completions")) {
+			url += "/v1/completions";
+		}
+
+		return url;
+	}
+
+	override preparePayload(params: BodyParams<TextGenerationInput>): Record<string, unknown> {
+		return {
+			model: params.model,
+			...omit(params.args, ["inputs", "parameters"]),
+			...(params.args.parameters
+				? {
+						max_tokens: params.args.parameters.max_new_tokens,
+						...omit(params.args.parameters, "max_new_tokens"),
+					}
+				: undefined),
+			prompt: params.args.inputs,
+		};
+	}
+
+	override async getResponse(response: HFInferenceTextCompletionOutput): Promise<TextGenerationOutput> {
+		if (
+			typeof response === "object" &&
+			"choices" in response &&
+			Array.isArray(response.choices) &&
+			typeof response.choices[0]?.text === "string"
+		) {
+			return { generated_text: response.choices[0].text };
 		}
 		throw new InferenceClientProviderOutputError(
-			"Received malformed response from HF-Inference text generation API: expected Array<{generated_text: string}>",
+			"Received malformed response from HF-Inference text generation API: expected {choices: [{text: string}]}",
 		);
 	}
 }


### PR DESCRIPTION
context: https://huggingface.slack.com/archives/C0AA7DZFGVC/p1779282978979449?thread_ts=1779271635.539769&cid=C0AA7DZFGVC

HFInferenceTextGenerationTask now routes to /v1/completions with an OpenAI-compatible payload (prompt, max_tokens, …) instead of the legacy POST /models/{id} format with {inputs, parameters}.

This matches how HFInferenceConversationalTask already routes to /v1/chat/completions, and fixes text-generation models served via vLLM on hf-inference which only expose the OpenAI-compatible endpoints.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `hf-inference` text-generation request URL, payload shape, and response parsing, which could break compatibility with models/endpoints still expecting the legacy `POST /models/{id}` format. Conversational routing is also adjusted to rely on route building rather than custom URL logic.
> 
> **Overview**
> Updates the `hf-inference` provider’s **text generation** to call the OpenAI-compatible `models/{model}/v1/completions` endpoint, translating the payload from `{inputs, parameters}` to `{prompt, max_tokens, ...}` and mapping the new `{choices: [{text}]}` response back to `generated_text`.
> 
> Aligns **conversational** requests with the same route-based approach by routing to `models/{model}/v1/chat/completions`, removing bespoke URL construction logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c2d66cb8ef96410b4a709ed93e681023a1e49f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->