### PR TITLE
Register Mobilint library with MXQ download counting

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -2312,6 +2312,29 @@ export const model2vec = (model: ModelData): string[] => [
 model = StaticModel.from_pretrained("${model.id}")`,
 ];
 
+export const mobilint = (model: ModelData): string[] => {
+	const modelName = nameWithoutNamespace(model.id);
+	return [
+		`# pip install mblt-model-zoo
+from mblt_model_zoo.vision import MBLT_Engine
+
+model = MBLT_Engine(
+    model_cls="${modelName}",
+    model_type="DEFAULT",
+    model_path="",
+    core_mode="global8",
+)
+
+try:
+    image = model.preprocess("path/to/image.jpg")
+    output = model(image)
+    result = model.postprocess(output)
+finally:
+    model.dispose()
+`,
+	];
+};
+
 export const pruna = (model: ModelData): string[] => {
 	let snippets: string[];
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -967,6 +967,15 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.model2vec,
 		filter: false,
 	},
+	mobilint: {
+		prettyLabel: "Mobilint",
+		repoName: "mblt-model-zoo",
+		repoUrl: "https://github.com/mobilint/mblt-model-zoo",
+		docsUrl: "https://docs.mobilint.com",
+		countDownloads: `path:"config.json" OR path_extension:"mxq"`,
+		snippets: snippets.mobilint,
+		filter: false,
+	},
 	moshi: {
 		prettyLabel: "Moshi",
 		repoName: "Moshi",


### PR DESCRIPTION
## Summary

This PR registers `mobilint` as a Hub model library and configures download counting for Mobilint `.mxq` deployment artifacts while preserving standard `config.json` counting.

The integration is intentionally opt-in. It applies to repositories that declare `library_name: mobilint` in their model card metadata. Repositories that continue to declare another library, such as `transformers`, are intentionally out of scope and should continue using their existing behavior.

## Changes

- Add `mobilint` to `packages/tasks/src/model-libraries.ts`
- Set Mobilint download counting to `path:"config.json" OR path_extension:"mxq"`
- Add a minimal Python snippet using `mblt-model-zoo`
- Link the library integration to `mobilint/mblt-model-zoo`
- Set `filter: false` for the newly registered library

## Download counting rationale

The Hub's default query files such as `config.json` remain valid for many Mobilint repositories and should continue to count downloads. For models that opt into `library_name: mobilint` and publish Mobilint deployment artifacts, users may also download `.mxq` files to run models on Mobilint NPUs through Mobilint SDK qb / qbruntime.

Therefore, the Mobilint library integration counts both the standard `config.json` signal and `.mxq` deployment artifacts.

The rule intentionally does not count `.onnx`, arbitrary `.json`, `.safetensors`, `.bin`, or other source/config files, and it does not affect repositories that remain associated with another library.

## Runtime snippet rationale

The Python snippet uses Mobilint Model Zoo's high-level `MBLT_Engine` API:
- load a model by `model_cls`
- let `mblt-model-zoo` download and cache the matching artifact when `model_path=""`
- run the standard preprocess, inference, and postprocess flow
- dispose the model after use

This keeps the Hub snippet minimal and leaves detailed model selection and runtime options to the Mobilint Model Zoo documentation.

## Scope

This PR does not propose `.mxq` as a generic Hub-wide file format. It scopes `.mxq` download counting to the Mobilint library/runtime ecosystem only.

## Validation

- [x] `pnpm --filter @huggingface/tasks format:check`
- [x] `pnpm --filter @huggingface/tasks lint:check`
- [x] `pnpm --filter @huggingface/tasks check`
- [x] `pnpm --filter @huggingface/tasks test`
