### PR TITLE
Add SCAIL-2 as a model library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1191,6 +1191,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.saelens,
 		filter: false,
 	},
+	"scail-2": {
+		prettyLabel: "SCAIL-2",
+		repoName: "SCAIL-2",
+		repoUrl: "https://github.com/zai-org/SCAIL-2",
+		filter: false,
+		countDownloads: `path:"model/1/fsdp2_rank_0000_checkpoint.pt"`,
+	},
 	sam2: {
 		prettyLabel: "sam2",
 		repoName: "sam2",


### PR DESCRIPTION
## Summary
- Add `scail-2` as a dedicated model library entry for SCAIL-2.
- Count downloads from the main checkpoint file: `model/1/fsdp2_rank_0000_checkpoint.pt`.

## Tests
- `pnpm --filter @huggingface/tasks format:check`
- `pnpm --filter @huggingface/tasks lint:check`