### PR TITLE
feat: add LiteRT-LM code snippet support

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1081,7 +1081,7 @@ pip install litert-lm
 litert-lm run \\
   --from-huggingface-repo=${model.id} \\
   model.litertlm \\
-  --prompt="Write me a poem"`
+  --prompt="Write me a poem"`,
 ];
 
 export const tf_keras = (model: ModelData): string[] => [

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1066,6 +1066,26 @@ python -m lerobot.record \\
 	return [];
 };
 
+export const litert_lm = (model: ModelData): string[] => [
+	`# LiteRT-LM runs on various platforms (Android, iOS, Windows, Linux, macOS, IoT, Web/WASM)
+# and supports many APIs (C++, Python, Kotlin, Swift, JavaScript, Flutter).
+# For platform-specific integration guides, please refer to the official developer website:
+# https://ai.google.dev/edge/litert-lm
+
+# To try LiteRT-LM, the easiest way is to use our CLI tool.
+# 1. Install the LiteRT-LM CLI tool via pip:
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade litert-lm
+
+# 2. Download and run this model locally:
+# See: https://ai.google.dev/edge/litert-lm/cli
+litert-lm run \\
+  --from-huggingface-repo=${model.id} \\
+  model.litertlm \\
+  --prompt="Write me a poem"`
+];
+
 export const tf_keras = (model: ModelData): string[] => [
 	`# Note: 'keras<3.x' or 'tf_keras' must be installed (legacy)
 # See https://github.com/keras-team/tf-keras for more details.

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1073,10 +1073,8 @@ export const litert_lm = (model: ModelData): string[] => [
 # https://ai.google.dev/edge/litert-lm
 
 # To try LiteRT-LM, the easiest way is to use our CLI tool.
-# 1. Install the LiteRT-LM CLI tool via pip:
-python3 -m venv .venv
-source .venv/bin/activate
-pip install --upgrade litert-lm
+# 1. Install the LiteRT-LM CLI tool:
+pip install litert-lm
 
 # 2. Download and run this model locally:
 # See: https://ai.google.dev/edge/litert-lm/cli

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -783,6 +783,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "LiteRT-LM",
 		repoName: "LiteRT-LM",
 		repoUrl: "https://github.com/google-ai-edge/LiteRT-LM",
+		snippets: snippets.litert_lm,
 		filter: false,
 		countDownloads: `path_extension:"litertlm" OR path_extension:"task"`,
 	},


### PR DESCRIPTION
This PR adds code snippet support for the litert-lm library tag, providing developers with our official CLI instructions and developer guide link.

To make sure this PR is legit, I'm sharing the following blogposts (which I'm one of the authors, Yu-Hui Chen) to prove that I'm the main developer for Google's LiteRT-LM project. 

https://developers.googleblog.com/on-device-genai-in-chrome-chromebook-plus-and-pixel-watch-with-litert-lm/
https://developers.googleblog.com/blazing-fast-on-device-genai-with-litert-lm/

Thanks!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI change in tasks package; no runtime auth, data, or inference logic.
> 
> **Overview**
> Models tagged with **`litert-lm`** now show a **Use this model** code block on the Hub.
> 
> The new snippet points developers to Google’s LiteRT-LM docs and shows **`pip install litert-lm`** plus a **`litert-lm run --from-huggingface-repo=…`** example that uses the current repo id and a sample prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd4fdeafb02422359e78b406a3e3a86ff95d138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->