### PR TITLE
fix: Add missing fs import to JS inference snippet templates

### DIFF
--- a/packages/inference/src/snippets/templates/js/huggingface.js/basicAudio.jinja
+++ b/packages/inference/src/snippets/templates/js/huggingface.js/basicAudio.jinja
@@ -1,3 +1,4 @@
+import fs from "fs";
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient("{{ accessToken }}");

--- a/packages/inference/src/snippets/templates/js/huggingface.js/basicImage.jinja
+++ b/packages/inference/src/snippets/templates/js/huggingface.js/basicImage.jinja
@@ -1,3 +1,4 @@
+import fs from "fs";
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient("{{ accessToken }}");

--- a/packages/inference/src/snippets/templates/js/huggingface.js/imageToImage.jinja
+++ b/packages/inference/src/snippets/templates/js/huggingface.js/imageToImage.jinja
@@ -1,3 +1,4 @@
+import fs from "fs";
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient("{{ accessToken }}");

--- a/packages/inference/src/snippets/templates/js/huggingface.js/imageToVideo.jinja
+++ b/packages/inference/src/snippets/templates/js/huggingface.js/imageToVideo.jinja
@@ -1,3 +1,4 @@
+import fs from "fs";
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient("{{ accessToken }}");

--- a/packages/tasks-gen/snippets-fixtures/automatic-speech-recognition/js/huggingface.js/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/automatic-speech-recognition/js/huggingface.js/0.hf-inference.js
@@ -1,3 +1,4 @@
+import fs from "fs";
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient(process.env.HF_TOKEN);

--- a/packages/tasks-gen/snippets-fixtures/image-classification/js/huggingface.js/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/image-classification/js/huggingface.js/0.hf-inference.js
@@ -1,3 +1,4 @@
+import fs from "fs";
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient(process.env.HF_TOKEN);

--- a/packages/tasks-gen/snippets-fixtures/image-to-image/js/huggingface.js/0.fal-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/image-to-image/js/huggingface.js/0.fal-ai.js
@@ -1,3 +1,4 @@
+import fs from "fs";
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient(process.env.HF_TOKEN);

--- a/packages/tasks-gen/snippets-fixtures/image-to-image/js/huggingface.js/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/image-to-image/js/huggingface.js/0.hf-inference.js
@@ -1,3 +1,4 @@
+import fs from "fs";
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient(process.env.HF_TOKEN);

--- a/packages/tasks-gen/snippets-fixtures/image-to-image/js/huggingface.js/0.replicate.js
+++ b/packages/tasks-gen/snippets-fixtures/image-to-image/js/huggingface.js/0.replicate.js
@@ -1,3 +1,4 @@
+import fs from "fs";
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient(process.env.HF_TOKEN);

--- a/packages/tasks-gen/snippets-fixtures/image-to-video/js/huggingface.js/0.fal-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/image-to-video/js/huggingface.js/0.fal-ai.js
@@ -1,3 +1,4 @@
+import fs from "fs";
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient(process.env.HF_TOKEN);


### PR DESCRIPTION
## Summary
The auto-generated JavaScript inference snippets for file-input tasks (audio transcription, image classification, image-to-image, image-to-video) emit `const data = fs.readFileSync(...)` but never import the Node `fs` module, so the generated code throws a ReferenceError when copy-pasted. The issue, opened by maintainer Wauplin off a PR review thread, explicitly calls out 'add an import statement for fs' and notes the snippets are intended to be Node-compatible.

Fixes #1294

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/snippet-only change with no runtime library or API behavior changes.
> 
> **Overview**
> Adds `import fs from "fs";` to the **InferenceClient** Jinja templates used for tasks that read local files (`basicAudio`, `basicImage`, `imageToImage`, `imageToVideo`). Generated snippets already called `fs.readFileSync` but omitted the import, so copy-pasted Node examples would throw **ReferenceError**.
> 
> Matching **tasks-gen** snippet fixtures are updated so generated output stays in sync with the templates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de610815848461abbf4c099456b951a04a8b5b88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->