### PR TITLE
Fix openclaw tests

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -211,7 +211,7 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		};
 		const snippet = snippetFunc(model);
 
-		expect(snippet[0].content).toContain(`llama-server -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`);
+		expect(snippet[0].content).toContain(`llama serve -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`);
 		expect(snippet[1].setup).toContain("npm install -g openclaw@latest");
 		expect(snippet[1].content).toContain("openclaw onboard --non-interactive --mode local");
 		expect(snippet[1].content).toContain("--auth-choice custom-api-key");


### PR DESCRIPTION
llama-server -> llama serve

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single assertion change in a unit test with no production code impact.
> 
> **Overview**
> Updates the **openclaw** local-apps test so the first snippet step expects **`llama serve -hf …`** instead of **`llama-server -hf …`**, matching the current llama.cpp command used elsewhere in the same spec (e.g. pi, hermes-agent, llama.cpp tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62849a4a0d42857b5bbd234b30ebdbbedc86d8dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->