### PR TITLE
🐢 [hub] Parallelize xet downloads with a downloadConcurrency option

### DIFF
--- a/packages/hub/src/lib/download-file.ts
+++ b/packages/hub/src/lib/download-file.ts
@@ -43,6 +43,14 @@ export async function downloadFile(
 		 * Can save an http request if provided
 		 */
 		downloadInfo?: FileDownloadInfoOutput;
+		/**
+		 * Number of CAS range requests to keep in flight when downloading via the
+		 * xet protocol. Higher values parallelize the transfer; ~8–10 is usually
+		 * enough to saturate a fast link. Defaults to `1` (serial). Ignored for
+		 * non-xet downloads.
+		 * @default 1
+		 */
+		downloadConcurrency?: number;
 	} & Partial<CredentialsParams>,
 ): Promise<Blob | null> {
 	const accessToken = checkCredentials(params);
@@ -71,6 +79,7 @@ export async function downloadFile(
 			accessToken,
 			size: info.size,
 			readToken: typeof params.xet === "object" ? params.xet.readToken : undefined,
+			downloadConcurrency: params.downloadConcurrency,
 		});
 	}
 

--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -811,6 +811,130 @@ describe("XetBlob", () => {
 			});
 		});
 
+		describe("downloadConcurrency", () => {
+			// Build a reconstruction spread over `termCount` distinct XORBs (one chunk
+			// each), so the per-term CAS range requests are genuinely independent and
+			// can overlap. The returned fetch counts how many range requests are in
+			// flight at once, gated on a shared promise released by the test.
+			function makeConcurrencyBlob(termCount: number, downloadConcurrency: number) {
+				const contents = Array(termCount)
+					.fill(0)
+					.map((_, i) => `chunk-${i}-`);
+				const chunks = contents.map((content) => makeChunk(content));
+				const expected: number[] = [];
+				for (const content of contents) {
+					for (const byte of new TextEncoder().encode(content)) {
+						expected.push(byte);
+					}
+				}
+				const totalSize = sum(contents.map((c) => c.length));
+
+				let inFlight = 0;
+				let maxInFlight = 0;
+				let release!: () => void;
+				const released = new Promise<void>((r) => {
+					release = r;
+				});
+
+				const blob = new XetBlob({
+					hash: "test",
+					size: totalSize,
+					refreshUrl: "https://huggingface.co",
+					downloadConcurrency,
+					fetch: async function (_url) {
+						const url = new URL(_url as string);
+
+						switch (url.hostname) {
+							case "huggingface.co": {
+								return new Response(JSON.stringify({ casUrl: "https://cas.co", accessToken: "boo", exp: 1_000_000 }));
+							}
+							case "cas.co": {
+								return new Response(
+									JSON.stringify({
+										terms: Array(termCount)
+											.fill(0)
+											.map((_, i) => ({
+												hash: `xorb${i}`,
+												range: { start: 0, end: 1 },
+												unpacked_length: contents[i].length,
+											})),
+										fetch_info: Object.fromEntries(
+											Array(termCount)
+												.fill(0)
+												.map((_, i) => [
+													`xorb${i}`,
+													[
+														{
+															url: `https://fetch.co/${i}`,
+															range: { start: 0, end: 1 },
+															url_range: { start: 0, end: chunks[i].byteLength - 1 },
+														},
+													],
+												]),
+										),
+										offset_into_first_range: 0,
+									} satisfies ReconstructionInfo),
+								);
+							}
+							case "fetch.co": {
+								// Range request for a single XORB: track concurrency, then wait
+								// for the test to release before returning the body.
+								inFlight++;
+								maxInFlight = Math.max(maxInFlight, inFlight);
+								await released;
+								inFlight--;
+
+								const i = Number(url.pathname.slice(1));
+								const chunk = chunks[i];
+								return new Response(
+									new ReadableStream({
+										pull(controller) {
+											controller.enqueue(chunk);
+											controller.close();
+										},
+									}),
+								);
+							}
+							default:
+								throw new Error("Unhandled URL");
+						}
+					},
+				});
+
+				return { blob, expected: new Uint8Array(expected), release, getMaxInFlight: () => maxInFlight };
+			}
+
+			it("fetches reconstruction ranges in parallel when downloadConcurrency > 1", async () => {
+				const { blob, expected, release, getMaxInFlight } = makeConcurrencyBlob(6, 4);
+
+				const read = blob.arrayBuffer();
+				// Let the scheduler launch its look-ahead window, then release the gated
+				// range requests.
+				await new Promise((r) => setTimeout(r, 20));
+				release();
+
+				const bytes = new Uint8Array(await read);
+
+				expect(bytes).toEqual(expected);
+				// With downloadConcurrency 4, the term being processed plus 3 look-ahead
+				// requests can be in flight at once.
+				expect(getMaxInFlight()).toBeGreaterThan(1);
+			});
+
+			it("keeps a single request in flight when downloadConcurrency is 1", async () => {
+				const { blob, expected, release, getMaxInFlight } = makeConcurrencyBlob(6, 1);
+
+				const read = blob.arrayBuffer();
+				await new Promise((r) => setTimeout(r, 20));
+				release();
+
+				const bytes = new Uint8Array(await read);
+
+				expect(bytes).toEqual(expected);
+				expect(getMaxInFlight()).toBe(1);
+			});
+		});
+
 		describe("loading one byte at a time", () => {
 			it("should load different slices", async () => {
 				const chunk1Content = "hello";

--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -933,6 +933,90 @@ describe("XetBlob", () => {
 				expect(bytes).toEqual(expected);
 				expect(getMaxInFlight()).toBe(1);
 			});
+
+			it("cancels prefetched range requests when a download fails", async () => {
+				const termCount = 3;
+				const contents = Array(termCount)
+					.fill(0)
+					.map((_, i) => `chunk-${i}-`);
+				const chunks = contents.map((content) => makeChunk(content));
+				const totalSize = sum(contents.map((c) => c.length));
+
+				// Track which prefetched range bodies get cancelled.
+				const cancelled = new Set<number>();
+
+				const blob = new XetBlob({
+					hash: "test",
+					size: totalSize,
+					refreshUrl: "https://huggingface.co",
+					downloadConcurrency: 4,
+					fetch: async function (_url) {
+						const url = new URL(_url as string);
+
+						switch (url.hostname) {
+							case "huggingface.co": {
+								return new Response(JSON.stringify({ casUrl: "https://cas.co", accessToken: "boo", exp: 1_000_000 }));
+							}
+							case "cas.co": {
+								return new Response(
+									JSON.stringify({
+										terms: Array(termCount)
+											.fill(0)
+											.map((_, i) => ({
+												hash: `xorb${i}`,
+												range: { start: 0, end: 1 },
+												unpacked_length: contents[i].length,
+											})),
+										fetch_info: Object.fromEntries(
+											Array(termCount)
+												.fill(0)
+												.map((_, i) => [
+													`xorb${i}`,
+													[
+														{
+															url: `https://fetch.co/${i}`,
+															range: { start: 0, end: 1 },
+															url_range: { start: 0, end: chunks[i].byteLength - 1 },
+														},
+													],
+												]),
+										),
+										offset_into_first_range: 0,
+									} satisfies ReconstructionInfo),
+								);
+							}
+							case "fetch.co": {
+								const i = Number(url.pathname.slice(1));
+								if (i === 0) {
+									// The first (consumed) term fails, aborting the whole download.
+									return new Response("boom", { status: 500 });
+								}
+								// Prefetched terms: their bodies must be cancelled on failure.
+								return new Response(
+									new ReadableStream({
+										pull(controller) {
+											controller.enqueue(chunks[i]);
+											controller.close();
+										},
+										cancel() {
+											cancelled.add(i);
+										},
+									}),
+								);
+							}
+							default:
+								throw new Error("Unhandled URL");
+						}
+					},
+				});
+
+				await expect(blob.arrayBuffer()).rejects.toBeDefined();
+				// Let the fire-and-forget body cancellations settle.
+				await new Promise((r) => setTimeout(r, 20));
+
+				expect(cancelled.has(1)).toBe(true);
+				expect(cancelled.has(2)).toBe(true);
+			});
 		});
 
 		describe("loading one byte at a time", () => {

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -318,270 +318,289 @@ export class XetBlob extends Blob {
 
 			pump();
 
-			for (const term of terms) {
-				if (totalBytesRead >= maxBytes) {
-					break;
-				}
+			// The reader for the term currently being consumed, tracked so the
+			// `finally` below can release it (and the prefetched responses) if the
+			// loop exits early via a thrown error or a cancelled stream.
+			let activeReader: ReadableStreamDefaultReader<Uint8Array> | undefined;
 
-				const rangeList = rangeLists.get(term.hash);
-				if (!rangeList) {
-					throw new Error(`Failed to find range list for term ${term.hash}`);
-				}
+			try {
+				for (const term of terms) {
+					if (totalBytesRead >= maxBytes) {
+						break;
+					}
 
-				{
-					const termRanges = rangeList.getRanges(term.range.start, term.range.end);
+					const rangeList = rangeLists.get(term.hash);
+					if (!rangeList) {
+						throw new Error(`Failed to find range list for term ${term.hash}`);
+					}
 
-					if (termRanges.every((range) => range.data)) {
-						log("all data available for term", term.hash, readBytesToSkip);
-						rangeLoop: for (const range of termRanges) {
-							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-							for (let chunk of range.data!) {
-								if (readBytesToSkip) {
-									const skipped = Math.min(readBytesToSkip, chunk.byteLength);
-									chunk = chunk.slice(skipped);
-									readBytesToSkip -= skipped;
-									if (!chunk.byteLength) {
-										continue;
+					{
+						const termRanges = rangeList.getRanges(term.range.start, term.range.end);
+
+						if (termRanges.every((range) => range.data)) {
+							log("all data available for term", term.hash, readBytesToSkip);
+							rangeLoop: for (const range of termRanges) {
+								// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+								for (let chunk of range.data!) {
+									if (readBytesToSkip) {
+										const skipped = Math.min(readBytesToSkip, chunk.byteLength);
+										chunk = chunk.slice(skipped);
+										readBytesToSkip -= skipped;
+										if (!chunk.byteLength) {
+											continue;
+										}
+									}
+									if (chunk.byteLength > maxBytes - totalBytesRead) {
+										chunk = chunk.slice(0, maxBytes - totalBytesRead);
+									}
+									totalBytesRead += chunk.byteLength;
+									// The stream consumer can decide to transfer ownership of the chunk, so we need to return a clone
+									// if there's more than one range for the same term
+									yield range.refCount > 1 ? chunk.slice() : chunk;
+									listener?.({ event: "progress", progress: { read: totalBytesRead, total: maxBytes } });
+
+									if (totalBytesRead >= maxBytes) {
+										break rangeLoop;
 									}
 								}
-								if (chunk.byteLength > maxBytes - totalBytesRead) {
-									chunk = chunk.slice(0, maxBytes - totalBytesRead);
-								}
-								totalBytesRead += chunk.byteLength;
-								// The stream consumer can decide to transfer ownership of the chunk, so we need to return a clone
-								// if there's more than one range for the same term
-								yield range.refCount > 1 ? chunk.slice() : chunk;
-								listener?.({ event: "progress", progress: { read: totalBytesRead, total: maxBytes } });
-
-								if (totalBytesRead >= maxBytes) {
-									break rangeLoop;
-								}
 							}
+							rangeList.remove(term.range.start, term.range.end);
+							continue;
 						}
-						rangeList.remove(term.range.start, term.range.end);
-						continue;
 					}
-				}
 
-				let fetchInfo = reconstructionInfo.fetch_info[term.hash].find(
-					(info) => info.range.start <= term.range.start && info.range.end >= term.range.end,
-				);
-
-				if (!fetchInfo) {
-					throw new Error(
-						`Failed to find fetch info for term ${term.hash} and range ${term.range.start}-${term.range.end}`,
-					);
-				}
-
-				log("term", term);
-				log("fetchinfo", fetchInfo);
-				log("readBytesToSkip", readBytesToSkip);
-
-				// Take the prefetched response for this range if one is in flight,
-				// otherwise fetch it now (concurrency == 1, window edge, or a range
-				// that was re-requested after a refresh).
-				const termKey = rangeKey(term.hash, fetchInfo);
-				let resp: Response;
-				const prefetched = inflight.get(termKey);
-				if (prefetched) {
-					inflight.delete(termKey);
-					resp = await prefetched;
-				} else {
-					resp = await customFetch(fetchInfo.url, {
-						headers: {
-							Range: `bytes=${fetchInfo.url_range.start}-${fetchInfo.url_range.end}`,
-						},
-					});
-				}
-				// Refill the look-ahead window now that a slot may have freed up.
-				pump();
-
-				if (resp.status === 403) {
-					// In case it's expired. The prefetched responses were signed with
-					// the now-stale URLs, so drop them; upcoming terms will re-fetch
-					// against the refreshed reconstruction info.
-					cancelInflight();
-					reconstructionInfo = await reloadReconstructionInfo();
-					fetchInfo = reconstructionInfo.fetch_info[term.hash]?.find(
+					let fetchInfo = reconstructionInfo.fetch_info[term.hash].find(
 						(info) => info.range.start <= term.range.start && info.range.end >= term.range.end,
 					);
+
 					if (!fetchInfo) {
 						throw new Error(
-							`Failed to find fetch info for term ${term.hash} and range ${term.range.start}-${term.range.end} after refresh`,
+							`Failed to find fetch info for term ${term.hash} and range ${term.range.start}-${term.range.end}`,
 						);
 					}
-					resp = await customFetch(fetchInfo.url, {
-						headers: {
-							Range: `bytes=${fetchInfo.url_range.start}-${fetchInfo.url_range.end}`,
-						},
-					});
-				}
 
-				if (!resp.ok) {
-					throw await createApiError(resp);
-				}
+					log("term", term);
+					log("fetchinfo", fetchInfo);
+					log("readBytesToSkip", readBytesToSkip);
 
-				log(
-					"expected content length",
-					resp.headers.get("content-length"),
-					"range",
-					fetchInfo.url_range,
-					resp.headers.get("content-range"),
-				);
-
-				const reader = resp.body?.getReader();
-				if (!reader) {
-					throw new Error("Failed to get reader from response body");
-				}
-
-				let done = false;
-				let chunkIndex = fetchInfo.range.start;
-				const ranges = rangeList.getRanges(fetchInfo.range.start, fetchInfo.range.end);
-
-				let leftoverBytes: Uint8Array | undefined = undefined;
-				let totalFetchBytes = 0;
-
-				fetchData: while (!done && totalBytesRead < maxBytes) {
-					const result = await reader.read();
-					listener?.({ event: "read" });
-
-					done = result.done;
-
-					log("read", result.value?.byteLength, "bytes", "total read", totalBytesRead, "toSkip", readBytesToSkip);
-
-					if (!result.value) {
-						log("no data in result, cancelled", result);
-						continue;
+					// Take the prefetched response for this range if one is in flight,
+					// otherwise fetch it now (concurrency == 1, window edge, or a range
+					// that was re-requested after a refresh).
+					const termKey = rangeKey(term.hash, fetchInfo);
+					let resp: Response;
+					const prefetched = inflight.get(termKey);
+					if (prefetched) {
+						inflight.delete(termKey);
+						resp = await prefetched;
+					} else {
+						resp = await customFetch(fetchInfo.url, {
+							headers: {
+								Range: `bytes=${fetchInfo.url_range.start}-${fetchInfo.url_range.end}`,
+							},
+						});
 					}
 
-					totalFetchBytes += result.value.byteLength;
-
-					if (leftoverBytes) {
-						result.value = combineUint8Arrays(leftoverBytes, result.value);
-						leftoverBytes = undefined;
-					}
-
-					while (totalBytesRead < maxBytes && result.value?.byteLength) {
-						if (result.value.byteLength < 8) {
-							// We need 8 bytes to parse the chunk header
-							leftoverBytes = result.value;
-							continue fetchData;
-						}
-
-						const header = new DataView(result.value.buffer, result.value.byteOffset, XET_CHUNK_HEADER_BYTES);
-						const chunkHeader: ChunkHeader = {
-							version: header.getUint8(0),
-							compressed_length: header.getUint8(1) | (header.getUint8(2) << 8) | (header.getUint8(3) << 16),
-							compression_scheme: header.getUint8(4),
-							uncompressed_length: header.getUint8(5) | (header.getUint8(6) << 8) | (header.getUint8(7) << 16),
-						};
-
-						log("chunk header", chunkHeader, "to skip", readBytesToSkip);
-
-						if (chunkHeader.version !== 0) {
-							throw new Error(`Unsupported chunk version ${chunkHeader.version}`);
-						}
-
-						if (
-							chunkHeader.compression_scheme !== XetChunkCompressionScheme.None &&
-							chunkHeader.compression_scheme !== XetChunkCompressionScheme.LZ4 &&
-							chunkHeader.compression_scheme !== XetChunkCompressionScheme.ByteGroupingLZ4
-						) {
+					if (resp.status === 403) {
+						// In case it's expired. The prefetched responses were signed with
+						// the now-stale URLs, so drop them; upcoming terms will re-fetch
+						// against the refreshed reconstruction info.
+						cancelInflight();
+						reconstructionInfo = await reloadReconstructionInfo();
+						fetchInfo = reconstructionInfo.fetch_info[term.hash]?.find(
+							(info) => info.range.start <= term.range.start && info.range.end >= term.range.end,
+						);
+						if (!fetchInfo) {
 							throw new Error(
-								`Unsupported compression scheme ${
-									compressionSchemeLabels[chunkHeader.compression_scheme] ?? chunkHeader.compression_scheme
-								}`,
+								`Failed to find fetch info for term ${term.hash} and range ${term.range.start}-${term.range.end} after refresh`,
 							);
 						}
-
-						if (result.value.byteLength < chunkHeader.compressed_length + XET_CHUNK_HEADER_BYTES) {
-							// We need more data to read the full chunk
-							leftoverBytes = result.value;
-							continue fetchData;
-						}
-
-						result.value = result.value.slice(XET_CHUNK_HEADER_BYTES);
-
-						let uncompressed =
-							chunkHeader.compression_scheme === XetChunkCompressionScheme.LZ4
-								? lz4_decompress(result.value.slice(0, chunkHeader.compressed_length), chunkHeader.uncompressed_length)
-								: chunkHeader.compression_scheme === XetChunkCompressionScheme.ByteGroupingLZ4
-									? bg4_regroup_bytes(
-											lz4_decompress(
-												result.value.slice(0, chunkHeader.compressed_length),
-												chunkHeader.uncompressed_length,
-											),
-										)
-									: result.value.slice(0, chunkHeader.compressed_length);
-
-						const range = ranges.find((range) => chunkIndex >= range.start && chunkIndex < range.end);
-						const shouldYield = chunkIndex >= term.range.start && chunkIndex < term.range.end;
-						const minRefCountToStore = shouldYield ? 2 : 1;
-						let stored = false;
-
-						// Assuming non-overlapping fetch_info ranges for the same hash
-						if (range && range.refCount >= minRefCountToStore) {
-							range.data ??= [];
-							range.data.push(uncompressed);
-							stored = true;
-						}
-
-						if (shouldYield) {
-							if (readBytesToSkip) {
-								const skipped = Math.min(readBytesToSkip, uncompressed.byteLength);
-								uncompressed = uncompressed.slice(readBytesToSkip);
-								readBytesToSkip -= skipped;
-							}
-
-							if (uncompressed.byteLength > maxBytes - totalBytesRead) {
-								uncompressed = uncompressed.slice(0, maxBytes - totalBytesRead);
-							}
-
-							if (uncompressed.byteLength) {
-								log(
-									"yield",
-									uncompressed.byteLength,
-									"bytes",
-									result.value.byteLength,
-									"total read",
-									totalBytesRead,
-									stored,
-								);
-								totalBytesRead += uncompressed.byteLength;
-								yield stored ? uncompressed.slice() : uncompressed;
-								listener?.({ event: "progress", progress: { read: totalBytesRead, total: maxBytes } });
-							}
-						}
-
-						chunkIndex++;
-						result.value = result.value.slice(chunkHeader.compressed_length);
+						resp = await customFetch(fetchInfo.url, {
+							headers: {
+								Range: `bytes=${fetchInfo.url_range.start}-${fetchInfo.url_range.end}`,
+							},
+						});
 					}
-				}
 
-				if (
-					done &&
-					totalBytesRead < maxBytes &&
-					totalFetchBytes < fetchInfo.url_range.end - fetchInfo.url_range.start + 1
-				) {
-					log("done", done, "total read", totalBytesRead, maxBytes, totalFetchBytes);
-					log("failed to fetch all data for term", term.hash);
-					throw new Error(
-						`Failed to fetch all data for term ${term.hash}, fetched ${totalFetchBytes} bytes out of ${
-							fetchInfo.url_range.end - fetchInfo.url_range.start + 1
-						}`,
+					if (!resp.ok) {
+						throw await createApiError(resp);
+					}
+
+					// The current response is healthy, so it's safe to refill the
+					// look-ahead window now that a slot has freed up.
+					pump();
+
+					log(
+						"expected content length",
+						resp.headers.get("content-length"),
+						"range",
+						fetchInfo.url_range,
+						resp.headers.get("content-range"),
 					);
+
+					const reader = resp.body?.getReader();
+					if (!reader) {
+						throw new Error("Failed to get reader from response body");
+					}
+					activeReader = reader;
+
+					let done = false;
+					let chunkIndex = fetchInfo.range.start;
+					const ranges = rangeList.getRanges(fetchInfo.range.start, fetchInfo.range.end);
+
+					let leftoverBytes: Uint8Array | undefined = undefined;
+					let totalFetchBytes = 0;
+
+					fetchData: while (!done && totalBytesRead < maxBytes) {
+						const result = await reader.read();
+						listener?.({ event: "read" });
+
+						done = result.done;
+
+						log("read", result.value?.byteLength, "bytes", "total read", totalBytesRead, "toSkip", readBytesToSkip);
+
+						if (!result.value) {
+							log("no data in result, cancelled", result);
+							continue;
+						}
+
+						totalFetchBytes += result.value.byteLength;
+
+						if (leftoverBytes) {
+							result.value = combineUint8Arrays(leftoverBytes, result.value);
+							leftoverBytes = undefined;
+						}
+
+						while (totalBytesRead < maxBytes && result.value?.byteLength) {
+							if (result.value.byteLength < 8) {
+								// We need 8 bytes to parse the chunk header
+								leftoverBytes = result.value;
+								continue fetchData;
+							}
+
+							const header = new DataView(result.value.buffer, result.value.byteOffset, XET_CHUNK_HEADER_BYTES);
+							const chunkHeader: ChunkHeader = {
+								version: header.getUint8(0),
+								compressed_length: header.getUint8(1) | (header.getUint8(2) << 8) | (header.getUint8(3) << 16),
+								compression_scheme: header.getUint8(4),
+								uncompressed_length: header.getUint8(5) | (header.getUint8(6) << 8) | (header.getUint8(7) << 16),
+							};
+
+							log("chunk header", chunkHeader, "to skip", readBytesToSkip);
+
+							if (chunkHeader.version !== 0) {
+								throw new Error(`Unsupported chunk version ${chunkHeader.version}`);
+							}
+
+							if (
+								chunkHeader.compression_scheme !== XetChunkCompressionScheme.None &&
+								chunkHeader.compression_scheme !== XetChunkCompressionScheme.LZ4 &&
+								chunkHeader.compression_scheme !== XetChunkCompressionScheme.ByteGroupingLZ4
+							) {
+								throw new Error(
+									`Unsupported compression scheme ${
+										compressionSchemeLabels[chunkHeader.compression_scheme] ?? chunkHeader.compression_scheme
+									}`,
+								);
+							}
+
+							if (result.value.byteLength < chunkHeader.compressed_length + XET_CHUNK_HEADER_BYTES) {
+								// We need more data to read the full chunk
+								leftoverBytes = result.value;
+								continue fetchData;
+							}
+
+							result.value = result.value.slice(XET_CHUNK_HEADER_BYTES);
+
+							let uncompressed =
+								chunkHeader.compression_scheme === XetChunkCompressionScheme.LZ4
+									? lz4_decompress(
+											result.value.slice(0, chunkHeader.compressed_length),
+											chunkHeader.uncompressed_length,
+										)
+									: chunkHeader.compression_scheme === XetChunkCompressionScheme.ByteGroupingLZ4
+										? bg4_regroup_bytes(
+												lz4_decompress(
+													result.value.slice(0, chunkHeader.compressed_length),
+													chunkHeader.uncompressed_length,
+												),
+											)
+										: result.value.slice(0, chunkHeader.compressed_length);
+
+							const range = ranges.find((range) => chunkIndex >= range.start && chunkIndex < range.end);
+							const shouldYield = chunkIndex >= term.range.start && chunkIndex < term.range.end;
+							const minRefCountToStore = shouldYield ? 2 : 1;
+							let stored = false;
+
+							// Assuming non-overlapping fetch_info ranges for the same hash
+							if (range && range.refCount >= minRefCountToStore) {
+								range.data ??= [];
+								range.data.push(uncompressed);
+								stored = true;
+							}
+
+							if (shouldYield) {
+								if (readBytesToSkip) {
+									const skipped = Math.min(readBytesToSkip, uncompressed.byteLength);
+									uncompressed = uncompressed.slice(readBytesToSkip);
+									readBytesToSkip -= skipped;
+								}
+
+								if (uncompressed.byteLength > maxBytes - totalBytesRead) {
+									uncompressed = uncompressed.slice(0, maxBytes - totalBytesRead);
+								}
+
+								if (uncompressed.byteLength) {
+									log(
+										"yield",
+										uncompressed.byteLength,
+										"bytes",
+										result.value.byteLength,
+										"total read",
+										totalBytesRead,
+										stored,
+									);
+									totalBytesRead += uncompressed.byteLength;
+									yield stored ? uncompressed.slice() : uncompressed;
+									listener?.({ event: "progress", progress: { read: totalBytesRead, total: maxBytes } });
+								}
+							}
+
+							chunkIndex++;
+							result.value = result.value.slice(chunkHeader.compressed_length);
+						}
+					}
+
+					if (
+						done &&
+						totalBytesRead < maxBytes &&
+						totalFetchBytes < fetchInfo.url_range.end - fetchInfo.url_range.start + 1
+					) {
+						log("done", done, "total read", totalBytesRead, maxBytes, totalFetchBytes);
+						log("failed to fetch all data for term", term.hash);
+						throw new Error(
+							`Failed to fetch all data for term ${term.hash}, fetched ${totalFetchBytes} bytes out of ${
+								fetchInfo.url_range.end - fetchInfo.url_range.start + 1
+							}`,
+						);
+					}
+
+					log("done", done, "total read", totalBytesRead, maxBytes, totalFetchBytes);
+
+					// Release the reader
+					log("cancel reader");
+					await reader.cancel();
+					activeReader = undefined;
 				}
-
-				log("done", done, "total read", totalBytesRead, maxBytes, totalFetchBytes);
-
-				// Release the reader
-				log("cancel reader");
-				await reader.cancel();
+			} finally {
+				// Runs on normal completion, an early-exit `break`, a thrown error
+				// (e.g. a non-ok response or a decompression failure), and when the
+				// consuming stream is cancelled. Cancel the in-progress reader (if any)
+				// and every prefetched-but-unused response so their bodies don't linger.
+				if (activeReader) {
+					await activeReader.cancel().catch(() => {});
+				}
+				cancelInflight();
 			}
-
-			// Early-exit / slice case: cancel any prefetched-but-unused responses so
-			// their bodies don't linger.
-			cancelInflight();
 		}
 
 		const iterator = readData(
@@ -606,6 +625,11 @@ export class XetBlob extends Blob {
 					if (result.done) {
 						controller.close();
 					}
+				},
+				async cancel() {
+					// Consumer cancelled the stream: return the generator so its
+					// `finally` runs and any in-flight prefetch requests are cancelled.
+					await iterator.return?.();
 				},
 				type: "bytes",
 				// todo: when Safari supports it, add autoAllocateChunkSize param

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -28,6 +28,13 @@ type XetBlobCreateOptions = {
 	 * Pre-fetched read token to avoid the refresh URL roundtrip.
 	 */
 	readToken?: XetReadToken;
+	/**
+	 * Number of CAS range requests to keep in flight while reconstructing the
+	 * file. The default (1) preserves the current fully-serial behavior; higher
+	 * values overlap the per-range requests to saturate faster links.
+	 * @default 1
+	 */
+	downloadConcurrency?: number;
 } & ({ hash: string; reconstructionUrl?: string } | { hash?: string; reconstructionUrl: string }) &
 	Partial<CredentialsParams>;
 
@@ -102,6 +109,7 @@ export class XetBlob extends Blob {
 	internalLogging = false;
 	reconstructionInfo: ReconstructionInfo | undefined;
 	listener: XetBlobCreateOptions["listener"];
+	downloadConcurrency = 1;
 
 	constructor(params: XetBlobCreateOptions) {
 		super([]);
@@ -114,6 +122,7 @@ export class XetBlob extends Blob {
 		this.hash = params.hash;
 		this.listener = params.listener;
 		this.internalLogging = params.internalLogging ?? false;
+		this.downloadConcurrency = Math.max(1, Math.floor(params.downloadConcurrency ?? 1));
 
 		if (params.readToken) {
 			const key = cacheKey({ refreshUrl: this.refreshUrl, initialAccessToken: this.accessToken });
@@ -145,6 +154,7 @@ export class XetBlob extends Blob {
 		blob.reconstructionInfo = this.reconstructionInfo;
 		blob.listener = this.listener;
 		blob.internalLogging = this.internalLogging;
+		blob.downloadConcurrency = this.downloadConcurrency;
 
 		return blob;
 	}
@@ -235,11 +245,80 @@ export class XetBlob extends Blob {
 			customFetch: typeof fetch,
 			maxBytes: number,
 			reloadReconstructionInfo: () => Promise<ReconstructionInfo>,
+			downloadConcurrency: number,
 		) {
 			let totalBytesRead = 0;
 			let readBytesToSkip = reconstructionInfo.offset_into_first_range;
 
-			for (const term of reconstructionInfo.terms) {
+			// --- bounded look-ahead prefetch of the per-term CAS range requests ---
+			//
+			// The reconstruction loop below consumes terms strictly in order and only
+			// the network fetch (step 2) is safe to start early: decompression and
+			// in-order yielding are untouched. We keep up to `downloadConcurrency`
+			// range requests in flight (the term being processed counts as one of
+			// them, so `downloadConcurrency === 1` stays fully serial). Requests are
+			// deduplicated by CAS range so we never issue more unique requests than
+			// the serial path — the RangeList cache below still serves already
+			// decompressed ranges without any network fetch.
+			const terms = reconstructionInfo.terms;
+
+			// Resolve the fetch_info entry (presigned URL + byte range) for a term,
+			// using the exact same predicate as the serial path below. Returns
+			// undefined when missing so the scheduler can skip it and let the consume
+			// path throw the detailed error.
+			const fetchInfoFor = (term: (typeof terms)[number]) =>
+				reconstructionInfo.fetch_info[term.hash]?.find(
+					(info) => info.range.start <= term.range.start && info.range.end >= term.range.end,
+				);
+
+			// Stable key for a CAS range so identical ranges share a single request.
+			const rangeKey = (hash: string, fetchInfo: { url_range: { start: number; end: number } }) =>
+				`${hash}:${fetchInfo.url_range.start}-${fetchInfo.url_range.end}`;
+
+			// key -> in-flight Response promise, plus the set of keys we've ever
+			// launched, so a range is never prefetched twice (the RangeList cache
+			// handles reuse of already-decompressed ranges).
+			const inflight = new Map<string, Promise<Response>>();
+			const launchedKeys = new Set<string>();
+			let prefetchIndex = 0;
+
+			const launch = (term: (typeof terms)[number]) => {
+				const fetchInfo = fetchInfoFor(term);
+				if (!fetchInfo) {
+					return;
+				}
+				const key = rangeKey(term.hash, fetchInfo);
+				if (launchedKeys.has(key)) {
+					return;
+				}
+				launchedKeys.add(key);
+				const p = customFetch(fetchInfo.url, {
+					headers: { Range: `bytes=${fetchInfo.url_range.start}-${fetchInfo.url_range.end}` },
+				});
+				// Avoid unhandled-rejection noise for prefetched-but-not-yet-awaited
+				// requests; the rejection is re-observed when the term is consumed.
+				p.catch(() => {});
+				inflight.set(key, p);
+			};
+
+			// The currently-processing term counts against the window, so only keep
+			// `downloadConcurrency - 1` requests queued ahead of it.
+			const pump = () => {
+				while (prefetchIndex < terms.length && inflight.size < downloadConcurrency - 1) {
+					launch(terms[prefetchIndex++]);
+				}
+			};
+
+			const cancelInflight = () => {
+				for (const p of inflight.values()) {
+					p.then((r) => r.body?.cancel()).catch(() => {});
+				}
+				inflight.clear();
+			};
+
+			pump();
+
+			for (const term of terms) {
 				if (totalBytesRead >= maxBytes) {
 					break;
 				}
@@ -298,14 +377,30 @@ export class XetBlob extends Blob {
 				log("fetchinfo", fetchInfo);
 				log("readBytesToSkip", readBytesToSkip);
 
-				let resp = await customFetch(fetchInfo.url, {
-					headers: {
-						Range: `bytes=${fetchInfo.url_range.start}-${fetchInfo.url_range.end}`,
-					},
-				});
+				// Take the prefetched response for this range if one is in flight,
+				// otherwise fetch it now (concurrency == 1, window edge, or a range
+				// that was re-requested after a refresh).
+				const termKey = rangeKey(term.hash, fetchInfo);
+				let resp: Response;
+				const prefetched = inflight.get(termKey);
+				if (prefetched) {
+					inflight.delete(termKey);
+					resp = await prefetched;
+				} else {
+					resp = await customFetch(fetchInfo.url, {
+						headers: {
+							Range: `bytes=${fetchInfo.url_range.start}-${fetchInfo.url_range.end}`,
+						},
+					});
+				}
+				// Refill the look-ahead window now that a slot may have freed up.
+				pump();
 
 				if (resp.status === 403) {
-					// In case it's expired
+					// In case it's expired. The prefetched responses were signed with
+					// the now-stale URLs, so drop them; upcoming terms will re-fetch
+					// against the refreshed reconstruction info.
+					cancelInflight();
 					reconstructionInfo = await reloadReconstructionInfo();
 					fetchInfo = reconstructionInfo.fetch_info[term.hash]?.find(
 						(info) => info.range.start <= term.range.start && info.range.end >= term.range.end,
@@ -483,6 +578,10 @@ export class XetBlob extends Blob {
 				log("cancel reader");
 				await reader.cancel();
 			}
+
+			// Early-exit / slice case: cancel any prefetched-but-unused responses so
+			// their bodies don't linger.
+			cancelInflight();
 		}
 
 		const iterator = readData(
@@ -490,6 +589,7 @@ export class XetBlob extends Blob {
 			this.fetch,
 			this.end - this.start,
 			this.#loadReconstructionInfo.bind(this),
+			this.downloadConcurrency,
 		);
 
 		// todo: when Chrome/Safari support it, use ReadableStream.from(readData)


### PR DESCRIPTION
I'd like to have this feature in the library since it was quite useful on onnx model processing in wasm.
https://onnxsim.github.io/onnxsim/ is where I deploy the onnx simplifier and https://github.com/onnxsim/onnxsim/pull/559 was the PR I've worked.
Currently I'm using `8` as preferred concurrency number (on my 100Mbps network, about 2MB/s was the serial speed and theoretical limit should be around 100MB/s so I've selected 8 to 10) but if there is other better value, I'd like to switch to it.

Rel: https://github.com/huggingface/huggingface.js/issues/1279

Add an optional `downloadConcurrency` to `downloadFile` (threaded into `XetBlob`) so a xet-backed file's reconstruction ranges can be fetched in parallel. Defaults to 1, preserving the current fully-serial behavior.

XetBlob's reconstruction loop awaits each term's CAS range request in order, so only one request is ever in flight, capping xet downloads at single-connection throughput. This adds a bounded look-ahead prefetch window: up to `downloadConcurrency` range requests are kept in flight, deduplicated by CAS range so it never issues more unique requests than the serial path and still honors the RangeList cache fast-path.

Decompression and in-order yielding are unchanged; only the launch of each per-term fetch moves earlier. Prefetched-but-unused responses (slice / maxBytes early-exit) are cancelled, and the 403 token-refresh path drops stale prefetched responses before retrying.


Claude-Session: https://claude.ai/code/session_01PfdUuzCxrTY8kNS7PKbxD2


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core xet reconstruction and streaming with new concurrency and cancellation paths; default remains serial, but higher concurrency increases load on CAS/CDN and relies on correct prefetch invalidation on 403/errors.
> 
> **Overview**
> Adds optional **`downloadConcurrency`** on `downloadFile` (forwarded to `XetBlob`) so xet reconstruction can issue multiple CAS byte-range fetches in parallel instead of one-at-a-time. Default **`1`** keeps today’s serial behavior.
> 
> **`XetBlob`** gains a bounded look-ahead prefetch: up to `downloadConcurrency` range requests can be in flight, deduped by CAS range key so prefetch never exceeds unique work the serial path would do. Decompression and in-order output are unchanged; only when each term’s HTTP fetch starts moves earlier.
> 
> Failure and lifecycle handling: on **403** token refresh, stale prefetched responses are dropped before retry; a **`finally`** block and stream **`cancel`** cancel the active reader and unused prefetched bodies (including when a term fails mid-download). Tests cover parallel vs serial in-flight counts and prefetch cancellation on error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7726229ebf2fcf45a5c52c732915e302d4822de5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->