### PR TITLE
Add hardware specs for my Lenovo Thinkpad P16V Gen2

### DIFF
--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -228,6 +228,14 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		power: 150,
 		releaseYear: 2023,
 	},
+	"RTX 2000 Ada Laptop": {
+		tflops: 12.9,
+		memory: [8],
+		computeCapability: 8.9,
+		msrp: 650,
+		power: 50,
+		releaseYear: 2023,
+	},
 	"RTX 2000 Ada": {
 		tflops: 12.0,
 		memory: [16],

--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -197,6 +197,12 @@ export const SKUS = {
 				power: 160,
 				releaseYear: 2025,
 			},
+			"Intel Core Ultra 7 155H": {
+				tflops: 1.488,
+				msrp: 503,
+				power: 115,
+				releaseYear: 2023,
+			},
 			"Intel Core Ultra 7 255HX": {
 				tflops: 1.62,
 				msrp: 583,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Data-only additions to hardware lookup tables with no runtime or security behavior changes.
> 
> **Overview**
> Adds two **static hardware SKU** entries so a Lenovo ThinkPad P16V Gen2 can be represented in the tasks hardware catalog.
> 
> In `hardware-nvidia.ts`, a new **`RTX 2000 Ada Laptop`** entry (8 GB VRAM, Ada 8.9, ~12.9 TFLOPS, 50 W) sits alongside the existing desktop **`RTX 2000 Ada`** variant, which differs mainly in memory and power.
> 
> In `hardware.ts`, **`Intel Core Ultra 7 155H`** is added under Intel CPUs with approximate tflops, MSRP, power, and 2023 release year.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2561df6d52ada5a35e66f2b4011aac3d04ebb437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->