### PR TITLE
update longcat-video-avatar-1.5 to model libraries

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -808,6 +808,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"liveportrait/landmark.onnx"`,
 	},
+	"longcat-video-avatar-1.5": {
+		prettyLabel: "LongCat-Video-Avatar-1.5",
+		repoName: "LongCat-Video-Avatar-1.5",
+		repoUrl: "https://github.com/meituan-longcat/LongCat-Video",
+		filter: false,
+		countDownloads: `path_extension:"safetensors" OR path:"config.json"`,
+	},
 	"llama-cpp-python": {
 		prettyLabel: "llama-cpp-python",
 		repoName: "llama-cpp-python",


### PR DESCRIPTION
update longcat-video-avatar-1.5 to model libraries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry entry with no runtime or security-sensitive logic changes.
> 
> **Overview**
> Registers **LongCat-Video-Avatar-1.5** as a Hub modeling library in `MODEL_LIBRARIES_UI_ELEMENTS`, keyed by `longcat-video-avatar-1.5` (matching `library_name` on models).
> 
> The entry points to the [LongCat-Video](https://github.com/meituan-longcat/LongCat-Video) repo, keeps the library off the main models filter (`filter: false`), and defines download counting via `.safetensors` files or `config.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac18cb1b5ca3657b6bee1267e3eb54f56801efae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->