### PR TITLE
Add timee-ts library for download tracking

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1512,6 +1512,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"checkpoints/checkpoint_1100000/state/checkpoint" OR path:"checkpoints/checkpoint_2150000/state/checkpoint" OR path_extension:"ckpt"`,
 	},
+	"timee-ts": {
+		prettyLabel: "timee-ts",
+		repoName: "timee-ts",
+		repoUrl: "https://github.com/liamsbhoo/timee",
+		filter: false,
+		countDownloads: `path:"model.safetensors"`,
+	},
 	timm: {
 		prettyLabel: "timm",
 		repoName: "pytorch-image-models",


### PR DESCRIPTION
## Summary

Adds `timee-ts` to the model libraries registry to enable download tracking on the Hub.

- **Library:** [timee-ts](https://pypi.org/project/timee-ts/)
- **Repo:** https://github.com/liamsbhoo/timee
- **HuggingFace model:** https://huggingface.co/liamsbhoo/timee
- **Paper:** https://arxiv.org/abs/2607.07500

TIMEE is a pretrained transformer for time series classification via in-context learning. The model is distributed as a single `model.safetensors` file, so `countDownloads` is set to `path:"model.safetensors"`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single additive registry row with no auth, runtime, or behavioral logic changes.
> 
> **Overview**
> Registers **`timee-ts`** in `MODEL_LIBRARIES_UI_ELEMENTS` so Hub models tagged with that `library_name` get library metadata and download counts.
> 
> The entry points at the [timee](https://github.com/liamsbhoo/timee) repo, keeps **`filter: false`** (not on the main models library filter), and sets **`countDownloads`** to `path:"model.safetensors"` to match TIMEE’s single-weight layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae154c1b01cd58b134d39905af1f075e0f0a5b92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->