### PR TITLE
[hub] XetBlob: use /v2/reconstructions with v1 fallback

### DIFF
--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from "vitest";
-import type { ReconstructionInfo } from "./XetBlob";
-import { bg4_regroup_bytes, bg4_split_bytes, XetBlob } from "./XetBlob";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { ReconstructionInfo, ReconstructionInfoV2 } from "./XetBlob";
+import { bg4_regroup_bytes, bg4_split_bytes, clearReconstructionApiVersionCache, XetBlob } from "./XetBlob";
 import { sum } from "./sum";
 
 describe("XetBlob", () => {
+	beforeEach(() => {
+		// The detected reconstruction API version is cached per CAS endpoint at module scope;
+		// reset it so tests don't leak state into each other.
+		clearReconstructionApiVersionCache();
+	});
+
 	it("should handle empty files (size 0) without making network requests", async () => {
 		let fetchCount = 0;
 
@@ -200,6 +206,215 @@ describe("XetBlob", () => {
 		expect(text.length).toBe(bridgeDownload.length);
 	});
 
+	describe("v2 reconstruction", () => {
+		function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+			const total = arrays.reduce((s, a) => s + a.byteLength, 0);
+			const out = new Uint8Array(total);
+			let offset = 0;
+			for (const a of arrays) {
+				out.set(a, offset);
+				offset += a.byteLength;
+			}
+			return out;
+		}
+
+		function makeMultipartResponse(
+			boundary: string,
+			parts: Array<{ range: { start: number; end: number }; total: number; data: Uint8Array }>,
+		): Response {
+			const enc = new TextEncoder();
+			const segments: Uint8Array[] = [];
+			for (const part of parts) {
+				segments.push(
+					enc.encode(
+						`\r\n--${boundary}\r\nContent-Type: application/octet-stream\r\n` +
+							`Content-Range: bytes ${part.range.start}-${part.range.end}/${part.total}\r\n\r\n`,
+					),
+					part.data,
+				);
+			}
+			segments.push(enc.encode(`\r\n--${boundary}--\r\n`));
+
+			return new Response(concatBytes(...segments), {
+				headers: { "Content-Type": `multipart/byteranges; boundary=${boundary}` },
+			});
+		}
+
+		it("fetches a multi-range xorb in one multipart/byteranges request", async () => {
+			const c0 = makeChunk("hello");
+			const c1 = makeChunk("world");
+			const c2 = makeChunk("foo");
+			const c3 = makeChunk("bar!");
+			const rangeAData = concatBytes(c0, c1);
+			const rangeBData = concatBytes(c2, c3);
+			const lenA = rangeAData.byteLength;
+			const lenB = rangeBData.byteLength;
+			const total = lenA + lenB;
+
+			const wholeText = "helloworldfoobar!";
+
+			let fetchCount = 0;
+			let multiRangeHeader: string | undefined;
+
+			const blob = new XetBlob({
+				hash: "test",
+				size: wholeText.length,
+				refreshUrl: "https://huggingface.co",
+				fetch: async function (_url, opts) {
+					const url = new URL(_url as string);
+					const headers = opts?.headers as Record<string, string> | undefined;
+
+					switch (url.hostname) {
+						case "huggingface.co":
+							return new Response(JSON.stringify({ casUrl: "https://v2cas.co", accessToken: "boo", exp: 1_000_000 }));
+						case "v2cas.co": {
+							expect(url.pathname).toContain("/v2/reconstructions/");
+							return new Response(
+								JSON.stringify({
+									terms: [
+										{ hash: "xorb1", range: { start: 0, end: 2 }, unpacked_length: 10 },
+										{ hash: "xorb1", range: { start: 2, end: 4 }, unpacked_length: 7 },
+									],
+									xorbs: {
+										xorb1: [
+											{
+												url: "https://v2fetch.co",
+												ranges: [
+													{ chunks: { start: 0, end: 2 }, bytes: { start: 0, end: lenA - 1 } },
+													{ chunks: { start: 2, end: 4 }, bytes: { start: lenA, end: total - 1 } },
+												],
+											},
+										],
+									},
+									offset_into_first_range: 0,
+								} satisfies ReconstructionInfoV2),
+							);
+						}
+						case "v2fetch.co": {
+							fetchCount++;
+							multiRangeHeader = headers?.["Range"];
+							return makeMultipartResponse("BOUNDARY", [
+								{ range: { start: 0, end: lenA - 1 }, total, data: rangeAData },
+								{ range: { start: lenA, end: total - 1 }, total, data: rangeBData },
+							]);
+						}
+						default:
+							throw new Error(`Unhandled URL ${url.hostname}`);
+					}
+				},
+			});
+
+			expect(await blob.text()).toBe(wholeText);
+			// Both ranges of the xorb are fetched together in a single multi-range request.
+			expect(fetchCount).toBe(1);
+			expect(multiRangeHeader).toBe(`bytes=0-${lenA - 1},${lenA}-${total - 1}`);
+		});
+
+		it("falls back to v1 when v2 returns 404", async () => {
+			const c0 = makeChunk("hello");
+			const c1 = makeChunk("world");
+			const xorbData = concatBytes(c0, c1);
+			const wholeText = "helloworld";
+
+			const versionsRequested: string[] = [];
+			let fetchCount = 0;
+
+			const blob = new XetBlob({
+				hash: "test",
+				size: wholeText.length,
+				refreshUrl: "https://huggingface.co",
+				fetch: async function (_url, opts) {
+					const url = new URL(_url as string);
+					const headers = opts?.headers as Record<string, string> | undefined;
+
+					switch (url.hostname) {
+						case "huggingface.co":
+							return new Response(JSON.stringify({ casUrl: "https://cas.co", accessToken: "boo", exp: 1_000_000 }));
+						case "cas.co": {
+							versionsRequested.push(url.pathname.includes("/v2/") ? "v2" : "v1");
+							if (url.pathname.includes("/v2/")) {
+								return new Response(null, { status: 404 });
+							}
+							return new Response(
+								JSON.stringify({
+									terms: [{ hash: "xorb1", range: { start: 0, end: 2 }, unpacked_length: 10 }],
+									fetch_info: {
+										xorb1: [
+											{
+												url: "https://fetch.co",
+												range: { start: 0, end: 2 },
+												url_range: { start: 0, end: xorbData.byteLength - 1 },
+											},
+										],
+									},
+									offset_into_first_range: headers?.["Range"]
+										? Number(headers["Range"].slice("bytes=".length).split("-")[0])
+										: 0,
+								} satisfies ReconstructionInfo),
+							);
+						}
+						case "fetch.co": {
+							fetchCount++;
+							return new Response(xorbData);
+						}
+						default:
+							throw new Error(`Unhandled URL ${url.hostname}`);
+					}
+				},
+			});
+
+			expect(await blob.text()).toBe(wholeText);
+			expect(versionsRequested).toEqual(["v2", "v1"]);
+			expect(fetchCount).toBe(1);
+		});
+
+		it("handles a single-range v2 xorb without multipart", async () => {
+			const c0 = makeChunk("hello");
+			const c1 = makeChunk("world");
+			const xorbData = concatBytes(c0, c1);
+			const wholeText = "helloworld";
+
+			let fetchCount = 0;
+
+			const blob = new XetBlob({
+				hash: "test",
+				size: wholeText.length,
+				refreshUrl: "https://huggingface.co",
+				fetch: async function (_url) {
+					const url = new URL(_url as string);
+
+					switch (url.hostname) {
+						case "huggingface.co":
+							return new Response(JSON.stringify({ casUrl: "https://v2cas.co", accessToken: "boo", exp: 1_000_000 }));
+						case "v2cas.co":
+							return new Response(
+								JSON.stringify({
+									terms: [{ hash: "xorb1", range: { start: 0, end: 2 }, unpacked_length: 10 }],
+									xorbs: {
+										xorb1: [
+											{
+												url: "https://v2fetch.co",
+												ranges: [{ chunks: { start: 0, end: 2 }, bytes: { start: 0, end: xorbData.byteLength - 1 } }],
+											},
+										],
+									},
+									offset_into_first_range: 0,
+								} satisfies ReconstructionInfoV2),
+							);
+						case "v2fetch.co":
+							fetchCount++;
+							return new Response(xorbData);
+						default:
+							throw new Error(`Unhandled URL ${url.hostname}`);
+					}
+				},
+			});
+
+			expect(await blob.text()).toBe(wholeText);
+			expect(fetchCount).toBe(1);
+		});
+	});
+
 	describe("bg4_regoup_bytes", () => {
 		it("should regroup bytes when the array is %4 length", () => {
 			expect(bg4_regroup_bytes(new Uint8Array([1, 5, 2, 6, 3, 7, 4, 8]))).toEqual(
@@ -306,6 +521,10 @@ describe("XetBlob", () => {
 								);
 							}
 							case "cas.co": {
+								if (url.pathname.includes("/v2/")) {
+									// Simulate a V1-only CAS endpoint: V2 reconstruction is unavailable.
+									return new Response(null, { status: 404 });
+								}
 								// This is the reconstruction info
 								const range = headers?.["Range"]?.slice("bytes=".length).split("-").map(Number);
 
@@ -409,6 +628,10 @@ describe("XetBlob", () => {
 								);
 							}
 							case "cas.co": {
+								if (url.pathname.includes("/v2/")) {
+									// Simulate a V1-only CAS endpoint: V2 reconstruction is unavailable.
+									return new Response(null, { status: 404 });
+								}
 								// This is the reconstruction info
 								const range = headers?.["Range"]?.slice("bytes=".length).split("-").map(Number);
 
@@ -524,6 +747,10 @@ describe("XetBlob", () => {
 								);
 							}
 							case "cas.co": {
+								if (url.pathname.includes("/v2/")) {
+									// Simulate a V1-only CAS endpoint: V2 reconstruction is unavailable.
+									return new Response(null, { status: 404 });
+								}
 								// This is the reconstruction info
 								const range = headers?.["Range"]?.slice("bytes=".length).split("-").map(Number);
 
@@ -634,6 +861,10 @@ describe("XetBlob", () => {
 								);
 							}
 							case "cas.co": {
+								if (url.pathname.includes("/v2/")) {
+									// Simulate a V1-only CAS endpoint: V2 reconstruction is unavailable.
+									return new Response(null, { status: 404 });
+								}
 								// This is the reconstruction info
 								const range = headers?.["Range"]?.slice("bytes=".length).split("-").map(Number);
 
@@ -742,6 +973,10 @@ describe("XetBlob", () => {
 								);
 							}
 							case "cas.co": {
+								if (url.pathname.includes("/v2/")) {
+									// Simulate a V1-only CAS endpoint: V2 reconstruction is unavailable.
+									return new Response(null, { status: 404 });
+								}
 								// This is the reconstruction info
 								const range = headers?.["Range"]?.slice("bytes=".length).split("-").map(Number);
 
@@ -849,6 +1084,10 @@ describe("XetBlob", () => {
 								);
 							}
 							case "cas.co": {
+								if (url.pathname.includes("/v2/")) {
+									// Simulate a V1-only CAS endpoint: V2 reconstruction is unavailable.
+									return new Response(null, { status: 404 });
+								}
 								// This is the reconstruction info
 								const range = headers?.["Range"]?.slice("bytes=".length).split("-").map(Number);
 

--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -413,6 +413,121 @@ describe("XetBlob", () => {
 			expect(await blob.text()).toBe(wholeText);
 			expect(fetchCount).toBe(1);
 		});
+
+		it("throws on a non-multipart response to a multi-range request", async () => {
+			const c0 = makeChunk("hello");
+			const c1 = makeChunk("world");
+			const c2 = makeChunk("foo");
+			const c3 = makeChunk("bar!");
+			const rangeAData = concatBytes(c0, c1);
+			const rangeBData = concatBytes(c2, c3);
+			const lenA = rangeAData.byteLength;
+			const total = lenA + rangeBData.byteLength;
+
+			const blob = new XetBlob({
+				hash: "test",
+				size: "helloworldfoobar!".length,
+				refreshUrl: "https://huggingface.co",
+				fetch: async function (_url) {
+					const url = new URL(_url as string);
+
+					switch (url.hostname) {
+						case "huggingface.co":
+							return new Response(JSON.stringify({ casUrl: "https://v2cas.co", accessToken: "boo", exp: 1_000_000 }));
+						case "v2cas.co":
+							return new Response(
+								JSON.stringify({
+									terms: [
+										{ hash: "xorb1", range: { start: 0, end: 2 }, unpacked_length: 10 },
+										{ hash: "xorb1", range: { start: 2, end: 4 }, unpacked_length: 7 },
+									],
+									xorbs: {
+										xorb1: [
+											{
+												url: "https://v2fetch.co",
+												ranges: [
+													{ chunks: { start: 0, end: 2 }, bytes: { start: 0, end: lenA - 1 } },
+													{ chunks: { start: 2, end: 4 }, bytes: { start: lenA, end: total - 1 } },
+												],
+											},
+										],
+									},
+									offset_into_first_range: 0,
+								} satisfies ReconstructionInfoV2),
+							);
+						case "v2fetch.co":
+							// Server ignored the multi-range request and returned the whole xorb.
+							return new Response(concatBytes(rangeAData, rangeBData));
+						default:
+							throw new Error(`Unhandled URL ${url.hostname}`);
+					}
+				},
+			});
+
+			await expect(blob.text()).rejects.toThrow(/multipart\/byteranges/);
+		});
+
+		it("throws instead of retrying single-range when a multipart part is missing", async () => {
+			const c0 = makeChunk("hello");
+			const c1 = makeChunk("world");
+			const c2 = makeChunk("foo");
+			const c3 = makeChunk("bar!");
+			const rangeAData = concatBytes(c0, c1);
+			const rangeBData = concatBytes(c2, c3);
+			const lenA = rangeAData.byteLength;
+			const total = lenA + rangeBData.byteLength;
+
+			const rangeHeaders: Array<string | undefined> = [];
+
+			const blob = new XetBlob({
+				hash: "test",
+				size: "helloworldfoobar!".length,
+				refreshUrl: "https://huggingface.co",
+				fetch: async function (_url, opts) {
+					const url = new URL(_url as string);
+					const headers = opts?.headers as Record<string, string> | undefined;
+
+					switch (url.hostname) {
+						case "huggingface.co":
+							return new Response(JSON.stringify({ casUrl: "https://v2cas.co", accessToken: "boo", exp: 1_000_000 }));
+						case "v2cas.co":
+							return new Response(
+								JSON.stringify({
+									terms: [
+										{ hash: "xorb1", range: { start: 0, end: 2 }, unpacked_length: 10 },
+										{ hash: "xorb1", range: { start: 2, end: 4 }, unpacked_length: 7 },
+									],
+									xorbs: {
+										xorb1: [
+											{
+												url: "https://v2fetch.co",
+												ranges: [
+													{ chunks: { start: 0, end: 2 }, bytes: { start: 0, end: lenA - 1 } },
+													{ chunks: { start: 2, end: 4 }, bytes: { start: lenA, end: total - 1 } },
+												],
+											},
+										],
+									},
+									offset_into_first_range: 0,
+								} satisfies ReconstructionInfoV2),
+							);
+						case "v2fetch.co":
+							rangeHeaders.push(headers?.["Range"]);
+							// Multipart response missing the second requested part.
+							return makeMultipartResponse("BOUNDARY", [
+								{ range: { start: 0, end: lenA - 1 }, total, data: rangeAData },
+							]);
+						default:
+							throw new Error(`Unhandled URL ${url.hostname}`);
+					}
+				},
+			});
+
+			await expect(blob.text()).rejects.toThrow(/did not produce all chunks/);
+			// The multi-range signed URL must never be fetched with a single-range header.
+			const multiRangeHeader = `bytes=0-${lenA - 1},${lenA}-${total - 1}`;
+			expect(rangeHeaders.every((h) => h === multiRangeHeader)).toBe(true);
+		});
 	});
 
 	describe("bg4_regoup_bytes", () => {

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -242,11 +242,6 @@ function decompressChunk(chunkHeader: ChunkHeader, compressed: Uint8Array): Uint
 	}
 }
 
-function parseSingleContentRange(value: string | null): { start: number; end: number } | undefined {
-	const match = value?.match(/bytes\s+(\d+)-(\d+)\//i);
-	return match ? { start: parseInt(match[1], 10), end: parseInt(match[2], 10) } : undefined;
-}
-
 /**
  * Decode a fully-buffered xorb chunk stream (one `multipart/byteranges` part) and store the
  * decompressed chunks into the range list, so the term reader can yield them from cache.
@@ -529,16 +524,13 @@ export class XetBlob extends Blob {
 					const body = new Uint8Array(await resp.arrayBuffer());
 					const contentType = resp.headers.get("content-type") ?? "";
 
-					const parts = contentType.includes("multipart/byteranges")
-						? parseMultipartByteRanges(contentType, body)
-						: // Single-range response (eg the server merged contiguous ranges): map the whole body to
-							// the matching descriptor by Content-Range, falling back to the first requested range.
-							[
-								{
-									range: parseSingleContentRange(resp.headers.get("content-range")) ?? group.ranges[0].url_range,
-									data: body,
-								},
-							];
+					if (!contentType.includes("multipart/byteranges")) {
+						// A server that coalesces or ignores the multi-range request cannot be mapped back to
+						// the requested ranges safely, so decoding the body heuristically risks corruption.
+						throw new Error(`Expected multipart/byteranges response for multi-range request, got "${contentType}"`);
+					}
+
+					const parts = parseMultipartByteRanges(contentType, body);
 
 					for (const part of parts) {
 						const descriptor =
@@ -560,6 +552,14 @@ export class XetBlob extends Blob {
 					if (located && located.group.ranges.length > 1) {
 						await fetchMultiRangeGroup(located.group);
 						termRanges = rangeList.getRanges(term.range.start, term.range.end);
+						if (!termRanges.every((range) => range.data)) {
+							// The single-range path below must never run against a multi-range signed URL:
+							// its signature covers the exact multi-range header, and partially-cached ranges
+							// would get streamed chunks appended, corrupting output.
+							throw new Error(
+								`Multi-range fetch did not produce all chunks for term ${term.hash} range ${term.range.start}-${term.range.end}`,
+							);
+						}
 					}
 				}
 

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -532,13 +532,13 @@ export class XetBlob extends Blob {
 					const parts = contentType.includes("multipart/byteranges")
 						? parseMultipartByteRanges(contentType, body)
 						: // Single-range response (eg the server merged contiguous ranges): map the whole body to
-						  // the matching descriptor by Content-Range, falling back to the first requested range.
-						  [
+							// the matching descriptor by Content-Range, falling back to the first requested range.
+							[
 								{
 									range: parseSingleContentRange(resp.headers.get("content-range")) ?? group.ranges[0].url_range,
 									data: body,
 								},
-						  ];
+							];
 
 					for (const part of parts) {
 						const descriptor =
@@ -961,7 +961,7 @@ async function getAccessToken(
 				...(initialAccessToken
 					? {
 							Authorization: `Bearer ${initialAccessToken}`,
-					  }
+						}
 					: {}),
 			},
 		});

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -4,6 +4,7 @@ import { checkCredentials } from "./checkCredentials";
 import { combineUint8Arrays } from "./combineUint8Arrays";
 import { decompress as lz4_decompress } from "../vendor/lz4js";
 import { RangeList } from "./RangeList";
+import { parseMultipartByteRanges } from "./multipart";
 
 const JWT_SAFETY_PERIOD = 60_000;
 const JWT_CACHE_SIZE = 1_000;
@@ -67,6 +68,121 @@ export interface ReconstructionInfo {
 	offset_into_first_range: number;
 }
 
+/**
+ * Response shape for `GET /v2/reconstructions/{hash}`.
+ *
+ * Unlike V1, a single signed URL can carry multiple byte ranges for a xorb. When more than one
+ * range is requested from a URL, the server replies with a `multipart/byteranges` body.
+ */
+export interface ReconstructionInfoV2 {
+	/**
+	 * List of CAS blocks (same as V1).
+	 */
+	terms: Array<{
+		hash: string;
+		unpacked_length: number;
+		range: { start: number; end: number };
+	}>;
+
+	/**
+	 * Map from CAS block hash => list of multi-range fetch entries. Typically one entry per xorb;
+	 * multiple entries when a URL length limit forces a split.
+	 */
+	xorbs: Record<
+		string,
+		Array<{
+			/** Signed URL covering all of the ranges below. The exact multi-range Range header must be sent. */
+			url: string;
+			ranges: Array<{
+				/** Chunk index range [start, end) within the xorb. */
+				chunks: { start: number; end: number };
+				/** Physical byte range [start, end] (inclusive end) for the HTTP Range header. */
+				bytes: { start: number; end: number };
+			}>;
+		}>
+	>;
+
+	offset_into_first_range: number;
+}
+
+/**
+ * A signed URL plus the chunk/byte ranges it covers. V1 and V2 reconstruction responses are both
+ * normalized into this shape: V1 yields one single-range group per fetch entry, V2 keeps the
+ * server's multi-range grouping.
+ */
+interface FetchGroup {
+	url: string;
+	ranges: Array<{
+		/** Chunk index range [start, end). */
+		range: { start: number; end: number };
+		/** Byte range [start, end] (inclusive end) for the Range header. */
+		url_range: { start: number; end: number };
+	}>;
+}
+
+interface NormalizedReconstructionInfo {
+	terms: ReconstructionInfo["terms"];
+	/** Map from CAS block hash => fetch groups. */
+	fetch_info: Record<string, FetchGroup[]>;
+	offset_into_first_range: number;
+}
+
+function normalizeV1(info: ReconstructionInfo): NormalizedReconstructionInfo {
+	const fetch_info: Record<string, FetchGroup[]> = {};
+	for (const [hash, infos] of Object.entries(info.fetch_info)) {
+		fetch_info[hash] = infos.map((info) => ({
+			url: info.url,
+			ranges: [{ range: info.range, url_range: info.url_range }],
+		}));
+	}
+	return { terms: info.terms, fetch_info, offset_into_first_range: info.offset_into_first_range };
+}
+
+function normalizeV2(info: ReconstructionInfoV2): NormalizedReconstructionInfo {
+	const fetch_info: Record<string, FetchGroup[]> = {};
+	for (const [hash, fetches] of Object.entries(info.xorbs)) {
+		fetch_info[hash] = fetches.map((fetch) => ({
+			url: fetch.url,
+			ranges: fetch.ranges.map((r) => ({ range: r.chunks, url_range: r.bytes })),
+		}));
+	}
+	return { terms: info.terms, fetch_info, offset_into_first_range: info.offset_into_first_range };
+}
+
+/**
+ * Cache of the detected reconstruction API version per CAS endpoint, to avoid re-probing V2 on
+ * every request once we've learned an endpoint only supports V1.
+ */
+const reconstructionApiVersions = new Map<string, 1 | 2>();
+
+// Exported for testing purposes: reset the per-endpoint reconstruction API version cache.
+export function clearReconstructionApiVersionCache(): void {
+	reconstructionApiVersions.clear();
+}
+
+/**
+ * Build the reconstruction URL for a given API version, or undefined when it can't be built.
+ *
+ * When an explicit `reconstructionUrl` is provided (from the `xet-reconstruction-info` Link header,
+ * which points at V1), other versions are derived by swapping the path segment.
+ */
+function reconstructionUrlForVersion(
+	params: { reconstructionUrl?: string; casUrl: string; hash?: string },
+	version: 1 | 2,
+): string | undefined {
+	if (params.reconstructionUrl) {
+		if (version === 1) {
+			return params.reconstructionUrl;
+		}
+		const derived = params.reconstructionUrl.replace("/v1/reconstructions/", `/v${version}/reconstructions/`);
+		return derived === params.reconstructionUrl ? undefined : derived;
+	}
+	if (params.hash) {
+		return `${params.casUrl}/v${version}/reconstructions/${params.hash}`;
+	}
+	return undefined;
+}
+
 export enum XetChunkCompressionScheme {
 	None = 0,
 	LZ4 = 1,
@@ -88,6 +204,88 @@ interface ChunkHeader {
 
 export const XET_CHUNK_HEADER_BYTES = 8;
 
+function parseChunkHeader(view: DataView): ChunkHeader {
+	const chunkHeader: ChunkHeader = {
+		version: view.getUint8(0),
+		compressed_length: view.getUint8(1) | (view.getUint8(2) << 8) | (view.getUint8(3) << 16),
+		compression_scheme: view.getUint8(4),
+		uncompressed_length: view.getUint8(5) | (view.getUint8(6) << 8) | (view.getUint8(7) << 16),
+	};
+
+	if (chunkHeader.version !== 0) {
+		throw new Error(`Unsupported chunk version ${chunkHeader.version}`);
+	}
+
+	if (
+		chunkHeader.compression_scheme !== XetChunkCompressionScheme.None &&
+		chunkHeader.compression_scheme !== XetChunkCompressionScheme.LZ4 &&
+		chunkHeader.compression_scheme !== XetChunkCompressionScheme.ByteGroupingLZ4
+	) {
+		throw new Error(
+			`Unsupported compression scheme ${
+				compressionSchemeLabels[chunkHeader.compression_scheme] ?? chunkHeader.compression_scheme
+			}`,
+		);
+	}
+
+	return chunkHeader;
+}
+
+function decompressChunk(chunkHeader: ChunkHeader, compressed: Uint8Array): Uint8Array {
+	switch (chunkHeader.compression_scheme) {
+		case XetChunkCompressionScheme.LZ4:
+			return lz4_decompress(compressed, chunkHeader.uncompressed_length);
+		case XetChunkCompressionScheme.ByteGroupingLZ4:
+			return bg4_regroup_bytes(lz4_decompress(compressed, chunkHeader.uncompressed_length));
+		default:
+			return compressed.slice();
+	}
+}
+
+function parseSingleContentRange(value: string | null): { start: number; end: number } | undefined {
+	const match = value?.match(/bytes\s+(\d+)-(\d+)\//i);
+	return match ? { start: parseInt(match[1], 10), end: parseInt(match[2], 10) } : undefined;
+}
+
+/**
+ * Decode a fully-buffered xorb chunk stream (one `multipart/byteranges` part) and store the
+ * decompressed chunks into the range list, so the term reader can yield them from cache.
+ */
+function storeChunks(
+	data: Uint8Array,
+	descriptor: FetchGroup["ranges"][number],
+	rangeList: RangeList<Uint8Array[]>,
+): void {
+	const ranges = rangeList.getRanges(descriptor.range.start, descriptor.range.end);
+	let chunkIndex = descriptor.range.start;
+	let offset = 0;
+
+	while (offset < data.byteLength) {
+		if (data.byteLength - offset < XET_CHUNK_HEADER_BYTES) {
+			throw new Error("Truncated chunk header in multipart part");
+		}
+
+		const chunkHeader = parseChunkHeader(new DataView(data.buffer, data.byteOffset + offset, XET_CHUNK_HEADER_BYTES));
+		const compressedStart = offset + XET_CHUNK_HEADER_BYTES;
+		const compressedEnd = compressedStart + chunkHeader.compressed_length;
+
+		if (compressedEnd > data.byteLength) {
+			throw new Error("Truncated chunk data in multipart part");
+		}
+
+		const uncompressed = decompressChunk(chunkHeader, data.subarray(compressedStart, compressedEnd));
+
+		const range = ranges.find((range) => chunkIndex >= range.start && chunkIndex < range.end);
+		if (range) {
+			range.data ??= [];
+			range.data.push(uncompressed);
+		}
+
+		chunkIndex++;
+		offset = compressedEnd;
+	}
+}
+
 /**
  * XetBlob is a blob implementation that fetches data directly from the Xet storage
  */
@@ -100,7 +298,7 @@ export class XetBlob extends Blob {
 	start = 0;
 	end = 0;
 	internalLogging = false;
-	reconstructionInfo: ReconstructionInfo | undefined;
+	reconstructionInfo: NormalizedReconstructionInfo | undefined;
 	listener: XetBlobCreateOptions["listener"];
 
 	constructor(params: XetBlobCreateOptions) {
@@ -166,7 +364,7 @@ export class XetBlob extends Blob {
 		return slice;
 	}
 
-	#reconstructionInfoPromise?: Promise<ReconstructionInfo>;
+	#reconstructionInfoPromise?: Promise<NormalizedReconstructionInfo>;
 
 	#loadReconstructionInfo() {
 		if (this.#reconstructionInfoPromise) {
@@ -176,24 +374,59 @@ export class XetBlob extends Blob {
 		this.#reconstructionInfoPromise = (async () => {
 			const connParams = await getAccessToken(this.accessToken, this.fetch, this.refreshUrl);
 
-			// debug(
-			// 	`curl '${connParams.casUrl}/v1/reconstructions/${this.hash}' -H 'Authorization: Bearer ${connParams.accessToken}'`
-			// );
+			const rangeHeader = `bytes=${this.start}-${this.end - 1}`;
+			const urlParams = { reconstructionUrl: this.reconstructionUrl, casUrl: connParams.casUrl, hash: this.hash };
 
-			const resp = await this.fetch(this.reconstructionUrl ?? `${connParams.casUrl}/v1/reconstructions/${this.hash}`, {
-				headers: {
-					Authorization: `Bearer ${connParams.accessToken}`,
-					Range: `bytes=${this.start}-${this.end - 1}`,
-				},
-			});
+			const fetchVersion = (version: 1 | 2): Promise<Response> | undefined => {
+				const url = reconstructionUrlForVersion(urlParams, version);
+				if (!url) {
+					return undefined;
+				}
 
-			if (!resp.ok) {
-				throw await createApiError(resp);
+				// debug(`curl '${url}' -H 'Authorization: Bearer ${connParams.accessToken}'`);
+
+				return this.fetch(url, {
+					headers: {
+						Authorization: `Bearer ${connParams.accessToken}`,
+						Range: rangeHeader,
+					},
+				});
+			};
+
+			// Prefer V2, falling back to V1 on 404/501, and remember the detected version per endpoint
+			// to avoid re-probing. Mirrors xet-core's RemoteClient behavior.
+			let version = reconstructionApiVersions.get(connParams.casUrl) ?? 2;
+
+			let normalized: NormalizedReconstructionInfo | undefined;
+
+			if (version === 2) {
+				const resp = await fetchVersion(2);
+				if (resp?.ok) {
+					normalized = normalizeV2((await resp.json()) as ReconstructionInfoV2);
+					reconstructionApiVersions.set(connParams.casUrl, 2);
+				} else if (!resp || resp.status === 404 || resp.status === 501) {
+					// V2 unavailable (or no V2 URL could be built): fall back to V1.
+					version = 1;
+				} else {
+					throw await createApiError(resp);
+				}
 			}
 
-			this.reconstructionInfo = (await resp.json()) as ReconstructionInfo;
+			if (!normalized) {
+				const resp = await fetchVersion(1);
+				if (!resp) {
+					throw new Error("Failed to build reconstruction URL");
+				}
+				if (!resp.ok) {
+					throw await createApiError(resp);
+				}
+				normalized = normalizeV1((await resp.json()) as ReconstructionInfo);
+				reconstructionApiVersions.set(connParams.casUrl, 1);
+			}
 
-			return this.reconstructionInfo;
+			this.reconstructionInfo = normalized;
+
+			return normalized;
 		})().finally(() => (this.#reconstructionInfoPromise = undefined));
 
 		return this.#reconstructionInfoPromise;
@@ -231,10 +464,10 @@ export class XetBlob extends Blob {
 		const log = this.internalLogging ? (...args: unknown[]) => console.log(...args) : () => {};
 
 		async function* readData(
-			reconstructionInfo: ReconstructionInfo,
+			reconstructionInfo: NormalizedReconstructionInfo,
 			customFetch: typeof fetch,
 			maxBytes: number,
-			reloadReconstructionInfo: () => Promise<ReconstructionInfo>,
+			reloadReconstructionInfo: () => Promise<NormalizedReconstructionInfo>,
 		) {
 			let totalBytesRead = 0;
 			let readBytesToSkip = reconstructionInfo.offset_into_first_range;
@@ -249,56 +482,132 @@ export class XetBlob extends Blob {
 					throw new Error(`Failed to find range list for term ${term.hash}`);
 				}
 
-				{
-					const termRanges = rangeList.getRanges(term.range.start, term.range.end);
-
-					if (termRanges.every((range) => range.data)) {
-						log("all data available for term", term.hash, readBytesToSkip);
-						rangeLoop: for (const range of termRanges) {
-							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-							for (let chunk of range.data!) {
-								if (readBytesToSkip) {
-									const skipped = Math.min(readBytesToSkip, chunk.byteLength);
-									chunk = chunk.slice(skipped);
-									readBytesToSkip -= skipped;
-									if (!chunk.byteLength) {
-										continue;
-									}
-								}
-								if (chunk.byteLength > maxBytes - totalBytesRead) {
-									chunk = chunk.slice(0, maxBytes - totalBytesRead);
-								}
-								totalBytesRead += chunk.byteLength;
-								// The stream consumer can decide to transfer ownership of the chunk, so we need to return a clone
-								// if there's more than one range for the same term
-								yield range.refCount > 1 ? chunk.slice() : chunk;
-								listener?.({ event: "progress", progress: { read: totalBytesRead, total: maxBytes } });
-
-								if (totalBytesRead >= maxBytes) {
-									break rangeLoop;
-								}
+				// Locate the fetch group + descriptor whose chunk range covers this term.
+				const locate = (info: NormalizedReconstructionInfo) => {
+					const groups = info.fetch_info[term.hash];
+					if (groups) {
+						for (const group of groups) {
+							const descriptor = group.ranges.find(
+								(r) => r.range.start <= term.range.start && r.range.end >= term.range.end,
+							);
+							if (descriptor) {
+								return { group, descriptor };
 							}
 						}
-						rangeList.remove(term.range.start, term.range.end);
-						continue;
+					}
+					return undefined;
+				};
+
+				// Fetch a multi-range group (V2) in one request, parse the multipart/byteranges response,
+				// and populate the range list cache. The signed URL covers the exact set of ranges, so we
+				// must request all of them together rather than one at a time.
+				const fetchMultiRangeGroup = async (group: FetchGroup): Promise<void> => {
+					const rangeHeaderFor = (g: FetchGroup) =>
+						`bytes=${g.ranges.map((r) => `${r.url_range.start}-${r.url_range.end}`).join(",")}`;
+
+					let resp = await customFetch(group.url, { headers: { Range: rangeHeaderFor(group) } });
+
+					if (resp.status === 403) {
+						// Signed URL expired: reload reconstruction info and relocate the covering group.
+						reconstructionInfo = await reloadReconstructionInfo();
+						const relocated = locate(reconstructionInfo);
+						if (!relocated) {
+							throw new Error(
+								`Failed to find fetch info for term ${term.hash} and range ${term.range.start}-${term.range.end} after refresh`,
+							);
+						}
+						group = relocated.group;
+						resp = await customFetch(group.url, { headers: { Range: rangeHeaderFor(group) } });
+					}
+
+					if (!resp.ok) {
+						throw await createApiError(resp);
+					}
+
+					listener?.({ event: "read" });
+
+					const body = new Uint8Array(await resp.arrayBuffer());
+					const contentType = resp.headers.get("content-type") ?? "";
+
+					const parts = contentType.includes("multipart/byteranges")
+						? parseMultipartByteRanges(contentType, body)
+						: // Single-range response (eg the server merged contiguous ranges): map the whole body to
+						  // the matching descriptor by Content-Range, falling back to the first requested range.
+						  [
+								{
+									range: parseSingleContentRange(resp.headers.get("content-range")) ?? group.ranges[0].url_range,
+									data: body,
+								},
+						  ];
+
+					for (const part of parts) {
+						const descriptor =
+							group.ranges.find((r) => r.url_range.start === part.range.start && r.url_range.end === part.range.end) ??
+							group.ranges.find((r) => r.url_range.start === part.range.start);
+						if (!descriptor) {
+							throw new Error(
+								`Multipart part bytes=${part.range.start}-${part.range.end} did not match any requested range for term ${term.hash}`,
+							);
+						}
+						storeChunks(part.data, descriptor, rangeList);
+					}
+				};
+
+				let termRanges = rangeList.getRanges(term.range.start, term.range.end);
+
+				if (!termRanges.every((range) => range.data)) {
+					const located = locate(reconstructionInfo);
+					if (located && located.group.ranges.length > 1) {
+						await fetchMultiRangeGroup(located.group);
+						termRanges = rangeList.getRanges(term.range.start, term.range.end);
 					}
 				}
 
-				let fetchInfo = reconstructionInfo.fetch_info[term.hash].find(
-					(info) => info.range.start <= term.range.start && info.range.end >= term.range.end,
-				);
+				if (termRanges.every((range) => range.data)) {
+					log("all data available for term", term.hash, readBytesToSkip);
+					rangeLoop: for (const range of termRanges) {
+						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+						for (let chunk of range.data!) {
+							if (readBytesToSkip) {
+								const skipped = Math.min(readBytesToSkip, chunk.byteLength);
+								chunk = chunk.slice(skipped);
+								readBytesToSkip -= skipped;
+								if (!chunk.byteLength) {
+									continue;
+								}
+							}
+							if (chunk.byteLength > maxBytes - totalBytesRead) {
+								chunk = chunk.slice(0, maxBytes - totalBytesRead);
+							}
+							totalBytesRead += chunk.byteLength;
+							// The stream consumer can decide to transfer ownership of the chunk, so we need to return a clone
+							// if there's more than one range for the same term
+							yield range.refCount > 1 ? chunk.slice() : chunk;
+							listener?.({ event: "progress", progress: { read: totalBytesRead, total: maxBytes } });
 
-				if (!fetchInfo) {
+							if (totalBytesRead >= maxBytes) {
+								break rangeLoop;
+							}
+						}
+					}
+					rangeList.remove(term.range.start, term.range.end);
+					continue;
+				}
+
+				// Single-range group (all V1, and V2 xorbs with a single range): stream and parse inline.
+				let located = locate(reconstructionInfo);
+				if (!located) {
 					throw new Error(
 						`Failed to find fetch info for term ${term.hash} and range ${term.range.start}-${term.range.end}`,
 					);
 				}
+				let fetchInfo = located.descriptor;
 
 				log("term", term);
 				log("fetchinfo", fetchInfo);
 				log("readBytesToSkip", readBytesToSkip);
 
-				let resp = await customFetch(fetchInfo.url, {
+				let resp = await customFetch(located.group.url, {
 					headers: {
 						Range: `bytes=${fetchInfo.url_range.start}-${fetchInfo.url_range.end}`,
 					},
@@ -307,15 +616,14 @@ export class XetBlob extends Blob {
 				if (resp.status === 403) {
 					// In case it's expired
 					reconstructionInfo = await reloadReconstructionInfo();
-					fetchInfo = reconstructionInfo.fetch_info[term.hash]?.find(
-						(info) => info.range.start <= term.range.start && info.range.end >= term.range.end,
-					);
-					if (!fetchInfo) {
+					located = locate(reconstructionInfo);
+					if (!located) {
 						throw new Error(
 							`Failed to find fetch info for term ${term.hash} and range ${term.range.start}-${term.range.end} after refresh`,
 						);
 					}
-					resp = await customFetch(fetchInfo.url, {
+					fetchInfo = located.descriptor;
+					resp = await customFetch(located.group.url, {
 						headers: {
 							Range: `bytes=${fetchInfo.url_range.start}-${fetchInfo.url_range.end}`,
 						},
@@ -374,30 +682,9 @@ export class XetBlob extends Blob {
 						}
 
 						const header = new DataView(result.value.buffer, result.value.byteOffset, XET_CHUNK_HEADER_BYTES);
-						const chunkHeader: ChunkHeader = {
-							version: header.getUint8(0),
-							compressed_length: header.getUint8(1) | (header.getUint8(2) << 8) | (header.getUint8(3) << 16),
-							compression_scheme: header.getUint8(4),
-							uncompressed_length: header.getUint8(5) | (header.getUint8(6) << 8) | (header.getUint8(7) << 16),
-						};
+						const chunkHeader = parseChunkHeader(header);
 
 						log("chunk header", chunkHeader, "to skip", readBytesToSkip);
-
-						if (chunkHeader.version !== 0) {
-							throw new Error(`Unsupported chunk version ${chunkHeader.version}`);
-						}
-
-						if (
-							chunkHeader.compression_scheme !== XetChunkCompressionScheme.None &&
-							chunkHeader.compression_scheme !== XetChunkCompressionScheme.LZ4 &&
-							chunkHeader.compression_scheme !== XetChunkCompressionScheme.ByteGroupingLZ4
-						) {
-							throw new Error(
-								`Unsupported compression scheme ${
-									compressionSchemeLabels[chunkHeader.compression_scheme] ?? chunkHeader.compression_scheme
-								}`,
-							);
-						}
 
 						if (result.value.byteLength < chunkHeader.compressed_length + XET_CHUNK_HEADER_BYTES) {
 							// We need more data to read the full chunk
@@ -407,17 +694,7 @@ export class XetBlob extends Blob {
 
 						result.value = result.value.slice(XET_CHUNK_HEADER_BYTES);
 
-						let uncompressed =
-							chunkHeader.compression_scheme === XetChunkCompressionScheme.LZ4
-								? lz4_decompress(result.value.slice(0, chunkHeader.compressed_length), chunkHeader.uncompressed_length)
-								: chunkHeader.compression_scheme === XetChunkCompressionScheme.ByteGroupingLZ4
-									? bg4_regroup_bytes(
-											lz4_decompress(
-												result.value.slice(0, chunkHeader.compressed_length),
-												chunkHeader.uncompressed_length,
-											),
-										)
-									: result.value.slice(0, chunkHeader.compressed_length);
+						let uncompressed = decompressChunk(chunkHeader, result.value.subarray(0, chunkHeader.compressed_length));
 
 						const range = ranges.find((range) => chunkIndex >= range.start && chunkIndex < range.end);
 						const shouldYield = chunkIndex >= term.range.start && chunkIndex < term.range.end;
@@ -684,7 +961,7 @@ async function getAccessToken(
 				...(initialAccessToken
 					? {
 							Authorization: `Bearer ${initialAccessToken}`,
-						}
+					  }
 					: {}),
 			},
 		});

--- a/packages/hub/src/utils/multipart.spec.ts
+++ b/packages/hub/src/utils/multipart.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { extractBoundary, parseMultipartByteRanges } from "./multipart";
+
+const enc = new TextEncoder();
+
+function concat(...arrays: Uint8Array[]): Uint8Array {
+	const total = arrays.reduce((sum, a) => sum + a.byteLength, 0);
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const a of arrays) {
+		out.set(a, offset);
+		offset += a.byteLength;
+	}
+	return out;
+}
+
+function buildPart(
+	boundary: string,
+	range: { start: number; end: number },
+	total: number,
+	data: Uint8Array,
+): Uint8Array {
+	return concat(
+		enc.encode(`--${boundary}\r\n`),
+		enc.encode(`Content-Type: application/octet-stream\r\n`),
+		enc.encode(`Content-Range: bytes ${range.start}-${range.end}/${total}\r\n\r\n`),
+		data,
+	);
+}
+
+describe("multipart", () => {
+	describe("extractBoundary", () => {
+		it("extracts an unquoted boundary", () => {
+			expect(extractBoundary("multipart/byteranges; boundary=something")).toBe("something");
+		});
+
+		it("extracts a quoted boundary", () => {
+			expect(extractBoundary('multipart/byteranges; boundary="quoted"')).toBe("quoted");
+		});
+
+		it("returns null when there is no boundary", () => {
+			expect(extractBoundary("multipart/byteranges")).toBeNull();
+		});
+	});
+
+	describe("parseMultipartByteRanges", () => {
+		it("parses multiple parts and preserves their data", () => {
+			const boundary = "BOUNDARY";
+			const data0 = new Uint8Array([1, 2, 3, 4, 5]);
+			const data1 = new Uint8Array([10, 20, 30]);
+
+			const body = concat(
+				buildPart(boundary, { start: 0, end: 4 }, 100, data0),
+				enc.encode("\r\n"),
+				buildPart(boundary, { start: 50, end: 52 }, 100, data1),
+				enc.encode(`\r\n--${boundary}--\r\n`),
+			);
+
+			const parts = parseMultipartByteRanges(`multipart/byteranges; boundary=${boundary}`, body);
+
+			expect(parts).toHaveLength(2);
+			expect(parts[0].range).toEqual({ start: 0, end: 4 });
+			expect(Array.from(parts[0].data)).toEqual([1, 2, 3, 4, 5]);
+			expect(parts[1].range).toEqual({ start: 50, end: 52 });
+			expect(Array.from(parts[1].data)).toEqual([10, 20, 30]);
+		});
+
+		it("sorts parts by byte range start", () => {
+			const boundary = "abc";
+			const body = concat(
+				buildPart(boundary, { start: 50, end: 51 }, 100, new Uint8Array([9, 9])),
+				enc.encode("\r\n"),
+				buildPart(boundary, { start: 0, end: 1 }, 100, new Uint8Array([1, 1])),
+				enc.encode(`\r\n--${boundary}--\r\n`),
+			);
+
+			const parts = parseMultipartByteRanges(`multipart/byteranges; boundary=${boundary}`, body);
+
+			expect(parts.map((p) => p.range.start)).toEqual([0, 50]);
+		});
+
+		it("handles binary data containing CR/LF bytes", () => {
+			const boundary = "xyz";
+			const data = new Uint8Array([0x0d, 0x0a, 0x00, 0x2d, 0x2d, 0xff]);
+			const body = concat(buildPart(boundary, { start: 0, end: 5 }, 6, data), enc.encode(`\r\n--${boundary}--\r\n`));
+
+			const parts = parseMultipartByteRanges(`multipart/byteranges; boundary=${boundary}`, body);
+
+			expect(parts).toHaveLength(1);
+			expect(Array.from(parts[0].data)).toEqual([0x0d, 0x0a, 0x00, 0x2d, 0x2d, 0xff]);
+		});
+
+		it("throws when the boundary is missing from the body", () => {
+			expect(() => parseMultipartByteRanges("multipart/byteranges; boundary=nope", enc.encode("garbage"))).toThrow();
+		});
+
+		it("throws when the content type has no boundary", () => {
+			expect(() => parseMultipartByteRanges("multipart/byteranges", new Uint8Array())).toThrow();
+		});
+	});
+});

--- a/packages/hub/src/utils/multipart.ts
+++ b/packages/hub/src/utils/multipart.ts
@@ -1,0 +1,116 @@
+/**
+ * A single part from a `multipart/byteranges` HTTP response.
+ */
+export interface MultipartPart {
+	/** Byte range covered by this part, inclusive end (as in the `Content-Range` header). */
+	range: { start: number; end: number };
+	data: Uint8Array;
+}
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export function extractBoundary(contentType: string): string | null {
+	for (const part of contentType.split(";")) {
+		const trimmed = part.trim();
+		if (trimmed.toLowerCase().startsWith("boundary=")) {
+			return trimmed.slice("boundary=".length).replace(/^"|"$/g, "");
+		}
+	}
+	return null;
+}
+
+function indexOfSubsequence(haystack: Uint8Array, needle: Uint8Array, from = 0): number {
+	outer: for (let i = from; i <= haystack.length - needle.length; i++) {
+		for (let j = 0; j < needle.length; j++) {
+			if (haystack[i + j] !== needle[j]) {
+				continue outer;
+			}
+		}
+		return i;
+	}
+	return -1;
+}
+
+function parseContentRange(headers: string): { start: number; end: number } | null {
+	for (const line of headers.split("\r\n")) {
+		const lower = line.toLowerCase();
+		if (lower.startsWith("content-range:")) {
+			// Content-Range: bytes <start>-<end>/<total>
+			const value = line.slice("content-range:".length).trim();
+			const match = value.match(/^bytes\s+(\d+)-(\d+)\//i);
+			if (match) {
+				// RFC 7233 Content-Range uses an inclusive end.
+				return { start: parseInt(match[1], 10), end: parseInt(match[2], 10) };
+			}
+		}
+	}
+	return null;
+}
+
+/**
+ * Parse a `multipart/byteranges` HTTP response body (RFC 7233 §4.1).
+ *
+ * Extracts the boundary from `contentType`, splits the body by boundary markers,
+ * parses the `Content-Range` header from each part, and returns parts sorted by byte range start.
+ *
+ * Ported from xet-core's `parse_multipart_byteranges`.
+ */
+export function parseMultipartByteRanges(contentType: string, body: Uint8Array): MultipartPart[] {
+	const boundary = extractBoundary(contentType);
+	if (!boundary) {
+		throw new Error(`No boundary found in Content-Type: ${contentType}`);
+	}
+
+	const firstDelim = textEncoder.encode(`--${boundary}`);
+	const delimiter = textEncoder.encode(`\r\n--${boundary}`);
+	const crlf = textEncoder.encode("\r\n");
+	const headerSeparator = textEncoder.encode("\r\n\r\n");
+
+	const start = indexOfSubsequence(body, firstDelim);
+	if (start === -1) {
+		throw new Error("No boundary found in multipart body");
+	}
+
+	const parts: MultipartPart[] = [];
+	let pos = start + firstDelim.length;
+
+	for (;;) {
+		// Each part starts with CRLF after the boundary marker. Anything else (eg `--` for the
+		// closing delimiter) ends the message.
+		if (body[pos] === crlf[0] && body[pos + 1] === crlf[1]) {
+			pos += 2;
+		} else {
+			break;
+		}
+
+		const nextBoundary = indexOfSubsequence(body, delimiter, pos);
+		const partEnd = nextBoundary === -1 ? body.length : nextBoundary;
+		const partData = body.subarray(pos, partEnd);
+
+		const headerEnd = indexOfSubsequence(partData, headerSeparator);
+		if (headerEnd === -1) {
+			throw new Error("Malformed multipart part: missing header/data separator");
+		}
+
+		const headers = textDecoder.decode(partData.subarray(0, headerEnd));
+		const range = parseContentRange(headers);
+		if (!range) {
+			throw new Error("No Content-Range header found in multipart part");
+		}
+
+		parts.push({
+			range,
+			data: partData.subarray(headerEnd + headerSeparator.length),
+		});
+
+		if (nextBoundary === -1) {
+			break;
+		}
+		pos = nextBoundary + delimiter.length;
+	}
+
+	parts.sort((a, b) => a.range.start - b.range.start);
+
+	return parts;
+}


### PR DESCRIPTION
## What

Updates `XetBlob` (the `@huggingface/hub` direct-from-Xet blob reader) to use the `/v2/reconstructions` endpoint, falling back to `/v1/reconstructions` when v2 is unavailable. This mirrors what `xet-core`'s `RemoteClient` already does.

## Why

The v2 reconstruction API returns multi-range signed URLs: a single URL can carry several byte ranges for a xorb, coalescing what v1 served as many separate single-range URLs. This reduces the number of fetch requests per download. xet-core already prefers v2 with a v1 fallback; this brings the JS client in line.

## How

- **Version routing** (`#loadReconstructionInfo`): build the v2 URL (from `casUrl`, or by swapping `/v1/reconstructions/` → `/v2/reconstructions/` on an explicit `reconstructionUrl`), try v2, and fall back to v1 on **404/501**. The detected version is cached per CAS endpoint to avoid re-probing.
- **Normalization**: both v1 (`fetch_info`) and v2 (`xorbs`) responses are converted into a common fetch-group shape — v1 yields one single-range group per entry, v2 keeps the server's multi-range grouping.
- **Reader**: the tuned streaming path is unchanged for single-range groups (all v1, and v2 xorbs with one range). For multi-range v2 groups, the reader issues one combined `Range: bytes=s1-e1,s2-e2,…` request, buffers and splits the `multipart/byteranges` response (RFC 7233 §4.1), and feeds each part through the existing chunk parser into the `RangeList` cache.
- **New util** `multipart.ts`: a port of xet-core's `parse_multipart_byteranges`.

A v2 multi-range response must be buffered (not streamed) because the signed URL signs the exact multi-range header, so the parts can only be split after the full body arrives.

## Tests

- New `multipart.spec.ts` (8 tests) for the byteranges parser.
- New `XetBlob` v2 tests: multi-range multipart fetch, v2→v1 fallback on 404, and single-range v2.
- Existing `XetBlob` mocks now simulate v1-only endpoints (404 on `/v2/`), so the fallback path is exercised; all prior tests still pass.

33 tests passing; eslint, prettier, and tsc clean on the changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core Xet download path and byte reconstruction logic; risk is mitigated by v1 fallback, explicit errors on ambiguous multipart responses, and broad new tests, but regressions could still affect large-file downloads.
> 
> **Overview**
> **`XetBlob`** now prefers **`/v2/reconstructions`** (with **`/v1`** fallback on **404/501**), caches the detected API version per CAS URL, and normalizes v1 `fetch_info` and v2 `xorbs` into a shared fetch-group model.
> 
> For v2 **multi-range** signed URLs, the reader issues one combined `Range` request, **buffers** the response, parses **`multipart/byteranges`** via new **`multipart.ts`**, and decodes parts into the existing `RangeList` cache; single-range paths still stream as before. Chunk header parse/decompress logic is shared (`parseChunkHeader`, `decompressChunk`, `storeChunks`), and incomplete or wrong multipart responses **throw** instead of degrading to single-range fetches that could corrupt data.
> 
> Tests add **`multipart.spec.ts`**, a **`v2 reconstruction`** suite (multi-range, fallback, error cases), **`clearReconstructionApiVersionCache`** in `beforeEach`, and v2 **404** stubs in existing mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b1ba93cc6ee4e2860479717eb5e510e4343c837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->