### PR TITLE
add device_map to transformers snippets

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1891,9 +1891,7 @@ export const transformers = (model: ModelData): string[] => {
 		pipelineSnippet.push(
 			"from transformers import pipeline",
 			"",
-			`pipe = pipeline("${model.pipeline_tag}", model="${model.id}"` +
-				remote_code_snippet +
-				', device_map="auto")',
+			`pipe = pipeline("${model.pipeline_tag}", model="${model.id}"` + remote_code_snippet + ', device_map="auto")',
 		);
 
 		if (model.tags.includes("conversational")) {

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1835,7 +1835,7 @@ export const transformers = (model: ModelData): string[] => {
 			`from transformers import ${info.processor}, ${info.auto_model}`,
 			"",
 			`${processorVarName} = ${info.processor}.from_pretrained("${model.id}"` + remote_code_snippet + ")",
-			`model = ${info.auto_model}.from_pretrained("${model.id}"` + remote_code_snippet + ")",
+			`model = ${info.auto_model}.from_pretrained("${model.id}"` + remote_code_snippet + ', device_map="auto")',
 		);
 		if (model.tags.includes("conversational") && hasChatTemplate(model)) {
 			if (model.tags.includes("image-text-to-text")) {
@@ -1872,7 +1872,9 @@ export const transformers = (model: ModelData): string[] => {
 		autoSnippet.push(
 			"# Load model directly",
 			`from transformers import ${info.auto_model}`,
-			`model = ${info.auto_model}.from_pretrained("${model.id}"` + remote_code_snippet + ', dtype="auto")',
+			`model = ${info.auto_model}.from_pretrained("${model.id}"` +
+				remote_code_snippet +
+				', dtype="auto", device_map="auto")',
 		);
 	}
 
@@ -1889,7 +1891,9 @@ export const transformers = (model: ModelData): string[] => {
 		pipelineSnippet.push(
 			"from transformers import pipeline",
 			"",
-			`pipe = pipeline("${model.pipeline_tag}", model="${model.id}"` + remote_code_snippet + ")",
+			`pipe = pipeline("${model.pipeline_tag}", model="${model.id}"` +
+				remote_code_snippet +
+				', device_map="auto")',
 		);
 
 		if (model.tags.includes("conversational")) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Snippet-only change in `model-libraries-snippets.ts` with no runtime or API impact; users may need `accelerate` for `device_map="auto"` when following the examples.
> 
> **Overview**
> Hub **transformers** code snippets now pass **`device_map="auto"`** on direct **`from_pretrained`** loads (with and without a processor) and on **`pipeline(...)`** construction, so copy-paste examples place weights on available accelerators instead of defaulting to CPU.
> 
> The processor-less path keeps **`dtype="auto"`** and only reformats the string for readability; behavior is otherwise unchanged aside from the new argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc631d21f249f75bc478cf50f3d9e2ed9a666688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->