### PR TITLE
Register real5-omnidocbench as an evaluation framework

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -107,6 +107,12 @@ export const EVALUATION_FRAMEWORKS = {
 			"MDPBench is a benchmark for evaluating multilingual document parsing across digital, photographed, Latin, and non-Latin document subsets.",
 		url: "https://github.com/Yuliang-Liu/MultimodalOCR",
 	},
+	"real5-omnidocbench": {
+		name: "real5-omnidocbench",
+		description:
+			"Real5-OmniDocBench is a benchmark for evaluating document parsing robustness under five real-world acquisition scenarios: scanning, warping, screen-photography, illumination, and skew.",
+		url: "https://huggingface.co/datasets/PaddlePaddle/Real5-OmniDocBench",
+	},
 	parsebench: {
 		name: "parsebench",
 		description:


### PR DESCRIPTION
## Summary
- Register `real5-omnidocbench` in `EVALUATION_FRAMEWORKS`.
- Allows Real5-OmniDocBench benchmark datasets to reference this framework from `eval.yaml`.

Dataset: https://huggingface.co/datasets/PaddlePaddle/Real5-OmniDocBench

## Testing
- `git diff --check`
- `corepack pnpm dlx oxfmt@0.26.0 --check packages/tasks/src/eval.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only registry addition with no runtime logic, auth, or data-path changes.
> 
> **Overview**
> Adds **`real5-omnidocbench`** to `EVALUATION_FRAMEWORKS` in `packages/tasks/src/eval.ts`, alongside existing document-parsing benchmarks like `mdpbench` and `parsebench`.
> 
> Benchmark datasets can now set this framework in **`eval.yaml`** so the hub recognizes Real5-OmniDocBench (document parsing under scanning, warping, screen-photography, illumination, and skew). The entry includes a short description and links to the PaddlePaddle Hugging Face dataset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1647d8e32c85dfa811c9550cae546a35ef97f72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->