### PR TITLE
Add RTX 3500 Ada Mobile specifications

### DIFF
--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -220,6 +220,14 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		power: 70,
 		releaseYear: 2023,
 	},
+  "RTX 3500 Ada Mobile": {
+    tflops: 15.8,
+    memory: [12],
+    computeCapability: 8.9,
+    msrp: 1_500,
+    power: 150,
+    releaseYear: 2023,
+  },
 	"RTX 2000 Ada": {
 		tflops: 12.0,
 		memory: [16],

--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -220,14 +220,14 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		power: 70,
 		releaseYear: 2023,
 	},
-  "RTX 3500 Ada Mobile": {
-    tflops: 15.8,
-    memory: [12],
-    computeCapability: 8.9,
-    msrp: 1_500,
-    power: 150,
-    releaseYear: 2023,
-  },
+	"RTX 3500 Ada Mobile": {
+		tflops: 15.8,
+		memory: [12],
+		computeCapability: 8.9,
+		msrp: 1_500,
+		power: 150,
+		releaseYear: 2023,
+	},
 	"RTX 2000 Ada": {
 		tflops: 12.0,
 		memory: [16],


### PR DESCRIPTION
Entry:
```
"RTX 3500 Ada Mobile": {
  tflops: 15.8,
  memory: [12],
  computeCapability: 8.9,
  msrp: 1_500,
  power: 150,
  releaseYear: 2023,
}
```

Specs sourced from TechPowerUp and Wikipedia.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only catalog addition with no logic or runtime behavior changes.
> 
> **Overview**
> Adds **RTX 3500 Ada Mobile** to `NVIDIA_SKUS` in `hardware-nvidia.ts`, slotted with the other Ada Lovelace workstation/mobile SKUs between RTX 4000 SFF Ada and RTX 2000 Ada.
> 
> The new entry records **15.8 TFLOPS**, **12 GB** VRAM, **compute capability 8.9**, **150 W** TDP, **$1,500** MSRP, and **2023** release year so task/hardware logic can recognize this laptop GPU alongside existing mobile Ada specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80f232f7064f7241fb787c33c845dc3d17ba6460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->