### PR TITLE
Add ask-my-agent bench v2 eval harness.

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -154,4 +154,5 @@ export const EVALUATION_FRAMEWORKS = {
 		description:
 			"ask-my-agent bench v2 is a benchmark for testing AI's usability on simple tasks on simple agent harness, ask-my-agent. Measures common agentic capabilities.",
 		url: "https://huggingface.co/datasets/sapbot/ask-my-agent-bench-2/"
+	}
 } as const;

--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -149,4 +149,9 @@ export const EVALUATION_FRAMEWORKS = {
 			"MMMU is a new benchmark designed to evaluate multimodal models on massive multi-discipline tasks demanding college-level subject knowledge and deliberate reasoning.",
 		url: "https://mmmu-benchmark.github.io/",
 	},
+	askmyagentbench2: {
+		name: "askmyagentbench2",
+		description:
+			"ask-my-agent bench v2 is a benchmark for testing AI's usability on simple tasks on simple agent harness, ask-my-agent. Measures common agentic capabilities.",
+		url: "https://huggingface.co/datasets/sapbot/ask-my-agent-bench-2/"
 } as const;


### PR DESCRIPTION
# Information
This benchmark is mainly about testing agentic capabilities on simple tasks, using simple tools. Mainly targeted at SLM, but testing big LM too.
---
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only registry change with no runtime or security impact.
> 
> **Overview**
> Registers **ask-my-agent bench v2** (`askmyagentbench2`) in `EVALUATION_FRAMEWORKS` so benchmark datasets can reference it from `eval.yaml`.
> 
> The new entry includes a short description (simple tasks on the ask-my-agent harness, common agentic capabilities) and links to the Hugging Face dataset page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e389d2ba7eff6c6f1e775714648c62ac6515c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->