### PR TITLE
Register NInfer model library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1014,6 +1014,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: true,
 		countDownloads: `path_extension:"nemo" OR path:"model_config.yaml" OR path_extension:"json"`,
 	},
+	ninfer: {
+		prettyLabel: "NInfer",
+		repoName: "NInfer",
+		repoUrl: "https://github.com/Neroued/ninfer",
+		filter: false,
+		countDownloads: `path_extension:"ninfer"`,
+	},
 	"nv-medtech": {
 		prettyLabel: "NV-MedTech",
 		repoName: "NV-MedTech",


### PR DESCRIPTION
## Summary

This PR registers [NInfer](https://github.com/Neroued/ninfer) as a Hub model library and enables download tracking for `.ninfer` artifacts.

NInfer is a from-scratch C++/CUDA engine built for maximum single-GPU inference performance. To the best of our knowledge, it is currently the fastest publicly documented Qwen3.6-35B-A3B inference engine on a single RTX 5090, reaching up to 661.2 decode tok/s with MTP3.

NInfer models are distributed as one self-contained `.ninfer` artifact per repository and downloaded directly by users. Both published models already declare `library_name: ninfer`:

- https://huggingface.co/neroued/Qwen3.6-27B-NInfer
- https://huggingface.co/neroued/Qwen3.6-35B-A3B-NInfer

Therefore, `path_extension:"ninfer"` accurately tracks downloads of the actual model artifact without counting auxiliary repository files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single additive registry entry with no changes to auth, APIs, or existing libraries.
> 
> **Overview**
> Registers **NInfer** as a Hub modeling library in `MODEL_LIBRARIES_UI_ELEMENTS`, keyed as `ninfer` to match `library_name` on existing model repos.
> 
> The entry wires display metadata (label, GitHub repo link) and sets **`countDownloads`** to `path_extension:"ninfer"` so Hub download stats track the self-contained `.ninfer` artifacts rather than other repo files. **`filter`** is left `false`, so it does not appear in the hf.co/models library filter until it meets the usual popularity threshold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bb22e88bf813615c973f49a7ba3a854c897d8c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->