### PR TITLE
CI fix e2e test 

### DIFF
--- a/e2e/deno/deno.json
+++ b/e2e/deno/deno.json
@@ -1,1 +1,3 @@
-{}
+{
+	"minimumDependencyAge": 0
+}


### PR DESCRIPTION
It uses only local packages so it's fine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Deno config for the e2e job; no production runtime or security-sensitive logic changes.
> 
> **Overview**
> **Fixes Deno e2e CI** by configuring `e2e/deno/deno.json` with `"minimumDependencyAge": 0`.
> 
> Deno can refuse very new npm packages by default; the e2e job pulls from a **local registry** (`localhost:4874`), so those packages would otherwise fail the age check. Setting the minimum age to **0** lets CI use those local packages without changing test logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4507d4a2e7d2c0ac656ccc433d45e38175359b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->