### PR TITLE
add LeRobot library to the list

### DIFF
--- a/packages/tasks/src/dataset-libraries.ts
+++ b/packages/tasks/src/dataset-libraries.ts
@@ -95,6 +95,12 @@ export const DATASET_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/NVIDIA-NeMo/DataDesigner",
 		docsUrl: "https://nvidia-nemo.github.io/DataDesigner/",
 	},
+	lerobot: {
+		prettyLabel: "LeRobot",
+		repoName: "lerobot",
+		repoUrl: "https://github.com/huggingface/lerobot",
+		docsUrl: "https://huggingface.co/docs/lerobot/index",
+	},
 } satisfies Record<string, DatasetLibraryUiElement>;
 
 /// List of the dataset libraries supported by the Hub


### PR DESCRIPTION
LeRobot was added to the list so that it's displayed in the datasets libraries section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry entry for UI/metadata; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Adds **LeRobot** as a supported dataset library in `DATASET_LIBRARIES_UI_ELEMENTS` (`packages/tasks/src/dataset-libraries.ts`), with display label, GitHub repo link, and docs URL so it appears in the Hub datasets libraries section like the other integrations.
> 
> `DatasetLibraryKey` picks up the new `lerobot` key automatically via `keyof typeof`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac5ecea174cf85e3303c53c56c2c68db79c30d1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->