### PR TITLE
support ONNX format model countDownloads for PaddleOCR

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1053,7 +1053,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		docsUrl: "https://www.paddleocr.ai/",
 		snippets: snippets.paddleocr,
 		filter: true,
-		countDownloads: `path_extension:"safetensors" OR path:"inference.pdiparams"`,
+		countDownloads: `path_extension:"safetensors" OR path:"inference.pdiparams" OR path:"inference.onnx"`,
 	},
 	peft: {
 		prettyLabel: "PEFT",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> One-line metadata query change for download analytics only; no runtime or auth impact.
> 
> **Overview**
> **PaddleOCR** Hub download counting now treats **`inference.onnx`** as a model artifact, alongside existing **safetensors** and **`inference.pdiparams`** paths.
> 
> The change is a single **`countDownloads`** Elasticsearch clause in `model-libraries.ts`, so ONNX-only PaddleOCR repos are included in library download stats instead of being undercounted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 799db5f912f62778453108a97bb7a24f7d4ded1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->