### PR TITLE
Add hi agent harness

### DIFF
--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -130,6 +130,12 @@ export const AGENT_HARNESSES = {
 		description: "Nous Research's self-improving, multi-provider terminal AI agent.",
 		envVars: { HERMES_SESSION_ID: "*" },
 	},
+	hi: {
+		prettyLabel: "hi",
+		repoUrl: "https://github.com/PipeNetwork/hi",
+		docsUrl: "https://github.com/PipeNetwork/hi#readme",
+		description: "Rust terminal coding agent with verification-in-the-loop.",
+	},
 	"kilo-code": {
 		prettyLabel: "Kilo Code",
 		repoUrl: "https://github.com/Kilo-Org/kilocode",


### PR DESCRIPTION
## Summary\n- Register the hi terminal coding agent in the agent harness registry\n- Rely on the standard AI_AGENT=hi / AGENT=hi detection path\n\n## Validation\n- Not run: pnpm/corepack are not installed in this environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry entry with metadata only; no detection logic or runtime behavior changes beyond recognizing a new agent id.
> 
> **Overview**
> Adds **hi** (Pipe Network’s Rust terminal coding agent) to `AGENT_HARNESSES` in `agent-harnesses.ts`, with repo/docs links and a short description.
> 
> No custom `envVars` are defined, so Hub activity is attributed when clients set `AI_AGENT=hi` or `AGENT=hi`, matching the standard agent-id path for recognized harness keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f843e8ab7138833443d9f55b9e61d0c8aa87cc97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->