### PR TITLE
fix(e2e): replace unavailable Llama-3.2-1B-Instruct with Qwen2.5-7B-Instruct

### DIFF
--- a/e2e/deno/index.ts
+++ b/e2e/deno/index.ts
@@ -16,7 +16,7 @@ if (token) {
 	console.log(tokenInfo);
 
 	const result = await hf.chatCompletion({
-		model: "meta-llama/Llama-3.2-1B-Instruct",
+		model: "Qwen/Qwen2.5-7B-Instruct",
 		messages: [{ role: "user", content: "Can you summarize the Eiffel Tower?" }],
 		max_tokens: 10,
 	});

--- a/e2e/svelte/src/routes/+page.svelte
+++ b/e2e/svelte/src/routes/+page.svelte
@@ -13,7 +13,7 @@
 		}
 
 		const result = await hf.chatCompletion({
-			model: "meta-llama/Llama-3.2-1B-Instruct",
+			model: "Qwen/Qwen2.5-7B-Instruct",
 			messages: [{ role: "user", content: "Can you summarize the Eiffel Tower?" }],
 			max_tokens: 10,
 		});

--- a/e2e/ts/src/index.ts
+++ b/e2e/ts/src/index.ts
@@ -11,7 +11,7 @@ const hf = new InferenceClient(hfToken);
 
 	if (hfToken) {
 		const result = await hf.chatCompletion({
-			model: "meta-llama/Llama-3.2-1B-Instruct",
+			model: "Qwen/Qwen2.5-7B-Instruct",
 			messages: [{ role: "user", content: "Can you summarize the Eiffel Tower?" }],
 			max_tokens: 10,
 		});


### PR DESCRIPTION
## Context

The e2e job fails on every push to `main` since 2026-06-05 ~11:20 UTC (e.g. the `@huggingface/hub 2.13.1` release run): the inference router no longer serves `meta-llama/Llama-3.2-1B-Instruct` and returns `400 model_not_supported`.

## Changes

Switch the chatCompletion smoke tests in `e2e/ts`, `e2e/deno` and `e2e/svelte` to `Qwen/Qwen2.5-7B-Instruct`, currently served by the router (verified via `GET /v1/models`).

Unblocks CI for unrelated PRs such as #2216.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only model id changes with no production or library behavior impact.
> 
> **Overview**
> **Fixes failing e2e CI** by swapping the `chatCompletion` smoke-test model from `meta-llama/Llama-3.2-1B-Instruct` (router returns `400 model_not_supported`) to **`Qwen/Qwen2.5-7B-Instruct`** in `e2e/ts`, `e2e/deno`, and `e2e/svelte`. Prompt and `max_tokens` are unchanged; only the model id updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a49e3eb9358686947ad60fe3daa70d49a640d17a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->