### PR TITLE
Add ClawBench evaluation framework

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -125,6 +125,12 @@ export const EVALUATION_FRAMEWORKS = {
 			"CLAW-Eval is an evaluation framework for assessing LLMs as autonomous agents across 300 human-verified tasks covering communication, finance, and productivity domains.",
 		url: "https://github.com/claw-eval/claw-eval",
 	},
+	"clawbench-eval": {
+		name: "clawbench-eval",
+		description:
+			"ClawBench is an evaluation framework for AI web agents on real-world online tasks, with isolated runs, five-layer behavioral traces, and final-request interception.",
+		url: "https://github.com/TIGER-AI-Lab/ClawBench",
+	},
 	researchclawbench: {
 		name: "researchclawbench",
 		description:


### PR DESCRIPTION
## Summary

- register `clawbench-eval` as a supported benchmark evaluation framework
- link the canonical ClawBench repository

The [ClawBench benchmark dataset](https://huggingface.co/datasets/TIGER-Lab/ClawBench) already declares this identifier in its root `eval.yaml`; adding it here satisfies the documented framework-enum requirement for native Hub benchmark registration.

## Validation

- `pnpm --filter @huggingface/tasks format:check`
- `pnpm --filter @huggingface/tasks check`

## Disclosure

I help maintain ClawBench. This focused contribution was prepared with assistance from OpenAI Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry entry with no runtime or security impact; only extends the allowed framework list for `eval.yaml`.
> 
> **Overview**
> Registers **`clawbench-eval`** in the `EVALUATION_FRAMEWORKS` registry in `eval.ts`, alongside existing frameworks like `claw-eval` and `researchclawbench`. The entry includes a short description of ClawBench (web-agent evaluation with isolated runs and behavioral traces) and links to `https://github.com/TIGER-AI-Lab/ClawBench`.
> 
> This aligns the tasks package with benchmark datasets whose root `eval.yaml` already reference this framework identifier for native Hub registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87e343990c1847695653fcdffa38531e42a71989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->