### PR TITLE
replace llama-server and llama-cli

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -14,9 +14,9 @@ describe("local-apps", () => {
 
 		expect(snippet[0].content).toEqual([
 			`# Start a local OpenAI-compatible server with a web UI:
-llama-server -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`,
+llama serve -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`,
 			`# Run inference directly in the terminal:
-llama-cli -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`,
+llama cli -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`,
 		]);
 	});
 
@@ -31,9 +31,9 @@ llama-cli -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`,
 
 		expect(snippet[0].content).toEqual([
 			`# Start a local OpenAI-compatible server with a web UI:
-llama-server -hf mlabonne/gemma-2b-GGUF:{{QUANT_TAG}}`,
+llama serve -hf mlabonne/gemma-2b-GGUF:{{QUANT_TAG}}`,
 			`# Run inference directly in the terminal:
-llama-cli -hf mlabonne/gemma-2b-GGUF:{{QUANT_TAG}}`,
+llama cli -hf mlabonne/gemma-2b-GGUF:{{QUANT_TAG}}`,
 		]);
 	});
 
@@ -132,7 +132,7 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		};
 		const snippet = snippetFunc(model);
 
-		expect(snippet[0].content).toContain(`llama-server -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`);
+		expect(snippet[0].content).toContain(`llama serve -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`);
 		expect(snippet[1].setup).toContain("npm install -g @mariozechner/pi-coding-agent");
 		expect(snippet[1].content).toContain(`"id": "bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}"`);
 		expect(snippet[2].content).toContain("pi");
@@ -171,7 +171,7 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		};
 		const snippet = snippetFunc(model);
 
-		expect(snippet[0].content).toContain(`llama-server -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`);
+		expect(snippet[0].content).toContain(`llama serve -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`);
 		expect(snippet[1].content).toContain("hermes config set model.provider custom");
 		expect(snippet[1].content).toContain("hermes config set model.base_url http://127.0.0.1:8080/v1");
 		expect(snippet[1].content).toContain(

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -174,12 +174,12 @@ const snippetLlamacpp = (model: ModelData, filepath?: string): LocalAppSnippet[]
 		{
 			title: "Install from brew",
 			setup: "brew install llama.cpp",
-			content: [serverCommand("llama-server"), cliCommand("llama-cli")],
+			content: [serverCommand("llama serve"), cliCommand("llama cli")],
 		},
 		{
 			title: "Install from WinGet (Windows)",
 			setup: "winget install llama.cpp",
-			content: [serverCommand("llama-server"), cliCommand("llama-cli")],
+			content: [serverCommand("llama serve"), cliCommand("llama cli")],
 		},
 		{
 			title: "Use pre-built binary",
@@ -481,7 +481,7 @@ const getLocalServerStep = (model: ModelData, filepath?: string): LocalAppSnippe
 		: {
 				title: "Start the llama.cpp server",
 				setup: "# Install llama.cpp:\nbrew install llama.cpp",
-				content: `# Start a local OpenAI-compatible server:\nllama-server -hf ${model.id}${getQuantTag(filepath)}`,
+				content: `# Start a local OpenAI-compatible server:\nllama serve -hf ${model.id}${getQuantTag(filepath)}`,
 			};
 };
 

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -172,8 +172,8 @@ const snippetLlamacpp = (model: ModelData, filepath?: string): LocalAppSnippet[]
 	};
 	return [
 		{
-			title: "Install from brew",
-			setup: "brew install llama.cpp",
+			title: "Install (macOS, Linux)",
+			setup: "curl -LsSf https://llama.app/install.sh | sh",
 			content: [serverCommand("llama serve"), cliCommand("llama cli")],
 		},
 		{


### PR DESCRIPTION
@pcuenca @ngxson 
<img width="1280" height="813" alt="image" src="https://github.com/user-attachments/assets/7a390a35-cb36-46f8-8585-ecdcb03c9722" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing documentation strings and tests only; no runtime or security-sensitive logic.
> 
> **Overview**
> Updates **model-page “Use locally” snippets** for llama.cpp to match the newer unified CLI: **`llama serve`** and **`llama cli`** instead of **`llama-server`** and **`llama-cli`**, for the curl installer, WinGet, and shared “start server” steps used by **Pi** and **Hermes Agent**.
> 
> On **macOS/Linux**, install instructions switch from **Homebrew** (`brew install llama.cpp`) to **`curl -LsSf https://llama.app/install.sh | sh`**, with the snippet title renamed to **Install (macOS, Linux)**. **Pre-built binary** and **build from source** paths in `snippetLlamacpp` still reference `./llama-server` / `./llama-cli` (unchanged in this PR). Tests in `local-apps.spec.ts` are aligned with the new strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2da1e16c47e865a0f5511aa55ed1cb3ce79d93b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->