### PR TITLE
ci: bump doc-builder workflow pins

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3 # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@b0f9a6e3b6aa912656cbda9f74896eb721d29421 # main
     with:
       commit_sha: ${{ github.sha }}
       package: huggingface.js

--- a/.github/workflows/pr-documentation.yml
+++ b/.github/workflows/pr-documentation.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3 # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@b0f9a6e3b6aa912656cbda9f74896eb721d29421 # main
     with:
       commit_sha: ${{ github.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/upload-pr-documentation.yml
+++ b/.github/workflows/upload-pr-documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6 # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@b0f9a6e3b6aa912656cbda9f74896eb721d29421 # main
     with:
       package_name: huggingface.js
     secrets:


### PR DESCRIPTION
## Context

Same issue as huggingface/hf-endpoints-documentation#166 (flagged by @coyotte508 in the Slack thread about the Inference Endpoints docs not updating): the doc workflows are pinned to outdated `doc-builder` commits, so doc builds can report success without actually updating the published documentation.

## Changes

- `documentation.yml`: bump `build_main_documentation.yml` pin from `90b4ee2c` to `b0f9a6e3b6aa912656cbda9f74896eb721d29421` (doc-builder main as of May 19)
- `pr-documentation.yml`: same bump for `build_pr_documentation.yml`
- `upload-pr-documentation.yml`: bump `upload_pr_documentation.yml` pin from `9ad2de85` to the same commit

## Verification

- `b0f9a6e3` exists on doc-builder `main` (commit "update (#788)", 2026-05-19); same pin already merged and verified working in hf-endpoints-documentation#166 (docs rebuilt and published on merge)
- The `paths` filter of `documentation.yml` includes the workflow file itself, so merging this PR triggers a doc rebuild directly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow pin updates with no application or runtime code changes; main risk is doc pipeline behavior if the new doc-builder commit regresses builds.
> 
> **Overview**
> Updates **pinned `huggingface/doc-builder` reusable workflow commits** so documentation CI actually publishes fresh docs instead of succeeding on stale workflow logic (same class of fix as hf-endpoints-documentation#166).
> 
> `documentation.yml` and `pr-documentation.yml` move **`build_main_documentation.yml` / `build_pr_documentation.yml`** from `90b4ee2c` to **`b0f9a6e3b6aa912656cbda9f74896eb721d29421`**. `upload-pr-documentation.yml` bumps **`upload_pr_documentation.yml`** from `9ad2de85` to that same commit, aligning all three doc pipelines on one doc-builder revision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaf584f1ee3a889f98404436ee307d65bcfc769f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->