### PR TITLE
Add RWKV download stats

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1184,6 +1184,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_extension:"safetensors"`,
 	},
+	rwkv: {
+		prettyLabel: "RWKV",
+		repoName: "RWKV-LM",
+		repoUrl: "https://github.com/BlinkDL/RWKV-LM",
+		docsUrl: "https://rwkv.com/",
+		filter: false,
+		countDownloads: `path_extension:"pth"`,
+	},
 	saelens: {
 		prettyLabel: "SAELens",
 		repoName: "SAELens",


### PR DESCRIPTION
Add RWKV download stats for https://huggingface.co/BlinkDL/rwkv7-g1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry addition with no auth or runtime behavior changes; only affects how download stats are attributed for the `rwkv` library tag.
> 
> **Overview**
> Registers **RWKV** as a modeling library in `MODEL_LIBRARIES_UI_ELEMENTS` so Hub models with `library_name: rwkv` get correct download accounting (e.g. `BlinkDL/rwkv7-g1`).
> 
> The new entry points at RWKV-LM and rwkv.com, sets `filter: false` (no models-page library filter), and counts downloads via Elasticsearch on files with extension **`.pth`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c06770b947b6e507e785066285db66760bab1d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->