### PR TITLE
Add more agent harnesses to the registry

### DIFF
--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -104,20 +104,6 @@ export const AGENT_HARNESSES = {
 		// `CrushEnvMarkers()` unconditionally sets `CRUSH=1` (plus `AGENT=crush`/`AI_AGENT=crush`) on every spawned shell.
 		envVars: { CRUSH: "*" },
 	},
-	"cursor-cli": {
-		// must stay before `cursor` so the more specific signal takes priority: when the CLI runs inside
-		// the Cursor editor's terminal, child processes inherit `CURSOR_TRACE_ID` and the CLI sets `CURSOR_AGENT`.
-		prettyLabel: "Cursor CLI",
-		docsUrl: "https://cursor.com/docs/cli/overview",
-		description: "Cursor's coding agent for the command line.",
-		envVars: { CURSOR_AGENT: "*" },
-	},
-	cursor: {
-		prettyLabel: "Cursor",
-		docsUrl: "https://cursor.com",
-		description: "AI-powered code editor.",
-		envVars: { CURSOR_TRACE_ID: "*" },
-	},
 	"gemini-cli": {
 		prettyLabel: "Gemini CLI",
 		repoUrl: "https://github.com/google-gemini/gemini-cli",
@@ -202,6 +188,21 @@ export const AGENT_HARNESSES = {
 		description: "High-performance code editor with an integrated AI agent panel and terminal.",
 		// `insert_zed_terminal_env()` sets `ZED_TERM=true` (and `TERM_PROGRAM=zed`) on the integrated terminal.
 		envVars: { ZED_TERM: "*" },
+	},
+	"cursor-cli": {
+		// Kept near the bottom (and before `cursor`): when another agent runs inside the Cursor editor's terminal,
+		// its child processes inherit `CURSOR_TRACE_ID`, so `cursor` must stay a low-priority fallback and lose to
+		// the agent's own marker. `cursor-cli` is the more specific Cursor signal (`CURSOR_AGENT`), so it comes first.
+		prettyLabel: "Cursor CLI",
+		docsUrl: "https://cursor.com/docs/cli/overview",
+		description: "Cursor's coding agent for the command line.",
+		envVars: { CURSOR_AGENT: "*" },
+	},
+	cursor: {
+		prettyLabel: "Cursor",
+		docsUrl: "https://cursor.com",
+		description: "AI-powered code editor.",
+		envVars: { CURSOR_TRACE_ID: "*" },
 	},
 	devin: {
 		prettyLabel: "Devin",

--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -55,6 +55,14 @@ export const STANDARD_AGENT_ENV_VARS = ["AI_AGENT", "AGENT"] as const;
  * `CLAUDE_CODE` and `CLAUDE_CODE_IS_COWORK` are set.
  */
 export const AGENT_HARNESSES = {
+	"amazon-q-cli": {
+		prettyLabel: "Amazon Q Developer CLI",
+		repoUrl: "https://github.com/aws/amazon-q-developer-cli",
+		docsUrl: "https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html",
+		description: "AWS's agentic AI assistant for the command line.",
+		// Injected into every shell command via `env_vars_with_user_agent()` as `AWS_EXECUTION_ENV=AmazonQ-For-CLI Version/<ver>`.
+		envVars: { AWS_EXECUTION_ENV: "AmazonQ-For-CLI*" },
+	},
 	antigravity: {
 		prettyLabel: "Antigravity",
 		docsUrl: "https://antigravity.google",
@@ -96,6 +104,14 @@ export const AGENT_HARNESSES = {
 		description: "OpenAI's lightweight coding agent that runs in your terminal.",
 		envVars: { CODEX_SANDBOX: "*", CODEX_CI: "*", CODEX_THREAD_ID: "*" },
 	},
+	crush: {
+		prettyLabel: "Crush",
+		repoUrl: "https://github.com/charmbracelet/crush",
+		docsUrl: "https://github.com/charmbracelet/crush",
+		description: "Charm's open-source AI coding agent for the terminal.",
+		// `CrushEnvMarkers()` unconditionally sets `CRUSH=1` (plus `AGENT=crush`/`AI_AGENT=crush`) on every spawned shell.
+		envVars: { CRUSH: "*" },
+	},
 	"cursor-cli": {
 		// must stay before `cursor` so the more specific signal takes priority: when the CLI runs inside
 		// the Cursor editor's terminal, child processes inherit `CURSOR_TRACE_ID` and the CLI sets `CURSOR_AGENT`.
@@ -110,6 +126,14 @@ export const AGENT_HARNESSES = {
 		description: "AI-powered code editor.",
 		envVars: { CURSOR_TRACE_ID: "*" },
 	},
+	"gemini-cli": {
+		prettyLabel: "Gemini CLI",
+		repoUrl: "https://github.com/google-gemini/gemini-cli",
+		docsUrl: "https://geminicli.com",
+		description: "Google's open-source terminal AI coding agent powered by Gemini models.",
+		// `ShellExecutionService` injects `GEMINI_CLI=1` into the environment of every spawned shell command.
+		envVars: { GEMINI_CLI: "*" },
+	},
 	"github-copilot": {
 		prettyLabel: "GitHub Copilot",
 		docsUrl: "https://docs.github.com/copilot",
@@ -122,6 +146,21 @@ export const AGENT_HARNESSES = {
 		docsUrl: "https://goose-docs.ai/",
 		description: "Open-source, extensible AI agent, originally from Block and now part of the Agentic AI Foundation.",
 		envVars: { GOOSE_TERMINAL: "*" },
+	},
+	"kilo-code": {
+		prettyLabel: "Kilo Code",
+		repoUrl: "https://github.com/Kilo-Org/kilocode",
+		docsUrl: "https://kilocode.ai/docs",
+		description: "Open-source agentic coding agent for VS Code, JetBrains, and the terminal.",
+		// `KILOCODE_FEATURE` (e.g. `cli` / `vscode-extension`) is set in-process and inherited by shell-tool subprocesses.
+		envVars: { KILOCODE_FEATURE: "*" },
+	},
+	kiro: {
+		prettyLabel: "Kiro",
+		docsUrl: "https://kiro.dev",
+		description: "AWS's agentic IDE for spec-driven AI software development.",
+		// `AGENT_CONTEXT_OUT` / `AGENT_DISPLAY_OUT` (FIFO paths) are exported only while the agent is driving a shell command.
+		envVars: { AGENT_CONTEXT_OUT: "*" },
 	},
 	openclaw: {
 		prettyLabel: "OpenClaw",
@@ -150,11 +189,35 @@ export const AGENT_HARNESSES = {
 		description: "Cloud development environment with an AI coding agent.",
 		envVars: { REPL_ID: "*" },
 	},
+	"roo-code": {
+		prettyLabel: "Roo Code",
+		repoUrl: "https://github.com/RooCodeInc/Roo-Code",
+		docsUrl: "https://docs.roocode.com",
+		description: "Open-source autonomous AI coding agent for VS Code.",
+		// `Terminal.getEnv()` sets `ROO_ACTIVE=true` on every command the agent runs through its terminal.
+		envVars: { ROO_ACTIVE: "*" },
+	},
 	trae: {
 		prettyLabel: "Trae",
 		docsUrl: "https://trae.ai",
 		description: "AI-powered IDE from ByteDance.",
 		envVars: { TRAE_AI_SHELL_ID: "*" },
+	},
+	warp: {
+		prettyLabel: "Warp",
+		repoUrl: "https://github.com/warpdotdev/Warp",
+		docsUrl: "https://docs.warp.dev",
+		description: "AI-powered terminal with an agentic Agent Mode.",
+		// Warp shell sessions set `TERM_PROGRAM=WarpTerminal`.
+		envVars: { TERM_PROGRAM: "WarpTerminal" },
+	},
+	zed: {
+		prettyLabel: "Zed",
+		repoUrl: "https://github.com/zed-industries/zed",
+		docsUrl: "https://zed.dev",
+		description: "High-performance code editor with an integrated AI agent panel and terminal.",
+		// `insert_zed_terminal_env()` sets `ZED_TERM=true` (and `TERM_PROGRAM=zed`) on the integrated terminal.
+		envVars: { ZED_TERM: "*" },
 	},
 	devin: {
 		prettyLabel: "Devin",

--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -123,6 +123,13 @@ export const AGENT_HARNESSES = {
 		description: "Open-source, extensible AI agent, originally from Block and now part of the Agentic AI Foundation.",
 		envVars: { GOOSE_TERMINAL: "*" },
 	},
+	"hermes-agent": {
+		prettyLabel: "Hermes Agent",
+		repoUrl: "https://github.com/NousResearch/hermes-agent",
+		docsUrl: "https://hermes-agent.nousresearch.com/docs",
+		description: "Nous Research's self-improving, multi-provider terminal AI agent.",
+		envVars: { HERMES_SESSION_ID: "*" },
+	},
 	"kilo-code": {
 		prettyLabel: "Kilo Code",
 		repoUrl: "https://github.com/Kilo-Org/kilocode",

--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -101,7 +101,6 @@ export const AGENT_HARNESSES = {
 		repoUrl: "https://github.com/charmbracelet/crush",
 		docsUrl: "https://github.com/charmbracelet/crush",
 		description: "Charm's open-source AI coding agent for the terminal.",
-		// `CrushEnvMarkers()` unconditionally sets `CRUSH=1` (plus `AGENT=crush`/`AI_AGENT=crush`) on every spawned shell.
 		envVars: { CRUSH: "*" },
 	},
 	"gemini-cli": {
@@ -109,7 +108,6 @@ export const AGENT_HARNESSES = {
 		repoUrl: "https://github.com/google-gemini/gemini-cli",
 		docsUrl: "https://geminicli.com",
 		description: "Google's open-source terminal AI coding agent powered by Gemini models.",
-		// `ShellExecutionService` injects `GEMINI_CLI=1` into the environment of every spawned shell command.
 		envVars: { GEMINI_CLI: "*" },
 	},
 	"github-copilot": {
@@ -130,14 +128,12 @@ export const AGENT_HARNESSES = {
 		repoUrl: "https://github.com/Kilo-Org/kilocode",
 		docsUrl: "https://kilocode.ai/docs",
 		description: "Open-source agentic coding agent for VS Code, JetBrains, and the terminal.",
-		// `KILOCODE_FEATURE` (e.g. `cli` / `vscode-extension`) is set in-process and inherited by shell-tool subprocesses.
 		envVars: { KILOCODE_FEATURE: "*" },
 	},
 	kiro: {
 		prettyLabel: "Kiro",
 		docsUrl: "https://kiro.dev",
 		description: "AWS's agentic IDE for spec-driven AI software development.",
-		// `AGENT_CONTEXT_OUT` / `AGENT_DISPLAY_OUT` (FIFO paths) are exported only while the agent is driving a shell command.
 		envVars: { AGENT_CONTEXT_OUT: "*" },
 	},
 	openclaw: {
@@ -178,7 +174,6 @@ export const AGENT_HARNESSES = {
 		repoUrl: "https://github.com/warpdotdev/Warp",
 		docsUrl: "https://docs.warp.dev",
 		description: "AI-powered terminal with an agentic Agent Mode.",
-		// Warp shell sessions set `TERM_PROGRAM=WarpTerminal`.
 		envVars: { TERM_PROGRAM: "WarpTerminal" },
 	},
 	zed: {
@@ -186,7 +181,6 @@ export const AGENT_HARNESSES = {
 		repoUrl: "https://github.com/zed-industries/zed",
 		docsUrl: "https://zed.dev",
 		description: "High-performance code editor with an integrated AI agent panel and terminal.",
-		// `insert_zed_terminal_env()` sets `ZED_TERM=true` (and `TERM_PROGRAM=zed`) on the integrated terminal.
 		envVars: { ZED_TERM: "*" },
 	},
 	"cursor-cli": {

--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -55,14 +55,6 @@ export const STANDARD_AGENT_ENV_VARS = ["AI_AGENT", "AGENT"] as const;
  * `CLAUDE_CODE` and `CLAUDE_CODE_IS_COWORK` are set.
  */
 export const AGENT_HARNESSES = {
-	"amazon-q-cli": {
-		prettyLabel: "Amazon Q Developer CLI",
-		repoUrl: "https://github.com/aws/amazon-q-developer-cli",
-		docsUrl: "https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html",
-		description: "AWS's agentic AI assistant for the command line.",
-		// Injected into every shell command via `env_vars_with_user_agent()` as `AWS_EXECUTION_ENV=AmazonQ-For-CLI Version/<ver>`.
-		envVars: { AWS_EXECUTION_ENV: "AmazonQ-For-CLI*" },
-	},
 	antigravity: {
 		prettyLabel: "Antigravity",
 		docsUrl: "https://antigravity.google",
@@ -188,14 +180,6 @@ export const AGENT_HARNESSES = {
 		docsUrl: "https://replit.com",
 		description: "Cloud development environment with an AI coding agent.",
 		envVars: { REPL_ID: "*" },
-	},
-	"roo-code": {
-		prettyLabel: "Roo Code",
-		repoUrl: "https://github.com/RooCodeInc/Roo-Code",
-		docsUrl: "https://docs.roocode.com",
-		description: "Open-source autonomous AI coding agent for VS Code.",
-		// `Terminal.getEnv()` sets `ROO_ACTIVE=true` on every command the agent runs through its terminal.
-		envVars: { ROO_ACTIVE: "*" },
 	},
 	trae: {
 		prettyLabel: "Trae",


### PR DESCRIPTION
Adds entries to `packages/tasks/src/agent-harnesses.ts` for popular coding agents that were missing from the registry. For each, I checked the harness's source code or documentation to confirm an environment variable it sets on the shell / subprocesses it spawns (so the `hf` CLI can detect it as a child process).

## Added entries

| Harness | Env var (pattern) | Where the env var is documented / set |
| ------- | ----------------- | ------------------------------------- |
| **Crush** | `CRUSH=*` | `CrushEnvMarkers()` unconditionally sets `CRUSH=1` (plus `AGENT=crush`/`AI_AGENT=crush`) on every spawned shell, explicitly for agent detection — [internal/shell/shell.go#L43-L49](https://github.com/charmbracelet/crush/blob/79993800475db0aaaea2e8abcb60dbd489fbb363/internal/shell/shell.go#L43-L49). |
| **Gemini CLI** | `GEMINI_CLI=*` | `ShellExecutionService` injects `GEMINI_CLI=1` into every spawned shell command — [shellExecutionService.ts](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/shellExecutionService.ts) (`GEMINI_CLI_IDENTIFICATION_ENV_VAR`). |
| **Hermes Agent** | `HERMES_SESSION_ID=*` | Auto-exported by the agent into every tool subprocess it spawns (terminal, execute_code, persistent shell, delegated subagents), set to the current session ID — [environment variables docs](https://hermes-agent.nousresearch.com/docs/reference/environment-variables). |
| **Kilo Code** | `KILOCODE_FEATURE=*` | Set in-process (`cli` / `vscode-extension`) and inherited by shell-tool subprocesses — [packages/opencode/src/index.ts#L49-L56](https://github.com/Kilo-Org/kilocode/blob/6ee090b5a404924f00c1f4771b09c1f4a1e352ca/packages/opencode/src/index.ts#L49-L56); confirmed via a real `printenv` dump in [issue #9599](https://github.com/Kilo-Org/kilocode/issues/9599). |
| **Kiro** | `AGENT_CONTEXT_OUT=*` | Exported (alongside `AGENT_DISPLAY_OUT`) only while the agent drives a shell command; docs recommend detection via `[ -n "${AGENT_CONTEXT_OUT:-}" ]` — [Kiro built-in tools docs](https://kiro.dev/docs/cli/reference/built-in-tools/). |
| **Warp** | `TERM_PROGRAM=WarpTerminal` | Warp shell sessions set `TERM_PROGRAM=WarpTerminal`, the value Warp's own docs use for gating — [Warp prompt docs](https://docs.warp.dev/terminal/appearance/prompt/). |
| **Zed** | `ZED_TERM=*` | `insert_zed_terminal_env()` sets `ZED_TERM=true` (and `TERM_PROGRAM=zed`) on the integrated terminal — [crates/terminal/src/terminal.rs](https://github.com/zed-industries/zed/blob/main/crates/terminal/src/terminal.rs). |

## Investigated but not added

I researched these too but left them out to avoid false/missed detections:

- **Roo Code** — removed (archived / per maintainer request).
- **Aider** — spawns shell commands without injecting any env var ([run_cmd.py](https://github.com/Aider-AI/aider/blob/main/aider/run_cmd.py)); `AIDER_*` vars are config it *reads*, not sets.
- **Windsurf** — closed-source; only inherited VS Code signals (`TERM_PROGRAM=vscode`), nothing Windsurf-specific confirmable.
- **OpenHands** — only sets `PS1`/`PS2`/`TERM` on its sandbox shell; no unique marker var.
- **Jules** — no documented self-set env var.
- **Factory Droid** — `FACTORY_PROJECT_DIR` is documented only for [hook execution](https://docs.factory.ai/reference/hooks-reference), not confirmed for general bash commands, so it would miss most activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only metadata and detection-order tweaks; no auth, data, or runtime logic changes beyond how agents are labeled when env vars match.
> 
> **Overview**
> Expands the Hub **agent harness registry** in `agent-harnesses.ts` so the `hf` CLI can recognize seven more coding agents via env markers: **Crush**, **Gemini CLI**, **Hermes Agent**, **Kilo Code**, **Kiro**, **Warp** (`TERM_PROGRAM=WarpTerminal`), and **Zed**.
> 
> **Cursor** and **Cursor CLI** are **moved toward the bottom** of the ordered map (still with `cursor-cli` before `cursor`). Comments now explain that when another agent runs inside Cursor’s terminal, children inherit `CURSOR_TRACE_ID`, so those Cursor entries must be low-priority fallbacks so the nested agent’s own marker wins first-match detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10fa058cefef799c211bb20eb85ee13624b41ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->