### PR TITLE
Accept null score in hf-inference image-segmentation response

### DIFF
--- a/packages/inference/src/providers/hf-inference.ts
+++ b/packages/inference/src/providers/hf-inference.ts
@@ -393,10 +393,15 @@ export class HFInferenceImageSegmentationTask extends HFInferenceTask implements
 				(x) =>
 					typeof x.label === "string" &&
 					typeof x.mask === "string" &&
-					(x.score === undefined || typeof x.score === "number"),
+					(x.score === undefined || x.score === null || typeof x.score === "number"),
 			)
 		) {
-			return response;
+			// Coerce `null` scores (returned by some HF models, e.g. face-parsing)
+			// to `undefined` so the result matches the declared
+			// `ImageSegmentationOutputElement` type (`score?: number`). Without
+			// this, downstream consumers using `if (segment.score !== undefined)`
+			// would treat `null` as a valid number and crash on numeric ops.
+			return response.map((x) => (x.score === null ? { ...x, score: undefined } : x));
 		}
 		throw new InferenceClientProviderOutputError(
 			"Received malformed response from HF-Inference image-segmentation API: expected Array<{label: string, mask: string, score: number}>",


### PR DESCRIPTION
Closes #1430.

### What

Loosens the `HFInferenceImageSegmentationTask.getResponse` type guard to accept `score === null` in addition to `undefined` and `number`.

### Why

The image-segmentation output schema in `packages/tasks/src/tasks/image-segmentation/inference.ts` declares `score` as optional:

```ts
score?: number;
```

…but the runtime validator in `packages/inference/src/providers/hf-inference.ts` only accepted `undefined` or a `number`, rejecting `null` with:

```
API Implementation Error: TypeError: Invalid output: output must be of type
Array<{label:string; score:number; mask: string}>
```

Several HF-Inference models (e.g. [`jonathandinu/face-parsing`](https://huggingface.co/jonathandinu/face-parsing), the one in the original report) return `null` for `score` on per-segment masks. That's consistent with the optional schema field, but the strict type guard treats it as a malformed response.

### Diff

```diff
 (x) =>
     typeof x.label === "string" &&
     typeof x.mask === "string" &&
-    (x.score === undefined || typeof x.score === "number"),
+    (x.score === undefined || x.score === null || typeof x.score === "number"),
```

### Out of scope

- Tightening `inference.ts` to make `score` explicitly nullable — leaving the schema as-is to avoid breaking anyone reading it.
- Other tasks: this is the only validator in `hf-inference.ts` whose schema declares `score` as optional, so the same `null`-acceptance change isn't symmetric across the file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-task response normalization in the HF-Inference provider with no auth, persistence, or API surface changes.
> 
> **Overview**
> Fixes **HF-Inference image-segmentation** responses that were rejected when models return **`score: null`** (e.g. `jonathandinu/face-parsing`), which previously triggered a malformed-output error despite optional `score` in the task schema.
> 
> `HFInferenceImageSegmentationTask.getResponse` now accepts `null` in its guard and **normalizes `null` scores to `undefined`** so returned data matches `score?: number` and callers using `score !== undefined` behave correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad3b9cab76c017e5e4859fe5251e7a2b81449660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->