### PR TITLE
gguf: fix GGML_PAD integer overflow via crafted general.alignment (CWE-190)

### DIFF
--- a/packages/gguf/src/gguf.ts
+++ b/packages/gguf/src/gguf.ts
@@ -40,6 +40,7 @@ const MAX_STRING_LENGTH = 10_000_000; // 10MB per string (CWE-770)
 const MAX_TENSOR_NDIMS = 8; // GGML supports up to 4, be generous (CWE-770)
 const MAX_ARRAY_RECURSION_DEPTH = 4; // nested ARRAY-of-ARRAY depth limit (CWE-674)
 const MAX_CHUNK_FETCHES_PER_VALUE = 30; // prevent infinite fetch loop (CWE-835)
+const MAX_ALIGNMENT = 1 << 30; // 2^30 — largest power-of-2 safe for JS bitwise ops (CWE-190)
 const GGML_PAD = (x: number, n: number) => (x + n - 1) & ~(n - 1); // defined in ggml.h
 const PARALLEL_DOWNLOADS = 20;
 
@@ -505,6 +506,12 @@ export async function gguf(
 	if (alignment <= 0 || !Number.isInteger(alignment)) {
 		throw new Error(`general.alignment must be a positive integer, got ${rawAlignment}`);
 	}
+	if ((alignment & (alignment - 1)) !== 0) {
+		throw new Error(`general.alignment must be a power of 2, got ${rawAlignment}`);
+	}
+	if (alignment > MAX_ALIGNMENT) {
+		throw new Error(`general.alignment ${rawAlignment} exceeds maximum safe value (${MAX_ALIGNMENT}) for JS bitwise operations`);
+	}
 	const tensorInfoEndBeforePadOffset = offset;
 	const tensorDataOffset = BigInt(GGML_PAD(offset, alignment));
 
@@ -654,6 +661,9 @@ export function serializeGgufMetadata(
 ): Uint8Array {
 	const littleEndian = options.littleEndian ?? true;
 	const alignment = options.alignment ?? GGUF_DEFAULT_ALIGNMENT;
+	if (alignment <= 0 || !Number.isInteger(alignment) || (alignment & (alignment - 1)) !== 0 || alignment > MAX_ALIGNMENT) {
+		throw new Error(`alignment must be a power of 2 in [1, ${MAX_ALIGNMENT}], got ${alignment}`);
+	}
 	const version = typedMetadata.version.value;
 
 	// Start with GGUF magic number: "GGUF"
@@ -762,6 +772,9 @@ export async function buildGgufHeader(
 	},
 ): Promise<Blob> {
 	const alignment = options.alignment ?? GGUF_DEFAULT_ALIGNMENT;
+	if (alignment <= 0 || !Number.isInteger(alignment) || (alignment & (alignment - 1)) !== 0 || alignment > MAX_ALIGNMENT) {
+		throw new Error(`alignment must be a power of 2 in [1, ${MAX_ALIGNMENT}], got ${alignment}`);
+	}
 	const version = updatedMetadata.version.value;
 
 	// Serialize the new metadata


### PR DESCRIPTION
## Summary

Fixes an integer overflow in `GGML_PAD` that can be triggered by a crafted GGUF file with `general.alignment >= 2^31`, bypassing the validation added in #2028.

### Root Cause

JavaScript bitwise operators (`&`, `~`) truncate operands to **32-bit signed integers**. When `alignment >= 2^31`:

```js
const GGML_PAD = (x, n) => (x + n - 1) & ~(n - 1);

GGML_PAD(1000, 2**31)   // → -2147483648  (should be 2147483648)
GGML_PAD(1000, 2**32-1) // → 0            (should be 4294967295)
```

A malicious GGUF with `general.alignment = 2147483648` (UINT32) passes all existing validation (positive, integer, within safe integer range) but produces a **negative `tensorDataOffset`**.

### Impact

| Entry point | Behavior |
|---|---|
| `gguf()` parser (line 509) | `tensorDataOffset` = negative BigInt → corrupted tensor data offset |
| `serializeGgufMetadata()` (line 710) | `new Uint8Array(negative)` → `RangeError` (DoS) |
| `buildGgufHeader()` (line 801) | Negative `padLen` → corrupted header or `RangeError` |

### Fix

- Add **power-of-2 validation** — matching llama.cpp's `gguf.cpp` [line 612](https://github.com/ggml-org/llama.cpp/blob/master/ggml/src/gguf.cpp#L612): `(alignment & (alignment - 1)) !== 0`
- Add **upper bound** `MAX_ALIGNMENT = 2^30` — the largest power-of-2 safe for JS bitwise operations
- Validate in all three entry points: `gguf()`, `serializeGgufMetadata()`, `buildGgufHeader()`

### Reproduction

```js
// Create minimal GGUF v3 with general.alignment = 2^31
const buf = new ArrayBuffer(64);
const view = new DataView(buf);
// ... magic "GGUF", version 3, 0 tensors, 1 KV entry ...
// KV: key="general.alignment", type=UINT32, value=2147483648

// Parse → tensorDataOffset will be -2147483648n (NEGATIVE)
```

### CWE

- **CWE-190**: Integer Overflow or Wraparound

## Test plan

- [x] Verify alignment = 32, 64, 1, 2^20, 2^30 are accepted
- [x] Verify alignment = 2^31, 2^32-1, 0, -1, 3, 33 are rejected
- [ ] Run existing test suite (`pnpm run test` in `packages/gguf`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets malicious/crafted GGUF input and header rebuild paths; behavior change rejects some alignment values that previously passed basic integer checks.
> 
> **Overview**
> Hardens **GGUF alignment** handling so crafted `general.alignment` values cannot break `GGML_PAD` via JavaScript’s 32-bit bitwise truncation (CWE-190).
> 
> Introduces **`MAX_ALIGNMENT` (2³⁰)** and rejects alignments that are not **powers of two** or exceed that cap. The same rules apply when parsing metadata in **`gguf()`** and when **`alignment`** is passed into **`serializeGgufMetadata()`** and **`buildGgufHeader()`**, closing paths that previously yielded negative `tensorDataOffset`, invalid buffer sizes, or corrupted headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e828ae6221abc4fbfb930824ac572972c5e6b9b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->