### PR TITLE
Add NVIDIA Model Optimizer as library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -967,6 +967,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.model2vec,
 		filter: false,
 	},
+	modelopt: {
+		prettyLabel: "NVIDIA Model Optimizer",
+		repoName: "Model-Optimizer",
+		repoUrl: "https://github.com/NVIDIA/Model-Optimizer",
+		docsUrl: "https://nvidia.github.io/Model-Optimizer/",
+		countDownloads: `path:"hf_quant_config.json"`,
+		filter: false,
+	},
 	mobilint: {
 		prettyLabel: "Mobilint",
 		repoName: "mblt-model-zoo",


### PR DESCRIPTION
Registers [NVIDIA TensorRT Model Optimizer](https://github.com/NVIDIA/Model-Optimizer) (ModelOpt) as a model library, following the pattern of #885, so that ModelOpt-quantized checkpoints get [download counting](https://huggingface.co/docs/hub/models-download-stats) and library attribution.

**Download counting rule:** `path:"hf_quant_config.json"` — a single file that every ModelOpt HF export carries alongside `config.json` (avoids multi-counting the safetensors shards).

**Example models:** [nvidia/DeepSeek-R1-FP4-v2](https://huggingface.co/nvidia/DeepSeek-R1-FP4-v2), [nvidia/Llama-3.3-70B-Instruct-FP8](https://huggingface.co/nvidia/Llama-3.3-70B-Instruct-FP8), [centml/DeepSeek-R1-NVFP4-v2-mlpinf](https://huggingface.co/centml/DeepSeek-R1-NVFP4-v2-mlpinf).

Note on the key: `modelopt` follows the pip package name (`nvidia-modelopt`). Some existing model cards carry `library_name: Model Optimizer` (spaced) — happy to change the key if the Hub normalizes that differently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a single metadata/registry entry with no runtime, auth, or data-path changes; only affects Hub library labeling and download attribution for ModelOpt checkpoints.
> 
> **Overview**
> Registers **NVIDIA Model Optimizer** (TensorRT Model Optimizer / ModelOpt) in `MODEL_LIBRARIES_UI_ELEMENTS` under the key `modelopt`, so Hub models tagged with that `library_name` get proper library attribution, repo/docs links, and download stats.
> 
> Download counting is scoped to **`hf_quant_config.json`** only (one count per ModelOpt HF export, avoiding inflated counts from sharded safetensors). The entry is **not** added to the models filter (`filter: false`), consistent with smaller or newer libraries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3758586a12167756f7b109e3e625bf24eba16d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->