### PR TITLE
Add RX 5700 / 5700 XT and GTX 1070 / 1080 to hardware list

### DIFF
--- a/packages/tasks/src/hardware-amd.ts
+++ b/packages/tasks/src/hardware-amd.ts
@@ -212,6 +212,22 @@ export const AMD_GPU_SKUS: Record<string, AmdGpuHardwareSpec> = {
 		power: 132,
 		releaseYear: 2021,
 	},
+	"RX 5700 XT": {
+		tflops: 19.51,
+		memory: [8],
+		gfxVersion: "gfx1010",
+		msrp: 399,
+		power: 225,
+		releaseYear: 2019,
+	},
+	"RX 5700": {
+		tflops: 15.9,
+		memory: [8],
+		gfxVersion: "gfx1010",
+		msrp: 349,
+		power: 180,
+		releaseYear: 2019,
+	},
 	"RX 5500 XT": {
 		tflops: 10.39,
 		memory: [4, 8],

--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -756,6 +756,14 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		power: 250,
 		releaseYear: 2017,
 	},
+	"GTX 1080": {
+		tflops: 8.87, // float32 (GPU does not support native float16)
+		memory: [8],
+		computeCapability: 6.1,
+		msrp: 599,
+		power: 180,
+		releaseYear: 2016,
+	},
 	"GTX 1070 Ti": {
 		tflops: 8.2, // float32 (GPU does not support native float16)
 		memory: [8],
@@ -763,6 +771,14 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		msrp: 450,
 		power: 180,
 		releaseYear: 2017,
+	},
+	"GTX 1070": {
+		tflops: 6.46, // float32 (GPU does not support native float16)
+		memory: [8],
+		computeCapability: 6.1,
+		msrp: 379,
+		power: 150,
+		releaseYear: 2016,
 	},
 	"GTX 1060": {
 		tflops: 3.9, // float32 (GPU does not support native float16)


### PR DESCRIPTION
## What

Adds four consumer GPUs that were missing from the hardware SKU lists while their immediate neighbors were already present:

**AMD** (`hardware-amd.ts`) — placed next to the existing `RX 5500 XT`:
- `RX 5700 XT` — 8 GB, gfx1010
- `RX 5700` — 8 GB, gfx1010

**NVIDIA** (`hardware-nvidia.ts`) — placed between the existing `GTX 1080 Ti` / `1070 Ti` / `1060` entries in descending order:
- `GTX 1080` — 8 GB, CC 6.1
- `GTX 1070` — 8 GB, CC 6.1

## TFLOPS convention

Followed the existing per-vendor convention already in the files:

- **AMD RDNA1** uses **FP16** (2× FP32). The new `RX 5700 XT` (19.51) and `RX 5700` (15.9) match how the sibling `RX 5500 XT` (10.39 = 2× its 5.196 FP32) is listed.
- **NVIDIA Pascal** uses **FP32**, since native FP16 runs at 1/64 rate — same as the existing `GTX 10-series` entries, and I carried over the same `// float32 (GPU does not support native float16)` comment.

MSRP / power / release-year are the standard reference figures for each card.

These are still common in homelab / multi-GPU inference setups, so having them selectable in the hardware profile is handy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static catalog data only; no runtime logic, auth, or data-path changes.
> 
> **Overview**
> Adds four missing consumer GPU entries to the tasks package hardware SKU catalogs so they can be selected in hardware profiles.
> 
> In `hardware-amd.ts`, **`RX 5700 XT`** and **`RX 5700`** are inserted before `RX 5500 XT` with **gfx1010**, 8 GB VRAM, and TFLOPS figures consistent with existing RDNA1 entries (FP16-style values like sibling SKUs).
> 
> In `hardware-nvidia.ts`, **`GTX 1080`** and **`GTX 1070`** are added among the Pascal GTX 10-series block with **compute capability 6.1**, FP32 TFLOPS, and the same float32 comment used on neighboring cards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a38961e10fc792525eeb8feb4e973f40d4194ea8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->