### PR TITLE
Add swift-litert-lm to model libraries

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -2208,6 +2208,26 @@ model = SwarmFormerModel.from_pretrained("${model.id}")
 `,
 ];
 
+export const swift_litert_lm = (model: ModelData): string[] => {
+	const repoBasename = model.id.split("/").pop() ?? "model";
+	const litertlmFile = `${repoBasename.replace(/-litert-lm$/, "")}.litertlm`;
+	return [
+		`// Run this model on iPhone / iPad / Mac, fully on-device (Metal GPU, multimodal),
+// or as an Apple Foundation Models backend.
+// Add the Swift package: https://github.com/john-rocky/swift-litert-lm
+import LiteRTFoundation
+
+// Downloads the .litertlm from this repo on first launch, then reuses it.
+let chat = try await LiteRTChat(
+    huggingFaceRepo: "${model.id}",
+    fileName: "${litertlmFile}")
+
+for try await token in chat.stream("Explain quantum computing in one sentence.") {
+    print(token, terminator: "")
+}`,
+	];
+};
+
 export const univa = (model: ModelData): string[] => [
 	`# Follow installation instructions at https://github.com/PKU-YuanGroup/UniWorld-V1
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1444,6 +1444,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.swarmformer,
 		filter: false,
 	},
+	"swift-litert-lm": {
+		prettyLabel: "swift-litert-lm",
+		repoName: "swift-litert-lm",
+		repoUrl: "https://github.com/john-rocky/swift-litert-lm",
+		snippets: snippets.swift_litert_lm,
+		filter: false,
+	},
 	"synthefy-migas": {
 		prettyLabel: "Migas",
 		repoName: "Migas",


### PR DESCRIPTION
Registers [swift-litert-lm](https://github.com/john-rocky/swift-litert-lm), a Swift package that runs `.litertlm` models (Gemma 4, etc.) on iOS / iPadOS / macOS via Google's [LiteRT-LM](https://github.com/google-ai-edge/litert-lm) runtime — Metal GPU inference, multimodal (text / image / audio / video), in-app download from the Hub, and an Apple Foundation Models `LanguageModel` backend (iOS 27+). Device-verified on iPhone 17 Pro (~50 tok/s decode, Gemma 4 E2B).

Following the [registration instructions](https://huggingface.co/docs/hub/models-adding-libraries#register-your-library):

- Entry inserted in alphabetical order (`swarmformer` → `swift-litert-lm` → `synthefy-migas`), `filter: false`.
- `snippets`: a Swift snippet using `LiteRTChat(huggingFaceRepo:fileName:)`, which downloads the `.litertlm` from the model repo on first launch and reuses it afterwards. The file name is derived from the repo name following the `litert-community` naming convention (e.g. `litert-community/gemma-4-E2B-it-litert-lm` → `gemma-4-E2B-it.litertlm`, verified against the repo contents).
- No `countDownloads` rule on purpose: `.litertlm` downloads are already counted by the existing `litert-lm` entry, and this library downloads those same files.

**Models referencing the library:** PRs adding the `swift-litert-lm` tag to [litert-community/gemma-4-E2B-it-litert-lm](https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm) and [litert-community/gemma-4-E4B-it-litert-lm](https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm) are being opened (I am a member of `litert-community`). This PR is a draft until [`?other=swift-litert-lm`](https://huggingface.co/models?other=swift-litert-lm) resolves; I'll mark it ready once the tags are live.

Example snippet as rendered for `litert-community/gemma-4-E2B-it-litert-lm`:

```swift
// Run this model on iPhone / iPad / Mac, fully on-device (Metal GPU, multimodal),
// or as an Apple Foundation Models backend.
// Add the Swift package: https://github.com/john-rocky/swift-litert-lm
import LiteRTFoundation

// Downloads the .litertlm from this repo on first launch, then reuses it.
let chat = try await LiteRTChat(
    huggingFaceRepo: "litert-community/gemma-4-E2B-it-litert-lm",
    fileName: "gemma-4-E2B-it.litertlm")

for try await token in chat.stream("Explain quantum computing in one sentence.") {
    print(token, terminator: "")
}
```
