### PR TITLE
Stop counting mxfp4, bitsandbytes and actorder bookkeeping tensors as parameters

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -306,11 +306,74 @@ describe("parseSafetensorsMetadata", () => {
 
 		const totalParams = parse.parameterTotal || sum(Object.values(parse.parameterCount));
 
-		assert.strictEqual(totalParams, 21_511_953_984); // 21.5B
-
-		assert.ok(parse.parameterCount.BF16 && parse.parameterCount.U8);
+		// 20.9B, matching OpenAI's published figure. Previously 21_511_953_984, which counted the
+		// 597_196_800 `..._scales` UE8M0 block exponents as parameters (+2.86%).
+		assert.strictEqual(totalParams, 20_914_757_184);
+		assert.deepStrictEqual(parse.parameterCount, { BF16: 1_804_459_584, U8: 19_110_297_600 });
 
 		assert.strictEqual(Object.keys(parse.headers).length, 3);
+	});
+
+	it("excludes mxfp4 block scales stored as `..._scales` (openai/gpt-oss-120b)", async () => {
+		// gpt-oss joins the scales suffix with an underscore rather than a dot, so it slips past the
+		// dotted auxiliary-suffix list. Counting the 3_583_180_800 U8 scales reported 120_412_337_472
+		// (120.4B) for a model OpenAI documents as 116.8B / "117B".
+		const parse = await parseSafetensorsMetadata({
+			repo: "openai/gpt-oss-120b",
+			revision: "b5c939de8f754692c1647ca79fbf85e8c1e70f8a",
+			computeParametersCount: true,
+		});
+
+		assert(parse.sharded);
+		assert.strictEqual(Object.keys(parse.headers).length, 15);
+		assert.deepStrictEqual(parse.parameterCount, {
+			BF16: 2_167_371_072,
+			U8: 114_661_785_600, // 57_330_892_800 packed bytes x 2, scales excluded
+		});
+		assert.strictEqual(sum(Object.values(parse.parameterCount)), 116_829_156_672);
+	});
+
+	it("excludes bitsandbytes double-quantization state (unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit)", async () => {
+		// `absmax` shares the weights' U8 container, so it was counted *and* doubled by the 4-bit
+		// packing factor — the same double error `weight_shape` had. Reported 8_248_929_342 for a
+		// model whose true size is Llama-3.1-8B's 8_030_261_248 (+2.72%).
+		const parse = await parseSafetensorsMetadata({
+			repo: "unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit",
+			revision: "f15c379fb32bb402fa06a7ae9aecb1febf4b79ec",
+			computeParametersCount: true,
+		});
+
+		assert(!parse.sharded);
+		assert.deepStrictEqual(parse.parameterCount, {
+			BF16: 1_050_939_392,
+			U8: 6_979_321_856, // 3_489_660_928 packed bytes x 2
+		});
+		assert.strictEqual(sum(Object.values(parse.parameterCount)), 8_030_261_248);
+		// the nested quant state (`nested_absmax` / `nested_quant_map` / `quant_map`) was the whole
+		// of the previously reported F32 count, so the dtype drops out entirely
+		assert.strictEqual(parse.parameterCount.F32, undefined);
+	});
+
+	it("excludes compressed-tensors `weight_g_idx` actorder indices (RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16)", async () => {
+		// `actorder: "group"` makes the pack-quantized compressor emit one I32 permutation index per
+		// input column. Being an integer container it was counted *and* multiplied by the packing
+		// factor: 6_225_920 indices x 8 = 49_807_360 phantom parameters.
+		const parse = await parseSafetensorsMetadata({
+			repo: "RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16",
+			revision: "7177921dd02c6436cc78d40861f497df2f575201",
+			computeParametersCount: true,
+		});
+
+		assert(parse.sharded);
+		assert.strictEqual(Object.keys(parse.headers).length, 8);
+		assert.deepStrictEqual(parse.parameterCount, {
+			I32: 68_451_041_280,
+			BF16: 2_102_665_216,
+		});
+		// exactly the unquantized meta-llama/Llama-3.3-70B-Instruct parameter count
+		assert.strictEqual(sum(Object.values(parse.parameterCount)), 70_553_706_496);
+		// `weight_shape` is `torch.tensor(shape)`, i.e. I64 here rather than I32 — also excluded
+		assert.strictEqual(parse.parameterCount.I64, undefined);
 	});
 
 	it("should support FP4 and UE8 data types in type system", () => {

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -64,12 +64,36 @@ const QUANTIZATION_AUXILIARY_SUFFIXES = [
 	"weight_global_scale",
 	"weight_zero_point",
 	"input_scale",
+	"input_global_scale",
 	"input_zero_point",
 	"zero_point",
 	// compressed-tensors records each packed tensor's logical shape alongside it; it's a 2-element
 	// I32 tensor, so it was not only counted but multiplied by the packing factor.
 	"weight_shape",
+	// Activation-ordering permutation indices, emitted by the pack-quantized compressor whenever
+	// `actorder: "group"`. One I32 index per input column, so — like `weight_shape` — it was both
+	// counted and scaled by the packing factor.
+	"weight_g_idx",
 ];
+
+/**
+ * MXFP4 block scales as gpt-oss names them: `..._blocks` holds the packed weights, `..._scales` the
+ * per-32-element UE8M0 exponents. The separator is an underscore rather than a dot, so
+ * `QUANTIZATION_AUXILIARY_SUFFIXES` cannot see them and they were counted as parameters — 3% of the
+ * reported total for both gpt-oss sizes.
+ */
+const MXFP4_SCALES_SUFFIX = "_scales";
+
+/**
+ * bitsandbytes keeps its double-quantization state beside each 4-bit weight: `absmax` (one value
+ * per 64-weight block), the nested quantization of those absmax values, and the NF4/FP4 lookup
+ * table. All bookkeeping — and because they share the weight's U8 container they were also
+ * multiplied by the 4-bit packing factor, the same double error `weight_shape` had.
+ */
+const BITSANDBYTES_AUXILIARY_SUFFIXES = ["absmax", "quant_map", "nested_absmax", "nested_quant_map"];
+
+/** Serialized quant state, e.g. `weight.quant_state.bitsandbytes__nf4` / `...__fp4`. */
+const BITSANDBYTES_QUANT_STATE_PREFIX = "bitsandbytes__";
 
 /**
  * Exponent-only float formats. These exist solely to hold MX-style block scales (`scale_fmt`
@@ -808,6 +832,19 @@ function shouldSkipTensor(tensorName: string, dtype: Dtype, quantConfig?: Quanti
 		return true;
 	}
 	const quantMethod = quantConfig.quant_method?.toLowerCase();
+
+	// gpt-oss-style mxfp4 keeps the UE8M0 block exponents in `..._scales` next to `..._blocks`.
+	// Gated on the U8 container the scales actually use, so a learnable `*_scales` parameter in some
+	// other architecture is left alone.
+	if (quantMethod === "mxfp4") {
+		return dtype === "U8" && getTensorSuffix(tensorName).endsWith(MXFP4_SCALES_SUFFIX);
+	}
+
+	if (quantMethod === "bitsandbytes") {
+		const bnbSuffix = getTensorSuffix(tensorName);
+		return BITSANDBYTES_AUXILIARY_SUFFIXES.includes(bnbSuffix) || bnbSuffix.startsWith(BITSANDBYTES_QUANT_STATE_PREFIX);
+	}
+
 	if (quantMethod !== "gptq" && quantMethod !== "awq") {
 		return false;
 	}


### PR DESCRIPTION
Follow-up to #2321. That PR established that block scales are quantization bookkeeping rather than model parameters, but applied the rule to only two of the four code paths that need it. The three remaining paths each overcount — two by more than the Kimi-K2.5 correction #2321 did make.

## Root causes

**1. `quant_method: "mxfp4"` (gpt-oss) counts its block scales.** transformers pairs [`{proj}_blocks` with `{proj}_scales`](https://github.com/huggingface/transformers/blob/dff4572dfa4bfa9f00cc8414e4b84877552fefe9/src/transformers/integrations/mxfp4.py#L111-L123) — joined with an **underscore**, not a dot — so `getTensorSuffix` returns the whole segment and `QUANTIZATION_AUXILIARY_SUFFIXES` can never match; `shouldSkipTensor` then bails because the method is neither gptq nor awq. That they're exponents and not weights is explicit in the dequant: [`scales.to(torch.int32) - 127`](https://github.com/huggingface/transformers/blob/dff4572dfa4bfa9f00cc8414e4b84877552fefe9/src/transformers/integrations/mxfp4.py#L271), one per 32 weights per the [`hidden_size // 32, 16` uint8 block shape](https://github.com/huggingface/transformers/blob/dff4572dfa4bfa9f00cc8414e4b84877552fefe9/src/transformers/integrations/mxfp4.py#L349-L360). Same UE8M0 scales #2321 already excludes for Kimi-K3 via `weight_scale`.

Gated on the `U8` container the scales actually use, mirroring the existing `_blocks` gate, so a learnable `*_scales` parameter elsewhere is left alone.

**2. bitsandbytes counts its double-quantization state, and doubles it.** The exact key set is upstream's [`valid_qs_keys` / `valid_qs_type_keys`](https://github.com/bitsandbytes-foundation/bitsandbytes/blob/b88ddac2d3e7484f6adfe4668053f4647be89809/bitsandbytes/functional.py#L423-L429): `absmax`, `quant_map`, `nested_absmax`, `nested_quant_map`, plus the `bitsandbytes__{nf4,fp4}` blob. Because `absmax` shares the weights' `U8` container it also picked up the 4-bit packing factor — counted **and** multiplied, exactly the double error `weight_shape` had.

**3. compressed-tensors `weight_g_idx` is not excluded.** [`pack_quantized.compression_param_names`](https://github.com/vllm-project/compressed-tensors/blob/46196ce607421d9992a47644612dc6b443f3c434/src/compressed_tensors/compressors/pack_quantized/base.py#L46-L54) emits `weight_packed`, `weight_scale`, `weight_shape`, `weight_zero_point`, and `weight_g_idx` when `actorder: "group"`. #2321 handles the first four. `weight_g_idx` is `I32`, so like `weight_shape` it was counted and scaled by the packing factor — one index per input column, ×8.

Also added `input_global_scale`, emitted by the [nvfp4 compressor](https://github.com/vllm-project/compressed-tensors/blob/46196ce607421d9992a47644612dc6b443f3c434/src/compressed_tensors/compressors/nvfp4/base.py#L37-L49) alongside the already-excluded `weight_global_scale`. A scalar, so numerically irrelevant; included for completeness.

## Verification

Every corrected total independently matches a published figure — exact counts, not thresholds:

| model | scheme | before | after | reference |
|---|---|---|---|---|
| `openai/gpt-oss-120b` | mxfp4 | 120,412,337,472 | **116,829,156,672** | OpenAI: 116.8B / "117B" |
| `openai/gpt-oss-20b` | mxfp4 | 21,511,953,984 | **20,914,757,184** | OpenAI: 20.9B / "21B" |
| `unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit` | bnb 4-bit | 8,248,929,342 | **8,030,261,248** | Llama-3.1-8B |
| `RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16` | ct `pack-quantized`, actorder | 70,603,514,976 | **70,553,706,496** | `meta-llama/Llama-3.3-70B-Instruct`, exactly |

The 70B row is the tightest check available: a w4a16 quantization should report the count of the model it came from, and it now matches to the digit. The `weight_g_idx` delta decomposes exactly too — 80 layers × (6 × 8192 + 28672) = 6,225,920 indices × 8 = 49,807,360. The `before` figures for gpt-oss and bnb are what the Hub API serves today.

## Not included

Further findings from reviewing #2321, left out to keep this reviewable:

- [ ] Scope the `fp8` + `expert_dtype` packing to experts — it currently applies to every integer container, safe today only because DeepSeek-V4-Pro's one non-expert integer tensor is `I64`
- [ ] `packingFactor` floors `containerBits / numBits`, but the compressor packs densely (`ceil(cols * num_bits / 32)`) — 3-bit gives 10 instead of 10.67
- [ ] Drop the `["fp6", 6]` entry, or fix it — `floor(8 / 6) === 1`, so it can never fire in an 8-bit container
- [ ] Fix #2321's blast-radius table: `Meta-Llama-3.1-8B-Instruct-quantized.w4a16` is `quant_method: "gptq"`, not compressed-tensors
- [ ] Rewrite the two "sub-byte data types" tests (`spec.ts:246`, `:344`) — they shadow the real counter with a local reimplementation, asserting `E8M0 === 24` and `UE8 === 5000` while production skips both dtypes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
