### PR TITLE
Add CCPFN library for download count

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -221,6 +221,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/cartesia-ai/cartesia_mlx",
 		snippets: snippets.cartesia_mlx,
 	},
+	ccpfn: {
+		prettyLabel: "CCPFN",
+		repoName: "CCPFN",
+		repoUrl: "https://huggingface.co/Layer6/CCPFN",
+		filter: false,
+		countDownloads: `path_extension:"pt" OR path_extension:"safetensors"`,
+	},
 	champ: {
 		prettyLabel: "Champ",
 		repoName: "Champ",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -226,7 +226,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "CCPFN",
 		repoUrl: "https://huggingface.co/Layer6/CCPFN",
 		filter: false,
-		countDownloads: `path_extension:"pt" OR path_extension:"safetensors"`,
+		countDownloads: `path_extension:"pt",
 	},
 	champ: {
 		prettyLabel: "Champ",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -226,7 +226,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "CCPFN",
 		repoUrl: "https://huggingface.co/Layer6/CCPFN",
 		filter: false,
-		countDownloads: `path_extension:"pt",
+		countDownloads: `path_extension:"pt"`,
 	},
 	champ: {
 		prettyLabel: "Champ",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single registry entry with no runtime logic changes; same pattern as other niche libraries.
> 
> **Overview**
> Registers **CCPFN** as a new modeling library in `MODEL_LIBRARIES_UI_ELEMENTS` so Hub models tagged with `library_name: ccpfn` get correct UI metadata and download stats.
> 
> Downloads are counted via Elasticsearch on files with the `.pt` extension. The library is **not** added to the public models filter (`filter: false`), and there are no code snippets—only label, repo link (`Layer6/CCPFN` on the Hub), and the download query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9294908000908d36643f0f04d6be34d3e9fc3e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->