### PR TITLE
[Tasks] udpate codeowner for eval.ts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,7 @@
 # Ownership for the Tasks Package
 
 /packages/tasks/ @SBrandeis @gary149 @Wauplin @julien-c @pcuenca @ngxson
+/packages/tasks/src/eval.ts @krampstudio @NathanHB @gary149 @julien-c @pcuenca
 
 # Ownership for the Hub Package
 


### PR DESCRIPTION
Adding @NathanHB and me as codeowners. So @NathanHB, whenever you approve a pr on that file, I can merge & release it. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only governance change with no runtime or security impact.
> 
> **Overview**
> Adds a **file-specific CODEOWNERS** entry for `packages/tasks/src/eval.ts`, assigning **@krampstudio**, **@NathanHB**, **@gary149**, **@julien-c**, and **@pcuenca** as required reviewers for that path (in addition to the broader `/packages/tasks/` owners).
> 
> No application or library code changes—only GitHub review routing for the tasks package eval framework registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f969a0f9d8a7d470d3bce56cc78db873440bb90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->