### PR TITLE
chore(eslint): require block statements via curly: all

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -24,6 +24,7 @@ module.exports = {
 		"@typescript-eslint/no-empty-interfaces": "off",
 		// For doc purposes, prefer interfaces
 		"@typescript-eslint/consistent-type-definitions": ["error", "interface"],
+		curly: ["error", "all"],
 	},
 	overrides: [
 		{

--- a/packages/agents/src/tools/imageToText.ts
+++ b/packages/agents/src/tools/imageToText.ts
@@ -12,7 +12,9 @@ export const imageToTextTool: Tool = {
 	],
 	call: async (input, inference) => {
 		const data = await input;
-		if (typeof data === "string") throw "Input must be a blob.";
+		if (typeof data === "string") {
+			throw "Input must be a blob.";
+		}
 
 		return (
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/agents/src/tools/speechToText.ts
+++ b/packages/agents/src/tools/speechToText.ts
@@ -12,7 +12,9 @@ export const speechToTextTool: Tool = {
 	],
 	call: async (input, inference) => {
 		const data = await input;
-		if (typeof data === "string") throw "Input must be a blob.";
+		if (typeof data === "string") {
+			throw "Input must be a blob.";
+		}
 
 		return (
 			await inference.automaticSpeechRecognition({

--- a/packages/agents/src/tools/textToImage.ts
+++ b/packages/agents/src/tools/textToImage.ts
@@ -17,7 +17,9 @@ export const textToImageTool: Tool = {
 	],
 	call: async (input, inference) => {
 		const data = await input;
-		if (typeof data !== "string") throw "Input must be a string.";
+		if (typeof data !== "string") {
+			throw "Input must be a string.";
+		}
 
 		return await inference.textToImage({
 			inputs: data,

--- a/packages/agents/src/tools/textToSpeech.ts
+++ b/packages/agents/src/tools/textToSpeech.ts
@@ -17,7 +17,9 @@ export const textToSpeechTool: Tool = {
 	],
 	call: async (input, inference) => {
 		const data = await input;
-		if (typeof data !== "string") throw "Input must be a string.";
+		if (typeof data !== "string") {
+			throw "Input must be a string.";
+		}
 
 		return inference.textToSpeech({
 			inputs: data,

--- a/packages/gguf/scripts/generate-llm.ts
+++ b/packages/gguf/scripts/generate-llm.ts
@@ -188,7 +188,9 @@ async function main() {
 		const tensorMatched = line.match(/LLM_TENSOR_[A-Z0-9_]+[,\s]+"(?<name>.+?)"/);
 		if (tensorMatched?.groups) {
 			const arch = archList.find((a) => a.cppConst === currCppConst);
-			if (arch) arch.tensorNames.push(tensorMatched.groups.name);
+			if (arch) {
+				arch.tensorNames.push(tensorMatched.groups.name);
+			}
 		}
 	}
 

--- a/packages/hub/cli.ts
+++ b/packages/hub/cli.ts
@@ -38,7 +38,9 @@ class UploadProgressManager {
 	}
 
 	async initialize(): Promise<void> {
-		if (this.isQuiet) return;
+		if (this.isQuiet) {
+			return;
+		}
 
 		try {
 			const cliProgress = await import("cli-progress");
@@ -60,7 +62,9 @@ class UploadProgressManager {
 	}
 
 	handleEvent(event: CommitProgressEvent): void {
-		if (this.isQuiet) return;
+		if (this.isQuiet) {
+			return;
+		}
 
 		if (event.event === "phase") {
 			this.logPhase(event.phase);
@@ -70,7 +74,9 @@ class UploadProgressManager {
 	}
 
 	private logPhase(phase: string): void {
-		if (this.isQuiet) return;
+		if (this.isQuiet) {
+			return;
+		}
 
 		const phaseMessages = {
 			preuploading: "📋 Preparing files for upload...",
@@ -82,7 +88,9 @@ class UploadProgressManager {
 	}
 
 	private updateFileProgress(path: string, progress: number, state: string): void {
-		if (this.isQuiet) return;
+		if (this.isQuiet) {
+			return;
+		}
 
 		if (this.cliProgressAvailable && this.multibar) {
 			// Use progress bars
@@ -124,7 +132,9 @@ class UploadProgressManager {
 	}
 
 	private truncateFilename(filename: string, maxLength: number): string {
-		if (filename.length <= maxLength) return filename;
+		if (filename.length <= maxLength) {
+			return filename;
+		}
 		return "..." + filename.slice(-(maxLength - 3));
 	}
 

--- a/packages/hub/src/lib/cache-management.ts
+++ b/packages/hub/src/lib/cache-management.ts
@@ -212,8 +212,8 @@ export async function scanRefsDir(refsPath: string, refsByHash: Map<string, stri
 	for (const refFile of refFiles) {
 		const refFilePath = join(refsPath, refFile.name);
 		if (refFile.isDirectory()) {
-			continue;
-		} // Skip directories
+			continue; // Skip directories
+		}
 
 		const commitHash = await readFile(refFilePath, "utf-8");
 		const refName = refFile.name;
@@ -232,8 +232,8 @@ export async function scanSnapshotDir(
 	const files = await readdir(revisionPath, { withFileTypes: true });
 	for (const file of files) {
 		if (file.isDirectory()) {
-			continue;
-		} // Skip directories
+			continue; // Skip directories
+		}
 
 		const filePath = join(revisionPath, file.name);
 		const blobPath = await realpath(filePath);

--- a/packages/hub/src/lib/cache-management.ts
+++ b/packages/hub/src/lib/cache-management.ts
@@ -70,7 +70,9 @@ export interface HFCacheInfo {
 }
 
 export async function scanCacheDir(cacheDir: string | undefined = undefined): Promise<HFCacheInfo> {
-	if (!cacheDir) cacheDir = getHFHubCachePath();
+	if (!cacheDir) {
+		cacheDir = getHFHubCachePath();
+	}
 
 	const s = await stat(cacheDir);
 	if (!s.isDirectory()) {
@@ -85,7 +87,9 @@ export async function scanCacheDir(cacheDir: string | undefined = undefined): Pr
 	const directories = await readdir(cacheDir);
 	for (const repo of directories) {
 		// skip .locks folder
-		if (repo === ".locks") continue;
+		if (repo === ".locks") {
+			continue;
+		}
 
 		// get the absolute path of the repo
 		const absolute = join(cacheDir, repo);
@@ -144,7 +148,9 @@ export async function scanCachedRepo(repoPath: string): Promise<CachedRepoInfo> 
 
 	const snapshotDirs = await readdir(snapshotsPath);
 	for (const dir of snapshotDirs) {
-		if (FILES_TO_IGNORE.includes(dir)) continue; // Ignore unwanted files
+		if (FILES_TO_IGNORE.includes(dir)) {
+			continue;
+		} // Ignore unwanted files
 
 		const revisionPath = join(snapshotsPath, dir);
 		const revisionStat = await stat(revisionPath);
@@ -205,7 +211,9 @@ export async function scanRefsDir(refsPath: string, refsByHash: Map<string, stri
 	const refFiles = await readdir(refsPath, { withFileTypes: true });
 	for (const refFile of refFiles) {
 		const refFilePath = join(refsPath, refFile.name);
-		if (refFile.isDirectory()) continue; // Skip directories
+		if (refFile.isDirectory()) {
+			continue;
+		} // Skip directories
 
 		const commitHash = await readFile(refFilePath, "utf-8");
 		const refName = refFile.name;
@@ -223,7 +231,9 @@ export async function scanSnapshotDir(
 ): Promise<void> {
 	const files = await readdir(revisionPath, { withFileTypes: true });
 	for (const file of files) {
-		if (file.isDirectory()) continue; // Skip directories
+		if (file.isDirectory()) {
+			continue;
+		} // Skip directories
 
 		const filePath = join(revisionPath, file.name);
 		const blobPath = await realpath(filePath);

--- a/packages/hub/src/lib/download-file-to-cache-dir.ts
+++ b/packages/hub/src/lib/download-file-to-cache-dir.ts
@@ -79,7 +79,9 @@ export async function downloadFileToCacheDir(
 	if (revision && REGEX_COMMIT_HASH.test(revision)) {
 		commitHash = revision;
 		const pointerPath = getFilePointer(storageFolder, revision, params.path);
-		if (await exists(pointerPath, true)) return pointerPath;
+		if (await exists(pointerPath, true)) {
+			return pointerPath;
+		}
 	}
 
 	const pathsInformation: PathInfo[] = await pathsInfo({
@@ -88,7 +90,9 @@ export async function downloadFileToCacheDir(
 		revision,
 		expand: true,
 	});
-	if (!pathsInformation || pathsInformation.length !== 1) throw new Error(`cannot get path info for ${params.path}`);
+	if (!pathsInformation || pathsInformation.length !== 1) {
+		throw new Error(`cannot get path info for ${params.path}`);
+	}
 
 	const info = pathsInformation[0];
 	let etag: string;

--- a/packages/hub/src/lib/jobs/stream-job-events.ts
+++ b/packages/hub/src/lib/jobs/stream-job-events.ts
@@ -51,7 +51,9 @@ export async function* streamJobEvents(
 	try {
 		while (true) {
 			const { done, value } = await reader.read();
-			if (done) break;
+			if (done) {
+				break;
+			}
 
 			buffer += decoder.decode(value, { stream: true });
 			const lines = buffer.split("\n");

--- a/packages/hub/src/lib/jobs/stream-job-logs.ts
+++ b/packages/hub/src/lib/jobs/stream-job-logs.ts
@@ -51,7 +51,9 @@ export async function* streamJobLogs(
 	try {
 		while (true) {
 			const { done, value } = await reader.read();
-			if (done) break;
+			if (done) {
+				break;
+			}
 
 			buffer += decoder.decode(value, { stream: true });
 			const lines = buffer.split("\n");

--- a/packages/hub/src/lib/jobs/stream-job-metrics.ts
+++ b/packages/hub/src/lib/jobs/stream-job-metrics.ts
@@ -51,7 +51,9 @@ export async function* streamJobMetrics(
 	try {
 		while (true) {
 			const { done, value } = await reader.read();
-			if (done) break;
+			if (done) {
+				break;
+			}
 
 			buffer += decoder.decode(value, { stream: true });
 			const lines = buffer.split("\n");

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -240,8 +240,12 @@ async function fetchAllHeaders(
 }
 
 function parseTotalParameters(value: string | number | undefined): number | undefined {
-	if (!value) return undefined;
-	if (typeof value === "number") return value;
+	if (!value) {
+		return undefined;
+	}
+	if (typeof value === "number") {
+		return value;
+	}
 	return parseInt(value);
 }
 
@@ -388,16 +392,22 @@ export function globMatch(pattern: string, str: string): boolean {
 		return pattern === str;
 	}
 
-	if (!str.startsWith(parts[0])) return false;
+	if (!str.startsWith(parts[0])) {
+		return false;
+	}
 	let pos = parts[0].length;
 
 	const lastPart = parts[parts.length - 1];
-	if (!str.endsWith(lastPart)) return false;
+	if (!str.endsWith(lastPart)) {
+		return false;
+	}
 	const end = str.length - lastPart.length;
 
 	for (let i = 1; i < parts.length - 1; i++) {
 		const idx = str.indexOf(parts[i], pos);
-		if (idx === -1 || idx + parts[i].length > end) return false;
+		if (idx === -1 || idx + parts[i].length > end) {
+			return false;
+		}
 		pos = idx + parts[i].length;
 	}
 
@@ -412,9 +422,13 @@ export function globMatch(pattern: string, str: string): boolean {
  * pattern contains a `*` we fall back to proper glob matching for flexibility.
  */
 export function isQuantizedTensor(tensorName: string, quantConfig?: QuantizationConfig): boolean {
-	if (!quantConfig) return false;
+	if (!quantConfig) {
+		return false;
+	}
 	const patterns = quantConfig.modules_to_not_convert;
-	if (!patterns?.length) return true;
+	if (!patterns?.length) {
+		return true;
+	}
 	return !patterns.some((pattern) =>
 		pattern.includes("*") ? globMatch(pattern, tensorName) : tensorName.includes(pattern),
 	);
@@ -520,10 +534,16 @@ function getTensorSuffix(tensorName: string): string {
 }
 
 function shouldSkipTensor(tensorName: string, quantConfig?: QuantizationConfig): boolean {
-	if (!quantConfig) return false;
+	if (!quantConfig) {
+		return false;
+	}
 	const quantMethod = quantConfig.quant_method?.toLowerCase();
-	if (quantMethod !== "gptq" && quantMethod !== "awq") return false;
-	if (!isQuantizedTensor(tensorName, quantConfig)) return false;
+	if (quantMethod !== "gptq" && quantMethod !== "awq") {
+		return false;
+	}
+	if (!isQuantizedTensor(tensorName, quantConfig)) {
+		return false;
+	}
 	const suffix = getTensorSuffix(tensorName);
 	return suffix !== GPTQ_QWEIGHT_SUFFIX && GPTQ_AWQ_AUXILIARY_SUFFIXES.includes(suffix);
 }

--- a/packages/hub/src/lib/paths-info.ts
+++ b/packages/hub/src/lib/paths-info.ts
@@ -118,7 +118,9 @@ export async function pathsInfo(
 	}
 
 	const json: unknown = await resp.json();
-	if (!Array.isArray(json)) throw new Error("malformed response: expected array");
+	if (!Array.isArray(json)) {
+		throw new Error("malformed response: expected array");
+	}
 
 	return json.map((item: PathInfo) => ({
 		path: item.path,

--- a/packages/hub/src/utils/createXorbs.ts
+++ b/packages/hub/src/utils/createXorbs.ts
@@ -61,7 +61,9 @@ function finalizeChunker(
 	chunker: ReturnType<typeof createChunker>,
 ): { hash: string; length: number; dedup: boolean }[] {
 	const last = finalize(chunker);
-	if (!last) return [];
+	if (!last) {
+		return [];
+	}
 	return [{ hash: hashToHex(last.hash), length: last.length, dedup: false }];
 }
 

--- a/packages/inference/scripts/export-templates.ts
+++ b/packages/inference/scripts/export-templates.ts
@@ -15,7 +15,9 @@ function exportTemplatesAsCode(): string {
 	const languages = readdirSync(TEMPLATES_DIR);
 	for (const language of languages) {
 		const languagePath = path.join(TEMPLATES_DIR, language);
-		if (!readdirSync(languagePath).length) continue;
+		if (!readdirSync(languagePath).length) {
+			continue;
+		}
 
 		templates[language] = {};
 
@@ -23,14 +25,18 @@ function exportTemplatesAsCode(): string {
 		const clients = readdirSync(languagePath);
 		for (const client of clients) {
 			const clientPath = path.join(languagePath, client);
-			if (!readdirSync(clientPath).length) continue;
+			if (!readdirSync(clientPath).length) {
+				continue;
+			}
 
 			templates[language][client] = {};
 
 			// Read all template files
 			const files = readdirSync(clientPath);
 			for (const file of files) {
-				if (!file.endsWith(".jinja")) continue;
+				if (!file.endsWith(".jinja")) {
+					continue;
+				}
 
 				const templatePath = path.join(clientPath, file);
 				const templateContent = readFileSync(templatePath, "utf8");

--- a/packages/inference/src/providers/hf-inference.ts
+++ b/packages/inference/src/providers/hf-inference.ts
@@ -356,7 +356,9 @@ export class HFInferenceDocumentQuestionAnsweringTask
 export class HFInferenceFeatureExtractionTask extends HFInferenceTask implements FeatureExtractionTaskHelper {
 	override async getResponse(response: FeatureExtractionOutput): Promise<FeatureExtractionOutput> {
 		const isNumArrayRec = (arr: unknown[], maxDepth: number, curDepth = 0): boolean => {
-			if (curDepth > maxDepth) return false;
+			if (curDepth > maxDepth) {
+				return false;
+			}
 			if (arr.every((x) => Array.isArray(x))) {
 				return arr.every((x) => isNumArrayRec(x as unknown[], maxDepth, curDepth + 1));
 			} else {

--- a/packages/inference/src/providers/replicate.ts
+++ b/packages/inference/src/providers/replicate.ts
@@ -236,8 +236,12 @@ export class ReplicateAutomaticSpeechRecognitionTask
 		_outputType?: undefined,
 		signal?: AbortSignal,
 	): Promise<AutomaticSpeechRecognitionOutput> {
-		if (typeof response?.output === "string") return { text: response.output };
-		if (Array.isArray(response?.output) && typeof response.output[0] === "string") return { text: response.output[0] };
+		if (typeof response?.output === "string") {
+			return { text: response.output };
+		}
+		if (Array.isArray(response?.output) && typeof response.output[0] === "string") {
+			return { text: response.output[0] };
+		}
 
 		const out = response?.output as
 			| undefined
@@ -247,8 +251,12 @@ export class ReplicateAutomaticSpeechRecognitionTask
 					txt_file?: string;
 			  };
 		if (out && typeof out === "object") {
-			if (typeof out.transcription === "string") return { text: out.transcription };
-			if (typeof out.translation === "string") return { text: out.translation };
+			if (typeof out.transcription === "string") {
+				return { text: out.transcription };
+			}
+			if (typeof out.translation === "string") {
+				return { text: out.translation };
+			}
 			if (typeof out.txt_file === "string") {
 				const r = await fetch(out.txt_file, { signal });
 				return { text: await r.text() };

--- a/packages/inference/src/providers/together.ts
+++ b/packages/inference/src/providers/together.ts
@@ -65,7 +65,9 @@ const AUDIO_MIME_TO_EXT: Record<string, string> = {
 };
 
 function mimeTypeToExtension(mimeType: string | undefined): string {
-	if (!mimeType) return "wav";
+	if (!mimeType) {
+		return "wav";
+	}
 	return AUDIO_MIME_TO_EXT[mimeType.toLowerCase()] ?? "wav";
 }
 
@@ -328,8 +330,12 @@ function normalizeTogetherVideoParameters(parameters: Record<string, unknown> | 
 		rest.steps = num_inference_steps;
 	}
 	if (target_size && typeof target_size === "object") {
-		if (target_size.width !== undefined) rest.width = target_size.width;
-		if (target_size.height !== undefined) rest.height = target_size.height;
+		if (target_size.width !== undefined) {
+			rest.width = target_size.width;
+		}
+		if (target_size.height !== undefined) {
+			rest.height = target_size.height;
+		}
 	}
 	return rest;
 }
@@ -586,7 +592,9 @@ export class TogetherAutomaticSpeechRecognitionTask
 
 		const fields = this.preparePayload(params);
 		for (const [key, value] of Object.entries(fields)) {
-			if (value === undefined || value === null) continue;
+			if (value === undefined || value === null) {
+				continue;
+			}
 			if (typeof value === "string") {
 				formData.append(key, value);
 			} else if (typeof value === "number" || typeof value === "boolean") {

--- a/packages/jinja/src/format.ts
+++ b/packages/jinja/src/format.ts
@@ -42,8 +42,12 @@ function getBinaryOperatorPrecedence(expr: BinaryExpression): number {
 		case "ComparisonBinaryOperator":
 			return 2;
 		case "Identifier":
-			if (expr.operator.value === "and") return 1;
-			if (expr.operator.value === "in" || expr.operator.value === "not in") return 2;
+			if (expr.operator.value === "and") {
+				return 1;
+			}
+			if (expr.operator.value === "in" || expr.operator.value === "not in") {
+				return 2;
+			}
 			return 0;
 	}
 	return 0;

--- a/packages/jinja/src/lexer.ts
+++ b/packages/jinja/src/lexer.ts
@@ -166,7 +166,9 @@ export function tokenize(source: string, options: PreprocessOptions = {}): Token
 				// Consume the backslash
 				++cursorPosition;
 				// Check for end of input
-				if (cursorPosition >= src.length) throw new SyntaxError("Unexpected end of input");
+				if (cursorPosition >= src.length) {
+					throw new SyntaxError("Unexpected end of input");
+				}
 
 				// Add the escaped character
 				const escaped = src[cursorPosition++];
@@ -179,7 +181,9 @@ export function tokenize(source: string, options: PreprocessOptions = {}): Token
 			}
 
 			str += src[cursorPosition++];
-			if (cursorPosition >= src.length) throw new SyntaxError("Unexpected end of input");
+			if (cursorPosition >= src.length) {
+				throw new SyntaxError("Unexpected end of input");
+			}
 		}
 		return str;
 	};

--- a/packages/jinja/src/runtime.ts
+++ b/packages/jinja/src/runtime.ts
@@ -1796,7 +1796,9 @@ export class Interpreter {
 	}
 
 	evaluate(statement: Statement | undefined, environment: Environment): AnyRuntimeValue {
-		if (!statement) return new UndefinedValue();
+		if (!statement) {
+			return new UndefinedValue();
+		}
 
 		switch (statement.type) {
 			// Program

--- a/packages/jinja/src/utils.ts
+++ b/packages/jinja/src/utils.ts
@@ -109,7 +109,9 @@ function escapeRegExp(s: string): string {
  * Function that mimics Python's string.replace() function.
  */
 export function replace(str: string, oldvalue: string, newvalue: string, count?: number | null): string {
-	if (count === 0) return str;
+	if (count === 0) {
+		return str;
+	}
 	let remaining = count == null || count < 0 ? Infinity : count;
 	// NB: Use a Unicode-aware global regex so unpaired surrogates won't match
 	const pattern = oldvalue.length === 0 ? new RegExp("(?=)", "gu") : new RegExp(escapeRegExp(oldvalue), "gu");

--- a/packages/ollama-utils/scripts/generate-automap.ts
+++ b/packages/ollama-utils/scripts/generate-automap.ts
@@ -46,7 +46,9 @@ const getSpecialTokens = (tmpl: string): string[] => {
 };
 
 (async () => {
-	if (DEBUG) writeFileSync("ollama_tmp.jsonl", ""); // clear the file
+	if (DEBUG) {
+		writeFileSync("ollama_tmp.jsonl", "");
+	} // clear the file
 
 	const models: string[] = [];
 	const output: OutputItem[] = [];
@@ -69,7 +71,9 @@ const getSpecialTokens = (tmpl: string): string[] => {
 	const workerGetTags = async () => {
 		while (true) {
 			const model = models.shift();
-			if (!model) return;
+			if (!model) {
+				return;
+			}
 			nDoing++;
 			console.log(`Getting tags ${nDoing} / ${nAll}`);
 			const html = await (await fetch(`https://ollama.com/${model}`)).text();
@@ -113,7 +117,9 @@ const getSpecialTokens = (tmpl: string): string[] => {
 	const workerGetTemplate = async () => {
 		while (true) {
 			const modelWithTag = modelsWithTag.shift();
-			if (!modelWithTag) return;
+			if (!modelWithTag) {
+				return;
+			}
 
 			nDoing++;
 			const [model, tag] = modelWithTag.split(":");
@@ -155,7 +161,9 @@ const getSpecialTokens = (tmpl: string): string[] => {
 					seenGGUFTemplate.add(ggufTmpl);
 					console.log(" --> GGUF chat template OK");
 					const tmplBlob = manifest.layers.find((l) => l.mediaType.match(/\.template/));
-					if (!tmplBlob) continue;
+					if (!tmplBlob) {
+						continue;
+					}
 					const ollamaTmplUrl = getBlobUrl(tmplBlob.digest);
 					if (!ollamaTmplUrl) {
 						console.log(" --> [X] No ollama template");
@@ -180,7 +188,9 @@ const getSpecialTokens = (tmpl: string): string[] => {
 					}
 					output.push(record);
 					addedModels.push(modelWithTag);
-					if (DEBUG) appendFileSync("ollama_tmp.jsonl", JSON.stringify(record) + "\n");
+					if (DEBUG) {
+						appendFileSync("ollama_tmp.jsonl", JSON.stringify(record) + "\n");
+					}
 				} catch (e) {
 					console.log(` --> [X] Skipping ${modelWithTag} due to error`, e);
 					skippedModelsDueToErr.push(modelWithTag);

--- a/packages/space-header/src/index.ts
+++ b/packages/space-header/src/index.ts
@@ -8,14 +8,18 @@ import { get_space } from "./utils/get_space";
 import { inject } from "./inject";
 
 async function main(initialSpace: string | Space, options?: Options) {
-	if (window === undefined) return console.error("Please run this script in a browser environment");
+	if (window === undefined) {
+		return console.error("Please run this script in a browser environment");
+	}
 	// Don't run on huggingface.co to avoid duplicate headers
 	const has_huggingface_ancestor = Object.values(
 		window.location?.ancestorOrigins ?? {
 			0: window.document.referrer,
 		},
 	).some((origin) => new URL(origin)?.origin === "https://huggingface.co");
-	if (has_huggingface_ancestor) return;
+	if (has_huggingface_ancestor) {
+		return;
+	}
 
 	inject_fonts();
 
@@ -23,7 +27,9 @@ async function main(initialSpace: string | Space, options?: Options) {
 
 	if (typeof initialSpace === "string") {
 		space = await get_space(initialSpace);
-		if (space === null) return console.error("Space not found");
+		if (space === null) {
+			return console.error("Space not found");
+		}
 	} else {
 		space = initialSpace;
 	}

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -2307,7 +2307,9 @@ export const nemo = (model: ModelData): string[] => {
 export const outetts = (model: ModelData): string[] => {
 	// Don’t show this block on GGUF / ONNX mirrors
 	const t = model.tags ?? [];
-	if (t.includes("gguf") || t.includes("onnx")) return [];
+	if (t.includes("gguf") || t.includes("onnx")) {
+		return [];
+	}
 
 	// v1.0 HF → minimal runnable snippet
 	return [


### PR DESCRIPTION
## Summary
- Enables ESLint's `curly: ["error", "all"]` so single-line `if`/`else`/`for`/`while` bodies must be wrapped in `{ }`.
- Auto-fixes the ~59 existing violations across 8 packages with `eslint --fix` + `oxfmt`.

Affected packages: `agents`, `gguf`, `hub`, `inference`, `jinja`, `ollama-utils`, `space-header`, `tasks`.

## Test plan
- [x] `pnpm -r --parallel lint` passes (rule applied, no remaining violations).
- [x] `pnpm format` clean.
- [ ] CI green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a repo-wide linting/style change that only adds required braces to single-line control statements, with no intended behavior changes.
> 
> **Overview**
> **Enforces brace-wrapped control statements** by enabling ESLint `curly: ["error", "all"]`.
> 
> Updates existing code across multiple packages (agents, hub, inference, jinja, scripts, etc.) to comply by converting one-line `if`/`for`/`while` bodies into block statements, without changing logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06f655771aa5c5a6007120ced1b66c0c1cc4b8eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->