### PR TITLE
fix(inference): resolve provider mapping by task when a model maps to several tasks

### DIFF
--- a/packages/inference/src/lib/getInferenceProviderMapping.ts
+++ b/packages/inference/src/lib/getInferenceProviderMapping.ts
@@ -139,15 +139,23 @@ export async function getInferenceProviderMapping(
 		return HARDCODED_MODEL_INFERENCE_MAPPING[params.provider][params.modelId];
 	}
 	const mappings = await fetchInferenceProviderMappingForModel(params.modelId, params.accessToken, options);
-	const providerMapping = mappings.find((mapping) => mapping.provider === params.provider);
-	if (providerMapping) {
+	const providerMappings = mappings.filter((mapping) => mapping.provider === params.provider);
+	if (providerMappings.length > 0) {
 		const equivalentTasks =
 			params.provider === "hf-inference" && typedInclude(EQUIVALENT_SENTENCE_TRANSFORMERS_TASKS, params.task)
 				? EQUIVALENT_SENTENCE_TRANSFORMERS_TASKS
 				: [params.task];
-		if (!typedInclude(equivalentTasks, providerMapping.task)) {
+		// A model can be mapped to the same provider for several tasks (e.g. a single checkpoint
+		// exposed for both text-to-image and image-to-image). Match on the requested task rather
+		// than blindly taking the first mapping for the provider, which would reject valid
+		// requests when the task we want is not the first entry returned by the API.
+		const providerMapping = providerMappings.find((mapping) => typedInclude(equivalentTasks, mapping.task));
+		if (!providerMapping) {
+			const supportedTasks = providerMappings.map((mapping) => mapping.task).join(", ");
 			throw new InferenceClientInputError(
-				`Model ${params.modelId} is not supported for task ${params.task} and provider ${params.provider}. Supported task: ${providerMapping.task}.`,
+				`Model ${params.modelId} is not supported for task ${params.task} and provider ${params.provider}. Supported task${
+					providerMappings.length > 1 ? "s" : ""
+				}: ${supportedTasks}.`,
 			);
 		}
 		if (providerMapping.status === "staging") {

--- a/packages/inference/test/getInferenceProviderMapping.spec.ts
+++ b/packages/inference/test/getInferenceProviderMapping.spec.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getInferenceProviderMapping, inferenceProviderMappingCache } from "../src/lib/getInferenceProviderMapping.js";
+import type { InferenceProviderMappingEntry } from "../src/types.js";
+
+/**
+ * Offline tests for getInferenceProviderMapping. We seed inferenceProviderMappingCache directly
+ * so no network call to the Hub is made.
+ */
+
+const MODEL = "black-forest-labs/FLUX.2-klein-4B";
+
+function seed(entries: InferenceProviderMappingEntry[]): void {
+	inferenceProviderMappingCache.set(MODEL, entries);
+}
+
+describe("getInferenceProviderMapping - model mapped to one provider for multiple tasks", () => {
+	beforeEach(() => {
+		inferenceProviderMappingCache.clear();
+	});
+	afterEach(() => {
+		inferenceProviderMappingCache.clear();
+	});
+
+	it("resolves each task to its own mapping", async () => {
+		seed([
+			{ provider: "together", hfModelId: MODEL, providerId: "flux2-t2i", status: "live", task: "text-to-image" },
+			{ provider: "together", hfModelId: MODEL, providerId: "flux2-i2i", status: "live", task: "image-to-image" },
+		]);
+
+		const t2i = await getInferenceProviderMapping({ modelId: MODEL, provider: "together", task: "text-to-image" }, {});
+		expect(t2i?.providerId).toBe("flux2-t2i");
+
+		// Regression: previously this threw because `.find` returned the first (text-to-image)
+		// mapping for the provider and then rejected it for not matching the requested task.
+		const i2i = await getInferenceProviderMapping({ modelId: MODEL, provider: "together", task: "image-to-image" }, {});
+		expect(i2i?.providerId).toBe("flux2-i2i");
+	});
+
+	it("resolves regardless of the order the mappings are returned in", async () => {
+		seed([
+			{ provider: "together", hfModelId: MODEL, providerId: "flux2-i2i", status: "live", task: "image-to-image" },
+			{ provider: "together", hfModelId: MODEL, providerId: "flux2-t2i", status: "live", task: "text-to-image" },
+		]);
+
+		const t2i = await getInferenceProviderMapping({ modelId: MODEL, provider: "together", task: "text-to-image" }, {});
+		expect(t2i?.providerId).toBe("flux2-t2i");
+	});
+
+	it("throws a helpful error listing all supported tasks when the requested task is unsupported", async () => {
+		seed([
+			{ provider: "together", hfModelId: MODEL, providerId: "flux2-t2i", status: "live", task: "text-to-image" },
+			{ provider: "together", hfModelId: MODEL, providerId: "flux2-i2i", status: "live", task: "image-to-image" },
+		]);
+
+		await expect(
+			getInferenceProviderMapping({ modelId: MODEL, provider: "together", task: "text-to-speech" }, {}),
+		).rejects.toThrow(/not supported for task text-to-speech.*Supported tasks: text-to-image, image-to-image/);
+	});
+
+	it("still returns the single mapping for the common one-task case", async () => {
+		seed([{ provider: "together", hfModelId: MODEL, providerId: "flux2-t2i", status: "live", task: "text-to-image" }]);
+
+		const res = await getInferenceProviderMapping({ modelId: MODEL, provider: "together", task: "text-to-image" }, {});
+		expect(res?.providerId).toBe("flux2-t2i");
+	});
+});


### PR DESCRIPTION
## What

`getInferenceProviderMapping` selected the first mapping matching the provider and only *then* validated the task, throwing when it didn't match:

```ts
const providerMapping = mappings.find((mapping) => mapping.provider === params.provider);
// ...later...
if (!typedInclude(equivalentTasks, providerMapping.task)) {
  throw new InferenceClientInputError(`Model ${modelId} is not supported for task ${task} ...`);
}
```

When a model is mapped to the **same provider for more than one task** (e.g. a single checkpoint exposed for both `text-to-image` and `image-to-image`), a request for any task other than the first one returned by the API is incorrectly rejected — even though a valid mapping exists.

## Fix

Filter the provider's mappings and find the one matching the requested task (keeping the existing `EQUIVALENT_SENTENCE_TRANSFORMERS_TASKS` equivalence for `hf-inference`). The "unsupported task" error is preserved and now lists **every** task the provider supports for the model.

## Tests

Adds `test/getInferenceProviderMapping.spec.ts` (offline — seeds `inferenceProviderMappingCache`, no network):

- resolves each task to its own mapping when a model maps to one provider for two tasks
- resolves regardless of the order the API returns the mappings in
- still throws a helpful error (now listing all supported tasks) for an unsupported task
- single-mapping case unchanged

## Why

This is needed for any provider registering one model under multiple tasks. We hit it while preparing a new provider integration (deAPI) where `black-forest-labs/FLUX.2-klein-4B` is mapped to both `text-to-image` and `image-to-image`, but the change is provider-agnostic.

cc @Wauplin @hanouticelina — happy to adjust the error wording or test placement if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inference request routing for multi-task provider mappings; behavior is narrowed and tested but affects which providerId is used for live API calls.
> 
> **Overview**
> Fixes **incorrect task rejection** when one model has **multiple Hub mappings for the same provider** (e.g. `text-to-image` and `image-to-image` on the same checkpoint).
> 
> `getInferenceProviderMapping` no longer takes the **first** provider match and then validates the task. It **filters** mappings for the provider and **selects the entry whose task matches** the request (still honoring `EQUIVALENT_SENTENCE_TRANSFORMERS_TASKS` for `hf-inference`). Unsupported tasks still throw `InferenceClientInputError`, but the message now lists **all** tasks that provider supports for that model.
> 
> Adds offline Vitest coverage in `getInferenceProviderMapping.spec.ts` (cache seeding, multi-task resolution, mapping order, error text, single-mapping regression).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06dc9e81892bbd499fc16e250b831cc87412f074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->