### PR TITLE
Make the sub-byte packing factor faithful to the reference compressors

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -6,6 +6,7 @@ import {
 	isQuantizedTensor,
 	matchesCompressedTensorsTarget,
 	computeNumOfParamsByDtypeSingleFile,
+	getQuantizationMultiplier,
 } from "./parse-safetensors-metadata";
 import type { Dtype, TensorInfo, SafetensorsFileHeader } from "./parse-safetensors-metadata";
 import { sum } from "../utils/sum";
@@ -363,6 +364,76 @@ describe("parseSafetensorsMetadata", () => {
 		assert.strictEqual(sum(Object.values(parse.parameterCount)), 70_553_706_496);
 		// `weight_shape` is `torch.tensor(shape)`, i.e. I64 here rather than I32 — also excluded
 		assert.strictEqual(parse.parameterCount.I64, undefined);
+	});
+
+	describe("getQuantizationMultiplier", () => {
+		const EXPERT = "model.layers.0.ffn.experts.3.w1.weight";
+
+		describe("fp8 with expert_dtype", () => {
+			const fp8 = { quant_method: "fp8" };
+
+			it("packs routed experts at the declared expert width", () => {
+				// DeepSeek-V4-Pro: fp8 attention, fp4 experts packed two-per-byte in I8
+				assert.strictEqual(getQuantizationMultiplier(EXPERT, "I8", fp8, "fp4"), 2);
+			});
+
+			it("leaves shared experts alone — they're dense, not routed", () => {
+				const shared = "model.layers.0.ffn.shared_experts.w1.weight";
+				assert.strictEqual(getQuantizationMultiplier(shared, "I8", fp8, "fp4"), 1);
+			});
+
+			it("does not apply the expert width to non-expert integer tensors", () => {
+				// The bug this guards: `expert_dtype` used to apply to every integer container, so a
+				// routing table or other bookkeeping was inflated by the packing factor — 8x for I32.
+				assert.strictEqual(getQuantizationMultiplier("model.layers.0.ffn.gate.tid2eid", "I32", fp8, "fp4"), 1);
+				assert.strictEqual(getQuantizationMultiplier("model.layers.0.attn.wkv.weight", "I8", fp8, "fp4"), 1);
+			});
+
+			it("leaves fp8 experts unpacked — one value per byte", () => {
+				assert.strictEqual(getQuantizationMultiplier(EXPERT, "F8_E4M3", fp8, "fp4"), 1);
+				assert.strictEqual(getQuantizationMultiplier(EXPERT, "I8", fp8, "fp8"), 1);
+			});
+
+			it("is a no-op without expert_dtype", () => {
+				assert.strictEqual(getQuantizationMultiplier(EXPERT, "I8", fp8, undefined), 1);
+			});
+		});
+
+		describe("compressed-tensors packing factor", () => {
+			const packed = (numBits: number) => ({
+				quant_method: "compressed-tensors",
+				format: "pack-quantized",
+				config_groups: { group_0: { weights: { num_bits: numBits } } },
+			});
+			const name = "model.layers.0.mlp.down_proj.weight_packed";
+
+			it("packs 4-bit eight-per-I32 and two-per-U8", () => {
+				assert.strictEqual(getQuantizationMultiplier(name, "I32", packed(4)), 8);
+				assert.strictEqual(getQuantizationMultiplier(name, "U8", packed(4)), 2);
+			});
+
+			it("packs 2-bit sixteen-per-I32", () => {
+				assert.strictEqual(getQuantizationMultiplier(name, "I32", packed(2)), 16);
+			});
+
+			it("uses the exact ratio for widths that don't divide the container", () => {
+				// Dense cross-element packing: 32 values occupy exactly num_bits I32 words, so an I32
+				// holds 32/3 values. Flooring to 10 undercounts a 3-bit model by 6%.
+				assert.strictEqual(getQuantizationMultiplier(name, "I32", packed(3)), 32 / 3);
+				assert.strictEqual(getQuantizationMultiplier(name, "I32", packed(5)), 32 / 5);
+			});
+
+			it("does not pack when the width fills the container", () => {
+				assert.strictEqual(getQuantizationMultiplier(name, "I8", packed(8)), 1);
+			});
+		});
+
+		it("ignores fp6, which is stored in native F6_* dtypes rather than packed", () => {
+			// A 6-bit width in an 8-bit container has no reference implementation, so claiming any
+			// packing for it would be a guess.
+			assert.strictEqual(getQuantizationMultiplier(EXPERT, "U8", { quant_method: "fp8" }, "fp6"), 1);
+			assert.strictEqual(getQuantizationMultiplier(EXPERT, "F6_E2M3", { quant_method: "fp8" }, "fp6"), 1);
+		});
 	});
 
 	describe("globMatch", () => {

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -117,7 +117,13 @@ const INTEGER_CONTAINER_BITS: Partial<Record<Dtype, number>> = {
 	I32: 32,
 };
 
-/** Sub-byte weight formats that may appear in `expert_dtype` / a compressed-tensors format string. */
+/**
+ * Sub-byte weight formats that may appear in `expert_dtype` / a compressed-tensors format string.
+ *
+ * NB: no `fp6` entry — MXFP6 weights are stored in the native `F6_E2M3` / `F6_E3M2` safetensors
+ * dtypes rather than packed into an integer container, so a 6-bit width here could only ever
+ * produce a wrong multiplier.
+ */
 const SUB_BYTE_FORMAT_BITS: Array<[pattern: string, bits: number]> = [
 	["nvfp4", 4],
 	["mxfp4", 4],
@@ -125,9 +131,19 @@ const SUB_BYTE_FORMAT_BITS: Array<[pattern: string, bits: number]> = [
 	["int4", 4],
 	["uint4", 4],
 	["nf4", 4],
-	["fp6", 6],
 	["int2", 2],
 ];
+
+/**
+ * Whether a tensor belongs to a *routed* expert, which is what `expert_dtype` describes.
+ *
+ * MoEs place them under an `experts` container — `…ffn.experts.0.w1.weight`,
+ * `…block_sparse_moe.experts.3.w2.weight_packed`. `shared_experts` are always-on dense layers
+ * quantized like the rest of the model, so they're excluded.
+ */
+function isRoutedExpertTensor(tensorName: string): boolean {
+	return tensorName.includes(".experts.") && !tensorName.includes("shared_experts");
+}
 
 /** Reads a bit width out of a free-form format/dtype string, e.g. `"mxfp4-pack-quantized"` -> 4. */
 function bitsFromFormatString(format: string | undefined): number | undefined {
@@ -141,13 +157,22 @@ function bitsFromFormatString(format: string | undefined): number | undefined {
 /**
  * Packing factor for `numBits` values inside `dtype`, or 1 when `dtype` isn't an integer container
  * (already-unpacked weights, e.g. an `F8_E4M3` fp8 tensor holds exactly one value per byte).
+ *
+ * The packing is dense across elements: the reference compressor stores
+ * `ceil(cols * num_bits / containerBits)` containers per row, so a container holds exactly
+ * `containerBits / num_bits` values — deliberately *not* floored, because that ratio isn't a whole
+ * number for widths which don't divide the container. Flooring 3-bit-in-`I32` to 10 values instead
+ * of 10.67 undercounts by 6%.
+ *
+ * Because of that `ceil`, the final column may be partly padding, so the result is an upper bound —
+ * off by at most `containerBits / num_bits - 1` values per row.
  */
 function packingFactor(dtype: Dtype, numBits: number | undefined): number {
 	const containerBits = INTEGER_CONTAINER_BITS[dtype];
 	if (!containerBits || !numBits || numBits <= 0 || numBits >= containerBits) {
 		return 1;
 	}
-	return Math.max(1, Math.floor(containerBits / numBits));
+	return containerBits / numBits;
 }
 
 class SafetensorParseError extends Error {}
@@ -683,9 +708,12 @@ export function matchesCompressedTensorsTarget(target: string, moduleName: strin
 }
 
 /**
- * Gets the parameter multiplier for a quantized tensor based on quantization method
+ * @internal
+ * Gets the parameter multiplier for a quantized tensor based on quantization method.
+ *
+ * May be fractional — see `packingFactor`.
  */
-function getQuantizationMultiplier(
+export function getQuantizationMultiplier(
 	tensorName: string,
 	dtype: Dtype,
 	quantConfig?: QuantizationConfig,
@@ -753,6 +781,13 @@ function getQuantizationMultiplier(
 			// But some fp8 MoEs keep their *experts* narrower still and declare it out-of-band in
 			// `expert_dtype` (DeepSeek-V4-Pro: "fp4"), storing them packed in an I8 container.
 			// Those experts dominate the parameter count, so missing this halves the total.
+			//
+			// `expert_dtype` describes the experts and nothing else, so it must not be applied to
+			// every integer tensor in the model: a routing table or other integer bookkeeping would
+			// otherwise be inflated by the packing factor — 8x for an I32 one.
+			if (!isRoutedExpertTensor(tensorName)) {
+				return 1;
+			}
 			return packingFactor(dtype, bitsFromFormatString(expertDtype));
 		}
 
@@ -799,7 +834,9 @@ export function computeNumOfParamsByDtypeSingleFile(
 		if (multiplier === 0) {
 			continue;
 		}
-		counter[v.dtype] = (counter[v.dtype] ?? 0) + elements * multiplier;
+		// Rounded because the packing factor is a ratio, not necessarily a whole number (see
+		// `packingFactor`); a parameter count is always an integer.
+		counter[v.dtype] = (counter[v.dtype] ?? 0) + Math.round(elements * multiplier);
 	}
 	return counter;
 }


### PR DESCRIPTION
Three latent issues from #2323's list. **No published model's count moves** — the pinned end-to-end totals, incl. DeepSeek-V4-Pro's exact per-dtype counts, are unchanged — so unit tests rather than Hub fixtures.

**1. `expert_dtype` applied to every integer container, not just experts.** It describes the routed experts only, so any integer bookkeeping tensor was inflated by the packing factor — 8x for an `I32` one. Now scoped to `.experts.`, excluding the dense `shared_experts` — the two are distinct modules: [`self.experts` vs `self.shared_experts`](https://github.com/huggingface/transformers/blob/7dc634120eacfaf73ca5176e6fc8053431ee0ddd/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py#L228-L231).

**2. `packingFactor` floored a ratio that isn't a whole number.** Sub-byte weights pack densely, so a container holds exactly `containerBits / num_bits` values. Cf. llama.cpp's 3-bit block — [`hmask[QK_K/8] + qs[QK_K/4]`](https://github.com/ggml-org/llama.cpp/blob/f5b9bd39b56c7a7839a9795a100b6a00b84ac961/ggml/src/ggml-common.h#L315-L321), i.e. `3*QK_K/8` bytes for `QK_K` weights = 8/3 per byte, not 2. Flooring 3-bit-in-`I32` to 10 instead of `32/3` undercounts by 6%. Counts are now rounded.

**3. Dropped the `fp6` width.** MXFP6 is stored in the native `F6_E2M3` / `F6_E3M2` safetensors dtypes, never packed into an integer container, and `floor(8/6) === 1` meant the entry was dead anyway.

10 unit tests over `getQuantizationMultiplier`, exported `@internal` as this file already does for `isQuantizedTensor` / `globMatch`. 51 pass; oxfmt, eslint, tsc clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Hub parameter-count logic for quantized and MoE models; impact is mitigated because existing pinned model totals are asserted unchanged, but wrong multipliers would misreport model size.
> 
> **Overview**
> Tightens how safetensors **parameter counts** infer packed sub-byte weights in `parse-safetensors-metadata`.
> 
> For **fp8 MoEs** with `expert_dtype`, the packing multiplier now applies only to **routed** expert weights (paths under `.experts.`, excluding `shared_experts` and other integer bookkeeping like routing tables).
> 
> **`packingFactor`** no longer floors `containerBits / num_bits`; it uses the exact ratio (e.g. 3-bit in `I32` → `32/3`), and per-tensor contributions are **`Math.round(elements * multiplier)`** so totals stay integers.
> 
> The **`fp6`** width mapping is removed because MXFP6 uses native `F6_*` dtypes, not integer packing.
> 
> **`getQuantizationMultiplier`** is exported `@internal` and covered by new unit tests; pinned Hub model totals are unchanged per the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6b61d6c8cdbb28be2a3412bc5e038de8a151de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->