### PR TITLE
Add Llama to local apps

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -275,6 +275,22 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		expect(deeplink(model).href).toBe("atomic-chat://models/huggingface/bartowski/Llama-3.2-3B-Instruct-GGUF");
 	});
 
+	it("llama deeplink", async () => {
+		const { displayOnModelPage, deeplink } = LOCAL_APPS["llama-app"];
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			gguf: { total: 1, context_length: 4096 },
+			inference: "",
+		};
+
+		expect(displayOnModelPage(model)).toBe(true);
+		expect(deeplink(model).href).toBe("llama://install?repo=bartowski/Llama-3.2-3B-Instruct-GGUF");
+		expect(deeplink(model, "Llama-3.2-3B-Instruct-Q4_K_M.gguf").href).toBe(
+			"llama://install?repo=bartowski/Llama-3.2-3B-Instruct-GGUF&quant=Q4_K_M",
+		);
+	});
+
 	it("unsloth tagged model", async () => {
 		const { displayOnModelPage, snippet: snippetFunc } = LOCAL_APPS.unsloth;
 		const model: ModelData = {

--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -300,6 +300,22 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		expect(displayOnModelPage(model)).toBe(false);
 	});
 
+	it("llama deeplink", async () => {
+		const { displayOnModelPage, deeplink } = LOCAL_APPS["llama-app"];
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			gguf: { total: 1, context_length: 4096 },
+			inference: "",
+		};
+
+		expect(displayOnModelPage(model)).toBe(true);
+		expect(deeplink(model).href).toBe("llama://install?repo=bartowski/Llama-3.2-3B-Instruct-GGUF");
+		expect(deeplink(model, "Llama-3.2-3B-Instruct-Q4_K_M.gguf").href).toBe(
+			"llama://install?repo=bartowski/Llama-3.2-3B-Instruct-GGUF&quant=Q4_K_M",
+		);
+	});
+
 	it("unsloth tagged model", async () => {
 		const { displayOnModelPage, deeplink } = LOCAL_APPS.unsloth;
 		const model: ModelData = {

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -703,6 +703,17 @@ export const LOCAL_APPS = {
 		displayOnModelPage: isLlamaCppGgufModel,
 		deeplink: (model) => new URL(`jan://models/huggingface/${model.id}`),
 	},
+	"llama-app": {
+		prettyLabel: "Llama",
+		docsUrl: "https://github.com/ggml-org/Llama-macOS",
+		mainTask: "text-generation",
+		macOSOnly: true,
+		displayOnModelPage: isLlamaCppGgufModel,
+		deeplink: (model, filepath?: string) => {
+			const quantLabel = filepath ? parseGGUFQuantLabel(filepath) : undefined;
+			return new URL(`llama://install?repo=${model.id}${quantLabel ? `&quant=${quantLabel}` : ""}`);
+		},
+	},
 	"atomic-chat": {
 		prettyLabel: "Atomic Chat",
 		docsUrl: "https://atomic.chat",

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -590,6 +590,17 @@ export const LOCAL_APPS = {
 		displayOnModelPage: isLlamaCppGgufModel,
 		snippet: snippetLlamacpp,
 	},
+	"llama-app": {
+		prettyLabel: "Llama",
+		docsUrl: "https://github.com/ggml-org/Llama-macOS",
+		mainTask: "text-generation",
+		macOSOnly: true,
+		displayOnModelPage: isLlamaCppGgufModel,
+		deeplink: (model, filepath?: string) => {
+			const quantLabel = filepath ? parseGGUFQuantLabel(filepath) : undefined;
+			return new URL(`llama://install?repo=${model.id}${quantLabel ? `&quant=${quantLabel}` : ""}`);
+		},
+	},
 	"node-llama-cpp": {
 		prettyLabel: "node-llama-cpp",
 		docsUrl: "https://node-llama-cpp.withcat.ai",


### PR DESCRIPTION
Deeplink: `llama://install?repo={org}/{repo}[&quant={label}]`. When a GGUF file is selected, its quant label is forwarded via `parseGGUFQuantLabel`; otherwise the app picks a default.

Icon: same as llama.cpp.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small registry addition and unit tests only; no auth, data, or runtime behavior changes beyond a new optional deeplink button on model pages.
> 
> **Overview**
> Adds **Llama** (macOS app) to the model page **Use this model** local apps list, alongside existing entries like llama.cpp.
> 
> The new `llama-app` entry is **macOS-only**, shows for the same GGUF models as llama.cpp (`isLlamaCppGgufModel`), and opens **`llama://install?repo={org}/{repo}`** when clicked. If the user picks a specific GGUF file, **`&quant={label}`** is appended using `parseGGUFQuantLabel`.
> 
> Tests cover visibility on a GGUF model and both deeplink URL shapes (with and without quant).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35452d7dae890fb4219cf2d2f903441820956389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->