### PR TITLE
Update countDownloads filter for intellifold to include 'zst' extension

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -691,7 +691,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "IntelliFold",
 		repoUrl: "https://github.com/IntelliGen-AI/IntelliFold",
 		filter: false,
-		countDownloads: `path_extension:"pt"`,
+		countDownloads: `path_extension:"pt" OR path_extension:"zst"`,
 	},
 	"ising-decoding": {
 		prettyLabel: "Ising Decoding",


### PR DESCRIPTION
We uploaded jax weights for our model with the extension of "zst"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata query tweak for download metrics; no auth, serving, or model-runtime behavior changes.
> 
> **Overview**
> Extends the **IntelliFold** library’s `countDownloads` Elasticsearch filter so Hub download stats include **`.zst`** artifacts (JAX weights), in addition to existing **`.pt`** files.
> 
> This is a one-line change in `model-libraries.ts` and only affects how IntelliFold model downloads are aggregated for display/analytics—not model loading or inference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72fa7b81c3df4b19d1fabbcacaa2124e7748aae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->