### PR TITLE
Add OpenASR to model-libraries.ts

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1183,6 +1183,18 @@ model, preprocess_train, preprocess_val = open_clip.create_model_and_transforms(
 tokenizer = open_clip.get_tokenizer('hf-hub:${model.id}')`,
 ];
 
+export const openasr = (model: ModelData): string[] => {
+	// OpenASR's local model registry keys packs by their short id (the final path segment
+	// of the Hub repo id, e.g. "xasr-zh-en" for "OpenASR/xasr-zh-en"), not the full
+	// "org/repo" reference, so the CLI commands below use that short id.
+	const modelId = model.id.split("/").pop() ?? model.id;
+	return [
+		`# Install the openasr CLI: https://github.com/QuintinShaw/openasr/releases
+openasr pull ${modelId}
+openasr transcribe audio.wav --model ${modelId}`,
+	];
+};
+
 export const paddlenlp = (model: ModelData): string[] => {
 	if (model.config?.architectures?.[0]) {
 		const architecture = model.config.architectures[0];

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1024,7 +1024,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	},
 	openasr: {
 		prettyLabel: "OpenASR",
-		repoName: "openasr",
+		repoName: "OpenASR",
 		repoUrl: "https://github.com/QuintinShaw/openasr",
 		docsUrl: "https://github.com/QuintinShaw/openasr/blob/main/docs/DOCS_INDEX.md",
 		snippets: snippets.openasr,

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1015,6 +1015,15 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 			OR path:"open_clip_pytorch_model.bin"
 			OR path:"pytorch_model.bin"`,
 	},
+	openasr: {
+		prettyLabel: "OpenASR",
+		repoName: "openasr",
+		repoUrl: "https://github.com/QuintinShaw/openasr",
+		docsUrl: "https://github.com/QuintinShaw/openasr/blob/main/docs/DOCS_INDEX.md",
+		snippets: snippets.openasr,
+		filter: false,
+		countDownloads: `path_extension:"oasr"`,
+	},
 	openpeerllm: {
 		prettyLabel: "OpenPeerLLM",
 		repoName: "OpenPeerLLM",


### PR DESCRIPTION
[OpenASR](https://github.com/QuintinShaw/openasr) is a local-first speech-to-text
runtime (Rust CLI + local HTTP API) that runs `.oasr` model packs natively with
ggml, no Python at inference time. The OpenASR org on the Hub
(https://huggingface.co/OpenASR) hosts our published model packs (Whisper, Qwen3-ASR,
X-ASR, Cohere Transcribe, diarization/embedding packs, etc.), each already tagged
`library_name: openasr` in its card metadata.

This PR registers `openasr` as a library so the Hub can:
- show a "Use with OpenASR" button + snippet on our model pages
- start counting downloads for our repos

### countDownloads

`path_extension:"oasr"` — every OpenASR model repo ships one or more
`<model-id>-<quant>.oasr` files (e.g. `xasr-zh-en-q8_0.oasr`,
`whisper-small-fp16.oasr`); `.oasr` is our own container format and not used by
any other library on the Hub, so the extension alone is an exact, unambiguous
match. Verified against the live `siblings` list on several `OpenASR/*` repos via
the Hub API.

### Snippet

The CLI resolves models by the short registry id (the final path segment of the
Hub repo, e.g. `xasr-zh-en` for `OpenASR/xasr-zh-en`), not the full `org/repo`
string, so the snippet derives that from `model.id` before building the two
commands (verified against `openasr pull --help` / `openasr transcribe --help`
on a real build):

```
openasr pull xasr-zh-en
openasr transcribe audio.wav --model xasr-zh-en
```

### Notes

- All current `OpenASR/*` model cards already set `library_name: openasr` in
  their frontmatter, so this should apply retroactively without any card edits.
- The CLI ships as prebuilt binaries on GitHub Releases (macOS arm64,
  Linux x86_64) or builds from source; the snippet links the Releases page
  instead of a fake `pip install` / `brew install` line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive registry and snippet-only changes in `packages/tasks` with no auth, inference, or shared runtime impact.
> 
> **Overview**
> Registers **OpenASR** as a Hub modeling library keyed on `library_name: openasr`, so repos like `OpenASR/*` get a **Use with OpenASR** CTA and usage snippet on model pages.
> 
> Download counting uses `path_extension:"oasr"` for OpenASR’s `.oasr` pack files. The snippet maps `model.id` to the CLI’s short registry id (repo name only) and shows `openasr pull` / `openasr transcribe` with a link to GitHub Releases instead of a pip install line. The library is not added to the models filter (`filter: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3fa7290a7704787e5bcee2f8d47fd36fc11bd54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->