### PR TITLE
Add wbench eval framework

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -119,4 +119,10 @@ export const EVALUATION_FRAMEWORKS = {
 			"WildClawBench is an in-the-wild benchmark for evaluating AI agents in the OpenClaw environment across 60 hand-built, end-to-end tasks spanning productivity, code intelligence, social interaction, search, creative synthesis, and safety domains.",
 		url: "https://github.com/InternLM/WildClawBench",
 	},
+	wbench: {
+		name: "wbench",
+		description:
+			"WBench is a comprehensive multi-turn benchmark for interactive video world model evaluation, assessing models across 5 dimensions (video quality, setting adherence, interaction adherence, consistency, physics compliance) and 22 metrics over 289 multi-turn interaction cases.",
+		url: "https://github.com/meituan-longcat/WBench",
+	},
 } as const;


### PR DESCRIPTION
## Summary

Adds `wbench` to the supported evaluation frameworks for benchmark dataset `eval.yaml` files.

WBench is a comprehensive multi-turn benchmark for interactive video world model evaluation, assessing models across 5 dimensions (video quality, setting adherence, interaction adherence, consistency, physics compliance) and 22 metrics over 289 multi-turn interaction cases.

Dataset prepared for the Hub Evaluation Results feature:
https://huggingface.co/datasets/meituan-longcat/WBench

The dataset repo already includes an `eval.yaml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only metadata change with no runtime logic, auth, or data path changes.
> 
> **Overview**
> Registers **`wbench`** in `EVALUATION_FRAMEWORKS` (`packages/tasks/src/eval.ts`) so benchmark datasets can declare it in `eval.yaml` and surface correctly on Hub Evaluation Results.
> 
> The new entry includes display name, a short description of WBench (multi-turn interactive video world model evaluation), and a link to the upstream repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f6c1cabccec5ac239c875b736872832b89e583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->