### PR TITLE
Add Pier evaluation framework for DeepSWE

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -33,6 +33,12 @@ export const EVALUATION_FRAMEWORKS = {
 		description: "Harbor is a framework for evaluating and optimizing agents and language models.",
 		url: "https://github.com/laude-institute/harbor",
 	},
+	pier: {
+		name: "pier",
+		description:
+			"Pier is a Harbor fork built for DeepSWE, with stronger support for CLI agents in no-internet tasks and more faithful, consistent agent trajectories.",
+		url: "https://github.com/datacurve-ai/pier",
+	},
 	archipelago: {
 		name: "archipelago",
 		description: "Archipelago is a system for running and evaluating AI agents against MCP applications.",


### PR DESCRIPTION
## Summary

Adds `pier` to the supported `eval.yaml` evaluation framework identifiers.

Pier is a Harbor fork built for DeepSWE, with stronger support for CLI agents in no-internet tasks and more faithful, consistent agent trajectories.

## Context

DeepSWE has been prepared for the Hub Evaluation Results feature on Hugging Face:
https://huggingface.co/datasets/datacurve/deep-swe

The dataset repo includes an `eval.yaml`:
https://huggingface.co/datasets/datacurve/deep-swe/blob/main/eval.yaml

DeepSWE currently uses the existing `harbor` framework identifier while this PR adds `pier` as the canonical identifier for Pier-backed benchmark datasets.

## Validation

- `pnpm exec eslint --ext .ts packages/tasks/src/eval.ts`
