### PR TITLE
Add MMMU-Pro eval framework

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,7 @@
 # Ownership for the Tasks Package
 
 /packages/tasks/ @SBrandeis @gary149 @Wauplin @julien-c @pcuenca @ngxson
+/packages/tasks/src/eval.ts @krampstudio @NathanHB @gary149 @julien-c @pcuenca
 
 # Ownership for the Hub Package
 

--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -119,4 +119,10 @@ export const EVALUATION_FRAMEWORKS = {
 			"WildClawBench is an in-the-wild benchmark for evaluating AI agents in the OpenClaw environment across 60 hand-built, end-to-end tasks spanning productivity, code intelligence, social interaction, search, creative synthesis, and safety domains.",
 		url: "https://github.com/InternLM/WildClawBench",
 	},
+	"mmmu-pro": {
+		name: "mmmu-pro",
+		description:
+			"MMMU-Pro is a rigorous benchmark for evaluating multimodal models on college-level questions across 30+ disciplines, extending MMMU with more challenging multi-image and vision-only tasks that demand expert-level reasoning.",
+		url: "https://mmmu-benchmark.github.io/",
+	},
 } as const;


### PR DESCRIPTION
## Summary

- Adds `mmmu-pro` to `EVALUATION_FRAMEWORKS` in `packages/tasks/src/eval.ts`
- MMMU-Pro is a rigorous multimodal benchmark for college-level reasoning across 30+ disciplines, extending the original MMMU with harder multi-image and vision-only tasks

## Test plan

- [ ] Verify `mmmu-pro` entry appears correctly in the eval framework list
- [ ] Check TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry and ownership metadata only; no evaluation or runtime behavior changes.
> 
> **Overview**
> Registers **MMMU-Pro** as a supported evaluation framework in `EVALUATION_FRAMEWORKS`, so benchmark datasets can reference it in `eval.yaml` with name, description, and project URL.
> 
> Also adds a **CODEOWNERS** rule for `packages/tasks/src/eval.ts` with dedicated reviewers alongside the existing tasks package owners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4439dc7d2fd4d21fed9fba2adf322866f4adb0f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->