### PR TITLE
Add ltx library for download counting

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1031,6 +1031,85 @@ import soundfile as sf
 sf.write('output.wav', audio, 24000)`,
 ];
 
+export const ltx = (model: ModelData): string[] => {
+	const localDir = `models/${nameWithoutNamespace(model.id)}`;
+	const install = `# Install the LTX-2 pipelines
+git clone https://github.com/Lightricks/LTX-2.git
+cd LTX-2
+uv sync --frozen`;
+
+	// Every pipeline needs the Gemma text encoder, which lives in a separate repo.
+	const download = `# Download the weights from this repo, plus the Gemma text encoder
+hf download ${model.id} --local-dir ${localDir}
+hf download google/gemma-3-12b-it-qat-q4_0-unquantized --local-dir models/gemma-3-12b`;
+
+	// Add "--image <path> <frame_idx> <strength>" to any command below to condition on
+	// an image (e.g. "--image image.jpg 0 0.8"), turning text-to-video into image-to-video.
+	const imageToVideoHint = `# For image-to-video, add: --image path/to/image.jpg 0 0.8`;
+
+	const tags = model.tags ?? [];
+
+	// IC-LoRA: video-to-video / image-to-video with a control (reference) signal.
+	// Checked before "lora" because an IC-LoRA repo may carry both tags.
+	if (tags.includes("ic-lora")) {
+		return [
+			install,
+			download,
+			`# Video-to-video with the IC-LoRA (runs on the distilled base model)
+uv run python -m ltx_pipelines.ic_lora \\
+    --distilled-checkpoint-path path/to/distilled_checkpoint.safetensors \\
+    --spatial-upsampler-path path/to/spatial_upsampler.safetensors \\
+    --gemma-root models/gemma-3-12b \\
+    --lora ${localDir}/<weights>.safetensors 1.0 \\
+    --video-conditioning reference.mp4 1.0 \\
+    --prompt "your prompt here" \\
+    --output-path output.mp4`,
+		];
+	}
+
+	// Standard LoRA applied on top of the base pipeline.
+	if (tags.includes("lora")) {
+		return [
+			install,
+			download,
+			`# Text/image-to-video with the LoRA on the HQ two-stage base pipeline
+uv run python -m ltx_pipelines.ti2vid_two_stages_hq \\
+    --checkpoint-path path/to/checkpoint.safetensors \\
+    --distilled-lora path/to/distilled_lora.safetensors 0.8 \\
+    --spatial-upsampler-path path/to/spatial_upsampler.safetensors \\
+    --gemma-root models/gemma-3-12b \\
+    --lora ${localDir}/<weights>.safetensors 1.0 \\
+    --prompt "your prompt here" \\
+    --output-path output.mp4
+${imageToVideoHint}`,
+		];
+	}
+
+	// Base model: the fast (distilled) and HQ (two-stage) pipelines. Substitute the
+	// .safetensors filenames with the ones listed under this repo's "Files and versions".
+	return [
+		install,
+		download,
+		`# Fast pipeline (distilled model, no distilled LoRA needed)
+uv run python -m ltx_pipelines.distilled \\
+    --distilled-checkpoint-path ${localDir}/<distilled-checkpoint>.safetensors \\
+    --spatial-upsampler-path ${localDir}/<spatial-upsampler>.safetensors \\
+    --gemma-root models/gemma-3-12b \\
+    --prompt "A beautiful sunset over the ocean" \\
+    --output-path output.mp4
+${imageToVideoHint}`,
+		`# HQ pipeline (two-stage, higher quality)
+uv run python -m ltx_pipelines.ti2vid_two_stages_hq \\
+    --checkpoint-path ${localDir}/<checkpoint>.safetensors \\
+    --distilled-lora ${localDir}/<distilled-lora>.safetensors 0.8 \\
+    --spatial-upsampler-path ${localDir}/<spatial-upsampler>.safetensors \\
+    --gemma-root models/gemma-3-12b \\
+    --prompt "A beautiful sunset over the ocean" \\
+    --output-path output.mp4
+${imageToVideoHint}`,
+	];
+};
+
 export const lightning_ir = (model: ModelData): string[] => {
 	if (model.tags.includes("bi-encoder")) {
 		return [

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -787,6 +787,15 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_extension:"pt"`,
 	},
+	ltx: {
+		prettyLabel: "LTX.io",
+		repoName: "LTX-2",
+		repoUrl: "https://github.com/Lightricks/LTX-2",
+		docsUrl: "https://github.com/Lightricks/LTX-2",
+		snippets: snippets.ltx,
+		filter: false,
+		countDownloads: `path_extension:"safetensors"`,
+	},
 	"lightning-ir": {
 		prettyLabel: "Lightning IR",
 		repoName: "Lightning IR",


### PR DESCRIPTION
## What

Registers a custom model library `ltx` (`packages/tasks/src/model-libraries.ts`) and adds model-page code snippets (`packages/tasks/src/model-libraries-snippets.ts`) for it.

## Why

LTX ([Lightricks/LTX-2](https://github.com/Lightricks/LTX-2)) publishes its base models, LoRAs and IC-LoRAs on the Hub as a top-level `.safetensors` file plus a README — with no `config.json`/`config.yaml` and no `library_name`. Because the Hub only counts a download when a request hits a designated *query file* (default `config.json`, etc.), these repos show **"Downloads are not tracked for this model."**

Reusing `diffusers` or `diffusion-single-file` would count the safetensors, but attaches inaccurate branding: LTX weights are **not** loaded via `diffusers` / a `config.json`, they load directly through the [`ltx-pipelines`](https://github.com/Lightricks/LTX-2) package (or `hf download`). Registering a dedicated `ltx` library gives accurate branding and a correct usage snippet.

## Details

- `countDownloads: path_extension:"safetensors"` — counts any safetensors request in the repo, matching how these repos actually distribute weights.
- `filter: false` — well under the 100-model threshold for the models-filter dropdown.
- The key `ltx` is intentionally version-agnostic so future LTX versions reuse it.
- The snippet branches on repo tags, since `library_name: ltx` is shared across three repo kinds:
  - `ic-lora` → `ltx_pipelines.ic_lora` (video-to-video with a reference/control signal)
  - `lora` → standard LoRA on the base two-stage pipeline
  - neither → base model, showing the fast (`ltx_pipelines.distilled`) and HQ (`ltx_pipelines.ti2vid_two_stages_hq`) pipelines, each for text-to-video and image-to-video
  - `ic-lora` is checked before `lora` because an IC-LoRA repo may carry both tags.

Example repos: [`Lightricks/LTX-2.3-22b-IC-LoRA-Ingredients`](https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Ingredients), [`Lightricks/LTX-2-19b-IC-LoRA-Union-Control`](https://huggingface.co/Lightricks/LTX-2-19b-IC-LoRA-Union-Control).

Verified: `pnpm --filter @huggingface/tasks build`, `lint`, `format:check`, and `test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and documentation-only changes in `@huggingface/tasks`; no runtime Hub logic, auth, or data handling.
> 
> **Overview**
> Registers a dedicated **`ltx`** model library so Lightricks LTX-2 Hub repos get correct **LTX.io** branding, **download counting** on `.safetensors` fetches (instead of “downloads not tracked”), and **usage snippets** for the real `ltx_pipelines` / `hf download` workflow—not diffusers.
> 
> Adds **`snippets.ltx`**, which picks install/download steps and pipeline examples from repo tags: **`ic-lora`** first (video conditioning), then **`lora`**, otherwise base **distilled** and **HQ two-stage** pipelines, with a shared image-to-video flag hint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd747c1f70d7a0f99c76225f34b4788c38714470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->