### PR TITLE
[jinja] Add support for integer division

### DIFF
--- a/packages/jinja/src/lexer.ts
+++ b/packages/jinja/src/lexer.ts
@@ -25,7 +25,7 @@ export const TOKEN_TYPES = Object.freeze({
 
 	CallOperator: "CallOperator", // ()
 	AdditiveBinaryOperator: "AdditiveBinaryOperator", // + - ~
-	MultiplicativeBinaryOperator: "MultiplicativeBinaryOperator", // * / %
+	MultiplicativeBinaryOperator: "MultiplicativeBinaryOperator", // * / // %
 	ComparisonBinaryOperator: "ComparisonBinaryOperator", // < > <= >= == !=
 	UnaryOperator: "UnaryOperator", // ! - +
 	Comment: "Comment", // {# ... #}
@@ -92,6 +92,7 @@ const ORDERED_MAPPING_TABLE: [string, TokenType][] = [
 	["-", TOKEN_TYPES.AdditiveBinaryOperator],
 	["~", TOKEN_TYPES.AdditiveBinaryOperator],
 	["*", TOKEN_TYPES.MultiplicativeBinaryOperator],
+	["//", TOKEN_TYPES.MultiplicativeBinaryOperator], // NOTE: must come before "/" so that "//" is matched first
 	["/", TOKEN_TYPES.MultiplicativeBinaryOperator],
 	["%", TOKEN_TYPES.MultiplicativeBinaryOperator],
 	// Assignment operator

--- a/packages/jinja/src/runtime.ts
+++ b/packages/jinja/src/runtime.ts
@@ -882,6 +882,12 @@ export class Interpreter {
 				}
 				case "/":
 					return new FloatValue(a / b);
+				case "//": {
+					// Floor division (rounds towards negative infinity, matching Python semantics)
+					const res = Math.floor(a / b);
+					const isFloat = left instanceof FloatValue || right instanceof FloatValue;
+					return isFloat ? new FloatValue(res) : new IntegerValue(res);
+				}
 				case "%": {
 					const rem = a % b;
 					const isFloat = left instanceof FloatValue || right instanceof FloatValue;

--- a/packages/jinja/test/templates.test.js
+++ b/packages/jinja/test/templates.test.js
@@ -52,6 +52,7 @@ const TEST_STRINGS = {
 	// Binary expressions
 	BINOP_EXPR: `{{ 1 % 2 }}{{ 1 < 2 }}{{ 1 > 2 }}{{ 1 >= 2 }}{{ 2 <= 2 }}{{ 2 == 2 }}{{ 2 != 3 }}{{ 2 + 3 }}`,
 	BINOP_EXPR_1: `{{ 1 ~ "+" ~ 2 ~ "=" ~ 3 ~ " is " ~ true }}`,
+	BINOP_EXPR_2: `|{{ 7 // 2 }}|{{ -7 // 2 }}|{{ -7.5 // 2 }}|{{ 7.5 // 2 }}|{{ 8 // 3 }}|{{ 9 // 3 }}|`,
 
 	// Strings
 	STRINGS: `{{ 'Bye' }}{{ bos_token + '[INST] ' }}`,
@@ -1085,6 +1086,45 @@ const TEST_PARSED = {
 		{ value: "~", type: "AdditiveBinaryOperator" },
 		{ value: "true", type: "Identifier" },
 		{ value: "}}", type: "CloseExpression" },
+	],
+	BINOP_EXPR_2: [
+		{ value: "|", type: "Text" },
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "7", type: "NumericLiteral" },
+		{ value: "//", type: "MultiplicativeBinaryOperator" },
+		{ value: "2", type: "NumericLiteral" },
+		{ value: "}}", type: "CloseExpression" },
+		{ value: "|", type: "Text" },
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "-7", type: "NumericLiteral" },
+		{ value: "//", type: "MultiplicativeBinaryOperator" },
+		{ value: "2", type: "NumericLiteral" },
+		{ value: "}}", type: "CloseExpression" },
+		{ value: "|", type: "Text" },
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "-7.5", type: "NumericLiteral" },
+		{ value: "//", type: "MultiplicativeBinaryOperator" },
+		{ value: "2", type: "NumericLiteral" },
+		{ value: "}}", type: "CloseExpression" },
+		{ value: "|", type: "Text" },
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "7.5", type: "NumericLiteral" },
+		{ value: "//", type: "MultiplicativeBinaryOperator" },
+		{ value: "2", type: "NumericLiteral" },
+		{ value: "}}", type: "CloseExpression" },
+		{ value: "|", type: "Text" },
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "8", type: "NumericLiteral" },
+		{ value: "//", type: "MultiplicativeBinaryOperator" },
+		{ value: "3", type: "NumericLiteral" },
+		{ value: "}}", type: "CloseExpression" },
+		{ value: "|", type: "Text" },
+		{ value: "{{", type: "OpenExpression" },
+		{ value: "9", type: "NumericLiteral" },
+		{ value: "//", type: "MultiplicativeBinaryOperator" },
+		{ value: "3", type: "NumericLiteral" },
+		{ value: "}}", type: "CloseExpression" },
+		{ value: "|", type: "Text" },
 	],
 
 	// Strings
@@ -4862,6 +4902,7 @@ const TEST_CONTEXT = {
 	// Binary expressions
 	BINOP_EXPR: {},
 	BINOP_EXPR_1: {},
+	BINOP_EXPR_2: {},
 
 	// Strings
 	STRINGS: {
@@ -5304,6 +5345,7 @@ const EXPECTED_OUTPUTS = {
 	// Binary expressions
 	BINOP_EXPR: "1truefalsefalsetruetruetrue5",
 	BINOP_EXPR_1: "1+2=3 is true",
+	BINOP_EXPR_2: "|3|-4|-4.0|3.0|2|3|",
 
 	// Strings
 	STRINGS: "Bye<s>[INST] ",


### PR DESCRIPTION
Never really needed it until now 🤷 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized arithmetic/lexer change with tests; no auth, I/O, or broad API surface.
> 
> **Overview**
> Adds Python/Jinja-style **floor division** (`//`) to the in-repo Jinja engine so templates can use integer division in expressions.
> 
> The **lexer** recognizes `//` as a multiplicative binary operator, with `//` registered **before** `/` so two slashes are not tokenized as two divides. The **runtime** evaluates `//` with `Math.floor(a / b)` (toward negative infinity) and returns `IntegerValue` or `FloatValue` when either operand is a float, consistent with existing `+`, `-`, `*`, and `%` behavior.
> 
> **Tests** add `BINOP_EXPR_2` covering positive/negative integers and floats (e.g. `7 // 2` → `3`, `-7 // 2` → `-4`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a78efd5e63fdde24aa463c7a5a1a28d198503653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->