### PR TITLE
Extend Hallo download stats query

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -605,7 +605,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		prettyLabel: "Hallo",
 		repoName: "Hallo",
 		repoUrl: "https://github.com/fudan-generative-vision/hallo",
-		countDownloads: `path:"hallo/net.pth"`,
+		countDownloads: `path:"hallo/net.pth" OR path:"hallo2/net.pth" OR path:"hallo3/1/mp_rank_00_model_states.pt" OR path:"hallo4/model_weight.ckpt"`,
 	},
 	hermes: {
 		prettyLabel: "HERMES",


### PR DESCRIPTION
## Summary

- extend the `hallo` model library download stats query to cover Hallo2, Hallo3, and Hallo4 primary weight files
- keep Champ unchanged because the upstream registry already counts `champ/motion_module.pth`

## Why

The Fudan Hallo model repos use `library_name: hallo`, but the Hub download stats query currently only counts `hallo/net.pth`. Hallo2/3/4 store their primary weights under version-specific paths, so downloads are not counted after setting model card metadata.

## Validation

- `pnpm --filter @huggingface/tasks exec tsc --noEmit --pretty false`
- `pnpm --filter @huggingface/tasks format:check`
- `pnpm --filter @huggingface/tasks lint:check`

Note: full `pnpm install --frozen-lockfile` hit an existing monorepo prepare/linking issue: `ERR_PNPM_MISSING_HOISTED_LOCATIONS acorn-jsx@5.3.2(acorn@8.8.2)`. The package-level checks above completed successfully after the partial install.