### PR TITLE
fix(inference): adapt Novita text generation requests

### DIFF
--- a/packages/inference/src/providers/novita.spec.ts
+++ b/packages/inference/src/providers/novita.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { InferenceClientProviderOutputError } from "../errors.js";
+import type { BodyParams } from "../types.js";
+import { NovitaTextGenerationTask } from "./novita.js";
+
+describe("NovitaTextGenerationTask", () => {
+	const task = new NovitaTextGenerationTask();
+
+	it("uses Novita's OpenAI-compatible chat completions route", () => {
+		expect(task.makeRoute()).toBe("/v3/openai/chat/completions");
+	});
+
+	it("converts text-generation inputs and parameters to an OpenAI chat completion payload", () => {
+		const params = {
+			model: "novita/model",
+			args: {
+				inputs: "Once upon a time",
+				parameters: {
+					max_new_tokens: 32,
+					temperature: 0.7,
+				},
+				provider: "novita",
+			},
+		} as BodyParams;
+
+		expect(task.preparePayload(params)).toEqual({
+			model: "novita/model",
+			messages: [{ role: "user", content: "Once upon a time" }],
+			provider: "novita",
+			max_tokens: 32,
+			temperature: 0.7,
+		});
+	});
+
+	it("converts the first chat completion choice to text-generation output", async () => {
+		await expect(task.getResponse({ choices: [{ message: { content: "The end." } }] })).resolves.toEqual({
+			generated_text: "The end.",
+		});
+	});
+
+	it("rejects malformed completion responses", async () => {
+		await expect(task.getResponse({ choices: [] })).rejects.toBeInstanceOf(InferenceClientProviderOutputError);
+	});
+});

--- a/packages/inference/src/providers/novita.ts
+++ b/packages/inference/src/providers/novita.ts
@@ -14,6 +14,7 @@
  *
  * Thanks!
  */
+import type { TextGenerationOutput } from "@huggingface/tasks";
 import { isUrl } from "../lib/isUrl.js";
 import type { TextToVideoArgs } from "../tasks/index.js";
 import type { BodyParams, UrlParams } from "../types.js";
@@ -37,6 +38,10 @@ export interface NovitaAsyncAPIOutput {
 	task_id: string;
 }
 
+interface NovitaChatCompletionResponse {
+	choices: Array<{ message?: { content?: string | null } }>;
+}
+
 export class NovitaTextGenerationTask extends BaseTextGenerationTask {
 	constructor() {
 		super("novita", NOVITA_API_BASE_URL);
@@ -44,6 +49,37 @@ export class NovitaTextGenerationTask extends BaseTextGenerationTask {
 
 	override makeRoute(): string {
 		return "/v3/openai/chat/completions";
+	}
+
+	override preparePayload(params: BodyParams): Record<string, unknown> {
+		const parameters = params.args.parameters as Record<string, unknown> | undefined;
+		return {
+			model: params.model,
+			messages: [{ role: "user", content: params.args.inputs }],
+			...omit(params.args, ["inputs", "parameters"]),
+			...(parameters
+				? {
+						max_tokens: parameters.max_new_tokens,
+						...omit(parameters, ["max_new_tokens"]),
+					}
+				: undefined),
+		};
+	}
+
+	override async getResponse(response: NovitaChatCompletionResponse): Promise<TextGenerationOutput> {
+		if (
+			typeof response === "object" &&
+			response !== null &&
+			Array.isArray(response.choices) &&
+			response.choices.length > 0 &&
+			typeof response.choices[0].message?.content === "string"
+		) {
+			return { generated_text: response.choices[0].message.content };
+		}
+
+		throw new InferenceClientProviderOutputError(
+			"Received malformed response from Novita text-generation API: expected OpenAI chat completion payload",
+		);
 	}
 }
 


### PR DESCRIPTION
## Summary
- adapt Novita text-generation requests to its OpenAI-compatible chat endpoint
- convert the first chat completion response into `TextGenerationOutput`
- add focused adapter coverage for route, payload, response, and malformed output

## Verification
- `pnpm --filter @huggingface/inference test -- --run src/providers/novita.spec.ts`
- `pnpm --filter @huggingface/inference check`
- `pnpm --filter @huggingface/inference lint:check`
- `pnpm --filter @huggingface/inference format:check`
- direct non-stream and SSE validation with `deepseek/deepseek-v4-flash-0731`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped Novita provider adapter change with tests; no auth or shared core logic changes.
> 
> **Overview**
> **Novita text-generation** now speaks Novita’s OpenAI-compatible **chat completions** API instead of relying on the generic text-generation payload/response shape.
> 
> `NovitaTextGenerationTask` maps `inputs` to a single user `messages` entry, renames `max_new_tokens` to `max_tokens`, and passes through other args/parameters. Responses are normalized from the first choice’s `message.content` into `{ generated_text }`, with `InferenceClientProviderOutputError` on invalid payloads.
> 
> Adds **vitest** coverage for route, payload mapping, successful parsing, and malformed responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5306f7fc5ddc1f2784a68af99bda4dc541e769e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->