### PR TITLE
update: longcat-video-avatar-1.5 to model libraries

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -809,9 +809,9 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"liveportrait/landmark.onnx"`,
 	},
-	"longcat-video": {
-		prettyLabel: "LongCat-Video",
-		repoName: "LongCat-Video",
+	"longcat-video-avatar-1.5": {
+		prettyLabel: "LongCat-Video-Avatar 1.5",
+		repoName: "LongCat-Video-Avatar 1.5",
 		repoUrl: "https://github.com/meituan-longcat/LongCat-Video",
 		filter: false,
 	},

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -809,6 +809,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"liveportrait/landmark.onnx"`,
 	},
+	"longcat-video": {
+		prettyLabel: "LongCat-Video",
+		repoName: "LongCat-Video",
+		repoUrl: "https://github.com/meituan-longcat/LongCat-Video",
+		filter: false,
+	}
 	"llama-cpp-python": {
 		prettyLabel: "llama-cpp-python",
 		repoName: "llama-cpp-python",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -814,7 +814,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "LongCat-Video",
 		repoUrl: "https://github.com/meituan-longcat/LongCat-Video",
 		filter: false,
-	}
+	},
 	"llama-cpp-python": {
 		prettyLabel: "llama-cpp-python",
 		repoName: "llama-cpp-python",


### PR DESCRIPTION
update longcat-video-avatar-1.5 to model libraries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata entry in the model libraries map with no runtime or security-sensitive logic.
> 
> **Overview**
> Registers **LongCat-Video-Avatar 1.5** as a Hub modeling library under the tag `longcat-video-avatar-1.5` in `MODEL_LIBRARIES_UI_ELEMENTS`, with display label, repo metadata pointing at Meituan LongCat’s **LongCat-Video** GitHub repo, and `filter: false` so it won’t appear in the popular libraries filter on hf.co/models.
> 
> No download-count query, docs URL, or code snippets are added in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c26ee8a0bdad5d2dd3051ce3860f17282e6861c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->