### PR TITLE
[hub] Fix stale abort listener terminating pooled sha256 workers

### DIFF
--- a/packages/hub/src/utils/sha256-abort.spec.ts
+++ b/packages/hub/src/utils/sha256-abort.spec.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sha256 } from "./sha256";
+
+// sha256() only reaches the worker path on the frontend.
+vi.mock("./isBackend", () => ({ isBackend: false }));
+
+/**
+ * Node has no global Worker, so the pooled web-worker path in sha256() is
+ * unreachable here without one. This stands in for it: it answers a single
+ * postMessage with a finished hash, and records whether it was terminated.
+ *
+ * This file is excluded from the browser config, where the real Worker exists.
+ */
+class FakeWorker {
+	static instances: FakeWorker[] = [];
+
+	terminated = 0;
+	private listeners: Record<string, Set<(event: unknown) => void>> = {};
+
+	constructor() {
+		FakeWorker.instances.push(this);
+	}
+
+	addEventListener(type: string, listener: (event: unknown) => void): void {
+		(this.listeners[type] ??= new Set()).add(listener);
+	}
+
+	removeEventListener(type: string, listener: (event: unknown) => void): void {
+		this.listeners[type]?.delete(listener);
+	}
+
+	postMessage(): void {
+		setTimeout(() => {
+			for (const listener of this.listeners["message"] ?? []) {
+				listener({ data: { sha256: "deadbeef" } });
+			}
+		}, 0);
+	}
+
+	terminate(): void {
+		this.terminated++;
+	}
+}
+
+async function drain(iterator: AsyncGenerator<number, string>): Promise<string> {
+	for (;;) {
+		const next = await iterator.next();
+		if (next.done) {
+			return next.value;
+		}
+	}
+}
+
+describe("sha256 (pooled worker abort lifecycle)", () => {
+	const originalWorker = globalThis.Worker;
+
+	afterEach(() => {
+		globalThis.Worker = originalWorker;
+		FakeWorker.instances = [];
+	});
+
+	it("should not terminate a pooled worker when its signal aborts after the hash completed", async () => {
+		globalThis.Worker = FakeWorker as unknown as typeof Worker;
+
+		const abortController = new AbortController();
+		const hash = await drain(
+			// minSize keeps the small blob off the crypto.subtle fast path.
+			sha256(new Blob(["hello"]), {
+				useWebWorker: { poolSize: 2, minSize: 1 },
+				abortSignal: abortController.signal,
+			}),
+		);
+
+		expect(hash).toBe("deadbeef");
+
+		const worker = FakeWorker.instances.at(-1);
+		expect(worker?.terminated).toBe(0);
+
+		// The caller aborts later — one signal typically covers a whole multi-file
+		// commit, so this is the ordinary case, not an exotic one. The hash is
+		// already done and its worker is back in the pool; aborting must not reach it.
+		abortController.abort();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(worker?.terminated).toBe(0);
+	});
+});

--- a/packages/hub/src/utils/sha256.ts
+++ b/packages/hub/src/utils/sha256.ts
@@ -100,10 +100,14 @@ export async function* sha256(
 				// Define handlers to allow removal
 				let messageHandler: (event: MessageEvent) => void;
 				let errorHandler: (event: ErrorEvent) => void;
+				let abortListener: (() => void) | undefined;
 
 				const cleanup = () => {
 					worker.removeEventListener("message", messageHandler);
 					worker.removeEventListener("error", errorHandler);
+					if (abortListener) {
+						opts?.abortSignal?.removeEventListener("abort", abortListener);
+					}
 				};
 
 				return yield* eventToGenerator<number, string>((yieldCallback, returnCallback, rejectCallback) => {
@@ -146,12 +150,11 @@ export async function* sha256(
 							return;
 						}
 
-						const abortListener = () => {
+						abortListener = () => {
 							cleanup();
 							destroyWorker(worker);
 
 							rejectCallback(opts.abortSignal?.reason ?? new DOMException("Aborted", "AbortError"));
-							opts.abortSignal?.removeEventListener("abort", abortListener);
 						};
 
 						opts.abortSignal.addEventListener("abort", abortListener);

--- a/packages/hub/vitest-browser.config.mts
+++ b/packages/hub/vitest-browser.config.mts
@@ -18,6 +18,7 @@ export default defineConfig({
 			"src/utils/shardParser.spec.ts",
 			// Because vi.mock is not supported in browser mode
 			"src/utils/uploadShards.spec.ts",
+			"src/utils/sha256-abort.spec.ts",
 		],
 	},
 });


### PR DESCRIPTION
Fixes #2311.

The abort listener in the pooled web-worker path is only removed when it fires, so a successful hash leaves it attached to the caller's signal. When that signal aborts later — one signal usually covers a whole multi-file commit, so this is the ordinary case — the listener runs against an operation that already finished and:

- terminates a worker that `freeWorker` already returned to `pendingWorkers`
- rejects a generator that already returned, producing an unhandled `AbortError`

`cleanup()` now removes the abort listener too, so every exit path — success, worker error, non-hash message, abort — drops it in one place.

The test drives the pooled path with a stand-in `Worker` (Node has no global one), completes a hash, then aborts. Without the fix it fails on the terminate count and throws an unhandled `ABORT_ERR`. It's excluded from the browser config for the same reason `uploadShards.spec.ts` is — `vi.mock`.

One thing I noticed but left alone: `destroyWorker` only deletes from `runningWorkers`, so a worker terminated while sitting in `pendingWorkers` stays in the pool and `getWorker` hands it to the next caller. Nothing reaches that state with this fix in place, but happy to harden it separately if you'd like.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fix to frontend sha256 worker cleanup with a focused unit test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a lifecycle bug in the **pooled web-worker** `sha256` path where the `abort` listener stayed on the caller’s `AbortSignal` after a hash finished successfully.
> 
> `cleanup()` now removes that listener on every exit (success, worker error, abort), so a later abort—typical when one signal covers a multi-file commit—no longer terminates a worker already returned to the pool or rejects an already-settled async generator.
> 
> Adds a Node-only regression test with a fake `Worker` and excludes it from the browser Vitest config (same pattern as `uploadShards.spec.ts` for `vi.mock`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e9cd20876d54e48101dc409357667fa4521453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->