### PR TITLE
Add QVAC to local apps

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -363,4 +363,37 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 			{ label: "Releases", url: "https://github.com/bartowski/Llama-3.2-3B-Instruct-GGUF/releases" },
 		]);
 	});
+	it("qvac", async () => {
+		const { snippet: snippetFunc } = LOCAL_APPS.qvac;
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			gguf: { total: 1, context_length: 4096 },
+			inference: "",
+		};
+		const snippet = snippetFunc(model);
+
+		expect(snippet[0].setup).toContain("npm install -g @qvac/cli");
+		expect(snippet[0].content).toContain('"type": "llamacpp-completion"');
+		expect(snippet[0].content).toContain(
+			'"src": "https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF/resolve/main/{{GGUF_FILE}}"',
+		);
+		expect(snippet[1].content).toContain("qvac serve openai --model Llama-3.2-3B-Instruct-GGUF");
+	});
+
+	it("qvac - resolved gguf file", async () => {
+		const { snippet: snippetFunc } = LOCAL_APPS.qvac;
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			gguf: { total: 1, context_length: 4096 },
+			inference: "",
+		};
+		const snippet = snippetFunc(model, "Llama-3.2-3B-Instruct-Q4_K_M.gguf");
+
+		expect(snippet[0].content).toContain(
+			'"src": "https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF/resolve/main/Llama-3.2-3B-Instruct-Q4_K_M.gguf"',
+		);
+		expect(snippet[0].content).not.toContain("{{GGUF_FILE}}");
+	});
 });

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -621,6 +621,41 @@ const snippetLemonade = (model: ModelData, filepath?: string): LocalAppSnippet[]
 	];
 };
 
+const snippetQvac = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
+	// QVAC is the inference engine itself, so there is no separate server step: the CLI
+	// serves the weights directly. `serve.models` only takes SDK model constants under the
+	// `model` shorthand, so non-registry weights (this GGUF) go through the explicit
+	// `{ type, src }` form, where `src` is handed to the SDK as `modelSrc` verbatim.
+	const alias = model.id.split("/").pop() ?? model.id;
+	const config = JSON.stringify(
+		{
+			serve: {
+				models: {
+					[alias]: {
+						type: "llamacpp-completion",
+						src: `https://huggingface.co/${model.id}/resolve/main/${filepath ?? "{{GGUF_FILE}}"}`,
+						default: true,
+					},
+				},
+			},
+		},
+		null,
+		2,
+	);
+
+	return [
+		{
+			title: "Configure the model in QVAC",
+			setup: "# Install the QVAC CLI (requires Node 22.17+):\nnpm install -g @qvac/cli",
+			content: `# Add to qvac.config.json in your project directory:\n${config}`,
+		},
+		{
+			title: "Start the QVAC server",
+			content: `# OpenAI-compatible server on http://127.0.0.1:11434/v1:\nqvac serve openai --model ${alias}`,
+		},
+	];
+};
+
 /**
  * Add your new local app here.
  *
@@ -838,6 +873,13 @@ export const LOCAL_APPS = {
 		mainTask: "text-generation",
 		displayOnModelPage: isToolCallingLocalAgentModel,
 		snippet: snippetOpenClaw,
+	},
+	qvac: {
+		prettyLabel: "QVAC",
+		docsUrl: "https://docs.qvac.tether.io",
+		mainTask: "text-generation",
+		displayOnModelPage: isLlamaCppGgufModel,
+		snippet: snippetQvac,
 	},
 } satisfies Record<string, LocalApp>;
 


### PR DESCRIPTION
## Summary
- Add [QVAC](https://docs.qvac.tether.io) as a local app for GGUF text-generation models
- QVAC is Tether's open-source local AI SDK (Apache 2.0, JS/TS). Its CLI ships an OpenAI-compatible server, so a GGUF hosted on the Hub runs locally with no cloud dependency
- Unlike Pi / Hermes Agent / OpenClaw, QVAC **is** the inference engine rather than a client of one, so the snippet has no separate llama.cpp server step: the CLI serves the weights itself
- `serve.models` resolves SDK model constants under the `model` shorthand, so Hub weights use the explicit `{ type, src }` form, where `src` is handed to the SDK as `modelSrc` verbatim

The snippet is two steps: install `@qvac/cli` plus a `qvac.config.json` registering the model, then `qvac serve openai`. It supports the `{{GGUF_FILE}}` placeholder and uses the resolved filename when one is selected.

## Verified before submitting
Ran the generated snippet for real against a Hub GGUF (`unsloth/Qwen3-0.6B-GGUF`, served straight from a `huggingface.co/.../resolve/main/...` URL):
- `GET /v1/models` lists the alias
- `POST /v1/chat/completions` returned a normal completion (`finish_reason: stop`, 73 completion tokens)

## Notes on two deliberate choices
- **`displayOnModelPage: isLlamaCppGgufModel`** is intentionally broad. Whether a given GGUF loads depends on the engine version and architecture support, which we cannot express as a predicate, so we would rather show the button widely and keep the engine catching up than hide QVAC from models it can already run.
- **`mainTask: "text-generation"`** understates what the same server does. Beyond chat, `qvac serve openai` also implements `/v1/embeddings`, `/v1/audio/transcriptions`, `/v1/audio/translations`, `/v1/audio/speech` (TTS), `/v1/images/generations`, `/v1/images/edits` and `/v1/videos`, all fully on-device. If you would like QVAC surfaced on text-to-image, ASR, TTS or text-to-video model pages too, we are glad to extend this entry or add more, just tell us the shape you prefer.

## Test plan
- `pnpm --filter @huggingface/tasks exec vitest run src/local-apps.spec.ts` (20 passed, includes 2 new QVAC cases: `{{GGUF_FILE}}` placeholder and resolved-filename)
- `pnpm --filter @huggingface/tasks format:check`
- `pnpm --filter @huggingface/tasks check`

Note the `qvac` app key will need its logo asset on your side, as with previous additions. Happy to adjust the label, docs URL or predicate.
