### PR TITLE
Update recommended models to GLM-5.2 and Gemma 4

### DIFF
--- a/packages/tasks/src/tasks/image-text-to-text/data.ts
+++ b/packages/tasks/src/tasks/image-text-to-text/data.ts
@@ -43,12 +43,16 @@ const taskData: TaskDataCustom = {
 	metrics: [],
 	models: [
 		{
-			description: "Small and efficient yet powerful vision language model.",
-			id: "HuggingFaceTB/SmolVLM-Instruct",
+			description: "Google's Gemma 4 vision-language model for multimodal chat.",
+			id: "google/gemma-4-31B-it",
 		},
 		{
 			description: "Cutting-edge reasoning vision language model.",
-			id: "zai-org/GLM-4.5V",
+			id: "zai-org/GLM-4.6V",
+		},
+		{
+			description: "Small and efficient yet powerful vision language model.",
+			id: "HuggingFaceTB/SmolVLM-Instruct",
 		},
 		{
 			description: "Cutting-edge small vision language model to convert documents to text.",
@@ -79,7 +83,7 @@ const taskData: TaskDataCustom = {
 	],
 	summary:
 		"Image-text-to-text models take in an image and text prompt and output text. These models are also called vision-language models, or VLMs. The difference from image-to-text models is that these models take an additional text input, not restricting the model to certain use cases like image captioning, and may also be trained to accept a conversation as input.",
-	widgetModels: ["zai-org/GLM-4.5V"],
+	widgetModels: ["google/gemma-4-31B-it"],
 	youtubeId: "IoGaGfU1CIg",
 };
 

--- a/packages/tasks/src/tasks/text-generation/data.ts
+++ b/packages/tasks/src/tasks/text-generation/data.ts
@@ -61,7 +61,10 @@ const taskData: TaskDataCustom = {
 		},
 	],
 	models: [
-		{ description: "A text-generation model trained to follow instructions.", id: "google/gemma-2-2b-it" },
+		{
+			description: "Powerful text generation model with strong reasoning and coding capabilities.",
+			id: "zai-org/GLM-5.2",
+		},
 		{
 			description: "Powerful text generation model for coding.",
 			id: "Qwen/Qwen3-Coder-480B-A35B-Instruct",
@@ -70,10 +73,7 @@ const taskData: TaskDataCustom = {
 			description: "Great text generation model with top-notch tool calling capabilities.",
 			id: "openai/gpt-oss-120b",
 		},
-		{
-			description: "Powerful text generation model.",
-			id: "zai-org/GLM-4.5",
-		},
+		{ description: "A text-generation model trained to follow instructions.", id: "google/gemma-2-2b-it" },
 		{
 			description: "A powerful small model with reasoning capabilities.",
 			id: "Qwen/Qwen3-4B-Thinking-2507",


### PR DESCRIPTION
## Summary
- Replace `zai-org/GLM-4.5` with `zai-org/GLM-5.2` as the flagship recommended text-generation model
- Add `google/gemma-4-31B-it` and replace `zai-org/GLM-4.5V` with `zai-org/GLM-4.6V` for image-text-to-text recommendations
- Point the image-text-to-text widget model at Gemma 4

This feeds [`/api/tasks`](https://huggingface.co/api/tasks), which Inference Providers docs use for the recommended models on [chat completion](https://huggingface.co/docs/inference-providers/en/tasks/chat-completion) and related task pages.

## Test plan
- [ ] Confirm `/api/tasks` lists the new model IDs after deploy
- [ ] Confirm models are `inference=warm` so they appear in generated Inference Providers docs
- [ ] Spot-check task pages for text-generation / image-text-to-text / chat-completion


Made with [Cursor](https://cursor.com)