### PR TITLE
add Q2_0 quant type

### DIFF
--- a/packages/gguf/src/quant-descriptions.ts
+++ b/packages/gguf/src/quant-descriptions.ts
@@ -144,6 +144,10 @@ export const GGUF_QUANT_DESCRIPTIONS: Record<GGMLQuantizationType, { txt: string
 		txt: "1-bit quantization with fp16 block scale. Each block has 128 weights, where 0 represents -block_scale and 1 represents +block_scale.",
 		src_url: "https://github.com/ggml-org/llama.cpp/pull/21273",
 	},
+	[GGMLQuantizationType.Q2_0]: {
+		txt: "2-bit quantization with fp16 block scale. Each block has 64 weights, where {0, 1, 2, 3} represents {-1, 0, +1, +2} * block_scale, resulting in 2.25 bits-per-weight.",
+		src_url: "https://github.com/ggml-org/llama.cpp/pull/24448",
+	},
 };
 
 const QK_K = 256;
@@ -188,4 +192,5 @@ export const GGML_QUANT_SIZES = {
 	[GGMLQuantizationType.MXFP4]: calcBPW(32, 1 + 16),
 	[GGMLQuantizationType.NVFP4]: calcBPW(64, 4 + 32),
 	[GGMLQuantizationType.Q1_0]: calcBPW(128, 2 + 16),
+	[GGMLQuantizationType.Q2_0]: calcBPW(64, 2 + 16),
 };

--- a/packages/tasks/src/gguf.ts
+++ b/packages/tasks/src/gguf.ts
@@ -43,6 +43,7 @@ export enum GGMLFileQuantizationType {
 	MXFP4_MOE = 38,
 	NVFP4 = 39,
 	Q1_0 = 40,
+	Q2_0 = 41,
 
 	// custom quants used by unsloth
 	// they are not officially a scheme enum value in GGUF, but only here for naming
@@ -121,6 +122,7 @@ export const GGUF_QUANT_ORDER: GGMLFileQuantizationType[] = [
 	GGMLFileQuantizationType.IQ2_S,
 	GGMLFileQuantizationType.IQ2_XS,
 	GGMLFileQuantizationType.IQ2_XXS,
+	GGMLFileQuantizationType.Q2_0,
 
 	// 1-bit quantizations
 	GGMLFileQuantizationType.IQ1_S,
@@ -208,4 +210,5 @@ export enum GGMLQuantizationType {
 	MXFP4 = 39,
 	NVFP4 = 40,
 	Q1_0 = 41,
+	Q2_0 = 42,
 }


### PR DESCRIPTION
sync with llama.cpp which added Q2_0 in ggml-org/llama.cpp#24448 (ternary quant, 64-weight blocks with fp16 scale, 2.25 bpw)

adds it to GGMLFileQuantizationType, GGMLQuantizationType, GGUF_QUANT_ORDER and the gguf quant descriptions/sizes

disclaimer: my julien-cto agent helped me write this

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive enum and metadata only; no runtime inference or parsing logic changes beyond existing quant registration patterns.
> 
> **Overview**
> Adds **Q2_0** support to stay aligned with llama.cpp ([ggml-org/llama.cpp#24448](https://github.com/ggml-org/llama.cpp/pull/24448)): a 2-bit scheme with fp16 block scale, 64 weights per block, and ~2.25 bpw.
> 
> In `packages/tasks`, `Q2_0` is registered on `GGMLFileQuantizationType` (41) and `GGMLQuantizationType` (42), and listed in `GGUF_QUANT_ORDER` under 2-bit quants so filename parsing and nearest-quant logic recognize it.
> 
> In `packages/gguf`, `quant-descriptions.ts` gains the human-readable description and `GGML_QUANT_SIZES` entry (`calcBPW(64, 2 + 16)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c68a9dc9c30ed9ab8c32ea1e97494580b7370327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->