### PR TITLE
Add mmmu-pro eval framework

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -137,4 +137,10 @@ export const EVALUATION_FRAMEWORKS = {
 			"nanoFold is a data-efficiency benchmark for protein structure prediction. Its goal is to evaluate models on scenarios with scarce data.",
 		url: "https://github.com/ChrisHayduk/nanoFold-Competition",
 	},
+	"mmmu-pro": {
+		name: "mmmu-pro",
+		description:
+			"MMMU-Pro is a rigorous benchmark for evaluating multimodal models on college-level questions across 30+ disciplines, extending MMMU with more challenging multi-image and vision-only tasks that demand expert-level reasoning.",
+		url: "https://mmmu-benchmark.github.io/",
+	},
 } as const;

--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -137,10 +137,10 @@ export const EVALUATION_FRAMEWORKS = {
 			"nanoFold is a data-efficiency benchmark for protein structure prediction. Its goal is to evaluate models on scenarios with scarce data.",
 		url: "https://github.com/ChrisHayduk/nanoFold-Competition",
 	},
-	"mmmu-pro": {
-		name: "mmmu-pro",
+	mmmu: {
+		name: "mmmu",
 		description:
-			"MMMU-Pro is a rigorous benchmark for evaluating multimodal models on college-level questions across 30+ disciplines, extending MMMU with more challenging multi-image and vision-only tasks that demand expert-level reasoning.",
+			"MMMU is a new benchmark designed to evaluate multimodal models on massive multi-discipline tasks demanding college-level subject knowledge and deliberate reasoning.",
 		url: "https://mmmu-benchmark.github.io/",
 	},
 } as const;


### PR DESCRIPTION
Used by https://huggingface.co/datasets/MMMU/MMMU_Pro

cc @merveenoyan 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry entry with no runtime or security impact.
> 
> **Overview**
> Registers **MMMU** as a supported evaluation framework in `EVALUATION_FRAMEWORKS`, so benchmark datasets can reference it in `eval.yaml` with name, description, and link to the MMMU benchmark site.
> 
> This aligns with MMMU/MMMU_Pro dataset usage on Hugging Face; the change is metadata-only in the tasks package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cbafe81fc7642546777c5bf2b0d4899cb327412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->