### PR TITLE
remove dtype and pipeline device_map from transformers snippets

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1872,9 +1872,7 @@ export const transformers = (model: ModelData): string[] => {
 		autoSnippet.push(
 			"# Load model directly",
 			`from transformers import ${info.auto_model}`,
-			`model = ${info.auto_model}.from_pretrained("${model.id}"` +
-				remote_code_snippet +
-				', dtype="auto", device_map="auto")',
+			`model = ${info.auto_model}.from_pretrained("${model.id}"` + remote_code_snippet + ', device_map="auto")',
 		);
 	}
 
@@ -1891,7 +1889,7 @@ export const transformers = (model: ModelData): string[] => {
 		pipelineSnippet.push(
 			"from transformers import pipeline",
 			"",
-			`pipe = pipeline("${model.pipeline_tag}", model="${model.id}"` + remote_code_snippet + ', device_map="auto")',
+			`pipe = pipeline("${model.pipeline_tag}", model="${model.id}"` + remote_code_snippet + ")",
 		);
 
 		if (model.tags.includes("conversational")) {


### PR DESCRIPTION
remove dtype="auto" from the AutoModel snippet and device_map="auto" from the pipeline snippet

disclaimer: my julien-cto agent helped me write this

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes displayed example strings in `packages/tasks`; no runtime inference or loading behavior in the app.
> 
> **Overview**
> Updates generated **Transformers** usage snippets on model pages so copy-paste examples match simpler defaults.
> 
> For the **direct `from_pretrained`** path when there is no processor, the snippet no longer passes **`dtype="auto"`**; it still uses **`device_map="auto"`** on that line. The **pipeline** helper line drops **`device_map="auto"`** entirely, so `pipeline(...)` only includes the task, model id, and optional `trust_remote_code`.
> 
> Snippets that load a processor/tokenizer and then the model are unchanged on **`device_map`** for the model load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2bbfcc968f2ad684320316db2e04d4f2a8385a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->