### PR TITLE
Add VT Code agent harness

### DIFF
--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -216,6 +216,15 @@ export const AGENT_HARNESSES = {
 		docsUrl: "https://devin.ai",
 		description: "Autonomous AI software engineer from Cognition.",
 	},
+	vtcode: {
+		prettyLabel: "VTCode",
+		repoUrl: "https://github.com/vinhnx/VTCode",
+		description:
+			"Rust coding agent with multi-provider LLM support, OS-native sandboxing, and extensible skills",
+		envVars: {
+			VTCODE: "1",
+		},
+	},
 } satisfies Record<string, AgentHarness>;
 
 /// List of the agent harnesses known to the Hub

--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -185,8 +185,7 @@ export const AGENT_HARNESSES = {
 	vtcode: {
 		prettyLabel: "VTCode",
 		repoUrl: "https://github.com/vinhnx/VTCode",
-		description:
-			"Rust coding agent with multi-provider LLM support, OS-native sandboxing, and extensible skills",
+		description: "Rust coding agent with multi-provider LLM support, OS-native sandboxing, and extensible skills",
 		envVars: {
 			VTCODE: "1",
 		},

--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -182,6 +182,18 @@ export const AGENT_HARNESSES = {
 		description: "AI-powered IDE from ByteDance.",
 		envVars: { TRAE_AI_SHELL_ID: "*" },
 	},
+	vtcode: {
+		// Before cursor-cli/cursor: VTCode has its own unique env var (VTCODE) and
+		// should not be shadowed by inherited Cursor env vars when running inside
+		// the Cursor editor's terminal.
+		prettyLabel: "VTCode",
+		repoUrl: "https://github.com/vinhnx/VTCode",
+		description:
+			"Rust coding agent with multi-provider LLM support, OS-native sandboxing, and extensible skills",
+		envVars: {
+			VTCODE: "1",
+		},
+	},
 	warp: {
 		prettyLabel: "Warp",
 		repoUrl: "https://github.com/warpdotdev/Warp",
@@ -215,15 +227,6 @@ export const AGENT_HARNESSES = {
 		prettyLabel: "Devin",
 		docsUrl: "https://devin.ai",
 		description: "Autonomous AI software engineer from Cognition.",
-	},
-	vtcode: {
-		prettyLabel: "VTCode",
-		repoUrl: "https://github.com/vinhnx/VTCode",
-		description:
-			"Rust coding agent with multi-provider LLM support, OS-native sandboxing, and extensible skills",
-		envVars: {
-			VTCODE: "1",
-		},
 	},
 } satisfies Record<string, AgentHarness>;
 

--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -183,9 +183,6 @@ export const AGENT_HARNESSES = {
 		envVars: { TRAE_AI_SHELL_ID: "*" },
 	},
 	vtcode: {
-		// Before cursor-cli/cursor: VTCode has its own unique env var (VTCODE) and
-		// should not be shadowed by inherited Cursor env vars when running inside
-		// the Cursor editor's terminal.
 		prettyLabel: "VTCode",
 		repoUrl: "https://github.com/vinhnx/VTCode",
 		description:


### PR DESCRIPTION
## Summary

Register [VT Code](https://github.com/vinhnx/VTCode) as a HuggingFace agent harness, so Hub traffic is attributed by name.

## About VT Code

VT Code is a Rust coding agent built for long-running autonomous workflows, with OS-native sandboxing, multi-provider LLM support (21+ providers), open protocols, and extensible Skills.

## Changes

- Added `vtcode` entry to `AGENT_HARNESSES` in `packages/tasks/src/agent-harnesses.ts`
- Detection via `VTCODE=1` environment variable

## References

- [Agent Harness Registration Guide](https://huggingface.co/docs/hub/main/en/agents-overview#register-your-agent-harness)
- [VT Code Repository](https://github.com/vinhnx/VTCode)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only metadata change with no auth, data, or runtime behavior impact.
> 
> **Overview**
> Registers **VTCode** in the Hub agent harness registry so Hub usage can be attributed when the agent sets `VTCODE=1`.
> 
> The new `vtcode` entry includes display metadata (`prettyLabel`, repo link, short description) and exact-match detection on the `VTCODE` environment variable, consistent with other harness entries in `agent-harnesses.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f1c14df7379504b3a8158b130716bc89d920774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->