### PR TITLE
feat(tasks): add device_map="auto" to the transformers pipeline snippet

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.spec.ts
+++ b/packages/tasks/src/model-libraries-snippets.spec.ts
@@ -1,8 +1,34 @@
 import { describe, expect, it } from "vitest";
 import type { ModelData } from "./model-data.js";
-import { llama_cpp_python } from "./model-libraries-snippets.js";
+import { llama_cpp_python, transformers } from "./model-libraries-snippets.js";
 
 describe("model-libraries-snippets", () => {
+	it("transformers pipeline and auto snippets include device_map auto", async () => {
+		const model: ModelData = {
+			id: "distilbert/distilbert-base-uncased-finetuned-sst-2-english",
+			pipeline_tag: "text-classification",
+			tags: [],
+			inference: "",
+			transformersInfo: {
+				auto_model: "AutoModelForSequenceClassification",
+				processor: "AutoTokenizer",
+				pipeline_tag: "text-classification",
+			},
+		};
+		const snippet = transformers(model);
+
+		expect(snippet[0]).toEqual(`# Use a pipeline as a high-level helper
+from transformers import pipeline
+
+pipe = pipeline("text-classification", model="distilbert/distilbert-base-uncased-finetuned-sst-2-english", device_map="auto")`);
+
+		expect(snippet[1]).toEqual(`# Load model directly
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+
+tokenizer = AutoTokenizer.from_pretrained("distilbert/distilbert-base-uncased-finetuned-sst-2-english")
+model = AutoModelForSequenceClassification.from_pretrained("distilbert/distilbert-base-uncased-finetuned-sst-2-english", device_map="auto")`);
+	});
+
 	it("llama_cpp_python conversational", async () => {
 		const model: ModelData = {
 			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1889,7 +1889,7 @@ export const transformers = (model: ModelData): string[] => {
 		pipelineSnippet.push(
 			"from transformers import pipeline",
 			"",
-			`pipe = pipeline("${model.pipeline_tag}", model="${model.id}"` + remote_code_snippet + ")",
+			`pipe = pipeline("${model.pipeline_tag}", model="${model.id}"` + remote_code_snippet + ', device_map="auto")',
 		);
 
 		if (model.tags.includes("conversational")) {


### PR DESCRIPTION
Fixes #2287

The AutoModel/AutoProcessor snippet paths already pass `device_map="auto"` to `from_pretrained`, but the `pipeline()` snippet did not — so the default copy-paste path on model pages loads models on CPU even on GPU machines.

## Changes

- Add `device_map="auto"` to the generated `pipeline(...)` call in `packages/tasks/src/model-libraries-snippets.ts` (one line — mirrors the argument the auto snippets already use).
- Add the first `transformers` coverage to `model-libraries-snippets.spec.ts`: exact-string assertions that both the pipeline snippet and the auto snippet include `device_map="auto"`.

## Testing

- `vitest run src/model-libraries-snippets.spec.ts` — 3/3 pass (new test + the two existing `llama_cpp_python` tests).
- `prettier --check` clean on both files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes generated example strings and unit tests; no runtime inference or auth paths.
> 
> **Overview**
> Model-page **transformers** copy-paste snippets now pass **`device_map="auto"`** on the **`pipeline(...)`** path, matching the direct **`from_pretrained`** snippets so the default example can use GPU when available instead of staying on CPU.
> 
> Adds **`transformers`** coverage in **`model-libraries-snippets.spec.ts`** with exact-string checks for both the pipeline and auto-model snippets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eae3dcdb6a09bf825ca07be9454337ce65e67fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->