### PR TITLE
Add Arc A380 to hardware.ts

### DIFF
--- a/packages/tasks/src/hardware.ts
+++ b/packages/tasks/src/hardware.ts
@@ -70,6 +70,13 @@ export const SKUS = {
 		NVIDIA: NVIDIA_SKUS,
 		AMD: AMD_GPU_SKUS,
 		INTEL: {
+			"Arc A380": {
+				tflops: 8.4,
+				memory: [6],
+				msrp: 139,
+				power: 75,
+				releaseYear: 2022,
+			},
 			"Arc A750": {
 				tflops: 34.41,
 				memory: [8],


### PR DESCRIPTION
That is the GPU I am using, a quite budget friendly Intel Arc. It would be nice to see it on Hugging Face :) I got the data from [Intel official specs](https://www.intel.com/content/www/us/en/products/sku/227959/intel-arc-a380-graphics/specifications.html) and MSRP in USB from a [presentation by Intel](https://cdrdv2-public.intel.com/779532/A380%20Product%20Guide%20V1.3.pdf).

Thanks!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static catalog data only; no runtime logic or security-sensitive paths changed.
> 
> **Overview**
> Adds **Intel Arc A380** to `SKUS.GPU.INTEL` in `packages/tasks/src/hardware.ts`, alongside existing Arc entries (A750, A770, etc.).
> 
> The new entry follows the same `HardwareSpec` shape: **8.4 TFLOPS**, **6 GB** VRAM, **$139** MSRP, **75 W** power, **2022** release year—sourced from Intel specs and product materials per the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8bcfbbebdbf1e0e829d6704d3ca88dea813bf69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->