### PR TITLE
[Inference Providers] deepinfra: add text-to-speech support

### DIFF
--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -69,6 +69,7 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 		"automatic-speech-recognition": new DeepInfra.DeepInfraAutomaticSpeechRecognitionTask(),
 		conversational: new DeepInfra.DeepInfraConversationalTask(),
 		"text-generation": new DeepInfra.DeepInfraTextGenerationTask(),
+		"text-to-speech": new DeepInfra.DeepInfraTextToSpeechTask(),
 	},
 	"fal-ai": {
 		"audio-to-audio": new FalAI.FalAIAudioToAudioTask(),

--- a/packages/inference/src/providers/deepinfra.ts
+++ b/packages/inference/src/providers/deepinfra.ts
@@ -29,6 +29,7 @@ import {
 	BaseConversationalTask,
 	BaseTextGenerationTask,
 	TaskProviderHelper,
+	type TextToSpeechTaskHelper,
 } from "./providerHelper.js";
 
 /**
@@ -212,6 +213,37 @@ export class DeepInfraAutomaticSpeechRecognitionTask
 		}
 		throw new InferenceClientProviderOutputError(
 			`Received malformed response from DeepInfra automatic-speech-recognition API: ${JSON.stringify(response)}`,
+		);
+	}
+}
+
+export class DeepInfraTextToSpeechTask extends TaskProviderHelper implements TextToSpeechTaskHelper {
+	constructor() {
+		super("deepinfra", DEEPINFRA_API_BASE_URL);
+	}
+
+	makeRoute(): string {
+		return "v1/openai/audio/speech";
+	}
+
+	preparePayload(params: BodyParams): Record<string, unknown> {
+		// `model` is applied last so caller parameters cannot override the mapped provider model.
+		// `voice` is model-specific and optional; we pass it through untouched and let the API
+		// surface a clear error when a model requires one.
+		return {
+			...omit(params.args, ["inputs", "parameters"]),
+			...(params.args.parameters as Record<string, unknown> | undefined),
+			input: params.args.inputs,
+			model: params.model,
+		};
+	}
+
+	async getResponse(response: Blob): Promise<Blob> {
+		if (response instanceof Blob) {
+			return response;
+		}
+		throw new InferenceClientProviderOutputError(
+			`Received malformed response from DeepInfra text-to-speech API: ${JSON.stringify(response)}`,
 		);
 	}
 }

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -1666,6 +1666,9 @@ describe.skip("InferenceClient", () => {
 			const ASR_HF_MODEL = "nvidia/nemotron-3.5-asr-streaming-0.6b";
 			const ASR_PROVIDER_ID = "nvidia/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b";
 
+			const TTS_HF_MODEL = "hexgrad/Kokoro-82M";
+			const TTS_PROVIDER_ID = "hexgrad/Kokoro-82M";
+
 			const setMapping = (task: "conversational" | "text-generation") => {
 				HARDCODED_MODEL_INFERENCE_MAPPING["deepinfra"] = {
 					[HF_MODEL]: {
@@ -1686,6 +1689,18 @@ describe.skip("InferenceClient", () => {
 						providerId: ASR_PROVIDER_ID,
 						status: "live",
 						task: "automatic-speech-recognition",
+					},
+				};
+			};
+
+			const setTtsMapping = () => {
+				HARDCODED_MODEL_INFERENCE_MAPPING["deepinfra"] = {
+					[TTS_HF_MODEL]: {
+						provider: "deepinfra",
+						hfModelId: TTS_HF_MODEL,
+						providerId: TTS_PROVIDER_ID,
+						status: "live",
+						task: "text-to-speech",
 					},
 				};
 			};
@@ -1751,6 +1766,17 @@ describe.skip("InferenceClient", () => {
 				});
 				expect(typeof res.text).toBe("string");
 				expect(res.text.length).toBeGreaterThan(0);
+			});
+
+			it("textToSpeech", async () => {
+				setTtsMapping();
+				const res = await client.textToSpeech({
+					model: TTS_HF_MODEL,
+					provider: "deepinfra",
+					inputs: "Hello from DeepInfra text to speech.",
+					parameters: { voice: "af_bella" },
+				});
+				expect(res).toBeInstanceOf(Blob);
 			});
 		},
 		TIMEOUT,


### PR DESCRIPTION
## What

Adds `text-to-speech` support to the **deepinfra** inference provider.

## Details

- New `DeepInfraTextToSpeechTask` (implements `TextToSpeechTaskHelper`) in `packages/inference/src/providers/deepinfra.ts`.
- Targets DeepInfra's OpenAI-compatible endpoint `POST /v1/openai/audio/speech` and returns the raw audio `Blob`.
- The mapped provider model is applied **last** in the payload so caller `parameters` cannot override it (consistent with the review feedback on the deepinfra ASR integration).
- `voice` is model-specific and optional, so it is passed through untouched and the API surfaces a clear error if a model requires one.
- Registered under `deepinfra` → `text-to-speech` in `getProviderHelper.ts`.
- Added a `textToSpeech` case to the existing `DeepInfra` test block.

Mirrors the existing `TogetherTextToSpeechTask` (also OpenAI-compatible `/v1/audio/speech` → Blob).

## Validation

- `pnpm run format:check` ✅
- `pnpm run lint` ✅
- `pnpm exec tsc --noEmit` ✅ (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive provider task following the existing Together TTS pattern; no auth or core routing changes beyond registering a new task helper.
> 
> **Overview**
> Adds **text-to-speech** for the **deepinfra** inference provider so `InferenceClient.textToSpeech` can route to DeepInfra when models are mapped to that task.
> 
> A new `DeepInfraTextToSpeechTask` calls DeepInfra’s OpenAI-compatible `POST v1/openai/audio/speech`, maps `inputs` → `input`, merges optional `parameters` (e.g. `voice`), and sets **`model` last** so callers cannot override the mapped provider model. Responses are returned as a raw audio **`Blob`**. The task is registered on the deepinfra provider map, and the DeepInfra integration tests include a `textToSpeech` case (Kokoro model + `af_bella` voice).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6ccf4018444b8ad819326405fc020ad602353d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->