### PR TITLE
fix: correct input keys for sentence similarity snippets

### DIFF
--- a/packages/tasks/src/snippets/inputs.ts
+++ b/packages/tasks/src/snippets/inputs.ts
@@ -70,8 +70,8 @@ const inputsFillMask = (model: ModelDataMinimal) => `"The answer to the universe
 
 const inputsSentenceSimilarity = () =>
 	`{
-    "source_sentence": "That is a happy person",
-    "sentences": [
+    "sentence": "That is a happy person",
+    "other_sentences": [
         "That is a happy dog",
         "That is a very happy person",
         "Today is a sunny day"


### PR DESCRIPTION
fix: correct input keys for sentence similarity snippets

The generated snippet for sentence similarity models used source_sentence and sentences as parameter names, but the inference API expects sentence and other_sentences. This caused copied snippets to fail.

Fixes #1680

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes a static example snippet string for `sentence-similarity` and does not affect inference logic or data handling.
> 
> **Overview**
> Fixes the generated input snippet for `sentence-similarity` models by renaming the JSON keys from `source_sentence`/`sentences` to the API-expected `sentence`/`other_sentences`, so copied examples work against the inference endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69bb843979aab15083fb1ca69a6268c4de33879f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->