### PR TITLE
Update litert-lm code snippet

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.spec.ts
+++ b/packages/tasks/src/model-libraries-snippets.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ModelData } from "./model-data.js";
-import { llama_cpp_python } from "./model-libraries-snippets.js";
+import { litert_lm, llama_cpp_python } from "./model-libraries-snippets.js";
 
 describe("model-libraries-snippets", () => {
 	it("llama_cpp_python conversational", async () => {
@@ -54,5 +54,30 @@ output = llm(
 	echo=True
 )
 print(output)`);
+	});
+
+	it("litert_lm", async () => {
+		const model: ModelData = {
+			id: "litert-community/gemma-4-E2B-it-litert-lm",
+			tags: [""],
+			inference: "",
+		};
+		const snippet = litert_lm(model);
+
+		expect(snippet.join("\n"))
+			.toEqual(`# LiteRT-LM runs on various platforms (Android, iOS, Windows, Linux, macOS, IoT, Web/WASM)
+# and supports many APIs (C++, Python, Kotlin, Swift, JavaScript, Flutter).
+# For platform-specific integration guides, please refer to the official developer website:
+# https://ai.google.dev/edge/litert-lm
+
+# To try LiteRT-LM, the easiest way is to use our CLI tool.
+# 1. Install the LiteRT-LM CLI tool (at least 0.14.0):
+pip install "litert-lm>=0.14.0"
+
+# 2. Download and run this model locally:
+# See: https://ai.google.dev/edge/litert-lm/cli
+litert-lm run \\
+  --from-huggingface-repo=litert-community/gemma-4-E2B-it-litert-lm \\
+  --prompt="Write me a poem"`);
 	});
 });

--- a/packages/tasks/src/model-libraries-snippets.spec.ts
+++ b/packages/tasks/src/model-libraries-snippets.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ModelData } from "./model-data.js";
-import { litert_lm, llama_cpp_python } from "./model-libraries-snippets.js";
+import { llama_cpp_python } from "./model-libraries-snippets.js";
 
 describe("model-libraries-snippets", () => {
 	it("llama_cpp_python conversational", async () => {
@@ -54,30 +54,5 @@ output = llm(
 	echo=True
 )
 print(output)`);
-	});
-
-	it("litert_lm", async () => {
-		const model: ModelData = {
-			id: "litert-community/gemma-4-E2B-it-litert-lm",
-			tags: [""],
-			inference: "",
-		};
-		const snippet = litert_lm(model);
-
-		expect(snippet.join("\n"))
-			.toEqual(`# LiteRT-LM runs on various platforms (Android, iOS, Windows, Linux, macOS, IoT, Web/WASM)
-# and supports many APIs (C++, Python, Kotlin, Swift, JavaScript, Flutter).
-# For platform-specific integration guides, please refer to the official developer website:
-# https://ai.google.dev/edge/litert-lm
-
-# To try LiteRT-LM, the easiest way is to use our CLI tool.
-# 1. Install the LiteRT-LM CLI tool (at least 0.14.0):
-pip install "litert-lm>=0.14.0"
-
-# 2. Download and run this model locally:
-# See: https://ai.google.dev/edge/litert-lm/cli
-litert-lm run \\
-  --from-huggingface-repo=litert-community/gemma-4-E2B-it-litert-lm \\
-  --prompt="Write me a poem"`);
 	});
 });

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1142,14 +1142,13 @@ export const litert_lm = (model: ModelData): string[] => [
 # https://ai.google.dev/edge/litert-lm
 
 # To try LiteRT-LM, the easiest way is to use our CLI tool.
-# 1. Install the LiteRT-LM CLI tool:
-pip install litert-lm
+# 1. Install the LiteRT-LM CLI tool (at least 0.14.0):
+pip install "litert-lm>=0.14.0"
 
 # 2. Download and run this model locally:
 # See: https://ai.google.dev/edge/litert-lm/cli
 litert-lm run \\
   --from-huggingface-repo=${model.id} \\
-  model.litertlm \\
   --prompt="Write me a poem"`,
 ];
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1142,8 +1142,8 @@ export const litert_lm = (model: ModelData): string[] => [
 # https://ai.google.dev/edge/litert-lm
 
 # To try LiteRT-LM, the easiest way is to use our CLI tool.
-# 1. Install the LiteRT-LM CLI tool (at least 0.14.0):
-pip install "litert-lm>=0.14.0"
+# 1. Install the LiteRT-LM CLI tool:
+pip install -U litert-lm
 
 # 2. Download and run this model locally:
 # See: https://ai.google.dev/edge/litert-lm/cli


### PR DESCRIPTION
The latest `litert-lm` CLI does not require specifying the model file name when running with `--from-huggingface-repo`.

Update the litert_lm snippet command across 3 lines without model.litertlm, and specify litert-lm>=0.14.0 in the installation instructions. Add a unit test verifying the exact output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to a documentation snippet string; no runtime or API behavior in the app.
> 
> **Overview**
> Updates the **LiteRT-LM** model-card snippet so it matches the current CLI behavior.
> 
> Install step now uses **`pip install -U litert-lm`** so users pick up a recent package. The **`litert-lm run`** example no longer passes a **`model.litertlm`** filename after **`--from-huggingface-repo`**—only the Hub repo id and **`--prompt`**—because newer CLI versions resolve the model file from the repo automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c71788c37154ee831804defd903fde9efbf395ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->