### PR TITLE
[languages] Fix language() returning inherited Object.prototype members

### DIFF
--- a/packages/languages/src/language.spec.ts
+++ b/packages/languages/src/language.spec.ts
@@ -25,4 +25,10 @@ describe("language", () => {
 	it("should return null for an invalid language code", () => {
 		expect(language("invalid")).toBeNull();
 	});
+
+	it("should return null for names inherited from Object.prototype", () => {
+		for (const code of ["toString", "constructor", "valueOf", "hasOwnProperty", "__proto__"]) {
+			expect(language(code)).toBeNull();
+		}
+	});
 });

--- a/packages/languages/src/language.ts
+++ b/packages/languages/src/language.ts
@@ -6,10 +6,10 @@ import type { Language } from "./types";
  * Be careful importing this function in frontend code, as it will import all languages.
  */
 export function language(code: string): Language | null {
-	if (code in LANGUAGES_ISO_639_1) {
+	if (Object.hasOwn(LANGUAGES_ISO_639_1, code)) {
 		return LANGUAGES_ISO_639_1[code as keyof typeof LANGUAGES_ISO_639_1];
 	}
-	if (code in LANGUAGES_ISO_639_3) {
+	if (Object.hasOwn(LANGUAGES_ISO_639_3, code)) {
 		return LANGUAGES_ISO_639_3[code as keyof typeof LANGUAGES_ISO_639_3];
 	}
 


### PR DESCRIPTION
Fixes #2310.

`language()` uses `code in TABLE`, and `in` walks the prototype chain — so `language("toString")` hands back `Object.prototype.toString`, a function, out of a signature typed `Language | null`. Same for `constructor`, `valueOf`, `hasOwnProperty` and `__proto__`.

The existing invalid-code test passes only because `"invalid"` isn't on `Object.prototype`, so the contract looked covered but wasn't.

Both lookups now use `Object.hasOwn` — the package is already ES2022 for `target` and `lib` — and the invalid-code test is extended to the inherited names. Without the source change that test fails with `expected [Function toString] to be null`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized lookup fix with added regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Fixes incorrect non-null results** when `language()` is called with keys that exist only on `Object.prototype` (e.g. `toString`, `constructor`).
> 
> Lookup in `language()` now uses **`Object.hasOwn`** on both ISO 639-1 and 639-3 tables instead of the **`in`** operator, so prototype-chain properties no longer match. Tests assert those inherited names return **`null`**, matching the `Language | null` contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c255701e3acbf44d1bf05bbe1b51259b4ef2805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->