### PR TITLE
Add Intel Core Ultra 7 255HX to CPU hardware spec sheet

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -197,6 +197,12 @@ export const SKUS = {
 				power: 160,
 				releaseYear: 2025,
 			},
+			"Intel Core Ultra 7 255HX": {
+				tflops: 1.62,
+				msrp: 583,
+				power: 160,
+				releaseYear: 2025,
+			},
 			"Intel Core Ultra 7 265KF": {
 				tflops: 1.53,
 				msrp: 400,


### PR DESCRIPTION
## Summary

- Adds the **Intel Core Ultra 7 255HX** (Arrow Lake HX, 2025 -> from Lenovo Legion 5i Laptop) to the `SKUS.CPU.Intel` table in `hardware.ts`
- Closes #2214

## Spec values used

| Field | Value | Source / Rationale |
|---|---|---|
| `tflops` | 1.62 | FP32 estimate using cpu-monkey methodology, scaled proportionally from the existing Ultra 9 275HX (1.89 TFLOPS). Both chips share 8 P-cores; the 255HX has 12 E-cores vs 16 on the 275HX, and slightly lower turbo frequencies (5.2 GHz vs 5.4 GHz P-core, 4.5 GHz vs 4.6 GHz E-core). |
| `msrp` | 583 | Intel OEM 1000-unit tray price estimate. The 275HX is ~$700; the 255HX sits one tier below in the Arrow Lake HX stack. |
| `power` | 160 | Maximum Turbo Power (MTP / PL2) per Intel ARK and Notebookcheck — same as the 275HX. |
| `releaseYear` | 2025 | Launched January 13, 2025. |

## CPU details

- Architecture: Arrow Lake HX (Intel 3 nm + TSMC tiles)
- Cores: 8 P-cores (Lion Cove) + 12 E-cores (Skymont) = 20 cores / 20 threads
- Max turbo: 5.2 GHz (P), 4.5 GHz (E)
- Base TDP: 55 W; MTP: 160 W
- Socket: FCBGA2114 (mobile, e.g. Lenovo Legion 5i)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single static data entry in a hardware lookup table with no runtime logic changes.
> 
> **Overview**
> Adds **Intel Core Ultra 7 255HX** (Arrow Lake HX, 2025) to `SKUS.CPU.Intel` in `hardware.ts`, placed between the existing Ultra 9 275HX and Ultra 7 265KF entries.
> 
> The new `HardwareSpec` uses **1.62** FP32 TFLOPS (scaled from the 275HX), **$583** MSRP, **160 W** MTP (same as 275HX), and **releaseYear 2025**, so tasks that reference this SKU table can recognize the chip for compute/regulatory estimates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3d89f147b9b3a547620398b62b31bfc58014f13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->