### PR TITLE
Add download stats filter for upcoming model release

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -838,6 +838,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/magenta/magenta-realtime",
 		countDownloads: `path:"checkpoints/llm_base_x4286_c1860k.tar" OR path:"checkpoints/llm_large_x3047_c1860k.tar" OR path:"checkpoints/llm_large_x3047_c1860k/checkpoint"`,
 	},
+	"magenta-realtime-2": {
+		prettyLabel: "Magenta RT 2",
+		repoName: "Magenta RT 2",
+		repoUrl: "https://github.com/magenta/magenta-realtime",
+		countDownloads: `path:"models/mrt2_base/mrt2_base.mlxfn" OR path:"models/mrt2_small/mrt2_small.mlxfn" OR path:"checkpoints/mrt2_base.safetensors" OR path:"checkpoints/mrt2_small.safetensors"`,
+	},
 	"mamba-ssm": {
 		prettyLabel: "MambaSSM",
 		repoName: "MambaSSM",


### PR DESCRIPTION
Repo contains checkpoints for 3 different pipeline components of the model. This download filter only counts downloads to the core LLM component (in either MLX or Safetensors format)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry entry in `model-libraries.ts` with no auth, billing, or runtime behavior changes.
> 
> **Overview**
> Registers **Magenta RT 2** as a Hub model library (`magenta-realtime-2`) so models tagged with that `library_name` get correct UI labels and repo links.
> 
> Adds a **custom download counter** that only counts pulls of the core LLM weights (`mrt2_base` / `mrt2_small` in `.mlxfn` or `.safetensors`), excluding other Magenta RT 2 pipeline artifacts in the same repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01917d470513a4b2a193d4cda1ebb24c956ce3e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->