### PR TITLE
Add nanofold benchmark details to eval.ts

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -131,4 +131,10 @@ export const EVALUATION_FRAMEWORKS = {
 			"WBench is a comprehensive multi-turn benchmark for interactive video world model evaluation, assessing models across 5 dimensions (video quality, setting adherence, interaction adherence, consistency, physics compliance) and 22 metrics over 289 multi-turn interaction cases.",
 		url: "https://github.com/meituan-longcat/WBench",
 	},
+	nanofold: {
+		name: "nanofold",
+		description:
+			"nanoFold is a data-efficiency benchmark for protein structure prediction. Its goal is to evaluate models on scenarios with scarce data.",
+		url: "https://github.com/meituan-longcat/WBench",
+	},
 } as const;

--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -135,6 +135,6 @@ export const EVALUATION_FRAMEWORKS = {
 		name: "nanofold",
 		description:
 			"nanoFold is a data-efficiency benchmark for protein structure prediction. Its goal is to evaluate models on scenarios with scarce data.",
-		url: "https://github.com/meituan-longcat/WBench",
+		url: "https://github.com/ChrisHayduk/nanoFold-Competition",
 	},
 } as const;


### PR DESCRIPTION
The objective is to include the [nanoFold dataset](https://huggingface.co/datasets/ChrisHayduk/nanofold-public) as a benchmark in the Hub. The dataset is part of the [nanoFold challenge](https://github.com/ChrisHayduk/nanoFold-Competition).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only registry entry with no runtime logic, auth, or data-path changes.
> 
> **Overview**
> Registers **nanoFold** as a supported evaluation framework in `EVALUATION_FRAMEWORKS` (`packages/tasks/src/eval.ts`), so benchmark datasets can reference it in `eval.yaml` on the Hub.
> 
> The new entry includes a short description (data-efficiency protein structure prediction under scarce data) and links to the [nanoFold-Competition](https://github.com/ChrisHayduk/nanoFold-Competition) repo, matching the pattern used for other frameworks like `wbench`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d57865f5fde787211160077805eba7f69f78d45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->