### PR TITLE
Fix safetensors parameter count for mixed-precision compressed-tensors models

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -4,6 +4,7 @@ import {
 	parseSafetensorsShardFilename,
 	globMatch,
 	isQuantizedTensor,
+	matchesCompressedTensorsTarget,
 } from "./parse-safetensors-metadata";
 import { sum } from "../utils/sum";
 
@@ -417,6 +418,46 @@ describe("parseSafetensorsMetadata", () => {
 			assert.strictEqual(isQuantizedTensor("model.lm_head.weight", config), false);
 			assert.strictEqual(isQuantizedTensor("model.embed_tokens.weight", config), false);
 			assert.strictEqual(isQuantizedTensor("model.layers.0.self_attn.q_proj.weight", config), true);
+		});
+	});
+
+	describe("matchesCompressedTensorsTarget", () => {
+		it("exact module name match", () => {
+			assert.strictEqual(
+				matchesCompressedTensorsTarget("model.language_model.embed_tokens", "model.language_model.embed_tokens"),
+				true,
+			);
+			assert.strictEqual(
+				matchesCompressedTensorsTarget(
+					"model.language_model.embed_tokens",
+					"model.language_model.embed_tokens_per_layer",
+				),
+				false,
+			);
+		});
+
+		it("class-name targets do not match module names", () => {
+			assert.strictEqual(matchesCompressedTensorsTarget("Linear", "model.layers.0.mlp.down_proj"), false);
+		});
+
+		it("re: targets with .* wildcard and $ anchor", () => {
+			assert.strictEqual(matchesCompressedTensorsTarget("re:.*lm_head$", "model.lm_head"), true);
+			assert.strictEqual(matchesCompressedTensorsTarget("re:.*lm_head$", "model.lm_head.weight"), false);
+			assert.strictEqual(matchesCompressedTensorsTarget("re:.*lm_head$", "lm_head"), true);
+		});
+
+		it("re: targets are anchored at the start, open-ended without $", () => {
+			assert.strictEqual(matchesCompressedTensorsTarget("re:model\\.layers.*", "model.layers.0.mlp.gate_proj"), true);
+			assert.strictEqual(matchesCompressedTensorsTarget("re:model\\.layers.*", "lm.model.layers.0"), false);
+			assert.strictEqual(matchesCompressedTensorsTarget("re:^model\\.layers.*", "model.layers.0"), true);
+		});
+
+		it("re: targets with unsupported regex syntax never match", () => {
+			assert.strictEqual(
+				matchesCompressedTensorsTarget("re:.*mlp\\.(gate|up)_proj.*", "model.layers.0.mlp.gate_proj"),
+				false,
+			);
+			assert.strictEqual(matchesCompressedTensorsTarget("re:(a+)+$", "aaaaaaaaaaaaaaaaaaaaab"), false);
 		});
 	});
 

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -377,7 +377,7 @@ export interface QuantizationConfig {
 	load_in_8bit?: boolean;
 	// compressed-tensors specific
 	format?: string;
-	config_groups?: Record<string, { weights?: { num_bits?: number } }>;
+	config_groups?: Record<string, { format?: string; targets?: string[]; weights?: { num_bits?: number } }>;
 }
 
 export interface ModelConfig {
@@ -441,6 +441,39 @@ export function isQuantizedTensor(tensorName: string, quantConfig?: Quantization
 }
 
 /**
+ * @internal
+ * Matches a module name against a compressed-tensors target.
+ *
+ * Targets are either exact module names, class names (e.g. `"Linear"`, which we
+ * cannot resolve from tensor names and therefore ignore), or Python regexes
+ * prefixed with `re:`. To avoid evaluating attacker-controlled RegExp from
+ * config.json (ReDoS, SyntaxError — see globMatch), we translate the common
+ * regex subset (`.*` wildcard, `^`/`$` anchors, `\.` escapes) to globMatch and
+ * treat targets using any other regex syntax as non-matching.
+ */
+export function matchesCompressedTensorsTarget(target: string, moduleName: string): boolean {
+	if (!target.startsWith("re:")) {
+		return target === moduleName;
+	}
+	let pattern = target.slice(3);
+	// Python's re.match anchors at the start; only `$` anchors the end.
+	if (pattern.startsWith("^")) {
+		pattern = pattern.slice(1);
+	}
+	if (pattern.endsWith("$")) {
+		pattern = pattern.slice(0, -1);
+	} else {
+		pattern += ".*";
+	}
+	const glob = pattern.replaceAll(".*", "*").replaceAll("\\.", ".");
+	if (/[\\+?()[\]{}|^$]/.test(glob)) {
+		// unsupported regex syntax — skip this target rather than risk a wrong match
+		return false;
+	}
+	return globMatch(glob, moduleName);
+}
+
+/**
  * Gets the parameter multiplier for a quantized tensor based on quantization method
  */
 function getQuantizationMultiplier(tensorName: string, dtype: Dtype, quantConfig?: QuantizationConfig): number {
@@ -472,10 +505,29 @@ function getQuantizationMultiplier(tensorName: string, dtype: Dtype, quantConfig
 			return 1;
 
 		case "compressed-tensors":
-			if (quantConfig.format === "pack-quantized" && dtype === "I32") {
-				const numBits =
-					Object.values(quantConfig.config_groups ?? {}).find((g) => g.weights?.num_bits)?.weights?.num_bits ?? 4;
-				return Math.floor(32 / numBits);
+			if (dtype === "I32") {
+				const groups = Object.values(quantConfig.config_groups ?? {});
+				// Mixed-precision models pack different modules at different bit widths
+				// (one config group per width), so resolve the group whose targets
+				// match this tensor's module name (e.g. "model.lm_head.weight_packed"
+				// -> "model.lm_head") instead of assuming a single global num_bits.
+				const suffixIndex = tensorName.lastIndexOf(".weight");
+				const moduleName = suffixIndex === -1 ? tensorName : tensorName.slice(0, suffixIndex);
+				const group = groups.find((g) =>
+					g.targets?.some((target) => matchesCompressedTensorsTarget(target, moduleName)),
+				);
+				if (group) {
+					if ((group.format ?? quantConfig.format) !== "pack-quantized") {
+						return 1;
+					}
+					const numBits = group.weights?.num_bits ?? 4;
+					return Math.max(1, Math.floor(32 / numBits));
+				}
+				// fallback when no group targets match: first group's num_bits
+				if (quantConfig.format === "pack-quantized") {
+					const numBits = groups.find((g) => g.weights?.num_bits)?.weights?.num_bits ?? 4;
+					return Math.max(1, Math.floor(32 / numBits));
+				}
 			}
 			return 1;
 


### PR DESCRIPTION
## Description

For `compressed-tensors` models with multiple `config_groups` at different bit widths, the pack-quantized multiplier used the **first** group's `num_bits` for **every** packed `I32` tensor — e.g. a model with 2-bit embeddings and 4-bit layers got all tensors unpacked at ×16 instead of ×8, inflating the parameter count (~5.5B shown as 9B in one real case).

### Fix

- Match each packed tensor's module name (`X.weight_packed` → `X`) against group `targets` and use that group's `num_bits`/`format`.
- New `matchesCompressedTensorsTarget` helper: exact names + `re:` regex targets, translated to the ReDoS-safe `globMatch` instead of evaluating `RegExp` from attacker-controlled `config.json`.
- No matching targets (e.g. class names like `["Linear"]`, the common single-group case) → previous behavior, so existing models are unaffected.

Verified byte-exactly against ground truth from the model's `weight_shape` tensors. Unit tests added for the matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how displayed parameter totals are computed for compressed-tensors models; logic is localized to hub metadata parsing with a safe fallback path.
> 
> **Overview**
> Fixes **inflated parameter counts** for `compressed-tensors` models that use **multiple `config_groups`** at different bit widths. Packed `I32` tensors were all unpacked with the **first** group's `num_bits`, so mixed setups (e.g. 2-bit embeddings vs 4-bit layers) could roughly double the reported total.
> 
> The hub now derives each tensor's module name from its safetensors key, finds the `config_group` whose **`targets`** match via new **`matchesCompressedTensorsTarget`** (exact names and a safe subset of `re:` patterns mapped to **`globMatch`**, not `RegExp` on `config.json`), and applies that group's **`format`** / **`num_bits`** for the pack-quantized multiplier. **`QuantizationConfig`** typing adds per-group **`targets`** and **`format`**. When no target matches, behavior stays the same as before (global `pack-quantized` + first `num_bits`). Unit tests cover the matcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b352b2a63cbf114bd53c3fce45d9797cf3708bd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->