### PR TITLE
[Inference Providers] cerebras: drop unsupported `store` param from chat completion payload

### DIFF
--- a/packages/inference/src/providers/cerebras.ts
+++ b/packages/inference/src/providers/cerebras.ts
@@ -15,10 +15,19 @@
  * Thanks!
  */
 
+import type { BodyParams } from "../types.js";
+import { omit } from "../utils/omit.js";
 import { BaseConversationalTask } from "./providerHelper.js";
 
 export class CerebrasConversationalTask extends BaseConversationalTask {
 	constructor() {
 		super("cerebras", "https://api.cerebras.ai");
+	}
+
+	override preparePayload(params: BodyParams): Record<string, unknown> {
+		// Cerebras strictly validates request bodies and rejects the OpenAI-proprietary `store`
+		// param with a 400 (`{"code":"wrong_api_format"}`). It has no meaning outside of OpenAI's
+		// own API, so drop it before forwarding rather than surfacing a spurious error to callers.
+		return omit(super.preparePayload(params), "store");
 	}
 }


### PR DESCRIPTION
## What

`CerebrasConversationalTask` inherits `BaseConversationalTask.preparePayload`, which forwards all client args verbatim (`{ ...params.args, model }`). The OpenAI-proprietary `store` param is therefore passed straight through to `api.cerebras.ai`, which strictly validates request bodies and rejects it with a `400`:

```json
{"message":"store: property 'store' is unsupported","type":"invalid_request_error","param":"validation_error","code":"wrong_api_format"}
```

This overrides `preparePayload` for Cerebras to `omit` `store` before forwarding. It's scoped to Cerebras rather than the base class because the `openai` provider also extends `BaseConversationalTask` and `store` is a valid param for `api.openai.com`.

## How it was noticed

While using `google/gemma-4-31B-it` with Pi (a coding agent built on the OpenAI JS SDK) via the `huggingface` provider, a plain `"hello"` returned `Error: 400 status code (no body)`. Pi sends `store: false` (it assumes full OpenAI compatibility for the HF router), and the router auto-routes `gemma-4-31B` to Cerebras, which `400`s on `store`. Other models "worked" only because their auto-route lands on providers (Together, Novita, …) that ignore `store`. The `(no body)` is an OpenAI JS SDK quirk on streaming errors — the `400` body was actually present, the SDK just didn't surface it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-provider payload sanitization with no auth or data-model changes; behavior only affects Cerebras-routed chat calls that included `store`.
> 
> **Overview**
> **Cerebras** chat completions were failing with **400** when clients (e.g. OpenAI-compatible SDKs) sent the OpenAI-only `store` field, because `BaseConversationalTask` forwards request args unchanged.
> 
> `CerebrasConversationalTask` now overrides `preparePayload` to call the base implementation and **omit `store`** before the body is sent to `api.cerebras.ai`. The change is limited to the Cerebras provider so OpenAI routes can still pass `store` where it is supported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a93ae9b1746d98594adde48a6788d4762f0496f9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->