### PR TITLE
fix: use causal LM auto class for text-generation snippets

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.spec.ts
+++ b/packages/tasks/src/model-libraries-snippets.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ModelData } from "./model-data.js";
-import { llama_cpp_python, transformers } from "./model-libraries-snippets.js";
+import { llama_cpp_python, pruna, transformers } from "./model-libraries-snippets.js";
 
 describe("model-libraries-snippets", () => {
 	it("llama_cpp_python conversational", async () => {
@@ -75,5 +75,27 @@ print(output)`);
 
 		expect(snippet).toContain("AutoModelForCausalLM");
 		expect(snippet).not.toContain("AutoModelForMultimodalLM");
+	});
+
+	it("pruna transformers cleanup stays consistent with the corrected auto_model", async () => {
+		const model: ModelData = {
+			id: "WeiboAI/VibeThinker-3B",
+			pipeline_tag: "text-generation",
+			tags: ["transformers"],
+			inference: "",
+			config: {
+				architectures: ["Qwen2ForCausalLM"],
+			},
+			transformersInfo: {
+				auto_model: "AutoModelForMultimodalLM",
+				pipeline_tag: "text-generation",
+				processor: "AutoTokenizer",
+			},
+		};
+		const snippet = pruna(model).join("\n");
+
+		expect(snippet).not.toContain("AutoModelForMultimodalLM");
+		expect(snippet).not.toContain("AutoModelForCausalLM.from_pretrained");
+		expect(snippet).toContain("PrunaModel.from_pretrained");
 	});
 });

--- a/packages/tasks/src/model-libraries-snippets.spec.ts
+++ b/packages/tasks/src/model-libraries-snippets.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ModelData } from "./model-data.js";
-import { llama_cpp_python } from "./model-libraries-snippets.js";
+import { llama_cpp_python, transformers } from "./model-libraries-snippets.js";
 
 describe("model-libraries-snippets", () => {
 	it("llama_cpp_python conversational", async () => {
@@ -54,5 +54,26 @@ output = llm(
 	echo=True
 )
 print(output)`);
+	});
+
+	it("transformers prefers AutoModelForCausalLM for text-generation models misclassified as multimodal", async () => {
+		const model: ModelData = {
+			id: "WeiboAI/VibeThinker-3B",
+			pipeline_tag: "text-generation",
+			tags: [],
+			inference: "",
+			config: {
+				architectures: ["Qwen2ForCausalLM"],
+			},
+			transformersInfo: {
+				auto_model: "AutoModelForMultimodalLM",
+				pipeline_tag: "text-generation",
+				processor: "AutoTokenizer",
+			},
+		};
+		const snippet = transformers(model).join("\n");
+
+		expect(snippet).toContain("AutoModelForCausalLM");
+		expect(snippet).not.toContain("AutoModelForMultimodalLM");
 	});
 });

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1,4 +1,4 @@
-import type { ModelData } from "./model-data.js";
+import type { ModelData, TransformersInfo } from "./model-data.js";
 import type { WidgetExampleTextInput, WidgetExampleSentenceSimilarityInput } from "./widget-example.js";
 import { LIBRARY_TASK_MAPPING, REMOVED_IN_V5_TRANSFORMERS_PIPELINES } from "./library-to-tasks.js";
 import { getModelInputSnippet } from "./snippets/inputs.js";
@@ -1735,9 +1735,14 @@ const hasChatTemplate = (model: ModelData): boolean =>
 	model.config?.processor_config?.chat_template !== undefined ||
 	model.config?.chat_template_jinja !== undefined;
 
-export const transformers = (model: ModelData): string[] => {
+/**
+ * Returns a shallow copy of `model.transformersInfo` with `auto_model` corrected
+ * to `AutoModelForCausalLM` for text-generation causal LM models that were
+ * misclassified as `AutoModelForMultimodalLM`. Does not mutate `model.transformersInfo`.
+ */
+const getTransformersInfoForSnippet = (model: ModelData): TransformersInfo | undefined => {
 	if (!model.transformersInfo) {
-		return [`# ⚠️ Type of model unknown`];
+		return undefined;
 	}
 	const info = { ...model.transformersInfo };
 	if (
@@ -1746,6 +1751,14 @@ export const transformers = (model: ModelData): string[] => {
 		model.config?.architectures?.some((architecture) => architecture.endsWith("ForCausalLM"))
 	) {
 		info.auto_model = "AutoModelForCausalLM";
+	}
+	return info;
+};
+
+export const transformers = (model: ModelData): string[] => {
+	const info = getTransformersInfoForSnippet(model);
+	if (!info) {
+		return [`# ⚠️ Type of model unknown`];
 	}
 	const remote_code_snippet = model.tags.includes(TAG_CUSTOM_CODE) ? ", trust_remote_code=True" : "";
 
@@ -2288,7 +2301,7 @@ const pruna_diffusers = (model: ModelData): string[] => {
 };
 
 const pruna_transformers = (model: ModelData): string[] => {
-	const info = model.transformersInfo;
+	const info = getTransformersInfoForSnippet(model);
 	const transformersSnippets = transformers(model);
 
 	// Replace pipeline with PrunaModel

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1736,9 +1736,16 @@ const hasChatTemplate = (model: ModelData): boolean =>
 	model.config?.chat_template_jinja !== undefined;
 
 export const transformers = (model: ModelData): string[] => {
-	const info = model.transformersInfo;
-	if (!info) {
+	if (!model.transformersInfo) {
 		return [`# ⚠️ Type of model unknown`];
+	}
+	const info = { ...model.transformersInfo };
+	if (
+		info.auto_model === "AutoModelForMultimodalLM" &&
+		model.pipeline_tag === "text-generation" &&
+		model.config?.architectures?.some((architecture) => architecture.endsWith("ForCausalLM"))
+	) {
+		info.auto_model = "AutoModelForCausalLM";
 	}
 	const remote_code_snippet = model.tags.includes(TAG_CUSTOM_CODE) ? ", trust_remote_code=True" : "";
 


### PR DESCRIPTION
## Summary

This PR fixes Transformers snippet generation for text-generation causal LM models whose `transformersInfo.auto_model` is incorrectly set to `AutoModelForMultimodalLM`.

## Problem

Some text-generation models, such as models with architectures like `Qwen2ForCausalLM`, can generate a snippet using:

```
AutoModelForMultimodalLM
```

even though the model is a text-generation causal language model. This can produce confusing or incorrect generated usage snippets.

## Fix

Inside `transformers()`, this PR now uses a local shallow copy of `model.transformersInfo` and overrides `auto_model` to `AutoModelForCausalLM` only when all of the following are true:

- `model.pipeline_tag === "text-generation"`
- `model.config?.architectures` contains an architecture ending with `ForCausalLM`
- `transformersInfo.auto_model === "AutoModelForMultimodalLM"`

The original `model.transformersInfo` object is not mutated.

## Tests

Added a test case matching the VibeThinker-3B shape:

- `pipeline_tag: "text-generation"`
- `architectures: ["Qwen2ForCausalLM"]`
- `auto_model: "AutoModelForMultimodalLM"`

The test verifies that the generated snippet contains `AutoModelForCausalLM` and does not contain `AutoModelForMultimodalLM`.

## Validation

- TypeScript type-check passed
- Vitest suite passed
- Existing multimodal snippet logic was not changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only snippet string changes with narrow, rule-gated overrides; no inference, auth, or persistence paths touched.
> 
> **Overview**
> Fixes **Transformers** and **Pruna** usage snippets for text-generation causal LMs whose metadata incorrectly lists `AutoModelForMultimodalLM` as `auto_model` (e.g. `Qwen2ForCausalLM` models like VibeThinker-3B).
> 
> Adds **`getTransformersInfoForSnippet`**, which returns a shallow copy of `transformersInfo` and overrides `auto_model` to **`AutoModelForCausalLM`** only when `pipeline_tag` is `text-generation`, an architecture ends with `ForCausalLM`, and the stored class is `AutoModelForMultimodalLM`—without mutating the original model object. **`transformers()`** and **`pruna_transformers()`** now build snippets from that corrected info.
> 
> Vitest cases assert generated snippets use the causal LM class (and that Pruna output still uses `PrunaModel.from_pretrained` without leaking the wrong auto class).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64d1e49e5c951c6874036d38e4e422ef46b085e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->