### PR TITLE
Add PocketPal local app

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -227,6 +227,22 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		expect(deeplink(model).href).toBe("atomic-chat://models/huggingface/bartowski/Llama-3.2-3B-Instruct-GGUF");
 	});
 
+	it("pocketpal deeplink", async () => {
+		const { displayOnModelPage, deeplink } = LOCAL_APPS.pocketpal;
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			gguf: { total: 1, context_length: 4096 },
+			inference: "",
+		};
+
+		expect(displayOnModelPage(model)).toBe(true);
+		expect(deeplink(model).href).toBe("pocketpal://hub/run?repo_id=bartowski/Llama-3.2-3B-Instruct-GGUF&source=hf");
+		expect(deeplink(model, "Llama-3.2-3B-Instruct-Q4_K_M.gguf").href).toBe(
+			"pocketpal://hub/run?repo_id=bartowski/Llama-3.2-3B-Instruct-GGUF&filename=Llama-3.2-3B-Instruct-Q4_K_M.gguf&source=hf",
+		);
+	});
+
 	it("unsloth tagged model", async () => {
 		const { displayOnModelPage, snippet: snippetFunc } = LOCAL_APPS.unsloth;
 		const model: ModelData = {

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -672,6 +672,14 @@ export const LOCAL_APPS = {
 		displayOnModelPage: isLlamaCppGgufModel,
 		deeplink: (model) => new URL(`jan://models/huggingface/${model.id}`),
 	},
+	pocketpal: {
+		prettyLabel: "PocketPal",
+		docsUrl: "https://github.com/a-ghorbani/pocketpal-ai",
+		mainTask: "text-generation",
+		displayOnModelPage: isLlamaCppGgufModel,
+		deeplink: (model, filepath?) =>
+			new URL(`pocketpal://hub/run?repo_id=${model.id}${filepath ? `&filename=${filepath}` : ""}&source=hf`),
+	},
 	"atomic-chat": {
 		prettyLabel: "Atomic Chat",
 		docsUrl: "https://atomic.chat",


### PR DESCRIPTION
This adds [PocketPal](https://github.com/a-ghorbani/pocketpal-ai) to the local-apps registry so a **Use this model ▸ PocketPal** entry shows up on GGUF model pages.

### App-side support is already shipped

The `pocketpal://hub/run` handler is merged in the app: a-ghorbani/pocketpal-ai#761. So this button works as soon as it lands.

### Tests

Added a `pocketpal deeplink` case in `local-apps.spec.ts` (with and without `filepath`). `pnpm build`, `pnpm vitest run src/local-apps.spec.ts` (17/17), `lint:check` and `format:check` all pass.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive registry and test change; no auth, data, or core inference paths touched.
> 
> **Overview**
> Adds **PocketPal** to the `LOCAL_APPS` registry in `packages/tasks/src/local-apps.ts`, so GGUF model pages can show **Use this model ▸ PocketPal** alongside other local apps.
> 
> The entry uses the same visibility rule as Jan and Atomic Chat (`isLlamaCppGgufModel`) and builds `pocketpal://hub/run` deeplinks with `repo_id`, optional `filename` when a GGUF file is selected, and `source=hf`. A matching **`pocketpal deeplink`** test in `local-apps.spec.ts` asserts both repo-only and file-specific URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc997cee9f94a6a0c6202b0ddda9b72fb7c9ccb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
