### PR TITLE
Default Orpheus TTS voice to tara on Together provider

### DIFF
--- a/packages/inference/src/providers/together.ts
+++ b/packages/inference/src/providers/together.ts
@@ -531,10 +531,14 @@ export class TogetherTextToSpeechTask extends TaskProviderHelper implements Text
 	preparePayload(params: BodyParams): Record<string, unknown> {
 		const userParams = (params.args.parameters as Record<string, unknown> | undefined) ?? {};
 		// Together's /v1/audio/speech requires a `voice` field. Voices are model-specific
-		// (Kokoro accepts `af_*`, Orpheus uses different names, etc.), so we only default
-		// when the target model is Kokoro — the only TTS model currently registered.
-		const isKokoro = params.model.toLowerCase().includes("kokoro");
-		const voice = userParams.voice ?? (isKokoro ? "af_alloy" : undefined);
+		// (Kokoro accepts `af_*`, Orpheus uses different names, etc.), so we default per model.
+		const model = params.model.toLowerCase();
+		const defaultVoice = model.includes("kokoro")
+			? "af_alloy"
+			: model.includes("orpheus")
+				? "tara"
+				: undefined;
+		const voice = userParams.voice ?? defaultVoice;
 
 		return {
 			...omit(params.args, ["inputs", "parameters"]),


### PR DESCRIPTION
## Summary
- Default the Together text-to-speech voice to `tara` when the model id contains `orpheus` (e.g. `canopylabs/orpheus-3b-0.1-ft`).
- Keeps the existing Kokoro default (`af_alloy`) and only applies defaults when no `parameters.voice` is provided.

## Test plan
- [ ] Call `textToSpeech` with `provider: "together"` and `model: "canopylabs/orpheus-3b-0.1-ft"` without a `voice` parameter and confirm audio is generated.
- [ ] Confirm an explicit `parameters.voice` still overrides the default.
- [ ] Confirm Kokoro models still default to `af_alloy`.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small provider payload tweak for optional voice defaults; no auth, data, or API surface changes beyond TTS request shaping.
> 
> **Overview**
> Together **text-to-speech** now picks a default `voice` when callers omit `parameters.voice`: Kokoro models still get **`af_alloy`**, and model ids containing **`orpheus`** get **`tara`**. Other models still send no default voice unless the user sets one.
> 
> Explicit **`parameters.voice`** continues to override these defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 953e979d22b09701dcb7992b1dd71a2f4d74965a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->