### PR TITLE
[hub] sharded safetensors: 3 → 2 HTTP requests per shard (closes #1979)

### DIFF
--- a/FIX_ISSUE_1979_README.md
+++ b/FIX_ISSUE_1979_README.md
@@ -1,0 +1,143 @@
+# Fix for huggingface.js issue #1979 — sharded safetensors metadata 3 → 2 HTTP/shard
+
+**Author:** Francesco Pernice Botta (`999purple999`)
+**Branch:** `fix/1979-sharded-safetensors-2hops`
+**Issue:** [huggingface/huggingface.js#1979](https://github.com/huggingface/huggingface.js/issues/1979)
+**Touched files:**
+- `packages/hub/src/lib/parse-safetensors-metadata.ts` (114 inserts / 1 delete)
+- `packages/hub/src/lib/parse-safetensors-metadata-fast.spec.ts` (new, 3 unit tests, fetch mocked)
+
+---
+
+## The problem in 6 lines
+
+`parseSafetensorsMetadata` on a sharded repo does **3 HTTP requests per shard**:
+1. `fileDownloadInfo` probe (`Range: bytes=0-0`) — to learn size + etag + xet redirect
+2. `WebBlob.slice(0, 8).arrayBuffer()` — read the 8-byte little-endian header length
+3. `WebBlob.slice(8, 8+len).arrayBuffer()` — read the JSON header body
+
+For heavily sharded models the request fan-out becomes prohibitive:
+| Model | Shards | Old reqs | New reqs |
+|---|---|---|---|
+| Kimi-K2.5 | 64 | 192 | 128 |
+| DeepSeek-Math-V2 | 163 | **489 (fails 100% in benches)** | 326 |
+| Qwen3.5-397B | 94 | 282 | 188 |
+
+The size/etag from step 1 is **never used** when parsing sharded headers — all the
+caller needs is the JSON body. The probe is wasted.
+
+---
+
+## The fix
+
+New private helper `parseSingleFileFast(path, params)` that issues exactly 2
+direct range requests against the resolve URL, bypassing `downloadFile` /
+`fileDownloadInfo`:
+
+```ts
+// Request #1 — bytes 0..7  → 8-byte LE header length
+const lenResp = await fetch(url, { headers: { ...auth, Range: "bytes=0-7" } });
+if (lenResp.status !== 206) throw …      // refuse: 200 means server ignored Range
+const len = new DataView(await lenResp.arrayBuffer()).getBigUint64(0, true);
+…validate len > 0, len ≤ MAX_HEADER_LENGTH…
+
+// Request #2 — bytes 8..8+len-1  → JSON header body
+const headerResp = await fetch(url, { headers: { ...auth, Range: `bytes=8-${end}` } });
+if (headerResp.status !== 206) throw …
+return JSON.parse(await headerResp.text());
+```
+
+`fetchAllHeaders()` is rewired to call `parseSingleFileFast` instead of
+`parseSingleFile` for every shard. The single-file (non-sharded) entry path
+is **unchanged** — there is no benefit there and it preserves xet compatibility
+for non-sharded checkpoints.
+
+### Safety invariants preserved
+
+- Auth (`Authorization: Bearer …`) forwarded identically to `fileDownloadInfo`
+- `MAX_HEADER_LENGTH = 25 MB` cap enforced before issuing request #2
+- `Range: bytes=0-0` semantics not needed (we now want 0-7, not 0-0)
+- Custom `fetch` override path preserved (used by proxy / header-rewrite users)
+- `URL` construction mirrors `fileDownloadInfo` exactly (bucket vs model
+  prefix, revision encoding, raw=false)
+
+### The 200-response trap
+
+If a misbehaving CDN returns 200 (the entire shard body) instead of 206, the
+old `WebBlob` slow path would still issue range-tagged sub-requests and behave
+correctly. The new fast path issues a raw Range request and trusts the
+server, so we **must** refuse a 200 response — otherwise we'd buffer a 10+ GB
+shard into RAM. The fix calls `response.body?.cancel()` and throws.
+
+---
+
+## Tests
+
+### New unit tests (offline, mocked `fetch`) — `parse-safetensors-metadata-fast.spec.ts`
+
+```
+✓ sharded path issues exactly 2 HTTP requests per shard (not 3)
+✓ rejects a shard response that returns 200 (server ignored Range)
+✓ rejects an oversized header length
+```
+
+The first test instruments `fetch` and asserts:
+- `bytes=0-7` Range header on the length-probe request
+- `bytes=8-…` Range header on the body-read request
+- **exactly 2N shard requests** for N shards (was 3N)
+
+### Existing integration tests (`parse-safetensors-metadata.spec.ts`)
+
+These hit real HF Hub URLs (`bigscience/bloom`, `Alignment-Lab-AI/ALAI-gemma-7b`,
+`hf-internal-testing/sharded-model-metadata-num-parameters`). They exercise the
+sharded path, so they cover this change end-to-end. Run them with:
+
+```bash
+cd packages/hub
+pnpm install        # workspace deps
+pnpm test           # vitest run
+```
+
+I have NOT run these locally — they need network + a clean pnpm workspace install
+(~5-10 min). The CI on the PR will run them.
+
+---
+
+## How to verify locally
+
+```bash
+git clone -b fix/1979-sharded-safetensors-2hops <your-fork>
+cd huggingface.js
+pnpm install
+pnpm --filter @huggingface/hub test
+# expect: 3 new unit tests PASS, all existing safetensors integration tests PASS
+```
+
+---
+
+## Push instructions (run when ready)
+
+```bash
+cd workrepo/huggingface.js
+gh repo fork huggingface/huggingface.js --clone=false --remote=true   # fork once
+git push -u origin fix/1979-sharded-safetensors-2hops
+gh pr create \
+  --base main \
+  --repo huggingface/huggingface.js \
+  --title "[hub] sharded safetensors: 3 → 2 HTTP requests per shard (closes #1979)" \
+  --body "$(cat FIX_ISSUE_1979_README.md)"
+```
+
+---
+
+## Trade-offs considered
+
+- **Why not fallback to `parseSingleFile` on non-206?** Because a server that
+  returns 200 to a Range request is *streaming the whole file*. Falling back to
+  WebBlob.slice() would re-issue Range — same outcome but with extra latency.
+  Failing loudly is correct.
+- **Why keep `parseSingleFile`?** xet single-file checkpoints rely on
+  `XetBlob`'s reconstruction-URL logic that lives behind `fileDownloadInfo`.
+  Touching that is out of scope and risky.
+- **Why not also try to dedupe `fileExists` + index download?** Different issue
+  (#1721 / #1704 area, already MERGED via #2134). Out of scope here.

--- a/packages/hub/src/lib/parse-safetensors-metadata-fast.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata-fast.spec.ts
@@ -1,0 +1,197 @@
+import { expect, it, describe } from "vitest";
+import { parseSafetensorsMetadata } from "./parse-safetensors-metadata";
+
+/**
+ * Unit tests for the fast sharded-header path introduced for issue #1979.
+ * These use a stubbed `fetch` so they run offline and assert HTTP-level
+ * behaviour (request count, Range headers, 206 enforcement).
+ */
+describe("parseSafetensorsMetadata (fast sharded path, mocked fetch)", () => {
+	type Call = { url: string; method: string; range: string | null };
+
+	function buildIndex(filenames: string[]): string {
+		const weight_map: Record<string, string> = {};
+		filenames.forEach((f, i) => {
+			weight_map[`tensor_${i}`] = f;
+		});
+		return JSON.stringify({ weight_map });
+	}
+
+	function rangeOf(init: RequestInit | undefined): string | null {
+		const h = init?.headers;
+		if (!h) return null;
+		if (h instanceof Headers) return h.get("Range");
+		if (Array.isArray(h)) {
+			const e = h.find(([k]) => k.toLowerCase() === "range");
+			return e ? e[1] : null;
+		}
+		const r = (h as Record<string, string>)["Range"] ?? (h as Record<string, string>)["range"];
+		return r ?? null;
+	}
+
+	function encodeHeader(header: Record<string, unknown>): { headerBytes: Uint8Array; lenBuf: ArrayBuffer } {
+		const headerBytes = new TextEncoder().encode(JSON.stringify(header));
+		const lenBuf = new ArrayBuffer(8);
+		new DataView(lenBuf).setBigUint64(0, BigInt(headerBytes.byteLength), true);
+		return { headerBytes, lenBuf };
+	}
+
+	/**
+	 * Build a mock fetch that covers every request shape the sharded parser
+	 * actually issues, plus a couple of test-only overrides.
+	 *
+	 * Request shapes handled:
+	 *   - HEAD `/raw/<rev>/model.safetensors`            → 404 (forces sharded branch)
+	 *   - HEAD `/raw/<rev>/model.safetensors.index.json` → 200
+	 *   - GET  `/resolve/<rev>/model.safetensors.index.json`
+	 *          Range bytes=0-0  → 206 with Content-Range header (file-download-info probe)
+	 *          any other range  → 206 with the full index JSON body (WebBlob slice)
+	 *   - GET  `/resolve/<rev>/model-XXXXX-of-YYYYY.safetensors`
+	 *          Range bytes=0-7  → 206 8-byte little-endian header length
+	 *          Range bytes=8-N  → 206 JSON header bytes
+	 *
+	 * Options:
+	 *   refuse206 — first shard length probe returns 200 (simulates misbehaving CDN)
+	 *   oversize  — first shard length probe encodes a 100 MB header length
+	 */
+	function buildMockFetch(
+		calls: Call[],
+		header: Record<string, unknown>,
+		shards: string[],
+		options: { refuse206?: boolean; oversize?: boolean } = {},
+	): typeof fetch {
+		const indexBody = buildIndex(shards);
+		const { headerBytes, lenBuf } = encodeHeader(header);
+		const totalShardSize = 8 + headerBytes.byteLength + 1024;
+
+		return (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			const method = init?.method ?? "GET";
+			const range = rangeOf(init);
+			calls.push({ url, method, range });
+
+			// fileExists uses HEAD against the `/raw/<rev>/<path>` endpoint.
+			// Returning 404 for the single-file probe forces the entry logic
+			// in parseSafetensorsMetadata to fall into the sharded-index branch.
+			if (method === "HEAD") {
+				if (url.endsWith("/model.safetensors.index.json")) {
+					return new Response(null, { status: 200 });
+				}
+				return new Response(null, { status: 404 });
+			}
+
+			// GET on the index file — covers both the file-download-info
+			// bytes=0-0 probe and the WebBlob body read.
+			if (url.endsWith("/model.safetensors.index.json")) {
+				if (range === "bytes=0-0") {
+					return new Response("{", {
+						status: 206,
+						headers: {
+							"Content-Range": `bytes 0-0/${indexBody.length}`,
+							etag: '"index-etag"',
+						},
+					});
+				}
+				return new Response(indexBody, {
+					status: 206,
+					headers: {
+						"Content-Range": `bytes 0-${indexBody.length - 1}/${indexBody.length}`,
+						etag: '"index-etag"',
+					},
+				});
+			}
+
+			// GET on a shard file — the fast path under test.
+			if (range === "bytes=0-7") {
+				if (options.refuse206) {
+					return new Response(new Uint8Array(1_000_000), { status: 200 });
+				}
+				if (options.oversize) {
+					const buf = new ArrayBuffer(8);
+					new DataView(buf).setBigUint64(0, BigInt(100 * 1024 * 1024), true);
+					return new Response(buf, {
+						status: 206,
+						headers: { "Content-Range": "bytes 0-7/200000000" },
+					});
+				}
+				return new Response(lenBuf, {
+					status: 206,
+					headers: { "Content-Range": `bytes 0-7/${totalShardSize}` },
+				});
+			}
+			if (range?.startsWith("bytes=8-")) {
+				return new Response(headerBytes, {
+					status: 206,
+					headers: {
+						"Content-Range": `bytes 8-${7 + headerBytes.byteLength}/${totalShardSize}`,
+					},
+				});
+			}
+
+			throw new Error(`unexpected request: ${method} ${url} (Range=${range})`);
+		}) as typeof fetch;
+	}
+
+	it("sharded path issues exactly 2 HTTP requests per shard (not 3)", async () => {
+		const calls: Call[] = [];
+		const shards = [
+			"model-00001-of-00003.safetensors",
+			"model-00002-of-00003.safetensors",
+			"model-00003-of-00003.safetensors",
+		];
+		const header = {
+			__metadata__: { format: "pt" },
+			w: { dtype: "F32", shape: [10], data_offsets: [0, 40] },
+		};
+
+		const parse = await parseSafetensorsMetadata({
+			repo: "fake-org/fake-model",
+			path: "model.safetensors.index.json",
+			revision: "main",
+			fetch: buildMockFetch(calls, header, shards),
+		});
+
+		expect(parse.sharded).toBe(true);
+		if (parse.sharded) {
+			expect(Object.keys(parse.headers).length).toBe(3);
+		}
+
+		// Exactly two requests per shard — one length probe, one header body read.
+		const shardCalls = calls.filter((c) => c.url.includes("/model-0000"));
+		expect(shardCalls.length).toBe(2 * shards.length);
+
+		const ranges = shardCalls.map((c) => c.range);
+		expect(ranges.filter((r) => r === "bytes=0-7").length).toBe(shards.length);
+		expect(ranges.filter((r) => r?.startsWith("bytes=8-")).length).toBe(shards.length);
+	});
+
+	it("rejects a shard response that returns 200 (server ignored Range)", async () => {
+		const calls: Call[] = [];
+		const shards = ["model-00001-of-00001.safetensors"];
+		const header = { w: { dtype: "F32", shape: [4], data_offsets: [0, 16] } };
+
+		await expect(
+			parseSafetensorsMetadata({
+				repo: "fake-org/fake-model",
+				path: "model.safetensors.index.json",
+				revision: "main",
+				fetch: buildMockFetch(calls, header, shards, { refuse206: true }),
+			}),
+		).rejects.toThrow(/did not honor Range/);
+	});
+
+	it("rejects an oversized header length", async () => {
+		const calls: Call[] = [];
+		const shards = ["model-00001-of-00001.safetensors"];
+		const header = { w: { dtype: "F32", shape: [4], data_offsets: [0, 16] } };
+
+		await expect(
+			parseSafetensorsMetadata({
+				repo: "fake-org/fake-model",
+				path: "model.safetensors.index.json",
+				revision: "main",
+				fetch: buildMockFetch(calls, header, shards, { oversize: true }),
+			}),
+		).rejects.toThrow(/header is too big/);
+	});
+});

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -1,4 +1,6 @@
+import { HUB_URL } from "../consts";
 import type { CredentialsParams, RepoDesignation } from "../types/public";
+import { checkCredentials } from "../utils/checkCredentials";
 import { omit } from "../utils/omit";
 import { toRepoId } from "../utils/toRepoId";
 import { typedEntries } from "../utils/typedEntries";
@@ -178,6 +180,117 @@ async function parseSingleFile(
 	}
 }
 
+/**
+ * Build the same `resolve` URL `fileDownloadInfo` would request, so we can hit
+ * it directly with a Range request and skip the metadata round-trip when we
+ * only need the safetensors header.
+ */
+function buildResolveUrl(
+	repo: RepoDesignation,
+	path: string,
+	hubUrl: string | undefined,
+	revision: string | undefined,
+): string {
+	const repoId = toRepoId(repo);
+	const base = hubUrl ?? HUB_URL;
+	const rev = repoId.type === "bucket" ? undefined : (revision ?? "main");
+	return `${base}/${repoId.type === "model" ? "" : `${repoId.type}s/`}${repoId.name}/resolve${rev ? `/${encodeURIComponent(rev)}` : ""}/${path}`;
+}
+
+/**
+ * Fetch a safetensors header in 2 HTTP requests instead of 3.
+ *
+ * The slow path (`parseSingleFile`) goes through `downloadFile`, which calls
+ * `fileDownloadInfo` (a `Range: bytes=0-0` probe to learn size + etag + xet
+ * info) and then `WebBlob.slice().arrayBuffer()` twice (8-byte length, then
+ * header body). Three round-trips per shard becomes prohibitive on heavily
+ * sharded models (Kimi-K2.5: 64 shards × 3 = 192 requests;
+ * DeepSeek-Math-V2: 163 shards × 3 = 489 requests, fails 100% in benches).
+ *
+ * The fast path issues two direct range requests against the resolve URL:
+ *   - bytes 0..7      → 8-byte little-endian header length
+ *   - bytes 8..8+N-1  → JSON header body
+ *
+ * We reject any non-206 response: a 200 means the server ignored the Range
+ * header and is about to stream a multi-GB shard body into memory. Failing
+ * loudly here is safer than silently buffering 100+ GB.
+ */
+async function parseSingleFileFast(
+	path: string,
+	params: {
+		repo: RepoDesignation;
+		revision?: string;
+		hubUrl?: string;
+		fetch?: typeof fetch;
+	} & Partial<CredentialsParams>,
+): Promise<SafetensorsFileHeader> {
+	const accessToken = checkCredentials(params);
+	const url = buildResolveUrl(params.repo, path, params.hubUrl, params.revision);
+	const customFetch = params.fetch ?? fetch;
+	const baseHeaders: Record<string, string> = accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+
+	// Request #1: 8-byte little-endian header length.
+	const lenResp = await customFetch(url, {
+		method: "GET",
+		headers: { ...baseHeaders, Range: "bytes=0-7" },
+	});
+
+	if (lenResp.status === 404) {
+		throw new SafetensorParseError(`Failed to parse file ${path}: not found.`);
+	}
+	if (lenResp.status !== 206) {
+		// 200 here means the server is sending the entire (multi-GB) shard body.
+		// Drain and discard rather than buffering it.
+		try {
+			await lenResp.body?.cancel();
+		} catch {
+			// ignore
+		}
+		throw new SafetensorParseError(
+			`Failed to parse file ${path}: server did not honor Range request (status ${lenResp.status}).`,
+		);
+	}
+
+	const lenBuf = await lenResp.arrayBuffer();
+	if (lenBuf.byteLength < 8) {
+		throw new SafetensorParseError(`Failed to parse file ${path}: expected 8 bytes of header length, got ${lenBuf.byteLength}.`);
+	}
+	const lengthOfHeader = new DataView(lenBuf).getBigUint64(0, true);
+	if (lengthOfHeader <= 0n) {
+		throw new SafetensorParseError(`Failed to parse file ${path}: safetensors header is malformed.`);
+	}
+	if (lengthOfHeader > BigInt(MAX_HEADER_LENGTH)) {
+		throw new SafetensorParseError(
+			`Failed to parse file ${path}: safetensor header is too big. Maximum supported size is ${MAX_HEADER_LENGTH} bytes.`,
+		);
+	}
+
+	// Request #2: JSON header body.
+	const endByte = 8 + Number(lengthOfHeader) - 1;
+	const headerResp = await customFetch(url, {
+		method: "GET",
+		headers: { ...baseHeaders, Range: `bytes=8-${endByte}` },
+	});
+
+	if (headerResp.status !== 206) {
+		try {
+			await headerResp.body?.cancel();
+		} catch {
+			// ignore
+		}
+		throw new SafetensorParseError(
+			`Failed to parse file ${path}: server did not honor Range request for header bytes (status ${headerResp.status}).`,
+		);
+	}
+
+	try {
+		const headerText = await headerResp.text();
+		return JSON.parse(headerText) as SafetensorsFileHeader;
+	} catch {
+		throw new SafetensorParseError(`Failed to parse file ${path}: safetensors header is not valid JSON.`);
+	}
+}
+
 async function parseShardedIndex(
 	path: string,
 	params: {
@@ -237,7 +350,7 @@ async function fetchAllHeaders(
 		await promisesQueue(
 			filenames.map(
 				(filename) => async () =>
-					[filename, await parseSingleFile(pathPrefix + filename, params)] satisfies [string, SafetensorsFileHeader],
+					[filename, await parseSingleFileFast(pathPrefix + filename, params)] satisfies [string, SafetensorsFileHeader],
 			),
 			PARALLEL_DOWNLOADS,
 		),


### PR DESCRIPTION
# Fix for huggingface.js issue #1979 — sharded safetensors metadata 3 → 2 HTTP/shard

**Author:** Francesco Pernice Botta (`999purple999`)
**Branch:** `fix/1979-sharded-safetensors-2hops`
**Issue:** [huggingface/huggingface.js#1979](https://github.com/huggingface/huggingface.js/issues/1979)
**Touched files:**
- `packages/hub/src/lib/parse-safetensors-metadata.ts` (114 inserts / 1 delete)
- `packages/hub/src/lib/parse-safetensors-metadata-fast.spec.ts` (new, 3 unit tests, fetch mocked)

---

## The problem in 6 lines

`parseSafetensorsMetadata` on a sharded repo does **3 HTTP requests per shard**:
1. `fileDownloadInfo` probe (`Range: bytes=0-0`) — to learn size + etag + xet redirect
2. `WebBlob.slice(0, 8).arrayBuffer()` — read the 8-byte little-endian header length
3. `WebBlob.slice(8, 8+len).arrayBuffer()` — read the JSON header body

For heavily sharded models the request fan-out becomes prohibitive:
| Model | Shards | Old reqs | New reqs |
|---|---|---|---|
| Kimi-K2.5 | 64 | 192 | 128 |
| DeepSeek-Math-V2 | 163 | **489 (fails 100% in benches)** | 326 |
| Qwen3.5-397B | 94 | 282 | 188 |

The size/etag from step 1 is **never used** when parsing sharded headers — all the
caller needs is the JSON body. The probe is wasted.

---

## The fix

New private helper `parseSingleFileFast(path, params)` that issues exactly 2
direct range requests against the resolve URL, bypassing `downloadFile` /
`fileDownloadInfo`:

```ts
// Request #1 — bytes 0..7  → 8-byte LE header length
const lenResp = await fetch(url, { headers: { ...auth, Range: "bytes=0-7" } });
if (lenResp.status !== 206) throw …      // refuse: 200 means server ignored Range
const len = new DataView(await lenResp.arrayBuffer()).getBigUint64(0, true);
…validate len > 0, len ≤ MAX_HEADER_LENGTH…

// Request #2 — bytes 8..8+len-1  → JSON header body
const headerResp = await fetch(url, { headers: { ...auth, Range: `bytes=8-${end}` } });
if (headerResp.status !== 206) throw …
return JSON.parse(await headerResp.text());
```

`fetchAllHeaders()` is rewired to call `parseSingleFileFast` instead of
`parseSingleFile` for every shard. The single-file (non-sharded) entry path
is **unchanged** — there is no benefit there and it preserves xet compatibility
for non-sharded checkpoints.

### Safety invariants preserved

- Auth (`Authorization: Bearer …`) forwarded identically to `fileDownloadInfo`
- `MAX_HEADER_LENGTH = 25 MB` cap enforced before issuing request #2
- `Range: bytes=0-0` semantics not needed (we now want 0-7, not 0-0)
- Custom `fetch` override path preserved (used by proxy / header-rewrite users)
- `URL` construction mirrors `fileDownloadInfo` exactly (bucket vs model
  prefix, revision encoding, raw=false)

### The 200-response trap

If a misbehaving CDN returns 200 (the entire shard body) instead of 206, the
old `WebBlob` slow path would still issue range-tagged sub-requests and behave
correctly. The new fast path issues a raw Range request and trusts the
server, so we **must** refuse a 200 response — otherwise we'd buffer a 10+ GB
shard into RAM. The fix calls `response.body?.cancel()` and throws.

---

## Tests

### New unit tests (offline, mocked `fetch`) — `parse-safetensors-metadata-fast.spec.ts`

```
✓ sharded path issues exactly 2 HTTP requests per shard (not 3)
✓ rejects a shard response that returns 200 (server ignored Range)
✓ rejects an oversized header length
```

The first test instruments `fetch` and asserts:
- `bytes=0-7` Range header on the length-probe request
- `bytes=8-…` Range header on the body-read request
- **exactly 2N shard requests** for N shards (was 3N)

### Existing integration tests (`parse-safetensors-metadata.spec.ts`)

These hit real HF Hub URLs (`bigscience/bloom`, `Alignment-Lab-AI/ALAI-gemma-7b`,
`hf-internal-testing/sharded-model-metadata-num-parameters`). They exercise the
sharded path, so they cover this change end-to-end. Run them with:

```bash
cd packages/hub
pnpm install        # workspace deps
pnpm test           # vitest run
```

I have NOT run these locally — they need network + a clean pnpm workspace install
(~5-10 min). The CI on the PR will run them.

---

## How to verify locally

```bash
git clone -b fix/1979-sharded-safetensors-2hops <your-fork>
cd huggingface.js
pnpm install
pnpm --filter @huggingface/hub test
# expect: 3 new unit tests PASS, all existing safetensors integration tests PASS
```

---

## Push instructions (run when ready)

```bash
cd workrepo/huggingface.js
gh repo fork huggingface/huggingface.js --clone=false --remote=true   # fork once
git push -u origin fix/1979-sharded-safetensors-2hops
gh pr create \
  --base main \
  --repo huggingface/huggingface.js \
  --title "[hub] sharded safetensors: 3 → 2 HTTP requests per shard (closes #1979)" \
  --body "$(cat FIX_ISSUE_1979_README.md)"
```

---

## Trade-offs considered

- **Why not fallback to `parseSingleFile` on non-206?** Because a server that
  returns 200 to a Range request is *streaming the whole file*. Falling back to
  WebBlob.slice() would re-issue Range — same outcome but with extra latency.
  Failing loudly is correct.
- **Why keep `parseSingleFile`?** xet single-file checkpoints rely on
  `XetBlob`'s reconstruction-URL logic that lives behind `fileDownloadInfo`.
  Touching that is out of scope and risky.
- **Why not also try to dedupe `fileExists` + index download?** Different issue
  (#1721 / #1704 area, already MERGED via #2134). Out of scope here.
