### PR TITLE
[gguf] Parse bare MXFP4 in GGUF filenames

### DIFF
--- a/packages/gguf/src/gguf.spec.ts
+++ b/packages/gguf/src/gguf.spec.ts
@@ -8,6 +8,7 @@ import {
 	ggufAllShards,
 	parseGgufShardFilename,
 	parseGGUFQuantLabel,
+	GGUF_QUANT_RE,
 	GGUF_QUANT_ORDER,
 	findNearestQuantType,
 	serializeGgufMetadata,
@@ -341,6 +342,27 @@ describe("gguf", () => {
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-IQ3_XS.gguf")).toEqual("IQ3_XS");
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-Q4_0_4_4.gguf")).toEqual("Q4_0"); // TODO: investigate Q4_0_4_4
 		expect(parseGGUFQuantLabel("Qwen3-4B-UD-Q2_K_XL.gguf")).toEqual("UD-Q2_K_XL"); // unsloth UD (Unsloth Dynamic) prefix
+		// llama.cpp names gpt-oss files after the tensor type (MXFP4) even though general.file_type is MXFP4_MOE
+		expect(parseGGUFQuantLabel("gpt-oss-20b-MXFP4.gguf")).toEqual("MXFP4");
+		expect(parseGGUFQuantLabel("gpt-oss-120b-MXFP4.gguf")).toEqual("MXFP4");
+		expect(parseGGUFQuantLabel("Qwable-v1-35B-A3B-MXFP4_MOE.gguf")).toEqual("MXFP4_MOE");
+	});
+
+	it("parse quant label groups", async () => {
+		const groups = (fname: string) => {
+			const { prefix, quant, sizeVariation } = parseGGUFQuantLabel(fname)?.match(GGUF_QUANT_RE)?.groups ?? {};
+			return { prefix, quant, sizeVariation };
+		};
+		expect(groups("gemma-2-9b-it-Q6_K_L.gguf")).toEqual({ prefix: undefined, quant: "Q6_K", sizeVariation: "L" });
+		expect(groups("Qwen3-4B-UD-Q2_K_XL.gguf")).toEqual({ prefix: "UD-", quant: "Q2_K", sizeVariation: "XL" });
+		// MXFP4_MOE must keep winning the alternation over the MXFP4 alias: parsing it as quant MXFP4 with
+		// sizeVariation MOE would make it sort as an unknown size among the other 4-bit quants
+		expect(groups("Qwable-v1-35B-A3B-MXFP4_MOE.gguf")).toEqual({
+			prefix: undefined,
+			quant: "MXFP4_MOE",
+			sizeVariation: undefined,
+		});
+		expect(groups("gpt-oss-20b-MXFP4.gguf")).toEqual({ prefix: undefined, quant: "MXFP4", sizeVariation: undefined });
 	});
 
 	it("calculate tensor data offset", async () => {

--- a/packages/tasks/src/gguf.ts
+++ b/packages/tasks/src/gguf.ts
@@ -56,8 +56,22 @@ export enum GGMLFileQuantizationType {
 }
 
 const ggufQuants = Object.values(GGMLFileQuantizationType).filter((v): v is string => typeof v === "string");
+/**
+ * Names that show up in GGUF *filenames* without being llama_ftype values.
+ *
+ * llama.cpp's gpt-oss conversion names its output after the tensor type it repacks the experts to
+ * (`GGMLQuantizationType.MXFP4`), while `general.file_type` is `MXFP4_MOE` — see
+ * https://github.com/ggml-org/llama.cpp/blob/master/conversion/gpt_oss.py. So the canonical releases
+ * are `gpt-oss-{20b,120b}-MXFP4.gguf`, which no `GGMLFileQuantizationType` name matches.
+ *
+ * Appended last so `MXFP4_MOE` still wins the alternation, instead of matching as `MXFP4` with
+ * sizeVariation `MOE`.
+ */
+const GGUF_QUANT_FILENAME_ALIASES = ["MXFP4"];
 export const GGUF_QUANT_RE = new RegExp(
-	"(?<prefix>UD-)?" + `(?<quant>${ggufQuants.join("|")})` + "(_(?<sizeVariation>[A-Z]+))?",
+	"(?<prefix>UD-)?" +
+		`(?<quant>${[...ggufQuants, ...GGUF_QUANT_FILENAME_ALIASES].join("|")})` +
+		"(_(?<sizeVariation>[A-Z]+))?",
 );
 export const GGUF_QUANT_RE_GLOBAL = new RegExp(GGUF_QUANT_RE, "g");
 


### PR DESCRIPTION
## Problem

GGUF has two quant enums: **file types** ([`llama_ftype`](https://github.com/ggml-org/llama.cpp/blob/5788b510a1e3394fcc2d6b13ba2d9d8fc4a5c139/include/llama.h#L119-L163), stored as `general.file_type`) and **tensor types** ([`ggml_type`](https://github.com/ggml-org/llama.cpp/blob/5788b510a1e3394fcc2d6b13ba2d9d8fc4a5c139/ggml/include/ggml.h#L390-L437), per tensor). `parseGGUFQuantLabel`, which labels the quants in the Hardware compatibility widget, matches filenames against the **file types**.

https://huggingface.co/ggml-org/gpt-oss-20b-GGUF
<img width="518" height="210" alt="image" src="https://github.com/user-attachments/assets/45d04e3d-8a90-4bb2-9747-ad15a8a0cee0" />

there should have been `MXFP4` type in the above screenshot because there is https://huggingface.co/ggml-org/gpt-oss-20b-GGUF/blob/main/gpt-oss-20b-MXFP4.gguf

There is only one MXFP4 file type, [`LLAMA_FTYPE_MOSTLY_MXFP4_MOE = 38`](https://github.com/ggml-org/llama.cpp/blob/5788b510a1e3394fcc2d6b13ba2d9d8fc4a5c139/include/llama.h#L155) — no bare `MXFP4`, that only exists as the tensor type [`GGML_TYPE_MXFP4 = 39`](https://github.com/ggml-org/llama.cpp/blob/5788b510a1e3394fcc2d6b13ba2d9d8fc4a5c139/ggml/include/ggml.h#L429). But the filename convention drops the `_MOE` and publishes `xyz-MXFP4.gguf` — llama.cpp's own conversion names the file after [the tensor type it repacks to](https://github.com/ggml-org/llama.cpp/blob/5788b510a1e3394fcc2d6b13ba2d9d8fc4a5c139/conversion/gpt_oss.py#L61), as in the [gpt-oss](https://huggingface.co/ggml-org/gpt-oss-20b-GGUF) releases — so the quant isn't extracted and those files are dropped from the widget.

## Solution

Fixed by accepting `MXFP4` as a filename alias in `GGUF_QUANT_RE`, in a separate list so `GGMLFileQuantizationType` keeps mirroring `llama_ftype`, and appended last so `MXFP4_MOE` still wins the alternation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to filename quant parsing and regex ordering, with focused tests and no auth or data-path impact.
> 
> **Overview**
> **GGUF quant labels** from filenames (e.g. Hardware compatibility) no longer miss **gpt-oss**-style names like `gpt-oss-20b-MXFP4.gguf`, where llama.cpp uses the tensor label `MXFP4` even though `general.file_type` is `MXFP4_MOE`.
> 
> `GGUF_QUANT_RE` now includes a separate **`GGUF_QUANT_FILENAME_ALIASES`** list with `MXFP4`, appended after official `GGMLFileQuantizationType` names so **`MXFP4_MOE` still matches as a whole** (not `MXFP4` + size variation `MOE`). Tests cover `parseGGUFQuantLabel` and regex capture groups for both cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ebf2738552acefc860af617fc1e0602d05aa459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->