### PR TITLE
Add Bodega One (app) and Bodega One Code (CLI) to Local Apps

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -621,6 +621,27 @@ const snippetLemonade = (model: ModelData, filepath?: string): LocalAppSnippet[]
 	];
 };
 
+const snippetBodegaOneCode = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
+	const command = [
+		"# Pull the model, then chat with it in the terminal UI:",
+		`bodega models pull hf.co/${model.id}${getQuantTag(filepath)}`,
+		"bodega",
+	].join("\n");
+	return [
+		{
+			title: "Install (macOS, Linux)",
+			setup:
+				"curl -fsSL https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/latest/download/install.sh | sh",
+			content: command,
+		},
+		{
+			title: "Install (Windows, PowerShell)",
+			setup: "irm https://github.com/BodegaoneAI/bodegaone-cli-releases/releases/latest/download/install.ps1 | iex",
+			content: command,
+		},
+	];
+};
+
 /**
  * Add your new local app here.
  *
@@ -838,6 +859,21 @@ export const LOCAL_APPS = {
 		mainTask: "text-generation",
 		displayOnModelPage: isToolCallingLocalAgentModel,
 		snippet: snippetOpenClaw,
+	},
+	"bodega-one": {
+		prettyLabel: "Bodega One",
+		docsUrl: "https://bodegaone.ai",
+		mainTask: "text-generation",
+		displayOnModelPage: isLlamaCppGgufModel,
+		deeplink: (model, filepath) =>
+			new URL(`bodega://models/huggingface/${model.id}${filepath ? `?file=${filepath}` : ""}`),
+	},
+	"bodega-one-code": {
+		prettyLabel: "Bodega One Code",
+		docsUrl: "https://bodegaone.ai",
+		mainTask: "text-generation",
+		displayOnModelPage: isLlamaCppGgufModel,
+		snippet: snippetBodegaOneCode,
 	},
 } satisfies Record<string, LocalApp>;
 


### PR DESCRIPTION
This PR adds two Bodega One entries to the "Use this model" local-apps dropdown:

**Bodega One** — a free, local-first AI IDE (chat mode + code mode) for Windows, macOS, and Linux, with a built-in GGUF catalog, hardware-fit checks, and one-click llama.cpp setup. Deeplink support: `bodega://models/huggingface/{owner}/{repo}` opens the app's model browser with the repo pre-searched and ready to download (quant picker included). The link works cold (app closed) and warm (app running), and unknown or malformed routes are safely ignored.

**Bodega One Code** — a terminal client (TUI + headless) for the same local engine, shipping for Windows, macOS, and Linux (amd64 + arm64). `bodega models pull hf.co/{owner}/{repo}:{quant}` pulls GGUFs directly from the Hub.

Both entries display on GGUF models (`isLlamaCppGgufModel`), following the LM Studio (deeplink) and Ollama (snippet) precedents.

- Website: https://bodegaone.ai
- App releases: https://github.com/BodegaoneAI/bodegaone-releases
- CLI releases: https://github.com/BodegaoneAI/bodegaone-cli-releases

The deeplink also tolerates a `?file=` query param (currently ignored) so direct GGUF-file selection can be wired in a follow-up without breaking older installed versions.

Happy to adjust naming, ordering, or anything else — thanks for taking a look!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive registry entries and external install/deeplink URLs only; no changes to auth, APIs, or model serving logic.
> 
> **Overview**
> Adds **Bodega One** and **Bodega One Code** to the model page **Use this model** local-apps list in `packages/tasks/src/local-apps.ts`.
> 
> **Bodega One** opens the IDE via `bodega://models/huggingface/{model.id}` with an optional `?file=` query param (same pattern as LM Studio). **Bodega One Code** exposes copy-paste CLI snippets: install scripts plus `bodega models pull hf.co/{id}{quant}` and `bodega` (aligned with Ollama-style snippets).
> 
> Both entries show only for GGUF models (`isLlamaCppGgufModel`), under `text-generation`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5cf8ee39b968262cf443002e6d440287008d577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->