### PR TITLE
don't restrict safetensors to model repos

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -282,12 +282,12 @@ const LIBRARY_WEIGHT_CANDIDATES: Record<string, Array<{ single: string; index: s
 };
 
 /**
- * Analyze model.safetensors.index.json or model.safetensors from a model hosted
- * on Hugging Face using smart range requests to extract its metadata.
+ * Analyze a safetensors file or index hosted in a Hugging Face repository
+ * using range requests to extract its metadata.
  */
 export async function parseSafetensorsMetadata(
 	params: {
-		/** Only models are supported */
+		/** Repository containing the safetensors file. */
 		repo: RepoDesignation;
 		/**
 		 * Relative file path to safetensors file inside `repo`. Defaults to `SAFETENSORS_FILE` or `SAFETENSORS_INDEX_FILE` (whichever one exists).
@@ -317,7 +317,7 @@ export async function parseSafetensorsMetadata(
 ): Promise<SetRequired<SafetensorsParseFromRepo, "parameterCount">>;
 export async function parseSafetensorsMetadata(
 	params: {
-		/** Only models are supported */
+		/** Repository containing the safetensors file. */
 		repo: RepoDesignation;
 		path?: string;
 		/**
@@ -358,12 +358,11 @@ export async function parseSafetensorsMetadata(
 ): Promise<SafetensorsParseFromRepo> {
 	const repoId = toRepoId(params.repo);
 
-	if (repoId.type !== "model") {
-		throw new TypeError("Only model repos should contain safetensors files.");
-	}
-
 	// Fetch model config for quantization information
-	const modelConfig = params.computeParametersCount ? await fetchModelConfig(params) : null;
+	const modelConfig =
+		params.computeParametersCount && repoId.type === "model"
+	    ? await fetchModelConfig(params)
+		  : null;
 	const quantConfig = modelConfig?.quantization_config ?? modelConfig?.text_config?.quantization_config;
 
 	// Resolve which file to parse, in order:
@@ -431,7 +430,7 @@ export async function parseSafetensorsMetadata(
 			filepaths: [path, ...Object.keys(shardedMap).map((filename) => pathPrefix + filename)],
 		};
 	} else {
-		throw new Error("model id does not seem to contain safetensors weights");
+		throw new Error("repo id does not seem to contain safetensors weights");
 	}
 }
 

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -359,10 +359,7 @@ export async function parseSafetensorsMetadata(
 	const repoId = toRepoId(params.repo);
 
 	// Fetch model config for quantization information
-	const modelConfig =
-		params.computeParametersCount && repoId.type === "model"
-	    ? await fetchModelConfig(params)
-		  : null;
+	const modelConfig = params.computeParametersCount && repoId.type === "model" ? await fetchModelConfig(params) : null;
 	const quantConfig = modelConfig?.quantization_config ?? modelConfig?.text_config?.quantization_config;
 
 	// Resolve which file to parse, in order:


### PR DESCRIPTION
datasets like:
https://huggingface.co/datasets/commaai/comma1M
https://huggingface.co/datasets/stady4d-anon/StaDy4D
https://huggingface.co/datasets/LAXMAYDAY/pdm3-ht-20260528-flux2-vae-latents-public
https://huggingface.co/datasets/Carnot-EBM/token-activations

are using safetensors to save tensor data, not model weights. which currently throws the error "TypeError: Only model repos should contain safetensors files."

this removes that check and changes the docstrings a bit to reflect that.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small API relaxation in hub metadata parsing; quantization-aware counting behavior for model repos is unchanged.
> 
> **Overview**
> **`parseSafetensorsMetadata`** no longer requires a **model** repo; any Hugging Face repo type can be parsed for safetensors headers and optional parameter counts.
> 
> The previous **`TypeError`** for non-model repos is removed. **`config.json`** (quantization hints for parameter counting) is still loaded only when **`computeParametersCount`** is true **and** the repo is a model; other repo types skip that fetch. Docs and the “no weights found” error now say **repo** instead of **model**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620eb6d2a239cf3b14326e04c000e72d95e59b43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->