### PR TITLE
add nobg code snippet

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -2187,6 +2187,26 @@ from models.birefnet import BiRefNet
 model = BiRefNet.from_pretrained("${model.id}")`,
 ];
 
+export const nobg = (model: ModelData): string[] => [
+	`# !pip install nobg
+
+import torch
+from loadimg import load_img
+from nobg import AutoModel, AutoProcessor
+
+model = AutoModel.from_pretrained("${model.id}").eval()
+processor = AutoProcessor.from_pretrained("${model.id}")
+
+image = load_img("input.jpg").convert("RGB")
+inputs = processor(image, return_tensors="pt")
+
+with torch.no_grad():
+    outputs = model(pixel_values=inputs["pixel_values"])
+
+alpha = processor.post_process_alpha_matting(outputs, target_sizes=[(image.height, image.width)])[0]
+processor.cutout(image, alpha).save("output.png")`,
+];
+
 export const supertonic = (): string[] => [
 	`from supertonic import TTS
 

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -2187,10 +2187,10 @@ from models.birefnet import BiRefNet
 model = BiRefNet.from_pretrained("${model.id}")`,
 ];
 
-export const nobg = (model: ModelData): string[] => [
-	`# !pip install nobg
+export const nobg = (model: ModelData): string[] => {
+	const installSnippet = `pip install nobg`;
 
-import torch
+	const exampleSnippet = `import torch
 from loadimg import load_img
 from nobg import AutoModel, AutoProcessor
 
@@ -2204,8 +2204,10 @@ with torch.no_grad():
     outputs = model(pixel_values=inputs["pixel_values"])
 
 alpha = processor.post_process_alpha_matting(outputs, target_sizes=[(image.height, image.width)])[0]
-processor.cutout(image, alpha).save("output.png")`,
-];
+processor.cutout(image, alpha).save("output.png")`;
+
+	return [installSnippet, exampleSnippet];
+};
 
 export const supertonic = (): string[] => [
 	`from supertonic import TTS

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1021,6 +1021,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_extension:"ninfer"`,
 	},
+	nobg: {
+		prettyLabel: "nobg",
+		repoName: "nobg",
+		repoUrl: "https://github.com/feyninc/nobg",
+		snippets: snippets.nobg,
+		filter: false,
+	},
 	"nv-medtech": {
 		prettyLabel: "NV-MedTech",
 		repoName: "NV-MedTech",


### PR DESCRIPTION
this pr adds code snippet for nobg: https://github.com/feyninc/nobg
a library i spearheaded its development which you can find one model under https://huggingface.co/feyninc/FeyNobg where it achieves SOTA performance across multiple benchmarks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and static code snippets only; no runtime, auth, or inference pipeline changes.
> 
> **Overview**
> Registers the **nobg** background-removal library on Hub model pages and shows copy-paste usage for models tagged with `library_name: nobg`.
> 
> Adds a `nobg` entry to `MODEL_LIBRARIES_UI_ELEMENTS` (label, GitHub repo link, snippet hook; not added to the models filter). Introduces a `nobg(model)` snippet generator with `pip install nobg` plus an example that loads `AutoModel` / `AutoProcessor` from the repo id, runs inference, post-processes alpha matting, and saves a cutout PNG.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a312a52200b8c05bba9e1fe6058ae247881500a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->