### PR TITLE
feat(tasks): register FinMirror evaluation framework

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -8,6 +8,11 @@ export const EVALUATION_FRAMEWORKS = {
 			"Exgentic is an open evaluation framework for general-purpose AI agents across diverse domains and benchmarks.",
 		url: "https://github.com/Exgentic/exgentic",
 	},
+	finmirror: {
+		name: "FinMirror",
+		description: "Deterministic paired-world reliability evaluation for financial RAG systems and agents.",
+		url: "https://github.com/faceWang753/finmirror",
+	},
 	"inspect-ai": {
 		name: "inspect-ai",
 		description: "Inspect AI is an open-source framework for large language model evaluations.",


### PR DESCRIPTION
## Summary

Registers FinMirror in the evaluation-framework metadata used to validate Hub `eval.yaml` files.

FinMirror is an open deterministic paired-world reliability evaluator for financial RAG systems and agents:

- Evaluator: https://github.com/faceWang753/finmirror
- Public dataset: https://huggingface.co/datasets/mingyang233/FinMirror
- Zero-key demo: https://facewang753.github.io/finmirror/

The dataset card is already public, but its `eval.yaml` is intentionally not uploaded until the framework name is registered and the separate Hub beta allow-list process is complete. This registry change does not imply allow-list approval.

## Checks

- `pnpm --filter @huggingface/tasks lint:check`
- `pnpm --filter @huggingface/tasks check`
- `pnpm --filter @huggingface/tasks test` (20/20 passing)
- single-file `oxfmt --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry entry with name, description, and URL; no auth, data paths, or eval execution changes.
> 
> **Overview**
> Adds **FinMirror** to `EVALUATION_FRAMEWORKS` in `packages/tasks/src/eval.ts` so Hub benchmark datasets can reference `finmirror` in `eval.yaml` and pass framework validation.
> 
> The new entry includes display name **FinMirror**, a short description of deterministic paired-world reliability evaluation for financial RAG/agents, and the GitHub URL. This is metadata-only registration; it does not change runtime eval logic or imply Hub beta allow-list approval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 876d0604daa10f86b832e29f3a7ccf7f47907906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->