### PR TITLE
Add RouteE Powertrain model library

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1533,6 +1533,28 @@ from renderformer import RenderFormerRenderingPipeline
 pipeline = RenderFormerRenderingPipeline.from_pretrained("${model.id}")`,
 ];
 
+export const routee_powertrain = (model: ModelData): string[] => [
+	`# pip install routee.powertrain
+import pandas as pd
+import routee.powertrain as pt
+from routee.powertrain.registry import HFRegistry
+
+registry = HFRegistry(repo_id="${model.id}")
+
+# find a vehicle: filter by make, model, year, powertrain type, features, ...
+pt.query_available_models(make="tesla", model="model 3", registry=registry)
+
+# load one by its id: "<make>/<vehicle_slug>/<year>/<config_slug>"
+model = pt.load_model("tesla/model_3_bev/2022/rf_c3326385", registry=registry)
+
+links = pd.DataFrame({
+    "distance": [0.1, 0.2],  # miles
+    "speed_mph": [30, 55],
+    "grade_percent": [-2.0, 1.0],
+})
+model.predict(links)`,
+];
+
 const tensorflowttsTextToMel = (model: ModelData): string[] => [
 	`from tensorflow_tts.inference import AutoProcessor, TFAutoModel
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1256,7 +1256,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	},
 	"routee-powertrain": {
 		prettyLabel: "RouteE-Powertrain",
-		repoName: "routee-powertrain",
+		repoName: "RouteE-Powertrain",
 		repoUrl: "https://github.com/NatLabRockies/routee-powertrain",
 		docsUrl: "https://natlabrockies.github.io/routee-powertrain/",
 		snippets: snippets.routee_powertrain,

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1254,6 +1254,15 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_extension:"safetensors"`,
 	},
+	"routee-powertrain": {
+		prettyLabel: "RouteE-Powertrain",
+		repoName: "routee-powertrain",
+		repoUrl: "https://github.com/NatLabRockies/routee-powertrain",
+		docsUrl: "https://natlabrockies.github.io/routee-powertrain/",
+		snippets: snippets.routee_powertrain,
+		filter: false,
+		countDownloads: `path_extension:"onnx" OR path_extension:"joblib"`,
+	},
 	rwkv: {
 		prettyLabel: "RWKV",
 		repoName: "RWKV-LM",


### PR DESCRIPTION
Registers a model library for RouteE Powertrain ([code](https://github.com/NatLabRockies/routee-powertrain), [docs](https://natlabrockies.github.io/routee-powertrain/intro.html), [hugging face repo](https://huggingface.co/NatLabRockies/routee-powertrain-model-library))


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only registration in the tasks package with no changes to auth, APIs, or runtime behavior.
> 
> **Overview**
> Registers **RouteE-Powertrain** on the Hub so models tagged with `library_name: routee-powertrain` get the standard library UI (label, repo/docs links, usage snippet, download counting).
> 
> The model page snippet walks through `HFRegistry` tied to the repo id, querying available vehicle configs, loading a model by id, and running **`predict`** on a link-level pandas DataFrame. Download stats count **`onnx`** and **`joblib`** artifacts; the library is **not** added to the public models filter (`filter: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b265e9ff84fb1219f6d05b0fa839519ed8f97a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->