### PR TITLE
Register `hailo` library with .hef download counting

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -59,21 +59,17 @@ model = BaseModel.from_pretrained("${model.id}")`,
 ];
 
 export const hailo = (model: ModelData): string[] => [
-	`# Hailo HEFs are compiled INT8 binaries for the Hailo-8 / Hailo-15 accelerators.
-# Install hailort + the Python bindings (aarch64 wheel) from
-# https://hailo.ai/developer-zone/.
+	`# Requires hailort + the hailo_platform Python wheel from
+# https://hailo.ai/developer-zone/ (Hailo-8 / Hailo-15 targets).
 from huggingface_hub import hf_hub_download
 from hailo_platform import HEF, VDevice
 
-hef_path = hf_hub_download("${model.id}", "model.hef")  # replace with the actual filename
+hef_path = hf_hub_download("${model.id}", "model.hef")  # set to the actual HEF filename
 hef = HEF(hef_path)
 
 with VDevice() as target:
     infer_model = target.create_infer_model(hef_path)
-    with infer_model.configure() as configured:
-        # Allocate input/output buffers per configured.input_vstreams_params /
-        # output_vstreams_params, then run inference.
-        ...`,
+    # See https://github.com/hailo-ai/hailort for the full inference API.`,
 ];
 
 export const audioseal = (model: ModelData): string[] => {

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -58,6 +58,24 @@ export const asteroid = (model: ModelData): string[] => [
 model = BaseModel.from_pretrained("${model.id}")`,
 ];
 
+export const hailo = (model: ModelData): string[] => [
+	`# Hailo HEFs are compiled INT8 binaries for the Hailo-8 / Hailo-15 accelerators.
+# Install hailort + the Python bindings (aarch64 wheel) from
+# https://hailo.ai/developer-zone/.
+from huggingface_hub import hf_hub_download
+from hailo_platform import HEF, VDevice
+
+hef_path = hf_hub_download("${model.id}", "model.hef")  # replace with the actual filename
+hef = HEF(hef_path)
+
+with VDevice() as target:
+    infer_model = target.create_infer_model(hef_path)
+    with infer_model.configure() as configured:
+        # Allocate input/output buffers per configured.input_vstreams_params /
+        # output_vstreams_params, then run inference.
+        ...`,
+];
+
 export const audioseal = (model: ModelData): string[] => {
 	const watermarkSnippet = `# Watermark Generator
 from audioseal import AudioSeal

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -592,6 +592,8 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "hailort",
 		repoUrl: "https://github.com/hailo-ai/hailort",
 		countDownloads: `path_extension:"hef"`,
+		snippets: snippets.hailo,
+		filter: false,
 	},
 	hallo: {
 		prettyLabel: "Hallo",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -587,6 +587,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_extension:"safetensors"`,
 	},
+	hailo: {
+		prettyLabel: "Hailo",
+		repoName: "hailort",
+		repoUrl: "https://github.com/hailo-ai/hailort",
+		countDownloads: `path_extension:"hef"`,
+	},
 	hallo: {
 		prettyLabel: "Hallo",
 		repoName: "Hallo",


### PR DESCRIPTION
Adds a `hailo` library entry to `model-libraries.ts` so that HEF (Hailo Executable Format) files hosted on the Hub get counted toward download stats.

## Why

[Hailo](https://hailo.ai/) makes the Hailo-8 / Hailo-15 PCIe AI accelerators (commonly seen as M.2 add-ons for the Raspberry Pi 5 AI Kit and other edge platforms). Models targeting these chips are compiled to `.hef` binaries via Hailo's Dataflow Compiler; the HEF is the actual deployment artifact, similar in role to a TensorRT engine or a CoreML `.mlpackage`.

Hailo's own model zoo is hosted on GitHub today, but third-party projects are starting to publish HEFs on the Hub alongside their source weights — e.g. [`k10z/birdvision-efficientnet-s`](https://huggingface.co/k10z/birdvision-efficientnet-s) (a fine-tuned EfficientNet-V2-S for bird species classification compiled to Hailo-8). These repos currently show no download counts because the Hub's default query files (`config.json`, `config.yaml`, etc.) aren't matched.

## What this does

Registers `hailo` with `countDownloads: path_extension:"hef"`, matching the pattern used for other accelerator-binary libraries (e.g. HoloMotion using `path_extension:"onnx"`).

```ts
hailo: {
    prettyLabel: "Hailo",
    repoName: "hailort",
    repoUrl: "https://github.com/hailo-ai/hailort",
    countDownloads: `path_extension:"hef"`,
    snippets: snippets.hailo,
    filter: false,
},
```

`repoUrl` points at the public [`hailort`](https://github.com/hailo-ai/hailort) runtime — the end-user dependency that actually loads HEFs at inference time.

Snippet is a minimal Hub-aware load pattern (`hf_hub_download` + `HEF` + `VDevice`) with a pointer to the `hailort` repo for the full inference API.

## Pre-merge checklist

- [x] Inserted alphabetically between `habibi-tts` and `hallo`
- [x] `filter: false` per the [integration guide](https://huggingface.co/docs/hub/models-adding-libraries#register-your-library)
- [x] At least one model on the Hub declares `library_name: hailo`: [`k10z/birdvision-efficientnet-s`](https://huggingface.co/k10z/birdvision-efficientnet-s)
- [x] Bugbot review clean