### PR TITLE
feat(hardware) Add Intel 7th-9th generation processors to hardware.ts

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -311,6 +311,68 @@ export const SKUS = {
 				power: 65,
 				releaseYear: 2020,
 			},
+			"Intel Core 9th Generation (i9)": {
+			    tflops: 0.42,
+			    msrp: 488,
+			    power: 200,
+			    releaseYear: 2018,
+			},
+			"Intel Core 9th Generation (i7)": {
+			    tflops: 0.38,
+			    msrp: 374,
+			    power: 125,
+			    releaseYear: 2018,
+			},
+			"Intel Core 9th Generation (i5)": {
+			    tflops: 0.32,
+			    msrp: 262,
+			    power: 95,
+			    releaseYear: 2018,
+			},
+			"Intel Core 9th Generation (i3)": {
+			    tflops: 0.27,
+			    msrp: 122,
+			    power: 65,
+			    releaseYear: 2019,
+			},
+			"Intel Core 8th Generation (i7)": {
+			    tflops: 0.35,
+			    msrp: 359,
+			    power: 95,
+			    releaseYear: 2017,
+			},
+			"Intel Core 8th Generation (i5)": {
+			    tflops: 0.30,
+			    msrp: 257,
+			    power: 95,
+			    releaseYear: 2017,
+			},
+			"Intel Core 8th Generation (i3)": {
+			    tflops: 0.24,
+			    msrp: 117,
+			    power: 65,
+			    releaseYear: 2017,
+			},
+			
+			// 7th Generation (Kaby Lake, 2017)
+			"Intel Core 7th Generation (i7)": {
+			    tflops: 0.25,
+			    msrp: 339,
+			    power: 91,
+			    releaseYear: 2017,
+			},
+			"Intel Core 7th Generation (i5)": {
+			    tflops: 0.21,
+			    msrp: 242,
+			    power: 91,
+			    releaseYear: 2017,
+			},
+			"Intel Core 7th Generation (i3)": {
+			    tflops: 0.17,
+			    msrp: 168,
+			    power: 60,
+			    releaseYear: 2017,
+			},
 		},
 		AMD: {
 			"EPYC 5th Generation Zen 5 (Turin)": {


### PR DESCRIPTION
certain info might be wrong :)
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Static hardware metadata additions with no runtime or security behavior changes; approximate spec values may affect estimates if used for compliance thresholds.
> 
> **Overview**
> Extends **`SKUS.CPU.Intel`** in `packages/tasks/src/hardware.ts` with **10 new family entries** for **Intel Core 9th** (i9/i7/i5/i3), **8th** (i7/i5/i3), and **7th** (i7/i5/i3) generations, each with **`tflops`**, **`msrp`**, **`power`**, and **`releaseYear`** like the existing 10th–14th gen rows.
> 
> This is **catalog data only**—no logic changes—so workloads that pick CPUs from this map can represent older desktop/laptop tiers back to ~2017–2019.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ab3b256d651e0be170e29446d4a397a3e1ab8fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->