### PR TITLE
Add TiRex-2 model library details

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1519,11 +1519,11 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path_extension:"ckpt"`,
 	},
 	"tirex-2": {
-    prettyLabel: "TiRex-2",
-    repoName: "TiRex-2",
-    repoUrl: "https://github.com/NX-AI/tirex-2",
-    countDownloads: `path:"model-config.yaml"`,
-  },
+		prettyLabel: "TiRex-2",
+		repoName: "TiRex-2",
+		repoUrl: "https://github.com/NX-AI/tirex-2",
+		countDownloads: `path:"model-config.yaml"`,
+	},
 	torchgeo: {
 		prettyLabel: "TorchGeo",
 		repoName: "TorchGeo",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1522,7 +1522,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
     prettyLabel: "TiRex-2",
     repoName: "TiRex-2",
     repoUrl: "https://github.com/NX-AI/tirex-2",
-    countDownloads: `path_extension:"ckpt"`,
+    countDownloads: `path:"model-config.yaml"`,
   },
 	torchgeo: {
 		prettyLabel: "TorchGeo",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1518,6 +1518,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/NX-AI/tirex",
 		countDownloads: `path_extension:"ckpt"`,
 	},
+	"tirex-2": {
+    prettyLabel: "TiRex-2",
+    repoName: "TiRex-2",
+    repoUrl: "https://github.com/NX-AI/tirex-2",
+    countDownloads: `path_extension:"ckpt"`,
+  },
 	torchgeo: {
 		prettyLabel: "TorchGeo",
 		repoName: "TorchGeo",


### PR DESCRIPTION
Adds library registration for TiRex-2 (NX-AI/tirex-2), analogous to the existing tirex entry. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry entry with no runtime logic changes; only affects Hub UI labels and download stats for models tagged with this library.
> 
> **Overview**
> Registers **TiRex-2** as a new modeling library in `MODEL_LIBRARIES_UI_ELEMENTS`, keyed as `tirex-2` to match Hub `library_name` tags.
> 
> The entry wires display label, repo link to NX-AI/tirex-2, and download metrics via Elasticsearch on `model-config.yaml` (unlike original TiRex, which counts `.ckpt` files). No snippets or `filter: true`, so it follows the same lightweight pattern as the existing `tirex` entry rather than appearing in the popular-library models filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8279fd1c1e74ed67c1bc2133290a3fd797445c33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->