### PR TITLE
feat(hardware): Add B300 + other GPUs to hardware-nvidia.ts

### DIFF
--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -52,13 +52,13 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		power: 700,
 		releaseYear: 2024,
 	},
-	H20: {
-		tflops: 148,
-		memory: [96],
+	H100: {
+		tflops: 267.6,
+		memory: [80],
 		computeCapability: 9.0,
-		msrp: 13_500,
-		power: 400,
-		releaseYear: 2024,
+		msrp: 30_000,
+		power: 700,
+		releaseYear: 2022,
 	},
 	H800: {
 		tflops: 237.2,
@@ -68,13 +68,13 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		power: 700,
 		releaseYear: 2023,
 	},
-	H100: {
-		tflops: 267.6,
-		memory: [80],
+	H20: {
+		tflops: 148,
+		memory: [96],
 		computeCapability: 9.0,
-		msrp: 30_000,
-		power: 700,
-		releaseYear: 2022,
+		msrp: 13_500,
+		power: 400,
+		releaseYear: 2024,
 	},
 	L40s: {
 		tflops: 91.61,

--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -29,10 +29,10 @@ export enum NvidiaComputeCapabilities {
 
 export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 	B300: {
-	  tflops: 496.6,
+	  tflops: 1232,
 	  memory: [288],
 	  computeCapability: 10.0,
-	  msrp: 50_000,
+	  msrp: 45_000,
 	  power: 1400,
 	  releaseYear: 2026,
 	},
@@ -61,7 +61,7 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		releaseYear: 2024,
 	},
 	H800: {
-		tflops: 197.9,
+		tflops: 237.2,
 		memory: [80],
 		computeCapability: 9.0,
 		msrp: 30_000,
@@ -325,11 +325,11 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		releaseYear: 2021,
 	},
 	A800: {
-		tflops: 312,
+		tflops: 77.97,
 		memory: [40, 80],
 		computeCapability: 8.0,
 		msrp: 12_000,
-		power: 250,
+		power: 400,
 		releaseYear: 2022,
 	},
 	A100: {

--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -477,7 +477,7 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		releaseYear: 2025,
 	},
 	"RTX 5050 Mobile": {
-		tflops: 13.17,
+		tflops: 7.7,
 		memory: [8],
 		computeCapability: 12.0,
 		msrp: 250,

--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -325,7 +325,7 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		releaseYear: 2021,
 	},
 	A800: {
-		tflops: 19.49,
+		tflops: 312,
 		memory: [40, 80],
 		computeCapability: 8.0,
 		msrp: 12_000,

--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -29,12 +29,12 @@ export enum NvidiaComputeCapabilities {
 
 export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 	B300: {
-	  tflops: 1232,
-	  memory: [288],
-	  computeCapability: 10.0,
-	  msrp: 45_000,
-	  power: 1400,
-	  releaseYear: 2026,
+		tflops: 1232,
+		memory: [288],
+		computeCapability: 10.0,
+		msrp: 45_000,
+		power: 1400,
+		releaseYear: 2026,
 	},
 	B200: {
 		tflops: 496.6,

--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -28,6 +28,14 @@ export enum NvidiaComputeCapabilities {
 }
 
 export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
+	B300: {
+	  tflops: 496.6,
+	  memory: [288],
+	  computeCapability: 10.0,
+	  msrp: 50_000,
+	  power: 1400,
+	  releaseYear: 2026,
+	},
 	B200: {
 		tflops: 496.6,
 		memory: [192],
@@ -43,6 +51,22 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		msrp: 32_000,
 		power: 700,
 		releaseYear: 2024,
+	},
+	H20: {
+		tflops: 148,
+		memory: [96],
+		computeCapability: 9.0,
+		msrp: 13_500,
+		power: 400,
+		releaseYear: 2024,
+	},
+	H800: {
+		tflops: 197.9,
+		memory: [80],
+		computeCapability: 9.0,
+		msrp: 30_000,
+		power: 700,
+		releaseYear: 2023,
 	},
 	H100: {
 		tflops: 267.6,
@@ -300,6 +324,14 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		power: 95,
 		releaseYear: 2021,
 	},
+	A800: {
+		tflops: 19.49,
+		memory: [40, 80],
+		computeCapability: 8.0,
+		msrp: 12_000,
+		power: 250,
+		releaseYear: 2022,
+	},
 	A100: {
 		tflops: 77.97,
 		memory: [80, 40],
@@ -433,6 +465,22 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		memory: [8],
 		computeCapability: 12.0,
 		msrp: 300,
+		power: 100,
+		releaseYear: 2025,
+	},
+	"RTX 5050": {
+		tflops: 13.17,
+		memory: [8],
+		computeCapability: 12.0,
+		msrp: 249,
+		power: 130,
+		releaseYear: 2025,
+	},
+	"RTX 5050 Mobile": {
+		tflops: 13.17,
+		memory: [8],
+		computeCapability: 12.0,
+		msrp: 250,
 		power: 100,
 		releaseYear: 2025,
 	},


### PR DESCRIPTION
Note that the TFLOP values are probably wrong ;)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static catalog additions only; no runtime behavior changes beyond possible estimates if unknown GPU names are matched.
> 
> **Overview**
> Extends **`NVIDIA_SKUS`** in `hardware-nvidia.ts` with seven new GPU entries so task/hardware tooling can recognize them by name.
> 
> **Datacenter / China-market variants:** **B300** (Blackwell, ahead of B200 in the table), **H800**, **H20**, and **A800**—each with the usual spec fields (TFLOPS, memory, compute capability, MSRP, power, release year).
> 
> **Consumer Blackwell:** **RTX 5050** and **RTX 5050 Mobile** (compute capability 12.0, 2025).
> 
> No lookup logic or exports change; new keys are picked up wherever `NVIDIA_SKUS` / `SKUS` is already used. The PR author flags that **TFLOP numbers may be inaccurate** and may need a follow-up pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1867e7a4dca3fbbb6b41a391a1ca1d077e2c3eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->