### PR TITLE
Add redline-bench evaluation framework

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -39,6 +39,12 @@ export const EVALUATION_FRAMEWORKS = {
 			"Pier is a Harbor fork built for DeepSWE, with stronger support for CLI agents in no-internet tasks and more faithful, consistent agent trajectories.",
 		url: "https://github.com/datacurve-ai/pier",
 	},
+	"redline-bench": {
+		name: "redline-bench",
+		description:
+			"RedlineBench measures multi-turn contract redlining: agents produce tracked-change .docx edits that are graded against attorney-authored weighted rubrics by an LLM judge panel across five dimensions. Report: https://intelligence.crosby.ai/benchmark/",
+		url: "https://github.com/crosbylegal/redline-bench",
+	},
 	archipelago: {
 		name: "archipelago",
 		description: "Archipelago is a system for running and evaluating AI agents against MCP applications.",


### PR DESCRIPTION
## Summary
- Adds the redline-bench framework entry for the RedlineBench benchmark dataset (crosbylegal/RedlineBench).

## Motivation
- Crosby Legal launched Crosby Intelligence (our research division) and RedlineBench (out first benchmark for contract negotiations)
- Clement Delague suggested we add it to the HuggingFace benchmarks page: https://x.com/clementdelangue/status/2067285570397651352?s=46&t=f-yRVb2xtyr2KcoXEjeJ4g


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only registry addition with no runtime logic, auth, or data-path changes.
> 
> **Overview**
> Registers **redline-bench** in `EVALUATION_FRAMEWORKS` so benchmark datasets can declare it in `eval.yaml` and surface on the Hugging Face benchmarks UI.
> 
> The new entry documents RedlineBench (multi-turn contract redlining with tracked-change `.docx` outputs and LLM judge grading) and points to `https://github.com/crosbylegal/redline-bench`, placed alongside existing frameworks such as `pier` and `archipelago`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39651a39b00c1673bd95526f7da1ec518b201f6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->