### PR TITLE
Add Ambient inference provider

### DIFF
--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -47,6 +47,7 @@ Your access token should be kept private. If you need to protect it in front-end
 You can send inference requests to third-party providers with the inference client.
 
 Currently, we support the following providers:
+- [Ambient](https://ambient.xyz)
 - [Fal.ai](https://fal.ai)
 - [Featherless AI](https://featherless.ai)
 - [Fireworks AI](https://fireworks.ai)
@@ -90,6 +91,7 @@ When authenticated with a Hugging Face access token, the request is routed throu
 When authenticated with a third-party provider key, the request is made directly against that provider's inference API.
 
 Only a subset of models are supported when requesting third-party providers. You can check the list of supported models per pipeline tasks here:
+- [Ambient supported models](https://huggingface.co/api/partners/ambient-xyz/models)
 - [Fal.ai supported models](https://huggingface.co/api/partners/fal-ai/models)
 - [Featherless AI supported models](https://huggingface.co/api/partners/featherless-ai/models)
 - [Fireworks AI supported models](https://huggingface.co/api/partners/fireworks-ai/models)

--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -1,3 +1,4 @@
+import * as Ambient from "../providers/ambient.js";
 import * as Baseten from "../providers/baseten.js";
 import * as Clarifai from "../providers/clarifai.js";
 import * as BlackForestLabs from "../providers/black-forest-labs.js";
@@ -62,6 +63,9 @@ import type { InferenceProvider, InferenceProviderOrPolicy, InferenceTask } from
 import { InferenceClientInputError } from "../errors.js";
 
 export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, TaskProviderHelper>>> = {
+	"ambient-xyz": {
+		conversational: new Ambient.AmbientConversationalTask(),
+	},
 	baseten: {
 		conversational: new Baseten.BasetenConversationalTask(),
 	},

--- a/packages/inference/src/providers/ambient.ts
+++ b/packages/inference/src/providers/ambient.ts
@@ -1,0 +1,23 @@
+/**
+ * See the registered mapping of HF model ID => Ambient model ID here:
+ *
+ * https://huggingface.co/api/partners/ambient-xyz/models
+ *
+ * This is a publicly available mapping.
+ *
+ * If you want to try to run inference for a new model locally before it's registered on huggingface.co,
+ * you can add it to the dictionary "HARDCODED_MODEL_ID_MAPPING" in consts.ts, for dev purposes.
+ *
+ * - If you work at Ambient and want to update this mapping, please use the model mapping API we provide on huggingface.co
+ * - If you're a community member and want to add a new supported HF model to Ambient, please open an issue on the present repo
+ * and we will tag Ambient team members.
+ *
+ * Thanks!
+ */
+import { BaseConversationalTask } from "./providerHelper.js";
+
+export class AmbientConversationalTask extends BaseConversationalTask {
+	constructor() {
+		super("ambient-xyz", "https://api.ambient.xyz");
+	}
+}

--- a/packages/inference/src/providers/consts.ts
+++ b/packages/inference/src/providers/consts.ts
@@ -18,6 +18,7 @@ export const HARDCODED_MODEL_INFERENCE_MAPPING: Record<
 	 * Example:
 	 * "Qwen/Qwen2.5-Coder-32B-Instruct": "Qwen2.5-Coder-32B-Instruct",
 	 */
+	"ambient-xyz": {},
 	baseten: {},
 	"black-forest-labs": {},
 	cerebras: {},

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -45,6 +45,7 @@ export interface Options {
 export type InferenceTask = Exclude<PipelineType, "other"> | "conversational";
 
 export const INFERENCE_PROVIDERS = [
+	"ambient-xyz",
 	"baseten",
 	"black-forest-labs",
 	"cerebras",
@@ -84,6 +85,7 @@ export type InferenceProviderOrPolicy = (typeof PROVIDERS_OR_POLICIES)[number];
  * Whenever possible, InferenceProvider should == org namespace
  */
 export const PROVIDERS_HUB_ORGS: Record<InferenceProvider, string> = {
+	"ambient-xyz": "ambient-xyz",
 	baseten: "baseten",
 	"black-forest-labs": "black-forest-labs",
 	cerebras: "cerebras",

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -2559,6 +2559,61 @@ describe.skip("InferenceClient", () => {
 	);
 
 	describe.concurrent(
+		"Ambient",
+		() => {
+			const client = new InferenceClient(env.HF_AMBIENT_XYZ_KEY ?? "dummy");
+
+			HARDCODED_MODEL_INFERENCE_MAPPING["ambient-xyz"] = {
+				"Qwen/Qwen3-Coder-30B-A3B-Instruct": {
+					provider: "ambient-xyz",
+					hfModelId: "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+					providerId: "qwen/qwen3-coder-30b-a3b-instruct",
+					status: "live",
+					task: "conversational",
+				},
+			};
+
+			it("chatCompletion", async () => {
+				const res = await client.chatCompletion({
+					model: "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+					provider: "ambient-xyz",
+					messages: [{ role: "user", content: "Reply with exactly: ok" }],
+					max_tokens: 20,
+				});
+				if (res.choices && res.choices.length > 0) {
+					const completion = res.choices[0].message?.content;
+					expect(completion).toContain("ok");
+				}
+			});
+
+			it("chatCompletion stream", async () => {
+				const stream = client.chatCompletionStream({
+					model: "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+					provider: "ambient-xyz",
+					messages: [{ role: "user", content: "Reply with exactly: ok" }],
+					stream: true,
+					max_tokens: 20,
+				}) as AsyncGenerator<ChatCompletionStreamOutput>;
+
+				let fullResponse = "";
+				for await (const chunk of stream) {
+					if (chunk.choices && chunk.choices.length > 0) {
+						const content = chunk.choices[0].delta?.content;
+						if (content) {
+							fullResponse += content;
+						}
+					}
+				}
+
+				// Verify we got a meaningful response
+				expect(fullResponse).toBeTruthy();
+				expect(fullResponse.length).toBeGreaterThan(0);
+			});
+		},
+		TIMEOUT,
+	);
+
+	describe.concurrent(
 		"PublicAI",
 		() => {
 			const client = new InferenceClient(env.HF_PUBLICAI_KEY ?? "dummy");


### PR DESCRIPTION
## Summary

Adds Ambient as an OpenAI-compatible conversational inference provider under the provider slug `ambient-xyz`.

Ambient is an inference provider offering OpenAI-compatible chat completions. Provider links:

- Website: https://ambient.xyz
- API docs: https://docs.ambient.xyz
- API base URL: `https://api.ambient.xyz/v1`
- Chat route: `/chat/completions` (OpenAI-compatible)
- Model metadata: `https://api.ambient.xyz/v1/models`

This PR:

- Registers `ambient-xyz` in the inference provider list and Hub org mapping.
- Adds an Ambient conversational task helper using `https://api.ambient.xyz/v1/chat/completions`.
- Documents Ambient in the provider list and supported model mapping links.
- Adds a representative provider smoke-test block following the existing third-party provider pattern.

The test mapping uses the canonical Hub model ID `Qwen/Qwen3-Coder-30B-A3B-Instruct` mapped to Ambient's provider ID `qwen/qwen3-coder-30b-a3b-instruct`.

## Validation

- `pnpm --filter @huggingface/inference run format:check`
- `pnpm --filter @huggingface/inference run check`
- `pnpm --filter @huggingface/inference run build`
- Live local smoke with `InferenceClient` + provider key against `Qwen/Qwen3-Coder-30B-A3B-Instruct` for non-streaming and streaming chat completion.

Ambient production compatibility checks already pass for `Inference-Id`, `/billing/request-costs`, and `/v1/models` pricing/context metadata.
