### PR TITLE
Add KerasFormers library for download counting

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -881,6 +881,19 @@ model = keras.saving.load_model("hf://${model.id}")
 `,
 ];
 
+export const kerasformers = (model: ModelData): string[] => [
+	`# Available backend options are: "jax", "torch", "tensorflow".
+import os
+os.environ["KERAS_BACKEND"] = "torch"
+
+# Use the kerasformers class for this model's architecture (e.g. a Qwen3 LLM).
+from kerasformers.models.qwen3 import Qwen3Generate, Qwen3Tokenizer
+
+model = Qwen3Generate.from_weights("${model.id}")
+tokenizer = Qwen3Tokenizer.from_weights("${model.id}")
+`,
+];
+
 const _keras_hub_causal_lm = (modelId: string): string => `
 import keras_hub
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -881,19 +881,6 @@ model = keras.saving.load_model("hf://${model.id}")
 `,
 ];
 
-export const kerasformers = (model: ModelData): string[] => [
-	`# Available backend options are: "jax", "torch", "tensorflow".
-import os
-os.environ["KERAS_BACKEND"] = "torch"
-
-# Use the kerasformers class for this model's architecture (e.g. a Qwen3 LLM).
-from kerasformers.models.qwen3 import Qwen3Generate, Qwen3Tokenizer
-
-model = Qwen3Generate.from_weights("${model.id}")
-tokenizer = Qwen3Tokenizer.from_weights("${model.id}")
-`,
-];
-
 const _keras_hub_causal_lm = (modelId: string): string => `
 import keras_hub
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -747,7 +747,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		docsUrl: "https://imvision12.github.io/KerasFormers/",
 		snippets: snippets.kerasformers,
 		countDownloads: `path:"model.weights.h5" OR path:"model.weights.json"`,
-		filter: true,
+		filter: false,
 	},
 	kernels: {
 		prettyLabel: "Kernels",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -740,6 +740,15 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.keras_hub,
 		filter: true,
 	},
+	kerasformers: {
+		prettyLabel: "KerasFormers",
+		repoName: "KerasFormers",
+		repoUrl: "https://github.com/IMvision12/KerasFormers",
+		docsUrl: "https://imvision12.github.io/KerasFormers/",
+		snippets: snippets.kerasformers,
+		countDownloads: `path:"model.weights.h5" OR path:"model.weights.json"`,
+		filter: true,
+	},
 	kernels: {
 		prettyLabel: "Kernels",
 		repoName: "Kernels",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -745,7 +745,6 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "KerasFormers",
 		repoUrl: "https://github.com/IMvision12/KerasFormers",
 		docsUrl: "https://imvision12.github.io/KerasFormers/",
-		snippets: snippets.kerasformers,
 		countDownloads: `path:"model.weights.h5" OR path:"model.weights.json"`,
 		filter: false,
 	},


### PR DESCRIPTION
 What

  Registers a custom model library kerasformers (packages/tasks/src/model-libraries.ts) and adds model-page code
  snippets (packages/tasks/src/model-libraries-snippets.ts) for it.

  Why

  KerasFormers (https://huggingface.co/KerasFormers) publishes pretrained transformers converted to pure Keras 3 on the
  Hub as a top-level model.weights.h5 (or, for models over 6 GB, a model.weights.json shard index plus
  model_00000.weights.h5 shards) alongside tokenizer.json and a README, with library_name: kerasformers but no
  config.json. Because the Hub only counts a download when a request hits a designated query file (default config.json,
  etc.), these repos show "Downloads are not tracked for this model."

  Reusing keras or keras-hub would attach inaccurate branding: kerasformers weights are not loaded via
  keras.saving.load_model or keras_hub, they load directly through the kerasformers
  (https://github.com/IMvision12/KerasFormers) package's from_weights API (backend-agnostic across JAX / PyTorch /
  TensorFlow). Registering a dedicated kerasformers library gives accurate branding and a correct usage snippet.

  Details

  - countDownloads: path:"model.weights.h5" OR path:"model.weights.json" — counts each model download once: the
  single-file model.weights.h5, or the model.weights.json shard index for sharded models. It deliberately does not match
  the individual model_00000.weights.h5 shards, so sharded repos are not over-counted.
  - filter: true — surfaces the library in the Hub models-filter dropdown (matches the sibling keras-hub entry).
  - The key kerasformers is version-agnostic, so all model families (Qwen, Llama, Gemma, Mistral, …) reuse the one
  entry.
  - The snippet sets KERAS_BACKEND (jax / torch / tensorflow) and loads the model via its family's Generate class plus
  the matching Tokenizer, mirroring the usage shown in the model cards.
  - Example repos: KerasFormers/qwen3-0.6b (https://huggingface.co/KerasFormers), Qwen conversions under the org.

  Verified: pnpm --filter @huggingface/tasks build, check, lint:check, format:check, and test all pass.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive registry entry only; no changes to auth, existing libraries, or download logic beyond a new Elasticsearch query for one library key.
> 
> **Overview**
> Registers **`kerasformers`** in `MODEL_LIBRARIES_UI_ELEMENTS` so Hub models tagged `library_name: kerasformers` get KerasFormers-specific branding and download metrics instead of falling back to untracked defaults (these repos ship **`model.weights.h5`** or a **`model.weights.json`** shard index, not **`config.json`**).
> 
> **`countDownloads`** is set to `path:"model.weights.h5" OR path:"model.weights.json"` so each download is counted once for single-file weights or via the shard index, without matching individual **`model_*.weights.h5`** shards. **`filter`** is **`false`**, so the library is not added to the models filter dropdown yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfb13c143241e1e3d47395a9d47a849049d9fc58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->