### PR TITLE
Add TuneJury model library details

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1532,6 +1532,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/microsoft/TRELLIS.2",
 		countDownloads: `path_extension:"safetensors"`,
 	},
+	tunejury: {
+		prettyLabel: "TuneJury",
+		repoName: "TuneJury",
+		repoUrl: "https://github.com/yonghyunk1m/TuneJury",
+		countDownloads: `path:"tunejury.pt"`,
+	},
+
 	ultralytics: {
 		prettyLabel: "ultralytics",
 		repoName: "ultralytics",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1536,7 +1536,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "TuneJury",
 		repoName: "TuneJury",
 		repoUrl: "https://github.com/yonghyunk1m/TuneJury",
-		countDownloads: `path:"tunejury.pt"`,
+		countDownloads: `path_extension:"pt"`,
 	},
 
 	ultralytics: {


### PR DESCRIPTION
Registers **TuneJury,** an open reward model for text-to-music (paper: https://arxiv.org/abs/2606.17006, model: https://huggingface.co/TuneJury/tunejury), so that downloads of its .pt checkpoint are tracked. The model card sets library_name: tunejury; this entry adds a countDownloads filter matching .pt files (path_extension:"pt").

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry entry with no runtime logic changes; only affects download metrics and library UI metadata for `library_name: tunejury`.
> 
> **Overview**
> Adds a **`tunejury`** entry to `MODEL_LIBRARIES_UI_ELEMENTS` in `model-libraries.ts`, matching models that use `library_name: tunejury` on the Hub.
> 
> The entry wires display metadata (label, GitHub repo) and sets **`countDownloads`** to count **`.pt`** checkpoint files so TuneJury reward-model downloads are attributed correctly instead of using the generic default file list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f52b9492efef12a71c510a4ab2cedbf06c49278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->