### PR TITLE
Add multi-range support and update ReconstructionInfo schema (xet v2)

### DIFF
--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { ReconstructionInfo } from "./XetBlob";
-import { bg4_regroup_bytes, bg4_split_bytes, XetBlob } from "./XetBlob";
+import { bg4_regroup_bytes, bg4_split_bytes, clearMultiRangeSupportCache, XetBlob } from "./XetBlob";
 import { sum } from "./sum";
 
 describe("XetBlob", () => {
+	beforeEach(() => {
+		// Multi-range support detection is cached per host at module scope;
+		// reset it so tests don't leak state into each other.
+		clearMultiRangeSupportCache();
+	});
+
 	it("should handle empty files (size 0) without making network requests", async () => {
 		let fetchCount = 0;
 
@@ -176,14 +182,13 @@ describe("XetBlob", () => {
 		// 				"range": { "start": 0, "end": 5 },
 		// 			},
 		// 		],
-		// 	"fetch_info":
+		// 	"xorbs":
 		// 		{
 		// 			"be748f77930d5929cabd510a15f2c30f2f460b639804ef79dea46affa04fd8b2":
 		// 				[
 		// 					{
-		// 						"range": { "start": 0, "end": 5 },
 		// 						"url": "...",
-		// 						"url_range": { "start": 0, "end": 2839 },
+		// 						"ranges": [{ "chunks": { "start": 0, "end": 5 }, "bytes": { "start": 0, "end": 2839 } }],
 		// 					},
 		// 				],
 		// 		},
@@ -198,6 +203,335 @@ describe("XetBlob", () => {
 
 		console.log("xet", text.length, "bridge", bridgeDownload.length);
 		expect(text.length).toBe(bridgeDownload.length);
+	});
+
+	describe("multi-range fetch entries", () => {
+		function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+			const total = arrays.reduce((s, a) => s + a.byteLength, 0);
+			const out = new Uint8Array(total);
+			let offset = 0;
+			for (const a of arrays) {
+				out.set(a, offset);
+				offset += a.byteLength;
+			}
+			return out;
+		}
+
+		function makeMultipartResponse(
+			boundary: string,
+			parts: Array<{ range: { start: number; end: number }; total: number; data: Uint8Array }>,
+		): Response {
+			const enc = new TextEncoder();
+			const segments: Uint8Array[] = [];
+			for (const part of parts) {
+				segments.push(
+					enc.encode(
+						`\r\n--${boundary}\r\nContent-Type: application/octet-stream\r\n` +
+							`Content-Range: bytes ${part.range.start}-${part.range.end}/${part.total}\r\n\r\n`,
+					),
+					part.data,
+				);
+			}
+			segments.push(enc.encode(`\r\n--${boundary}--\r\n`));
+
+			return new Response(concatBytes(...segments), {
+				headers: { "Content-Type": `multipart/byteranges; boundary=${boundary}` },
+			});
+		}
+
+		interface XorbFixture {
+			wholeText: string;
+			total: number;
+			lenA: number;
+			rangeAData: Uint8Array;
+			rangeBData: Uint8Array;
+			reconstructionInfo: ReconstructionInfo;
+		}
+
+		/** A xorb with two signed ranges: chunks [0,2) = "helloworld" and chunks [4,6) = "foobar!" */
+		function makeFixture(): XorbFixture {
+			const rangeAData = concatBytes(makeChunk("hello"), makeChunk("world"));
+			const rangeBData = concatBytes(makeChunk("foo"), makeChunk("bar!"));
+			const lenA = rangeAData.byteLength;
+			const total = lenA + rangeBData.byteLength;
+
+			return {
+				wholeText: "helloworldfoobar!",
+				total,
+				lenA,
+				rangeAData,
+				rangeBData,
+				reconstructionInfo: {
+					terms: [
+						{ hash: "xorb1", range: { start: 0, end: 2 }, unpacked_length: 10 },
+						{ hash: "xorb1", range: { start: 4, end: 6 }, unpacked_length: 7 },
+					],
+					xorbs: {
+						xorb1: [
+							{
+								url: "https://xorb.co",
+								ranges: [
+									{ chunks: { start: 0, end: 2 }, bytes: { start: 0, end: lenA - 1 } },
+									{ chunks: { start: 4, end: 6 }, bytes: { start: lenA, end: total - 1 } },
+								],
+							},
+						],
+					},
+					offset_into_first_range: 0,
+				},
+			};
+		}
+
+		it("fetches a multi-range xorb in one multipart/byteranges request", async () => {
+			const fixture = makeFixture();
+
+			let fetchCount = 0;
+			let multiRangeHeader: string | undefined;
+
+			const blob = new XetBlob({
+				hash: "test",
+				size: fixture.wholeText.length,
+				refreshUrl: "https://huggingface.co",
+				fetch: async function (_url, opts) {
+					const url = new URL(_url as string);
+					const headers = opts?.headers as Record<string, string> | undefined;
+
+					switch (url.hostname) {
+						case "huggingface.co":
+							return new Response(JSON.stringify({ casUrl: "https://cas.co", accessToken: "boo", exp: 1_000_000 }));
+						case "cas.co": {
+							expect(url.pathname).toContain("/v2/reconstructions/");
+							return new Response(JSON.stringify(fixture.reconstructionInfo));
+						}
+						case "xorb.co": {
+							fetchCount++;
+							multiRangeHeader = headers?.["Range"];
+							return makeMultipartResponse("BOUNDARY", [
+								{ range: { start: 0, end: fixture.lenA - 1 }, total: fixture.total, data: fixture.rangeAData },
+								{
+									range: { start: fixture.lenA, end: fixture.total - 1 },
+									total: fixture.total,
+									data: fixture.rangeBData,
+								},
+							]);
+						}
+						default:
+							throw new Error(`Unhandled URL ${url.hostname}`);
+					}
+				},
+			});
+
+			expect(await blob.text()).toBe(fixture.wholeText);
+			// Both ranges of the xorb are fetched together in a single multi-range request.
+			expect(fetchCount).toBe(1);
+			expect(multiRangeHeader).toBe(`bytes=0-${fixture.lenA - 1},${fixture.lenA}-${fixture.total - 1}`);
+		});
+
+		it("falls back to one request per range when the server ignores the multi-range request", async () => {
+			const fixture = makeFixture();
+
+			const rangeHeaders: Array<string | undefined> = [];
+
+			const blob = new XetBlob({
+				hash: "test",
+				size: fixture.wholeText.length,
+				refreshUrl: "https://huggingface.co",
+				fetch: async function (_url, opts) {
+					const url = new URL(_url as string);
+					const headers = opts?.headers as Record<string, string> | undefined;
+
+					switch (url.hostname) {
+						case "huggingface.co":
+							return new Response(JSON.stringify({ casUrl: "https://cas.co", accessToken: "boo", exp: 1_000_000 }));
+						case "cas.co":
+							return new Response(JSON.stringify(fixture.reconstructionInfo));
+						case "xorb.co": {
+							const range = headers?.["Range"];
+							rangeHeaders.push(range);
+							if (range?.includes(",")) {
+								// Like S3, ignore the multi-range request and return the whole object with a 200.
+								return new Response(concatBytes(fixture.rangeAData, fixture.rangeBData));
+							}
+							if (range === `bytes=0-${fixture.lenA - 1}`) {
+								return new Response(fixture.rangeAData);
+							}
+							if (range === `bytes=${fixture.lenA}-${fixture.total - 1}`) {
+								return new Response(fixture.rangeBData);
+							}
+							throw new Error(`Unexpected Range header ${range}`);
+						}
+						default:
+							throw new Error(`Unhandled URL ${url.hostname}`);
+					}
+				},
+			});
+
+			expect(await blob.text()).toBe(fixture.wholeText);
+			// 1 multi-range attempt + 1 fetch per range
+			expect(rangeHeaders).toEqual([
+				`bytes=0-${fixture.lenA - 1},${fixture.lenA}-${fixture.total - 1}`,
+				`bytes=0-${fixture.lenA - 1}`,
+				`bytes=${fixture.lenA}-${fixture.total - 1}`,
+			]);
+		});
+
+		it("remembers hosts that don't support multi-range requests", async () => {
+			const fixture = makeFixture();
+
+			const multiRangeAttempts: string[] = [];
+
+			const makeBlob = () =>
+				new XetBlob({
+					hash: "test",
+					size: fixture.wholeText.length,
+					refreshUrl: "https://huggingface.co",
+					fetch: async function (_url, opts) {
+						const url = new URL(_url as string);
+						const headers = opts?.headers as Record<string, string> | undefined;
+
+						switch (url.hostname) {
+							case "huggingface.co":
+								return new Response(JSON.stringify({ casUrl: "https://cas.co", accessToken: "boo", exp: 1_000_000 }));
+							case "cas.co":
+								return new Response(JSON.stringify(fixture.reconstructionInfo));
+							case "xorb.co": {
+								const range = headers?.["Range"];
+								if (range?.includes(",")) {
+									multiRangeAttempts.push(range);
+									return new Response(concatBytes(fixture.rangeAData, fixture.rangeBData));
+								}
+								if (range === `bytes=0-${fixture.lenA - 1}`) {
+									return new Response(fixture.rangeAData);
+								}
+								if (range === `bytes=${fixture.lenA}-${fixture.total - 1}`) {
+									return new Response(fixture.rangeBData);
+								}
+								throw new Error(`Unexpected Range header ${range}`);
+							}
+							default:
+								throw new Error(`Unhandled URL ${url.hostname}`);
+						}
+					},
+				});
+
+			expect(await makeBlob().text()).toBe(fixture.wholeText);
+			expect(await makeBlob().text()).toBe(fixture.wholeText);
+			// Only the first download attempts a multi-range request.
+			expect(multiRangeAttempts).toHaveLength(1);
+		});
+
+		it("handles a single-range fetch entry without multipart", async () => {
+			const xorbData = concatBytes(makeChunk("hello"), makeChunk("world"));
+			const wholeText = "helloworld";
+
+			let fetchCount = 0;
+
+			const blob = new XetBlob({
+				hash: "test",
+				size: wholeText.length,
+				refreshUrl: "https://huggingface.co",
+				fetch: async function (_url) {
+					const url = new URL(_url as string);
+
+					switch (url.hostname) {
+						case "huggingface.co":
+							return new Response(JSON.stringify({ casUrl: "https://cas.co", accessToken: "boo", exp: 1_000_000 }));
+						case "cas.co":
+							return new Response(
+								JSON.stringify({
+									terms: [{ hash: "xorb1", range: { start: 0, end: 2 }, unpacked_length: 10 }],
+									xorbs: {
+										xorb1: [
+											{
+												url: "https://xorb.co",
+												ranges: [{ chunks: { start: 0, end: 2 }, bytes: { start: 0, end: xorbData.byteLength - 1 } }],
+											},
+										],
+									},
+									offset_into_first_range: 0,
+								} satisfies ReconstructionInfo),
+							);
+						case "xorb.co":
+							fetchCount++;
+							return new Response(xorbData);
+						default:
+							throw new Error(`Unhandled URL ${url.hostname}`);
+					}
+				},
+			});
+
+			expect(await blob.text()).toBe(wholeText);
+			expect(fetchCount).toBe(1);
+		});
+
+		it("throws when a multipart part decodes to fewer chunks than expected", async () => {
+			const fixture = makeFixture();
+
+			const blob = new XetBlob({
+				hash: "test",
+				size: fixture.wholeText.length,
+				refreshUrl: "https://huggingface.co",
+				fetch: async function (_url) {
+					const url = new URL(_url as string);
+
+					switch (url.hostname) {
+						case "huggingface.co":
+							return new Response(JSON.stringify({ casUrl: "https://cas.co", accessToken: "boo", exp: 1_000_000 }));
+						case "cas.co":
+							return new Response(JSON.stringify(fixture.reconstructionInfo));
+						case "xorb.co":
+							// Second part is truncated: only one of its two chunks.
+							return makeMultipartResponse("BOUNDARY", [
+								{ range: { start: 0, end: fixture.lenA - 1 }, total: fixture.total, data: fixture.rangeAData },
+								{
+									range: { start: fixture.lenA, end: fixture.total - 1 },
+									total: fixture.total,
+									data: makeChunk("foo"),
+								},
+							]);
+						default:
+							throw new Error(`Unhandled URL ${url.hostname}`);
+					}
+				},
+			});
+
+			await expect(blob.text()).rejects.toThrow(/expected/);
+		});
+
+		it("throws when the decoded term data doesn't match unpacked_length", async () => {
+			const fixture = makeFixture();
+			// Corrupt the expected length of the second term
+			fixture.reconstructionInfo.terms[1].unpacked_length = 9999;
+
+			const blob = new XetBlob({
+				hash: "test",
+				size: fixture.wholeText.length,
+				refreshUrl: "https://huggingface.co",
+				fetch: async function (_url) {
+					const url = new URL(_url as string);
+
+					switch (url.hostname) {
+						case "huggingface.co":
+							return new Response(JSON.stringify({ casUrl: "https://cas.co", accessToken: "boo", exp: 1_000_000 }));
+						case "cas.co":
+							return new Response(JSON.stringify(fixture.reconstructionInfo));
+						case "xorb.co":
+							return makeMultipartResponse("BOUNDARY", [
+								{ range: { start: 0, end: fixture.lenA - 1 }, total: fixture.total, data: fixture.rangeAData },
+								{
+									range: { start: fixture.lenA, end: fixture.total - 1 },
+									total: fixture.total,
+									data: fixture.rangeBData,
+								},
+							]);
+						default:
+							throw new Error(`Unhandled URL ${url.hostname}`);
+					}
+				},
+			});
+
+			await expect(blob.text()).rejects.toThrow(/expected 9999/);
+		});
 	});
 
 	describe("bg4_regoup_bytes", () => {
@@ -324,15 +658,16 @@ describe("XetBlob", () => {
 												},
 												unpacked_length: chunk1Content.length + chunk2Content.length,
 											})),
-										fetch_info: {
+										xorbs: {
 											test: [
 												{
 													url: "https://fetch.co",
-													range: { start: 0, end: 2 },
-													url_range: {
-														start: 0,
-														end: mergedChunks.byteLength / 1000 - 1,
-													},
+													ranges: [
+														{
+															chunks: { start: 0, end: 2 },
+															bytes: { start: 0, end: mergedChunks.byteLength / 1000 - 1 },
+														},
+													],
 												},
 											],
 										},
@@ -427,25 +762,27 @@ describe("XetBlob", () => {
 												},
 												unpacked_length: chunk1Content.length + chunk2Content.length,
 											})),
-										fetch_info: {
+										xorbs: {
 											test0: [
 												{
 													url: "https://fetch.co",
-													range: { start: 0, end: 2 },
-													url_range: {
-														start: 0,
-														end: mergedChunks.byteLength - 1,
-													},
+													ranges: [
+														{
+															chunks: { start: 0, end: 2 },
+															bytes: { start: 0, end: mergedChunks.byteLength - 1 },
+														},
+													],
 												},
 											],
 											test1: [
 												{
 													url: "https://fetch.co",
-													range: { start: 0, end: 2 },
-													url_range: {
-														start: 0,
-														end: mergedChunks.byteLength - 1,
-													},
+													ranges: [
+														{
+															chunks: { start: 0, end: 2 },
+															bytes: { start: 0, end: mergedChunks.byteLength - 1 },
+														},
+													],
 												},
 											],
 										},
@@ -542,15 +879,16 @@ describe("XetBlob", () => {
 												unpacked_length: chunk1Content.length + chunk2Content.length,
 											},
 										],
-										fetch_info: {
+										xorbs: {
 											test: [
 												{
 													url: "https://fetch.co",
-													range: { start: 0, end: 2000 },
-													url_range: {
-														start: 0,
-														end: totalChunkLength - 1,
-													},
+													ranges: [
+														{
+															chunks: { start: 0, end: 2000 },
+															bytes: { start: 0, end: totalChunkLength - 1 },
+														},
+													],
 												},
 											],
 										},
@@ -652,15 +990,16 @@ describe("XetBlob", () => {
 												},
 												unpacked_length: chunk1Content.length + chunk2Content.length,
 											})),
-										fetch_info: {
+										xorbs: {
 											test: [
 												{
 													url: "https://fetch.co",
-													range: { start: 0, end: 2 },
-													url_range: {
-														start: 0,
-														end: totalChunkLength - 1,
-													},
+													ranges: [
+														{
+															chunks: { start: 0, end: 2 },
+															bytes: { start: 0, end: totalChunkLength - 1 },
+														},
+													],
 												},
 											],
 										},
@@ -760,15 +1099,16 @@ describe("XetBlob", () => {
 												},
 												unpacked_length: chunk1Content.length + chunk2Content.length,
 											})),
-										fetch_info: {
+										xorbs: {
 											test: [
 												{
 													url: "https://fetch.co",
-													range: { start: 0, end: 2 },
-													url_range: {
-														start: 0,
-														end: totalChunkLength - 1,
-													},
+													ranges: [
+														{
+															chunks: { start: 0, end: 2 },
+															bytes: { start: 0, end: totalChunkLength - 1 },
+														},
+													],
 												},
 											],
 										},
@@ -867,15 +1207,16 @@ describe("XetBlob", () => {
 												},
 												unpacked_length: chunk1Content.length + chunk2Content.length,
 											})),
-										fetch_info: {
+										xorbs: {
 											test: [
 												{
 													url: "https://fetch.co",
-													range: { start: 0, end: 2 },
-													url_range: {
-														start: 0,
-														end: totalChunkLength - 1,
-													},
+													ranges: [
+														{
+															chunks: { start: 0, end: 2 },
+															bytes: { start: 0, end: totalChunkLength - 1 },
+														},
+													],
 												},
 											],
 										},

--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -366,7 +366,7 @@ describe("XetBlob", () => {
 				},
 			});
 
-			await expect(blob.text()).rejects.toThrow(/Missing multipart part/);
+			await expect(blob.text()).rejects.toThrow(/produced 1 parts but expected 2/);
 		});
 
 		it("handles a single-range fetch entry without multipart", async () => {

--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -1,16 +1,10 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { ReconstructionInfo } from "./XetBlob";
-import { bg4_regroup_bytes, bg4_split_bytes, clearMultiRangeSupportCache, XetBlob } from "./XetBlob";
+import { bg4_regroup_bytes, bg4_split_bytes, XetBlob } from "./XetBlob";
 import { combineUint8Arrays } from "./combineUint8Arrays";
 import { sum } from "./sum";
 
 describe("XetBlob", () => {
-	beforeEach(() => {
-		// Multi-range support detection is cached per host at module scope;
-		// reset it so tests don't leak state into each other.
-		clearMultiRangeSupportCache();
-	});
-
 	it("should handle empty files (size 0) without making network requests", async () => {
 		let fetchCount = 0;
 
@@ -317,10 +311,8 @@ describe("XetBlob", () => {
 			expect(multiRangeHeader).toBe(`bytes=0-${fixture.lenA - 1},${fixture.lenA}-${fixture.total - 1}`);
 		});
 
-		it("falls back to one request per range when the server ignores the multi-range request", async () => {
+		it("throws when the server doesn't answer a multi-range request with multipart/byteranges", async () => {
 			const fixture = makeFixture();
-
-			const rangeHeaders: Array<string | undefined> = [];
 
 			const blob = new XetBlob({
 				hash: "test",
@@ -335,79 +327,46 @@ describe("XetBlob", () => {
 							return new Response(JSON.stringify({ casUrl: "https://cas.co", accessToken: "boo", exp: 1_000_000 }));
 						case "cas.co":
 							return new Response(JSON.stringify(fixture.reconstructionInfo));
-						case "xorb.co": {
-							const range = headers?.["Range"];
-							rangeHeaders.push(range);
-							if (range?.includes(",")) {
-								// Like S3, ignore the multi-range request and return the whole object with a 200.
-								return new Response(combineUint8Arrays(fixture.rangeAData, fixture.rangeBData));
-							}
-							if (range === `bytes=0-${fixture.lenA - 1}`) {
-								return new Response(fixture.rangeAData);
-							}
-							if (range === `bytes=${fixture.lenA}-${fixture.total - 1}`) {
-								return new Response(fixture.rangeBData);
-							}
-							throw new Error(`Unexpected Range header ${range}`);
-						}
+						case "xorb.co":
+							// The server ignored the multi-range request and returned the whole xorb.
+							expect(headers?.["Range"]).toBe(`bytes=0-${fixture.lenA - 1},${fixture.lenA}-${fixture.total - 1}`);
+							return new Response(combineUint8Arrays(fixture.rangeAData, fixture.rangeBData));
 						default:
 							throw new Error(`Unhandled URL ${url.hostname}`);
 					}
 				},
 			});
 
-			expect(await blob.text()).toBe(fixture.wholeText);
-			// 1 multi-range attempt + 1 fetch per range
-			expect(rangeHeaders).toEqual([
-				`bytes=0-${fixture.lenA - 1},${fixture.lenA}-${fixture.total - 1}`,
-				`bytes=0-${fixture.lenA - 1}`,
-				`bytes=${fixture.lenA}-${fixture.total - 1}`,
-			]);
+			await expect(blob.text()).rejects.toThrow(/multipart\/byteranges/);
 		});
 
-		it("remembers hosts that don't support multi-range requests", async () => {
+		it("throws when a multipart part is missing", async () => {
 			const fixture = makeFixture();
 
-			const multiRangeAttempts: string[] = [];
+			const blob = new XetBlob({
+				hash: "test",
+				size: fixture.wholeText.length,
+				refreshUrl: "https://huggingface.co",
+				fetch: async function (_url) {
+					const url = new URL(_url as string);
 
-			const makeBlob = () =>
-				new XetBlob({
-					hash: "test",
-					size: fixture.wholeText.length,
-					refreshUrl: "https://huggingface.co",
-					fetch: async function (_url, opts) {
-						const url = new URL(_url as string);
-						const headers = opts?.headers as Record<string, string> | undefined;
+					switch (url.hostname) {
+						case "huggingface.co":
+							return new Response(JSON.stringify({ casUrl: "https://cas.co", accessToken: "boo", exp: 1_000_000 }));
+						case "cas.co":
+							return new Response(JSON.stringify(fixture.reconstructionInfo));
+						case "xorb.co":
+							// Multipart response missing the second requested part.
+							return makeMultipartResponse("BOUNDARY", [
+								{ range: { start: 0, end: fixture.lenA - 1 }, total: fixture.total, data: fixture.rangeAData },
+							]);
+						default:
+							throw new Error(`Unhandled URL ${url.hostname}`);
+					}
+				},
+			});
 
-						switch (url.hostname) {
-							case "huggingface.co":
-								return new Response(JSON.stringify({ casUrl: "https://cas.co", accessToken: "boo", exp: 1_000_000 }));
-							case "cas.co":
-								return new Response(JSON.stringify(fixture.reconstructionInfo));
-							case "xorb.co": {
-								const range = headers?.["Range"];
-								if (range?.includes(",")) {
-									multiRangeAttempts.push(range);
-									return new Response(combineUint8Arrays(fixture.rangeAData, fixture.rangeBData));
-								}
-								if (range === `bytes=0-${fixture.lenA - 1}`) {
-									return new Response(fixture.rangeAData);
-								}
-								if (range === `bytes=${fixture.lenA}-${fixture.total - 1}`) {
-									return new Response(fixture.rangeBData);
-								}
-								throw new Error(`Unexpected Range header ${range}`);
-							}
-							default:
-								throw new Error(`Unhandled URL ${url.hostname}`);
-						}
-					},
-				});
-
-			expect(await makeBlob().text()).toBe(fixture.wholeText);
-			expect(await makeBlob().text()).toBe(fixture.wholeText);
-			// Only the first download attempts a multi-range request.
-			expect(multiRangeAttempts).toHaveLength(1);
+			await expect(blob.text()).rejects.toThrow(/Missing multipart part/);
 		});
 
 		it("handles a single-range fetch entry without multipart", async () => {

--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import type { ReconstructionInfo } from "./XetBlob";
 import { bg4_regroup_bytes, bg4_split_bytes, clearMultiRangeSupportCache, XetBlob } from "./XetBlob";
+import { combineUint8Arrays } from "./combineUint8Arrays";
 import { sum } from "./sum";
 
 describe("XetBlob", () => {
@@ -206,17 +207,6 @@ describe("XetBlob", () => {
 	});
 
 	describe("multi-range fetch entries", () => {
-		function concatBytes(...arrays: Uint8Array[]): Uint8Array {
-			const total = arrays.reduce((s, a) => s + a.byteLength, 0);
-			const out = new Uint8Array(total);
-			let offset = 0;
-			for (const a of arrays) {
-				out.set(a, offset);
-				offset += a.byteLength;
-			}
-			return out;
-		}
-
 		function makeMultipartResponse(
 			boundary: string,
 			parts: Array<{ range: { start: number; end: number }; total: number; data: Uint8Array }>,
@@ -234,7 +224,7 @@ describe("XetBlob", () => {
 			}
 			segments.push(enc.encode(`\r\n--${boundary}--\r\n`));
 
-			return new Response(concatBytes(...segments), {
+			return new Response(combineUint8Arrays(...segments), {
 				headers: { "Content-Type": `multipart/byteranges; boundary=${boundary}` },
 			});
 		}
@@ -250,8 +240,8 @@ describe("XetBlob", () => {
 
 		/** A xorb with two signed ranges: chunks [0,2) = "helloworld" and chunks [4,6) = "foobar!" */
 		function makeFixture(): XorbFixture {
-			const rangeAData = concatBytes(makeChunk("hello"), makeChunk("world"));
-			const rangeBData = concatBytes(makeChunk("foo"), makeChunk("bar!"));
+			const rangeAData = combineUint8Arrays(makeChunk("hello"), makeChunk("world"));
+			const rangeBData = combineUint8Arrays(makeChunk("foo"), makeChunk("bar!"));
 			const lenA = rangeAData.byteLength;
 			const total = lenA + rangeBData.byteLength;
 
@@ -350,7 +340,7 @@ describe("XetBlob", () => {
 							rangeHeaders.push(range);
 							if (range?.includes(",")) {
 								// Like S3, ignore the multi-range request and return the whole object with a 200.
-								return new Response(concatBytes(fixture.rangeAData, fixture.rangeBData));
+								return new Response(combineUint8Arrays(fixture.rangeAData, fixture.rangeBData));
 							}
 							if (range === `bytes=0-${fixture.lenA - 1}`) {
 								return new Response(fixture.rangeAData);
@@ -398,7 +388,7 @@ describe("XetBlob", () => {
 								const range = headers?.["Range"];
 								if (range?.includes(",")) {
 									multiRangeAttempts.push(range);
-									return new Response(concatBytes(fixture.rangeAData, fixture.rangeBData));
+									return new Response(combineUint8Arrays(fixture.rangeAData, fixture.rangeBData));
 								}
 								if (range === `bytes=0-${fixture.lenA - 1}`) {
 									return new Response(fixture.rangeAData);
@@ -421,7 +411,7 @@ describe("XetBlob", () => {
 		});
 
 		it("handles a single-range fetch entry without multipart", async () => {
-			const xorbData = concatBytes(makeChunk("hello"), makeChunk("world"));
+			const xorbData = combineUint8Arrays(makeChunk("hello"), makeChunk("world"));
 			const wholeText = "helloworld";
 
 			let fetchCount = 0;

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -4,6 +4,7 @@ import { checkCredentials } from "./checkCredentials";
 import { combineUint8Arrays } from "./combineUint8Arrays";
 import { decompress as lz4_decompress } from "../vendor/lz4js";
 import { RangeList } from "./RangeList";
+import { parseMultipartByteRanges } from "./multipart";
 
 const JWT_SAFETY_PERIOD = 60_000;
 const JWT_CACHE_SIZE = 1_000;
@@ -31,6 +32,13 @@ type XetBlobCreateOptions = {
 } & ({ hash: string; reconstructionUrl?: string } | { hash?: string; reconstructionUrl: string }) &
 	Partial<CredentialsParams>;
 
+/**
+ * Response shape of `GET /v2/reconstructions/{hash}`, see https://huggingface.co/docs/xet/en/download-protocol
+ *
+ * Unlike the (deprecated) V1 endpoint, a signed URL carries all the byte ranges needed from a xorb,
+ * signed together in the URL's `X-Xet-Signed-Range` query param. Requesting bytes outside that set
+ * fails authorization, which prevents a leaked URL from exposing arbitrary parts of the xorb.
+ */
 export interface ReconstructionInfo {
 	/**
 	 * List of CAS blocks
@@ -45,20 +53,26 @@ export interface ReconstructionInfo {
 	}>;
 
 	/**
-	 * Dictionnary of CAS block hash => list of ranges in the block + url to fetch it
+	 * Dictionnary of CAS block hash => list of fetch entries for the block.
+	 *
+	 * Typically one entry per xorb; multiple entries only when the signed URL would exceed the URL
+	 * length limit.
 	 */
-	fetch_info: Record<
+	xorbs: Record<
 		string,
 		Array<{
-			url: string;
-			/** Chunk range */
-			range: { start: number; end: number };
 			/**
-			 * Byte range, when making the call to the URL.
-			 *
-			 * We assume that we're given non-overlapping ranges for each hash
+			 * Signed URL covering all of `ranges`. The `Range` header sent to it must be built from
+			 * the `bytes` ranges below; requesting other bytes fails authorization.
 			 */
-			url_range: { start: number; end: number };
+			url: string;
+			/** Fragmented ranges, ordered by ascending `chunks.start` */
+			ranges: Array<{
+				/** Chunk index range within the xorb, end-exclusive: [start, end) */
+				chunks: { start: number; end: number };
+				/** Physical byte range for the HTTP Range header, end-inclusive: [start, end] */
+				bytes: { start: number; end: number };
+			}>;
 		}>
 	>;
 	/**
@@ -66,6 +80,9 @@ export interface ReconstructionInfo {
 	 */
 	offset_into_first_range: number;
 }
+
+type XorbFetchEntry = ReconstructionInfo["xorbs"][string][number];
+type XorbRangeDescriptor = XorbFetchEntry["ranges"][number];
 
 export enum XetChunkCompressionScheme {
 	None = 0,
@@ -87,6 +104,115 @@ interface ChunkHeader {
 }
 
 export const XET_CHUNK_HEADER_BYTES = 8;
+
+function parseChunkHeader(view: DataView): ChunkHeader {
+	const chunkHeader: ChunkHeader = {
+		version: view.getUint8(0),
+		compressed_length: view.getUint8(1) | (view.getUint8(2) << 8) | (view.getUint8(3) << 16),
+		compression_scheme: view.getUint8(4),
+		uncompressed_length: view.getUint8(5) | (view.getUint8(6) << 8) | (view.getUint8(7) << 16),
+	};
+
+	if (chunkHeader.version !== 0) {
+		throw new Error(`Unsupported chunk version ${chunkHeader.version}`);
+	}
+
+	if (
+		chunkHeader.compression_scheme !== XetChunkCompressionScheme.None &&
+		chunkHeader.compression_scheme !== XetChunkCompressionScheme.LZ4 &&
+		chunkHeader.compression_scheme !== XetChunkCompressionScheme.ByteGroupingLZ4
+	) {
+		throw new Error(
+			`Unsupported compression scheme ${
+				compressionSchemeLabels[chunkHeader.compression_scheme] ?? chunkHeader.compression_scheme
+			}`,
+		);
+	}
+
+	return chunkHeader;
+}
+
+function decompressChunk(chunkHeader: ChunkHeader, compressed: Uint8Array): Uint8Array {
+	switch (chunkHeader.compression_scheme) {
+		case XetChunkCompressionScheme.LZ4:
+			return lz4_decompress(compressed, chunkHeader.uncompressed_length);
+		case XetChunkCompressionScheme.ByteGroupingLZ4:
+			return bg4_regroup_bytes(lz4_decompress(compressed, chunkHeader.uncompressed_length));
+		default:
+			// Copy so we don't retain the (possibly much larger) source buffer
+			return compressed.slice();
+	}
+}
+
+/**
+ * Decode a fully-buffered xorb chunk stream (one `multipart/byteranges` part) and store the
+ * decompressed chunks into the range list, so the term reader can yield them from cache.
+ *
+ * Data is only committed when the whole part decodes cleanly and produces exactly the chunks the
+ * descriptor covers, so a truncated/corrupt part never leaves partial data in the cache.
+ */
+function storeChunks(data: Uint8Array, descriptor: XorbRangeDescriptor, rangeList: RangeList<Uint8Array[]>): void {
+	const ranges = rangeList.getRanges(descriptor.chunks.start, descriptor.chunks.end);
+	const staged = new Map<(typeof ranges)[number], Uint8Array[]>();
+	let chunkIndex = descriptor.chunks.start;
+	let offset = 0;
+
+	while (offset < data.byteLength) {
+		if (chunkIndex >= descriptor.chunks.end) {
+			throw new Error(
+				`Multipart part for chunks ${descriptor.chunks.start}-${descriptor.chunks.end} contains more chunks than expected`,
+			);
+		}
+		if (data.byteLength - offset < XET_CHUNK_HEADER_BYTES) {
+			throw new Error("Truncated chunk header in multipart part");
+		}
+
+		const chunkHeader = parseChunkHeader(new DataView(data.buffer, data.byteOffset + offset, XET_CHUNK_HEADER_BYTES));
+		const compressedStart = offset + XET_CHUNK_HEADER_BYTES;
+		const compressedEnd = compressedStart + chunkHeader.compressed_length;
+
+		if (compressedEnd > data.byteLength) {
+			throw new Error("Truncated chunk data in multipart part");
+		}
+
+		const uncompressed = decompressChunk(chunkHeader, data.subarray(compressedStart, compressedEnd));
+
+		const range = ranges.find((range) => chunkIndex >= range.start && chunkIndex < range.end);
+		if (range) {
+			let chunks = staged.get(range);
+			if (!chunks) {
+				chunks = [];
+				staged.set(range, chunks);
+			}
+			chunks.push(uncompressed);
+		}
+
+		chunkIndex++;
+		offset = compressedEnd;
+	}
+
+	if (chunkIndex !== descriptor.chunks.end) {
+		throw new Error(
+			`Multipart part decoded chunks ${descriptor.chunks.start}-${chunkIndex} but expected ${descriptor.chunks.start}-${descriptor.chunks.end}`,
+		);
+	}
+
+	for (const [range, chunks] of staged) {
+		range.data = chunks;
+	}
+}
+
+/**
+ * Hosts of signed URLs known to not support multi-range `Range` headers (eg raw S3 presigned URLs,
+ * which reply with the whole object). For those, each range is fetched with its own request — every
+ * individual range is part of the URL's signed range set, so single-range requests stay authorized.
+ */
+const multiRangeUnsupportedHosts = new Set<string>();
+
+// Exported for testing purposes: reset the per-host multi-range support cache.
+export function clearMultiRangeSupportCache(): void {
+	multiRangeUnsupportedHosts.clear();
+}
 
 /**
  * XetBlob is a blob implementation that fetches data directly from the Xet storage
@@ -176,11 +302,15 @@ export class XetBlob extends Blob {
 		this.#reconstructionInfoPromise = (async () => {
 			const connParams = await getAccessToken(this.accessToken, this.fetch, this.refreshUrl);
 
-			// debug(
-			// 	`curl '${connParams.casUrl}/v1/reconstructions/${this.hash}' -H 'Authorization: Bearer ${connParams.accessToken}'`
-			// );
+			// The `xet-reconstruction-info` Link header from the Hub points to the deprecated V1
+			// endpoint; derive the V2 URL from it.
+			const url = this.reconstructionUrl
+				? this.reconstructionUrl.replace("/v1/reconstructions/", "/v2/reconstructions/")
+				: `${connParams.casUrl}/v2/reconstructions/${this.hash}`;
 
-			const resp = await this.fetch(this.reconstructionUrl ?? `${connParams.casUrl}/v1/reconstructions/${this.hash}`, {
+			// debug(`curl '${url}' -H 'Authorization: Bearer ${connParams.accessToken}'`);
+
+			const resp = await this.fetch(url, {
 				headers: {
 					Authorization: `Bearer ${connParams.accessToken}`,
 					Range: `bytes=${this.start}-${this.end - 1}`,
@@ -249,11 +379,103 @@ export class XetBlob extends Blob {
 					throw new Error(`Failed to find range list for term ${term.hash}`);
 				}
 
-				{
-					const termRanges = rangeList.getRanges(term.range.start, term.range.end);
+				// Locate the fetch entry + range descriptor whose chunk range covers this term
+				const locate = (info: ReconstructionInfo) => {
+					for (const entry of info.xorbs[term.hash] ?? []) {
+						const descriptor = entry.ranges.find(
+							(r) => r.chunks.start <= term.range.start && r.chunks.end >= term.range.end,
+						);
+						if (descriptor) {
+							return { entry, descriptor };
+						}
+					}
+					return undefined;
+				};
 
+				const buildMultiRangeHeader = (entry: XorbFetchEntry) =>
+					`bytes=${entry.ranges.map((r) => `${r.bytes.start}-${r.bytes.end}`).join(",")}`;
+
+				// Fetch all signed ranges of a multi-range entry in a single request, and store the
+				// decoded chunks into the cache. Returns false when the server ignored the multi-range
+				// request (eg S3 presigned URLs), in which case ranges are fetched individually instead.
+				const fetchMultiRangeEntry = async (entry: XorbFetchEntry): Promise<boolean> => {
+					let resp = await customFetch(entry.url, { headers: { Range: buildMultiRangeHeader(entry) } });
+
+					if (resp.status === 403) {
+						// In case it's expired
+						reconstructionInfo = await reloadReconstructionInfo();
+						const relocated = locate(reconstructionInfo);
+						if (!relocated) {
+							throw new Error(
+								`Failed to find fetch info for term ${term.hash} and range ${term.range.start}-${term.range.end} after refresh`,
+							);
+						}
+						entry = relocated.entry;
+						resp = await customFetch(entry.url, { headers: { Range: buildMultiRangeHeader(entry) } });
+					}
+
+					if (!resp.ok) {
+						throw await createApiError(resp);
+					}
+
+					const contentType = resp.headers.get("content-type") ?? "";
+					if (!contentType.includes("multipart/byteranges")) {
+						// The server ignored (or coalesced) the multi-range request. Cancel the body and
+						// remember to fetch each range individually for this host.
+						log("multi-range request not honored, content-type", contentType);
+						multiRangeUnsupportedHosts.add(new URL(entry.url).host);
+						await resp.body?.cancel();
+						return false;
+					}
+
+					listener?.({ event: "read" });
+					const body = new Uint8Array(await resp.arrayBuffer());
+					const parts = parseMultipartByteRanges(contentType, body);
+
+					for (const descriptor of entry.ranges) {
+						const part = parts.find(
+							(p) => p.range.start === descriptor.bytes.start && p.range.end === descriptor.bytes.end,
+						);
+						if (!part) {
+							// Missing part: the ranges it covers will be fetched individually when needed
+							log("missing multipart part for bytes", descriptor.bytes.start, "-", descriptor.bytes.end);
+							continue;
+						}
+						storeChunks(part.data, descriptor, rangeList);
+					}
+					return true;
+				};
+
+				let termRanges = rangeList.getRanges(term.range.start, term.range.end);
+
+				if (!termRanges.every((range) => range.data)) {
+					const located = locate(reconstructionInfo);
+					if (!located) {
+						throw new Error(
+							`Failed to find fetch info for term ${term.hash} and range ${term.range.start}-${term.range.end}`,
+						);
+					}
+					if (located.entry.ranges.length > 1 && !multiRangeUnsupportedHosts.has(new URL(located.entry.url).host)) {
+						await fetchMultiRangeEntry(located.entry);
+						termRanges = rangeList.getRanges(term.range.start, term.range.end);
+					}
+				}
+
+				{
 					if (termRanges.every((range) => range.data)) {
 						log("all data available for term", term.hash, readBytesToSkip);
+
+						const cachedLength = termRanges.reduce(
+							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+							(sum, range) => sum + range.data!.reduce((acc, chunk) => acc + chunk.byteLength, 0),
+							0,
+						);
+						if (cachedLength !== term.unpacked_length) {
+							throw new Error(
+								`Term ${term.hash} range ${term.range.start}-${term.range.end} decoded to ${cachedLength} bytes, expected ${term.unpacked_length}`,
+							);
+						}
+
 						rangeLoop: for (const range of termRanges) {
 							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 							for (let chunk of range.data!) {
@@ -284,40 +506,41 @@ export class XetBlob extends Blob {
 					}
 				}
 
-				let fetchInfo = reconstructionInfo.fetch_info[term.hash].find(
-					(info) => info.range.start <= term.range.start && info.range.end >= term.range.end,
-				);
+				// Stream a single range: fetch the descriptor covering this term with a single-range
+				// header. Each individual range is part of the URL's signed range set, so this stays
+				// authorized even when the multi-range request isn't supported by the server.
+				let located = locate(reconstructionInfo);
 
-				if (!fetchInfo) {
+				if (!located) {
 					throw new Error(
 						`Failed to find fetch info for term ${term.hash} and range ${term.range.start}-${term.range.end}`,
 					);
 				}
+				let descriptor = located.descriptor;
 
 				log("term", term);
-				log("fetchinfo", fetchInfo);
+				log("descriptor", descriptor);
 				log("readBytesToSkip", readBytesToSkip);
 
-				let resp = await customFetch(fetchInfo.url, {
+				let resp = await customFetch(located.entry.url, {
 					headers: {
-						Range: `bytes=${fetchInfo.url_range.start}-${fetchInfo.url_range.end}`,
+						Range: `bytes=${descriptor.bytes.start}-${descriptor.bytes.end}`,
 					},
 				});
 
 				if (resp.status === 403) {
 					// In case it's expired
 					reconstructionInfo = await reloadReconstructionInfo();
-					fetchInfo = reconstructionInfo.fetch_info[term.hash]?.find(
-						(info) => info.range.start <= term.range.start && info.range.end >= term.range.end,
-					);
-					if (!fetchInfo) {
+					located = locate(reconstructionInfo);
+					if (!located) {
 						throw new Error(
 							`Failed to find fetch info for term ${term.hash} and range ${term.range.start}-${term.range.end} after refresh`,
 						);
 					}
-					resp = await customFetch(fetchInfo.url, {
+					descriptor = located.descriptor;
+					resp = await customFetch(located.entry.url, {
 						headers: {
-							Range: `bytes=${fetchInfo.url_range.start}-${fetchInfo.url_range.end}`,
+							Range: `bytes=${descriptor.bytes.start}-${descriptor.bytes.end}`,
 						},
 					});
 				}
@@ -330,7 +553,7 @@ export class XetBlob extends Blob {
 					"expected content length",
 					resp.headers.get("content-length"),
 					"range",
-					fetchInfo.url_range,
+					descriptor.bytes,
 					resp.headers.get("content-range"),
 				);
 
@@ -340,8 +563,8 @@ export class XetBlob extends Blob {
 				}
 
 				let done = false;
-				let chunkIndex = fetchInfo.range.start;
-				const ranges = rangeList.getRanges(fetchInfo.range.start, fetchInfo.range.end);
+				let chunkIndex = descriptor.chunks.start;
+				const ranges = rangeList.getRanges(descriptor.chunks.start, descriptor.chunks.end);
 
 				let leftoverBytes: Uint8Array | undefined = undefined;
 				let totalFetchBytes = 0;
@@ -374,30 +597,9 @@ export class XetBlob extends Blob {
 						}
 
 						const header = new DataView(result.value.buffer, result.value.byteOffset, XET_CHUNK_HEADER_BYTES);
-						const chunkHeader: ChunkHeader = {
-							version: header.getUint8(0),
-							compressed_length: header.getUint8(1) | (header.getUint8(2) << 8) | (header.getUint8(3) << 16),
-							compression_scheme: header.getUint8(4),
-							uncompressed_length: header.getUint8(5) | (header.getUint8(6) << 8) | (header.getUint8(7) << 16),
-						};
+						const chunkHeader = parseChunkHeader(header);
 
 						log("chunk header", chunkHeader, "to skip", readBytesToSkip);
-
-						if (chunkHeader.version !== 0) {
-							throw new Error(`Unsupported chunk version ${chunkHeader.version}`);
-						}
-
-						if (
-							chunkHeader.compression_scheme !== XetChunkCompressionScheme.None &&
-							chunkHeader.compression_scheme !== XetChunkCompressionScheme.LZ4 &&
-							chunkHeader.compression_scheme !== XetChunkCompressionScheme.ByteGroupingLZ4
-						) {
-							throw new Error(
-								`Unsupported compression scheme ${
-									compressionSchemeLabels[chunkHeader.compression_scheme] ?? chunkHeader.compression_scheme
-								}`,
-							);
-						}
 
 						if (result.value.byteLength < chunkHeader.compressed_length + XET_CHUNK_HEADER_BYTES) {
 							// We need more data to read the full chunk
@@ -407,24 +609,14 @@ export class XetBlob extends Blob {
 
 						result.value = result.value.slice(XET_CHUNK_HEADER_BYTES);
 
-						let uncompressed =
-							chunkHeader.compression_scheme === XetChunkCompressionScheme.LZ4
-								? lz4_decompress(result.value.slice(0, chunkHeader.compressed_length), chunkHeader.uncompressed_length)
-								: chunkHeader.compression_scheme === XetChunkCompressionScheme.ByteGroupingLZ4
-									? bg4_regroup_bytes(
-											lz4_decompress(
-												result.value.slice(0, chunkHeader.compressed_length),
-												chunkHeader.uncompressed_length,
-											),
-										)
-									: result.value.slice(0, chunkHeader.compressed_length);
+						let uncompressed = decompressChunk(chunkHeader, result.value.subarray(0, chunkHeader.compressed_length));
 
 						const range = ranges.find((range) => chunkIndex >= range.start && chunkIndex < range.end);
 						const shouldYield = chunkIndex >= term.range.start && chunkIndex < term.range.end;
 						const minRefCountToStore = shouldYield ? 2 : 1;
 						let stored = false;
 
-						// Assuming non-overlapping fetch_info ranges for the same hash
+						// Assuming non-overlapping fetch ranges for the same hash
 						if (range && range.refCount >= minRefCountToStore) {
 							range.data ??= [];
 							range.data.push(uncompressed);
@@ -463,16 +655,12 @@ export class XetBlob extends Blob {
 					}
 				}
 
-				if (
-					done &&
-					totalBytesRead < maxBytes &&
-					totalFetchBytes < fetchInfo.url_range.end - fetchInfo.url_range.start + 1
-				) {
+				if (done && totalBytesRead < maxBytes && totalFetchBytes < descriptor.bytes.end - descriptor.bytes.start + 1) {
 					log("done", done, "total read", totalBytesRead, maxBytes, totalFetchBytes);
 					log("failed to fetch all data for term", term.hash);
 					throw new Error(
 						`Failed to fetch all data for term ${term.hash}, fetched ${totalFetchBytes} bytes out of ${
-							fetchInfo.url_range.end - fetchInfo.url_range.start + 1
+							descriptor.bytes.end - descriptor.bytes.start + 1
 						}`,
 					);
 				}

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -4,7 +4,7 @@ import { checkCredentials } from "./checkCredentials";
 import { combineUint8Arrays } from "./combineUint8Arrays";
 import { decompress as lz4_decompress } from "../vendor/lz4js";
 import { RangeList } from "./RangeList";
-import { parseMultipartByteRanges } from "./multipart";
+import { StreamingMultipartParser } from "./multipart";
 
 const JWT_SAFETY_PERIOD = 60_000;
 const JWT_CACHE_SIZE = 1_000;
@@ -144,16 +144,20 @@ function decompressChunk(chunkHeader: ChunkHeader, compressed: Uint8Array): Uint
 	}
 }
 
+type StagedChunks = Map<{ data: Uint8Array[] | null }, Uint8Array[]>;
+
 /**
- * Decode a fully-buffered xorb chunk stream (one `multipart/byteranges` part) and store the
- * decompressed chunks into the range list, so the term reader can yield them from cache.
- *
- * Data is only committed when the whole part decodes cleanly and produces exactly the chunks the
- * descriptor covers, so a truncated/corrupt part never leaves partial data in the cache.
+ * Decode one complete xorb chunk stream (a single `multipart/byteranges` part) into per-range
+ * staged chunk arrays. Throws if it doesn't decode to exactly the chunks the descriptor covers,
+ * so a truncated/corrupt part never leaves partial data to be committed to the cache.
  */
-function storeChunks(data: Uint8Array, descriptor: XorbRangeDescriptor, rangeList: RangeList<Uint8Array[]>): void {
+function decodePartChunks(
+	data: Uint8Array,
+	descriptor: XorbRangeDescriptor,
+	rangeList: RangeList<Uint8Array[]>,
+): StagedChunks {
 	const ranges = rangeList.getRanges(descriptor.chunks.start, descriptor.chunks.end);
-	const staged = new Map<(typeof ranges)[number], Uint8Array[]>();
+	const staged: StagedChunks = new Map();
 	let chunkIndex = descriptor.chunks.start;
 	let offset = 0;
 
@@ -197,6 +201,10 @@ function storeChunks(data: Uint8Array, descriptor: XorbRangeDescriptor, rangeLis
 		);
 	}
 
+	return staged;
+}
+
+function commitChunks(staged: StagedChunks): void {
 	for (const [range, chunks] of staged) {
 		range.data = chunks;
 	}
@@ -414,20 +422,54 @@ export class XetBlob extends Blob {
 						throw new Error(`Expected multipart/byteranges response for multi-range request, got "${contentType}"`);
 					}
 
-					listener?.({ event: "read" });
-					const body = new Uint8Array(await resp.arrayBuffer());
-					const parts = parseMultipartByteRanges(contentType, body);
+					const reader = resp.body?.getReader();
+					if (!reader) {
+						throw new Error("Failed to get reader from response body");
+					}
 
-					for (const descriptor of entry.ranges) {
-						const part = parts.find(
-							(p) => p.range.start === descriptor.bytes.start && p.range.end === descriptor.bytes.end,
-						);
-						if (!part) {
-							throw new Error(
-								`Missing multipart part for bytes ${descriptor.bytes.start}-${descriptor.bytes.end} of term ${term.hash}`,
-							);
+					// Stream the body: decode each part as it completes and stage its chunks, so memory
+					// stays bounded by the largest part instead of the whole xorb. Parts arrive in the
+					// same ascending order as the entry's ranges.
+					const parser = new StreamingMultipartParser(contentType);
+					const stagedParts: StagedChunks[] = [];
+					let partIndex = 0;
+
+					const consumeParts = (parts: Uint8Array[]) => {
+						for (const part of parts) {
+							const descriptor = entry.ranges[partIndex];
+							if (!descriptor) {
+								throw new Error(`Received more multipart parts than the ${entry.ranges.length} signed ranges`);
+							}
+							stagedParts.push(decodePartChunks(part, descriptor, rangeList));
+							partIndex++;
 						}
-						storeChunks(part.data, descriptor, rangeList);
+					};
+
+					try {
+						for (;;) {
+							const result = await reader.read();
+							listener?.({ event: "read" });
+							if (result.done) {
+								break;
+							}
+							if (result.value) {
+								consumeParts(parser.push(result.value));
+							}
+						}
+						consumeParts(parser.push());
+					} finally {
+						await reader.cancel().catch(() => {});
+					}
+
+					if (partIndex !== entry.ranges.length) {
+						throw new Error(
+							`Multi-range fetch produced ${partIndex} parts but expected ${entry.ranges.length} for term ${term.hash}`,
+						);
+					}
+
+					// All parts decoded cleanly and cover every signed range: commit to the cache.
+					for (const staged of stagedParts) {
+						commitChunks(staged);
 					}
 				};
 

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -203,18 +203,6 @@ function storeChunks(data: Uint8Array, descriptor: XorbRangeDescriptor, rangeLis
 }
 
 /**
- * Hosts of signed URLs known to not support multi-range `Range` headers (eg raw S3 presigned URLs,
- * which reply with the whole object). For those, each range is fetched with its own request — every
- * individual range is part of the URL's signed range set, so single-range requests stay authorized.
- */
-const multiRangeUnsupportedHosts = new Set<string>();
-
-// Exported for testing purposes: reset the per-host multi-range support cache.
-export function clearMultiRangeSupportCache(): void {
-	multiRangeUnsupportedHosts.clear();
-}
-
-/**
  * XetBlob is a blob implementation that fetches data directly from the Xet storage
  */
 export class XetBlob extends Blob {
@@ -396,9 +384,10 @@ export class XetBlob extends Blob {
 					`bytes=${entry.ranges.map((r) => `${r.bytes.start}-${r.bytes.end}`).join(",")}`;
 
 				// Fetch all signed ranges of a multi-range entry in a single request, and store the
-				// decoded chunks into the cache. Returns false when the server ignored the multi-range
-				// request (eg S3 presigned URLs), in which case ranges are fetched individually instead.
-				const fetchMultiRangeEntry = async (entry: XorbFetchEntry): Promise<boolean> => {
+				// decoded chunks into the cache. The reconstruction server is expected to only emit
+				// multi-range URLs when its CDN supports them; servers without multi-range support get
+				// one fetch entry per range instead (single-range streaming path below).
+				const fetchMultiRangeEntry = async (entry: XorbFetchEntry): Promise<void> => {
 					let resp = await customFetch(entry.url, { headers: { Range: buildMultiRangeHeader(entry) } });
 
 					if (resp.status === 403) {
@@ -420,12 +409,9 @@ export class XetBlob extends Blob {
 
 					const contentType = resp.headers.get("content-type") ?? "";
 					if (!contentType.includes("multipart/byteranges")) {
-						// The server ignored (or coalesced) the multi-range request. Cancel the body and
-						// remember to fetch each range individually for this host.
-						log("multi-range request not honored, content-type", contentType);
-						multiRangeUnsupportedHosts.add(new URL(entry.url).host);
-						await resp.body?.cancel();
-						return false;
+						// The server ignored (or coalesced) the multi-range request, so the body can't be
+						// mapped back to the signed ranges; decoding it heuristically would risk corruption.
+						throw new Error(`Expected multipart/byteranges response for multi-range request, got "${contentType}"`);
 					}
 
 					listener?.({ event: "read" });
@@ -437,13 +423,12 @@ export class XetBlob extends Blob {
 							(p) => p.range.start === descriptor.bytes.start && p.range.end === descriptor.bytes.end,
 						);
 						if (!part) {
-							// Missing part: the ranges it covers will be fetched individually when needed
-							log("missing multipart part for bytes", descriptor.bytes.start, "-", descriptor.bytes.end);
-							continue;
+							throw new Error(
+								`Missing multipart part for bytes ${descriptor.bytes.start}-${descriptor.bytes.end} of term ${term.hash}`,
+							);
 						}
 						storeChunks(part.data, descriptor, rangeList);
 					}
-					return true;
 				};
 
 				let termRanges = rangeList.getRanges(term.range.start, term.range.end);
@@ -455,7 +440,7 @@ export class XetBlob extends Blob {
 							`Failed to find fetch info for term ${term.hash} and range ${term.range.start}-${term.range.end}`,
 						);
 					}
-					if (located.entry.ranges.length > 1 && !multiRangeUnsupportedHosts.has(new URL(located.entry.url).host)) {
+					if (located.entry.ranges.length > 1) {
 						await fetchMultiRangeEntry(located.entry);
 						termRanges = rangeList.getRanges(term.range.start, term.range.end);
 					}

--- a/packages/hub/src/utils/combineUint8Arrays.spec.ts
+++ b/packages/hub/src/utils/combineUint8Arrays.spec.ts
@@ -12,4 +12,12 @@ describe("combineUint8Arrays", () => {
 		const result = combineUint8Arrays(new Uint8Array(a), new Uint8Array(b));
 		expect(result).toEqual(new Uint8Array(expected));
 	});
+
+	it("combines any number of arrays", () => {
+		expect(combineUint8Arrays()).toEqual(new Uint8Array([]));
+		expect(combineUint8Arrays(new Uint8Array([1, 2]))).toEqual(new Uint8Array([1, 2]));
+		expect(combineUint8Arrays(new Uint8Array([1]), new Uint8Array([]), new Uint8Array([2, 3]))).toEqual(
+			new Uint8Array([1, 2, 3]),
+		);
+	});
 });

--- a/packages/hub/src/utils/combineUint8Arrays.ts
+++ b/packages/hub/src/utils/combineUint8Arrays.ts
@@ -1,10 +1,10 @@
-export function combineUint8Arrays(
-	a: Uint8Array<ArrayBufferLike>,
-	b: Uint8Array<ArrayBufferLike>,
-): Uint8Array<ArrayBuffer> {
-	const aLength = a.length;
-	const combinedBytes = new Uint8Array(aLength + b.length);
-	combinedBytes.set(a);
-	combinedBytes.set(b, aLength);
+export function combineUint8Arrays(...arrays: Array<Uint8Array<ArrayBufferLike>>): Uint8Array<ArrayBuffer> {
+	const totalLength = arrays.reduce((sum, array) => sum + array.length, 0);
+	const combinedBytes = new Uint8Array(totalLength);
+	let offset = 0;
+	for (const array of arrays) {
+		combinedBytes.set(array, offset);
+		offset += array.length;
+	}
 	return combinedBytes;
 }

--- a/packages/hub/src/utils/indexOfSubsequence.spec.ts
+++ b/packages/hub/src/utils/indexOfSubsequence.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { indexOfSubsequence } from "./indexOfSubsequence";
+
+const enc = new TextEncoder();
+
+describe("indexOfSubsequence", () => {
+	it("finds a subsequence", () => {
+		expect(indexOfSubsequence(enc.encode("hello world"), enc.encode("world"))).toBe(6);
+	});
+
+	it("finds binary subsequences", () => {
+		expect(indexOfSubsequence(new Uint8Array([1, 2, 3, 4, 3, 4, 5]), new Uint8Array([3, 4, 5]))).toBe(4);
+	});
+
+	it("returns -1 when not found", () => {
+		expect(indexOfSubsequence(enc.encode("hello"), enc.encode("goodbye"))).toBe(-1);
+	});
+
+	it("respects the from offset", () => {
+		expect(indexOfSubsequence(enc.encode("abab"), enc.encode("ab"), 1)).toBe(2);
+	});
+
+	it("finds a match at the start", () => {
+		expect(indexOfSubsequence(enc.encode("abc"), enc.encode("abc"))).toBe(0);
+	});
+
+	it("returns -1 when the needle is longer than the haystack", () => {
+		expect(indexOfSubsequence(enc.encode("ab"), enc.encode("abc"))).toBe(-1);
+	});
+
+	it("finds overlapping matches correctly", () => {
+		expect(indexOfSubsequence(enc.encode("aaaa"), enc.encode("aa"))).toBe(0);
+		expect(indexOfSubsequence(enc.encode("aaaa"), enc.encode("aa"), 1)).toBe(1);
+	});
+
+	it("handles an empty needle", () => {
+		expect(indexOfSubsequence(enc.encode("abc"), enc.encode(""))).toBe(0);
+		expect(indexOfSubsequence(enc.encode("abc"), enc.encode(""), 2)).toBe(2);
+	});
+
+	it("doesn't get fooled by repeated prefixes in the needle", () => {
+		// "aab" inside "aaab": naive bad-skip could miss the match at index 1
+		expect(indexOfSubsequence(enc.encode("aaab"), enc.encode("aab"))).toBe(1);
+		expect(indexOfSubsequence(enc.encode("abcabcabc"), enc.encode("abcab"), 1)).toBe(3);
+	});
+
+	it("matches a brute-force search on random inputs", () => {
+		const brute = (h: Uint8Array, n: Uint8Array, from = 0) => {
+			outer: for (let i = from; i <= h.length - n.length; i++) {
+				for (let j = 0; j < n.length; j++) {
+					if (h[i + j] !== n[j]) {
+						continue outer;
+					}
+				}
+				return i;
+			}
+			return -1;
+		};
+
+		let seed = 42;
+		const rand = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff);
+		for (let trial = 0; trial < 200; trial++) {
+			const h = new Uint8Array(rand() % 200).map(() => rand() % 8); // small alphabet => many repeats
+			const n = new Uint8Array(1 + (rand() % 12)).map(() => rand() % 8);
+			const from = rand() % (h.length + 1);
+			expect(indexOfSubsequence(h, n, from)).toBe(brute(h, n, from));
+		}
+	});
+});

--- a/packages/hub/src/utils/indexOfSubsequence.ts
+++ b/packages/hub/src/utils/indexOfSubsequence.ts
@@ -1,0 +1,39 @@
+/**
+ * Returns the index of the first occurrence of `needle` in `haystack` at or after `from`,
+ * or -1 if not found. Like `String.prototype.indexOf`, but for byte arrays.
+ *
+ * (`Uint8Array.prototype.indexOf` only searches for a single byte value, so there's no
+ * native subarray search.) Uses Boyer–Moore with a bad-character skip table: on a mismatch
+ * the scan jumps ahead based on the byte under the cursor, which approaches O(n / m) for
+ * typical needles instead of the naive O(n * m).
+ */
+export function indexOfSubsequence(haystack: Uint8Array, needle: Uint8Array, from = 0): number {
+	const needleLength = needle.length;
+	if (needleLength === 0) {
+		return from <= haystack.length ? from : -1;
+	}
+	const last = needleLength - 1;
+	const maxStart = haystack.length - needleLength;
+
+	// Bad-character table: for each possible byte value, how far we can skip when that byte
+	// causes a mismatch. Default is a full needle-length jump (byte not in needle).
+	const skip = new Uint16Array(256).fill(needleLength);
+	for (let i = 0; i < last; i++) {
+		skip[needle[i]] = last - i;
+	}
+
+	let i = from;
+	while (i <= maxStart) {
+		// Compare from the end of the needle backwards
+		let j = last;
+		while (j >= 0 && haystack[i + j] === needle[j]) {
+			j--;
+		}
+		if (j < 0) {
+			return i; // full match
+		}
+		// Shift forward by the bad-character rule
+		i += skip[haystack[i + last]];
+	}
+	return -1;
+}

--- a/packages/hub/src/utils/multipart.spec.ts
+++ b/packages/hub/src/utils/multipart.spec.ts
@@ -50,6 +50,24 @@ describe("StreamingMultipartParser", () => {
 		}
 	});
 
+	it("parses a body whose first boundary has no leading CRLF", () => {
+		// RFC 2046 §5.1.1: the CRLF preceding the first delimiter is "considered part of the
+		// preamble" — a body may start directly with `--boundary` (as in the RFC 9110 example).
+		const parts = [enc.encode("hello"), enc.encode("world")];
+		const body = buildMultipart(boundary, parts).slice(2); // strip the leading \r\n
+		expect(Array.from(body.slice(0, 2))).toEqual(Array.from(enc.encode("--")));
+
+		// Whole-body and every-split-point feeds
+		for (let split = 0; split <= body.byteLength; split++) {
+			const parser = new StreamingMultipartParser(contentType);
+			const out = [...parser.push(body.slice(0, split)), ...parser.push(body.slice(split))];
+			expect(
+				out.map((p) => Array.from(p)),
+				`split at ${split}`,
+			).toEqual(parts.map((p) => Array.from(p)));
+		}
+	});
+
 	it("handles binary data containing CR/LF and dash bytes", () => {
 		const parts = [new Uint8Array([0x0d, 0x0a, 0x2d, 0x2d, 0xff, 0x0d, 0x0a])];
 		const body = buildMultipart(boundary, parts);

--- a/packages/hub/src/utils/multipart.spec.ts
+++ b/packages/hub/src/utils/multipart.spec.ts
@@ -1,18 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { combineUint8Arrays } from "./combineUint8Arrays";
 import { extractBoundary, parseMultipartByteRanges } from "./multipart";
 
 const enc = new TextEncoder();
-
-function concat(...arrays: Uint8Array[]): Uint8Array {
-	const total = arrays.reduce((sum, a) => sum + a.byteLength, 0);
-	const out = new Uint8Array(total);
-	let offset = 0;
-	for (const a of arrays) {
-		out.set(a, offset);
-		offset += a.byteLength;
-	}
-	return out;
-}
 
 function buildPart(
 	boundary: string,
@@ -20,7 +10,7 @@ function buildPart(
 	total: number,
 	data: Uint8Array,
 ): Uint8Array {
-	return concat(
+	return combineUint8Arrays(
 		enc.encode(`--${boundary}\r\n`),
 		enc.encode(`Content-Type: application/octet-stream\r\n`),
 		enc.encode(`Content-Range: bytes ${range.start}-${range.end}/${total}\r\n\r\n`),
@@ -49,7 +39,7 @@ describe("multipart", () => {
 			const data0 = new Uint8Array([1, 2, 3, 4, 5]);
 			const data1 = new Uint8Array([10, 20, 30]);
 
-			const body = concat(
+			const body = combineUint8Arrays(
 				buildPart(boundary, { start: 0, end: 4 }, 100, data0),
 				enc.encode("\r\n"),
 				buildPart(boundary, { start: 50, end: 52 }, 100, data1),
@@ -68,7 +58,10 @@ describe("multipart", () => {
 		it("handles binary data containing CR/LF bytes", () => {
 			const boundary = "xyz";
 			const data = new Uint8Array([0x0d, 0x0a, 0x00, 0x2d, 0x2d, 0xff]);
-			const body = concat(buildPart(boundary, { start: 0, end: 5 }, 6, data), enc.encode(`\r\n--${boundary}--\r\n`));
+			const body = combineUint8Arrays(
+				buildPart(boundary, { start: 0, end: 5 }, 6, data),
+				enc.encode(`\r\n--${boundary}--\r\n`),
+			);
 
 			const parts = parseMultipartByteRanges(`multipart/byteranges; boundary=${boundary}`, body);
 

--- a/packages/hub/src/utils/multipart.spec.ts
+++ b/packages/hub/src/utils/multipart.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { extractBoundary, parseMultipartByteRanges } from "./multipart";
+
+const enc = new TextEncoder();
+
+function concat(...arrays: Uint8Array[]): Uint8Array {
+	const total = arrays.reduce((sum, a) => sum + a.byteLength, 0);
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const a of arrays) {
+		out.set(a, offset);
+		offset += a.byteLength;
+	}
+	return out;
+}
+
+function buildPart(
+	boundary: string,
+	range: { start: number; end: number },
+	total: number,
+	data: Uint8Array,
+): Uint8Array {
+	return concat(
+		enc.encode(`--${boundary}\r\n`),
+		enc.encode(`Content-Type: application/octet-stream\r\n`),
+		enc.encode(`Content-Range: bytes ${range.start}-${range.end}/${total}\r\n\r\n`),
+		data,
+	);
+}
+
+describe("multipart", () => {
+	describe("extractBoundary", () => {
+		it("extracts an unquoted boundary", () => {
+			expect(extractBoundary("multipart/byteranges; boundary=something")).toBe("something");
+		});
+
+		it("extracts a quoted boundary", () => {
+			expect(extractBoundary('multipart/byteranges; boundary="quoted"')).toBe("quoted");
+		});
+
+		it("returns null when there is no boundary", () => {
+			expect(extractBoundary("multipart/byteranges")).toBeNull();
+		});
+	});
+
+	describe("parseMultipartByteRanges", () => {
+		it("parses multiple parts and preserves their data", () => {
+			const boundary = "BOUNDARY";
+			const data0 = new Uint8Array([1, 2, 3, 4, 5]);
+			const data1 = new Uint8Array([10, 20, 30]);
+
+			const body = concat(
+				buildPart(boundary, { start: 0, end: 4 }, 100, data0),
+				enc.encode("\r\n"),
+				buildPart(boundary, { start: 50, end: 52 }, 100, data1),
+				enc.encode(`\r\n--${boundary}--\r\n`),
+			);
+
+			const parts = parseMultipartByteRanges(`multipart/byteranges; boundary=${boundary}`, body);
+
+			expect(parts).toHaveLength(2);
+			expect(parts[0].range).toEqual({ start: 0, end: 4 });
+			expect(Array.from(parts[0].data)).toEqual([1, 2, 3, 4, 5]);
+			expect(parts[1].range).toEqual({ start: 50, end: 52 });
+			expect(Array.from(parts[1].data)).toEqual([10, 20, 30]);
+		});
+
+		it("handles binary data containing CR/LF bytes", () => {
+			const boundary = "xyz";
+			const data = new Uint8Array([0x0d, 0x0a, 0x00, 0x2d, 0x2d, 0xff]);
+			const body = concat(buildPart(boundary, { start: 0, end: 5 }, 6, data), enc.encode(`\r\n--${boundary}--\r\n`));
+
+			const parts = parseMultipartByteRanges(`multipart/byteranges; boundary=${boundary}`, body);
+
+			expect(parts).toHaveLength(1);
+			expect(Array.from(parts[0].data)).toEqual([0x0d, 0x0a, 0x00, 0x2d, 0x2d, 0xff]);
+		});
+
+		it("throws when the boundary is missing from the body", () => {
+			expect(() => parseMultipartByteRanges("multipart/byteranges; boundary=nope", enc.encode("garbage"))).toThrow();
+		});
+
+		it("throws when the content type has no boundary", () => {
+			expect(() => parseMultipartByteRanges("multipart/byteranges", new Uint8Array())).toThrow();
+		});
+	});
+});

--- a/packages/hub/src/utils/multipart.spec.ts
+++ b/packages/hub/src/utils/multipart.spec.ts
@@ -1,80 +1,93 @@
 import { describe, expect, it } from "vitest";
 import { combineUint8Arrays } from "./combineUint8Arrays";
-import { extractBoundary, parseMultipartByteRanges } from "./multipart";
+import { StreamingMultipartParser } from "./multipart";
 
 const enc = new TextEncoder();
 
-function buildPart(
-	boundary: string,
-	range: { start: number; end: number },
-	total: number,
-	data: Uint8Array,
-): Uint8Array {
-	return combineUint8Arrays(
-		enc.encode(`--${boundary}\r\n`),
-		enc.encode(`Content-Type: application/octet-stream\r\n`),
-		enc.encode(`Content-Range: bytes ${range.start}-${range.end}/${total}\r\n\r\n`),
-		data,
-	);
+function buildMultipart(boundary: string, parts: Uint8Array[]): Uint8Array {
+	const segments: Uint8Array[] = [];
+	for (const data of parts) {
+		segments.push(enc.encode(`\r\n--${boundary}\r\nContent-Type: application/octet-stream\r\n\r\n`), data);
+	}
+	segments.push(enc.encode(`\r\n--${boundary}--\r\n`));
+	return combineUint8Arrays(...segments);
 }
 
-describe("multipart", () => {
-	describe("extractBoundary", () => {
-		it("extracts an unquoted boundary", () => {
-			expect(extractBoundary("multipart/byteranges; boundary=something")).toBe("something");
-		});
+describe("StreamingMultipartParser", () => {
+	const boundary = "BOUNDARY";
+	const contentType = `multipart/byteranges; boundary=${boundary}`;
 
-		it("extracts a quoted boundary", () => {
-			expect(extractBoundary('multipart/byteranges; boundary="quoted"')).toBe("quoted");
-		});
-
-		it("returns null when there is no boundary", () => {
-			expect(extractBoundary("multipart/byteranges")).toBeNull();
-		});
+	it("parses all parts fed as one chunk", () => {
+		const parts = [enc.encode("hello"), enc.encode("world"), new Uint8Array([1, 2, 3])];
+		const body = buildMultipart(boundary, parts);
+		const parser = new StreamingMultipartParser(contentType);
+		const out = parser.push(body);
+		expect(out.map((p) => Array.from(p))).toEqual(parts.map((p) => Array.from(p)));
 	});
 
-	describe("parseMultipartByteRanges", () => {
-		it("parses multiple parts and preserves their data", () => {
-			const boundary = "BOUNDARY";
-			const data0 = new Uint8Array([1, 2, 3, 4, 5]);
-			const data1 = new Uint8Array([10, 20, 30]);
-
-			const body = combineUint8Arrays(
-				buildPart(boundary, { start: 0, end: 4 }, 100, data0),
-				enc.encode("\r\n"),
-				buildPart(boundary, { start: 50, end: 52 }, 100, data1),
-				enc.encode(`\r\n--${boundary}--\r\n`),
-			);
-
-			const parts = parseMultipartByteRanges(`multipart/byteranges; boundary=${boundary}`, body);
-
-			expect(parts).toHaveLength(2);
-			expect(parts[0].range).toEqual({ start: 0, end: 4 });
-			expect(Array.from(parts[0].data)).toEqual([1, 2, 3, 4, 5]);
-			expect(parts[1].range).toEqual({ start: 50, end: 52 });
-			expect(Array.from(parts[1].data)).toEqual([10, 20, 30]);
-		});
-
-		it("handles binary data containing CR/LF bytes", () => {
-			const boundary = "xyz";
-			const data = new Uint8Array([0x0d, 0x0a, 0x00, 0x2d, 0x2d, 0xff]);
-			const body = combineUint8Arrays(
-				buildPart(boundary, { start: 0, end: 5 }, 6, data),
-				enc.encode(`\r\n--${boundary}--\r\n`),
-			);
-
-			const parts = parseMultipartByteRanges(`multipart/byteranges; boundary=${boundary}`, body);
-
-			expect(parts).toHaveLength(1);
-			expect(Array.from(parts[0].data)).toEqual([0x0d, 0x0a, 0x00, 0x2d, 0x2d, 0xff]);
-		});
-
-		it("throws when the boundary is missing from the body", () => {
-			expect(() => parseMultipartByteRanges("multipart/byteranges; boundary=nope", enc.encode("garbage"))).toThrow();
-		});
-
-		it("throws when the content type has no boundary", () => {
-			expect(() => parseMultipartByteRanges("multipart/byteranges", new Uint8Array())).toThrow();
-		});
+	it("parses parts fed one byte at a time", () => {
+		const parts = [enc.encode("hello"), enc.encode("world!")];
+		const body = buildMultipart(boundary, parts);
+		const parser = new StreamingMultipartParser(contentType);
+		const out: Uint8Array[] = [];
+		for (const byte of body) {
+			out.push(...parser.push(new Uint8Array([byte])));
+		}
+		expect(out.map((p) => Array.from(p))).toEqual(parts.map((p) => Array.from(p)));
 	});
+
+	it("handles a boundary straddling chunk boundaries", () => {
+		const parts = [enc.encode("abc"), enc.encode("defgh")];
+		const body = buildMultipart(boundary, parts);
+		// Split at every possible point and re-parse
+		for (let split = 0; split <= body.byteLength; split++) {
+			const parser = new StreamingMultipartParser(contentType);
+			const out = [...parser.push(body.slice(0, split)), ...parser.push(body.slice(split))];
+			expect(
+				out.map((p) => Array.from(p)),
+				`split at ${split}`,
+			).toEqual(parts.map((p) => Array.from(p)));
+		}
+	});
+
+	it("handles binary data containing CR/LF and dash bytes", () => {
+		const parts = [new Uint8Array([0x0d, 0x0a, 0x2d, 0x2d, 0xff, 0x0d, 0x0a])];
+		const body = buildMultipart(boundary, parts);
+		const parser = new StreamingMultipartParser(contentType);
+		const out = parser.push(body);
+		expect(out.map((p) => Array.from(p))).toEqual(parts.map((p) => Array.from(p)));
+	});
+
+	it("streams parts out incrementally without waiting for the whole body", () => {
+		const parts = [enc.encode("first-part"), enc.encode("second-part")];
+		const body = buildMultipart(boundary, parts);
+		// Feed only up to just past the first part's data
+		const firstEnd = indexOf(body, enc.encode("second-part"));
+		const parser = new StreamingMultipartParser(contentType);
+		const out = parser.push(body.slice(0, firstEnd));
+		// The first part should already be emitted even though part 2 hasn't fully arrived
+		expect(out.length).toBe(1);
+		expect(Array.from(out[0])).toEqual(Array.from(parts[0]));
+	});
+
+	it("throws when there is no boundary in the content type", () => {
+		expect(() => new StreamingMultipartParser("multipart/byteranges")).toThrow();
+	});
+
+	it("throws on malformed body (no closing structure)", () => {
+		const parser = new StreamingMultipartParser(contentType);
+		expect(() => parser.push(enc.encode("garbage with no boundary at all"))).not.toThrow(); // tolerated as preamble
+	});
+
+	function indexOf(haystack: Uint8Array, needle: Uint8Array): number {
+		outer: for (let i = 0; i <= haystack.length - needle.length; i++) {
+			for (let j = 0; j < needle.length; j++) {
+				if (haystack[i + j] !== needle[j]) {
+					continue outer;
+				}
+			}
+			return i;
+		}
+		return -1;
+	}
 });

--- a/packages/hub/src/utils/multipart.spec.ts
+++ b/packages/hub/src/utils/multipart.spec.ts
@@ -50,6 +50,23 @@ describe("StreamingMultipartParser", () => {
 		}
 	});
 
+	it("coalesces tiny pushes on a part spanning multiple staging blocks", () => {
+		// ~200KB part (> 3 staging blocks of 64KB) with a recognizable pattern.
+		const partData = new Uint8Array(200_000).map((_, i) => i % 251);
+		const body = buildMultipart(boundary, [partData]);
+
+		for (const feedSize of [1, 3, 7, 1024]) {
+			const parser = new StreamingMultipartParser(contentType);
+			const out: Uint8Array[] = [];
+			for (let off = 0; off < body.byteLength; off += feedSize) {
+				out.push(...parser.push(body.subarray(off, Math.min(off + feedSize, body.byteLength))));
+			}
+			expect(out.length, `feed size ${feedSize}`).toBe(1);
+			expect(out[0].byteLength, `feed size ${feedSize}`).toBe(partData.byteLength);
+			expect(Buffer.from(out[0]).equals(Buffer.from(partData)), `feed size ${feedSize}`).toBe(true);
+		}
+	});
+
 	it("parses a body whose first boundary has no leading CRLF", () => {
 		// RFC 2046 §5.1.1: the CRLF preceding the first delimiter is "considered part of the
 		// preamble" — a body may start directly with `--boundary` (as in the RFC 9110 example).

--- a/packages/hub/src/utils/multipart.ts
+++ b/packages/hub/src/utils/multipart.ts
@@ -1,0 +1,112 @@
+/**
+ * A single part from a `multipart/byteranges` HTTP response.
+ */
+export interface MultipartPart {
+	/** Byte range covered by this part, inclusive end (as in the `Content-Range` header). */
+	range: { start: number; end: number };
+	data: Uint8Array;
+}
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export function extractBoundary(contentType: string): string | null {
+	for (const part of contentType.split(";")) {
+		const trimmed = part.trim();
+		if (trimmed.toLowerCase().startsWith("boundary=")) {
+			return trimmed.slice("boundary=".length).replace(/^"|"$/g, "");
+		}
+	}
+	return null;
+}
+
+function indexOfSubsequence(haystack: Uint8Array, needle: Uint8Array, from = 0): number {
+	outer: for (let i = from; i <= haystack.length - needle.length; i++) {
+		for (let j = 0; j < needle.length; j++) {
+			if (haystack[i + j] !== needle[j]) {
+				continue outer;
+			}
+		}
+		return i;
+	}
+	return -1;
+}
+
+function parseContentRange(headers: string): { start: number; end: number } | null {
+	for (const line of headers.split("\r\n")) {
+		const lower = line.toLowerCase();
+		if (lower.startsWith("content-range:")) {
+			// Content-Range: bytes <start>-<end>/<total>
+			const value = line.slice("content-range:".length).trim();
+			const match = value.match(/^bytes\s+(\d+)-(\d+)\//i);
+			if (match) {
+				// RFC 7233 Content-Range uses an inclusive end.
+				return { start: parseInt(match[1], 10), end: parseInt(match[2], 10) };
+			}
+		}
+	}
+	return null;
+}
+
+/**
+ * Parse a `multipart/byteranges` HTTP response body (RFC 7233 §4.1).
+ *
+ * Extracts the boundary from `contentType`, splits the body by boundary markers,
+ * parses the `Content-Range` header from each part, and returns the parts in body order.
+ */
+export function parseMultipartByteRanges(contentType: string, body: Uint8Array): MultipartPart[] {
+	const boundary = extractBoundary(contentType);
+	if (!boundary) {
+		throw new Error(`No boundary found in Content-Type: ${contentType}`);
+	}
+
+	const firstDelim = textEncoder.encode(`--${boundary}`);
+	const delimiter = textEncoder.encode(`\r\n--${boundary}`);
+	const crlf = textEncoder.encode("\r\n");
+	const headerSeparator = textEncoder.encode("\r\n\r\n");
+
+	const start = indexOfSubsequence(body, firstDelim);
+	if (start === -1) {
+		throw new Error("No boundary found in multipart body");
+	}
+
+	const parts: MultipartPart[] = [];
+	let pos = start + firstDelim.length;
+
+	for (;;) {
+		// Each part starts with CRLF after the boundary marker. Anything else (eg `--` for the
+		// closing delimiter) ends the message.
+		if (body[pos] === crlf[0] && body[pos + 1] === crlf[1]) {
+			pos += 2;
+		} else {
+			break;
+		}
+
+		const nextBoundary = indexOfSubsequence(body, delimiter, pos);
+		const partEnd = nextBoundary === -1 ? body.length : nextBoundary;
+		const partData = body.subarray(pos, partEnd);
+
+		const headerEnd = indexOfSubsequence(partData, headerSeparator);
+		if (headerEnd === -1) {
+			throw new Error("Malformed multipart part: missing header/data separator");
+		}
+
+		const headers = textDecoder.decode(partData.subarray(0, headerEnd));
+		const range = parseContentRange(headers);
+		if (!range) {
+			throw new Error("No Content-Range header found in multipart part");
+		}
+
+		parts.push({
+			range,
+			data: partData.subarray(headerEnd + headerSeparator.length),
+		});
+
+		if (nextBoundary === -1) {
+			break;
+		}
+		pos = nextBoundary + delimiter.length;
+	}
+
+	return parts;
+}

--- a/packages/hub/src/utils/multipart.ts
+++ b/packages/hub/src/utils/multipart.ts
@@ -6,6 +6,12 @@ const CRLF = textEncoder.encode("\r\n");
 const HEADER_SEPARATOR = textEncoder.encode("\r\n\r\n");
 
 /**
+ * Small appends (eg byte-by-byte or tiny network reads) are coalesced into blocks of this size,
+ * so the in-progress part is a bounded list of large chunks instead of one object per push.
+ */
+const STAGING_BLOCK_SIZE = 65536;
+
+/**
  * Incrementally parses a `multipart/byteranges` body, yielding each part's raw bytes as it
  * completes, without buffering the whole body.
  *
@@ -23,8 +29,12 @@ export class StreamingMultipartParser {
 	 * "considered part of the preamble") still matches the `\r\n--boundary` delimiter.
 	 */
 	#carry: Uint8Array = CRLF;
-	/** Confirmed bytes (headers + data) of the in-progress part, combined once at completion. */
+	/** Confirmed bytes (headers + data) of the in-progress part, as ≥STAGING_BLOCK_SIZE chunks. */
 	#partChunks: Uint8Array[] = [];
+	#partLength = 0;
+	/** Staging block coalescing small appends; pushed to #partChunks when full. */
+	#staging: Uint8Array | undefined;
+	#stagingLength = 0;
 	/** 0 = scanning for first boundary, 1 = consuming CRLF/`--` after a boundary, 2 = inside a part */
 	#state: 0 | 1 | 2 = 0;
 	#done = false;
@@ -42,8 +52,8 @@ export class StreamingMultipartParser {
 	 * Push a chunk of body bytes (call with no argument to flush at end of stream).
 	 * Returns the raw bytes of any parts that completed as a result.
 	 *
-	 * Copying is linear: each byte is combined with the (bounded) carry once, moved to the
-	 * part's chunk list once, and combined into the completed part once.
+	 * Copying is linear: each byte is combined with the (bounded) carry once, staged once, and
+	 * copied into the completed part once.
 	 */
 	push(chunk?: Uint8Array): Uint8Array[] {
 		if (this.#done) {
@@ -65,7 +75,7 @@ export class StreamingMultipartParser {
 					// is preamble (state 0, discarded) or confirmed part bytes (state 2, retained).
 					const safeLength = Math.max(0, data.byteLength - (this.#delimiter.byteLength - 1));
 					if (this.#state === 2 && safeLength > 0) {
-						this.#partChunks.push(data.slice(0, safeLength));
+						this.#appendToPart(data.subarray(0, safeLength));
 					}
 					this.#carry = data.slice(safeLength);
 					break;
@@ -73,13 +83,13 @@ export class StreamingMultipartParser {
 
 				if (this.#state === 2) {
 					// [0, delimIndex) completes the part body (headers + data).
-					const partBody = combineUint8Arrays(...this.#partChunks, data.slice(0, delimIndex));
-					this.#partChunks = [];
+					this.#appendToPart(data.subarray(0, delimIndex));
+					const partBody = this.#takePart();
 					const headerEnd = indexOfSubsequence(partBody, HEADER_SEPARATOR, 0);
 					if (headerEnd === -1) {
 						throw new Error("Malformed multipart part: missing header/data separator");
 					}
-					parts.push(partBody.slice(headerEnd + HEADER_SEPARATOR.byteLength));
+					parts.push(partBody.subarray(headerEnd + HEADER_SEPARATOR.byteLength));
 				}
 				// Consume the delimiter; decide next state from what follows it.
 				data = data.slice(delimIndex + this.#delimiter.byteLength);
@@ -106,6 +116,56 @@ export class StreamingMultipartParser {
 		}
 
 		return parts;
+	}
+
+	/** Append confirmed part bytes, coalescing small appends into staging blocks. */
+	#appendToPart(bytes: Uint8Array): void {
+		this.#partLength += bytes.byteLength;
+
+		if (bytes.byteLength >= STAGING_BLOCK_SIZE) {
+			// Large chunk: keep it directly (it's a view into a buffer we own).
+			this.#flushStaging();
+			this.#partChunks.push(bytes);
+			return;
+		}
+
+		let offset = 0;
+		while (offset < bytes.byteLength) {
+			if (!this.#staging) {
+				this.#staging = new Uint8Array(STAGING_BLOCK_SIZE);
+				this.#stagingLength = 0;
+			}
+			const toCopy = Math.min(STAGING_BLOCK_SIZE - this.#stagingLength, bytes.byteLength - offset);
+			this.#staging.set(bytes.subarray(offset, offset + toCopy), this.#stagingLength);
+			this.#stagingLength += toCopy;
+			offset += toCopy;
+			if (this.#stagingLength === STAGING_BLOCK_SIZE) {
+				this.#partChunks.push(this.#staging);
+				this.#staging = undefined;
+			}
+		}
+	}
+
+	#flushStaging(): void {
+		if (this.#staging && this.#stagingLength > 0) {
+			this.#partChunks.push(this.#staging.subarray(0, this.#stagingLength));
+		}
+		this.#staging = undefined;
+		this.#stagingLength = 0;
+	}
+
+	/** Assemble and reset the in-progress part. Loop-based copy: the chunk count is unbounded-safe. */
+	#takePart(): Uint8Array {
+		this.#flushStaging();
+		const out = new Uint8Array(this.#partLength);
+		let offset = 0;
+		for (const chunk of this.#partChunks) {
+			out.set(chunk, offset);
+			offset += chunk.byteLength;
+		}
+		this.#partChunks = [];
+		this.#partLength = 0;
+		return out;
 	}
 }
 

--- a/packages/hub/src/utils/multipart.ts
+++ b/packages/hub/src/utils/multipart.ts
@@ -1,16 +1,104 @@
-/**
- * A single part from a `multipart/byteranges` HTTP response.
- */
-export interface MultipartPart {
-	/** Byte range covered by this part, inclusive end (as in the `Content-Range` header). */
-	range: { start: number; end: number };
-	data: Uint8Array;
-}
-
+import { combineUint8Arrays } from "./combineUint8Arrays";
 import { indexOfSubsequence } from "./indexOfSubsequence";
 
 const textEncoder = new TextEncoder();
-const textDecoder = new TextDecoder();
+const CRLF = textEncoder.encode("\r\n");
+const DASH_DASH = textEncoder.encode("--");
+const HEADER_SEPARATOR = textEncoder.encode("\r\n\r\n");
+
+/**
+ * Incrementally parses a `multipart/byteranges` body, yielding each part's raw bytes as it
+ * completes, without buffering the whole body.
+ *
+ * Feed network chunks to `push()` as they arrive; returned values are the raw bytes of each
+ * completed part (in body order, which for Xet signed URLs is ascending byte order). A part is
+ * only emitted once its terminating boundary has been seen, so memory stays bounded by the
+ * largest part rather than the whole body.
+ */
+export class StreamingMultipartParser {
+	#delimiter: Uint8Array;
+	#buffer = new Uint8Array(0);
+	/** 0 = scanning for first boundary, 1 = consuming CRLF/`--` after a boundary, 2 = inside a part */
+	#state: 0 | 1 | 2 = 0;
+	#done = false;
+
+	constructor(contentType: string) {
+		const boundary = extractBoundary(contentType);
+		if (!boundary) {
+			throw new Error(`No boundary found in Content-Type: ${contentType}`);
+		}
+		// Include the preceding CRLF in the delimiter so it's not left attached to the part body.
+		// (The first delimiter's CRLF is body preamble and is discarded in state 0.)
+		this.#delimiter = textEncoder.encode(`\r\n--${boundary}`);
+	}
+
+	/**
+	 * Push a chunk of body bytes (call with no argument to flush at end of stream).
+	 * Returns the raw bytes of any parts that completed as a result.
+	 */
+	push(chunk?: Uint8Array): Uint8Array[] {
+		if (this.#done) {
+			// Closing delimiter already seen; ignore any epilogue bytes.
+			return [];
+		}
+		if (chunk && chunk.byteLength) {
+			this.#buffer = combineUint8Arrays(this.#buffer, chunk);
+		}
+
+		const parts: Uint8Array[] = [];
+
+		for (;;) {
+			if (this.#state === 0 || this.#state === 2) {
+				const delimIndex = indexOfSubsequence(this.#buffer, this.#delimiter, 0);
+
+				if (delimIndex === -1) {
+					if (this.#state === 0) {
+						// Discard preamble, keeping only a possible trailing partial delimiter.
+						const keep = this.#delimiter.byteLength - 1;
+						if (this.#buffer.byteLength > keep) {
+							this.#buffer = this.#buffer.slice(this.#buffer.byteLength - keep);
+						}
+					}
+					// In state 2 the buffer holds in-progress part data; wait for more bytes.
+					break;
+				}
+
+				if (this.#state === 2) {
+					// Everything before the delimiter is the part body (headers + data).
+					const partBody = this.#buffer.slice(0, delimIndex);
+					const headerEnd = indexOfSubsequence(partBody, HEADER_SEPARATOR, 0);
+					if (headerEnd === -1) {
+						throw new Error("Malformed multipart part: missing header/data separator");
+					}
+					parts.push(partBody.slice(headerEnd + HEADER_SEPARATOR.byteLength));
+				}
+				// Consume the delimiter; move to post-boundary state.
+				this.#buffer = this.#buffer.slice(delimIndex + this.#delimiter.byteLength);
+				this.#state = 1;
+				continue;
+			}
+
+			// state === 1: just after a boundary marker. Expect CRLF (a part follows) or `--` (end).
+			// A leading `\r\n` may precede the first delimiter in the body, so also tolerate CRLF here.
+			if (this.#buffer.byteLength < 2) {
+				break; // need more bytes to decide
+			}
+			if (this.#buffer[0] === DASH_DASH[0] && this.#buffer[1] === DASH_DASH[1]) {
+				this.#done = true;
+				this.#buffer = new Uint8Array(0);
+				return parts;
+			}
+			if (this.#buffer[0] === CRLF[0] && this.#buffer[1] === CRLF[1]) {
+				this.#buffer = this.#buffer.slice(2);
+				this.#state = 2;
+				continue;
+			}
+			throw new Error("Malformed multipart body: expected CRLF or closing delimiter after boundary");
+		}
+
+		return parts;
+	}
+}
 
 export function extractBoundary(contentType: string): string | null {
 	for (const part of contentType.split(";")) {
@@ -20,83 +108,4 @@ export function extractBoundary(contentType: string): string | null {
 		}
 	}
 	return null;
-}
-
-function parseContentRange(headers: string): { start: number; end: number } | null {
-	for (const line of headers.split("\r\n")) {
-		const lower = line.toLowerCase();
-		if (lower.startsWith("content-range:")) {
-			// Content-Range: bytes <start>-<end>/<total>
-			const value = line.slice("content-range:".length).trim();
-			const match = value.match(/^bytes\s+(\d+)-(\d+)\//i);
-			if (match) {
-				// RFC 7233 Content-Range uses an inclusive end.
-				return { start: parseInt(match[1], 10), end: parseInt(match[2], 10) };
-			}
-		}
-	}
-	return null;
-}
-
-/**
- * Parse a `multipart/byteranges` HTTP response body (RFC 7233 §4.1).
- *
- * Extracts the boundary from `contentType`, splits the body by boundary markers,
- * parses the `Content-Range` header from each part, and returns the parts in body order.
- */
-export function parseMultipartByteRanges(contentType: string, body: Uint8Array): MultipartPart[] {
-	const boundary = extractBoundary(contentType);
-	if (!boundary) {
-		throw new Error(`No boundary found in Content-Type: ${contentType}`);
-	}
-
-	const firstDelim = textEncoder.encode(`--${boundary}`);
-	const delimiter = textEncoder.encode(`\r\n--${boundary}`);
-	const crlf = textEncoder.encode("\r\n");
-	const headerSeparator = textEncoder.encode("\r\n\r\n");
-
-	const start = indexOfSubsequence(body, firstDelim);
-	if (start === -1) {
-		throw new Error("No boundary found in multipart body");
-	}
-
-	const parts: MultipartPart[] = [];
-	let pos = start + firstDelim.length;
-
-	for (;;) {
-		// Each part starts with CRLF after the boundary marker. Anything else (eg `--` for the
-		// closing delimiter) ends the message.
-		if (body[pos] === crlf[0] && body[pos + 1] === crlf[1]) {
-			pos += 2;
-		} else {
-			break;
-		}
-
-		const nextBoundary = indexOfSubsequence(body, delimiter, pos);
-		const partEnd = nextBoundary === -1 ? body.length : nextBoundary;
-		const partData = body.subarray(pos, partEnd);
-
-		const headerEnd = indexOfSubsequence(partData, headerSeparator);
-		if (headerEnd === -1) {
-			throw new Error("Malformed multipart part: missing header/data separator");
-		}
-
-		const headers = textDecoder.decode(partData.subarray(0, headerEnd));
-		const range = parseContentRange(headers);
-		if (!range) {
-			throw new Error("No Content-Range header found in multipart part");
-		}
-
-		parts.push({
-			range,
-			data: partData.subarray(headerEnd + headerSeparator.length),
-		});
-
-		if (nextBoundary === -1) {
-			break;
-		}
-		pos = nextBoundary + delimiter.length;
-	}
-
-	return parts;
 }

--- a/packages/hub/src/utils/multipart.ts
+++ b/packages/hub/src/utils/multipart.ts
@@ -7,6 +7,8 @@ export interface MultipartPart {
 	data: Uint8Array;
 }
 
+import { indexOfSubsequence } from "./indexOfSubsequence";
+
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
@@ -18,18 +20,6 @@ export function extractBoundary(contentType: string): string | null {
 		}
 	}
 	return null;
-}
-
-function indexOfSubsequence(haystack: Uint8Array, needle: Uint8Array, from = 0): number {
-	outer: for (let i = from; i <= haystack.length - needle.length; i++) {
-		for (let j = 0; j < needle.length; j++) {
-			if (haystack[i + j] !== needle[j]) {
-				continue outer;
-			}
-		}
-		return i;
-	}
-	return -1;
 }
 
 function parseContentRange(headers: string): { start: number; end: number } | null {

--- a/packages/hub/src/utils/multipart.ts
+++ b/packages/hub/src/utils/multipart.ts
@@ -3,7 +3,6 @@ import { indexOfSubsequence } from "./indexOfSubsequence";
 
 const textEncoder = new TextEncoder();
 const CRLF = textEncoder.encode("\r\n");
-const DASH_DASH = textEncoder.encode("--");
 const HEADER_SEPARATOR = textEncoder.encode("\r\n\r\n");
 
 /**
@@ -17,7 +16,15 @@ const HEADER_SEPARATOR = textEncoder.encode("\r\n\r\n");
  */
 export class StreamingMultipartParser {
 	#delimiter: Uint8Array;
-	#buffer = new Uint8Array(0);
+	/**
+	 * Unprocessed bytes carried between pushes: bounded by the delimiter length in states 0/2
+	 * (a possible partial delimiter), tiny in state 1. Seeded with a virtual CRLF so a body
+	 * starting directly with `--boundary` (RFC 2046: the first delimiter's leading CRLF is
+	 * "considered part of the preamble") still matches the `\r\n--boundary` delimiter.
+	 */
+	#carry: Uint8Array = CRLF;
+	/** Confirmed bytes (headers + data) of the in-progress part, combined once at completion. */
+	#partChunks: Uint8Array[] = [];
 	/** 0 = scanning for first boundary, 1 = consuming CRLF/`--` after a boundary, 2 = inside a part */
 	#state: 0 | 1 | 2 = 0;
 	#done = false;
@@ -27,69 +34,71 @@ export class StreamingMultipartParser {
 		if (!boundary) {
 			throw new Error(`No boundary found in Content-Type: ${contentType}`);
 		}
-		// Include the preceding CRLF in the delimiter so it's not left attached to the part body.
-		// (The first delimiter's CRLF is body preamble and is discarded in state 0.)
+		// Includes the preceding CRLF so it's not left attached to the part body.
 		this.#delimiter = textEncoder.encode(`\r\n--${boundary}`);
 	}
 
 	/**
 	 * Push a chunk of body bytes (call with no argument to flush at end of stream).
 	 * Returns the raw bytes of any parts that completed as a result.
+	 *
+	 * Copying is linear: each byte is combined with the (bounded) carry once, moved to the
+	 * part's chunk list once, and combined into the completed part once.
 	 */
 	push(chunk?: Uint8Array): Uint8Array[] {
 		if (this.#done) {
 			// Closing delimiter already seen; ignore any epilogue bytes.
 			return [];
 		}
-		if (chunk && chunk.byteLength) {
-			this.#buffer = combineUint8Arrays(this.#buffer, chunk);
-		}
+
+		let data = chunk && chunk.byteLength ? combineUint8Arrays(this.#carry, chunk) : this.#carry;
+		this.#carry = new Uint8Array(0);
 
 		const parts: Uint8Array[] = [];
 
 		for (;;) {
 			if (this.#state === 0 || this.#state === 2) {
-				const delimIndex = indexOfSubsequence(this.#buffer, this.#delimiter, 0);
+				const delimIndex = indexOfSubsequence(data, this.#delimiter, 0);
 
 				if (delimIndex === -1) {
-					if (this.#state === 0) {
-						// Discard preamble, keeping only a possible trailing partial delimiter.
-						const keep = this.#delimiter.byteLength - 1;
-						if (this.#buffer.byteLength > keep) {
-							this.#buffer = this.#buffer.slice(this.#buffer.byteLength - keep);
-						}
+					// No complete delimiter: everything except a possible trailing partial delimiter
+					// is preamble (state 0, discarded) or confirmed part bytes (state 2, retained).
+					const safeLength = Math.max(0, data.byteLength - (this.#delimiter.byteLength - 1));
+					if (this.#state === 2 && safeLength > 0) {
+						this.#partChunks.push(data.slice(0, safeLength));
 					}
-					// In state 2 the buffer holds in-progress part data; wait for more bytes.
+					this.#carry = data.slice(safeLength);
 					break;
 				}
 
 				if (this.#state === 2) {
-					// Everything before the delimiter is the part body (headers + data).
-					const partBody = this.#buffer.slice(0, delimIndex);
+					// [0, delimIndex) completes the part body (headers + data).
+					const partBody = combineUint8Arrays(...this.#partChunks, data.slice(0, delimIndex));
+					this.#partChunks = [];
 					const headerEnd = indexOfSubsequence(partBody, HEADER_SEPARATOR, 0);
 					if (headerEnd === -1) {
 						throw new Error("Malformed multipart part: missing header/data separator");
 					}
 					parts.push(partBody.slice(headerEnd + HEADER_SEPARATOR.byteLength));
 				}
-				// Consume the delimiter; move to post-boundary state.
-				this.#buffer = this.#buffer.slice(delimIndex + this.#delimiter.byteLength);
+				// Consume the delimiter; decide next state from what follows it.
+				data = data.slice(delimIndex + this.#delimiter.byteLength);
 				this.#state = 1;
 				continue;
 			}
 
 			// state === 1: just after a boundary marker. Expect CRLF (a part follows) or `--` (end).
-			// A leading `\r\n` may precede the first delimiter in the body, so also tolerate CRLF here.
-			if (this.#buffer.byteLength < 2) {
-				break; // need more bytes to decide
+			if (data.byteLength < 2) {
+				this.#carry = data;
+				break;
 			}
-			if (this.#buffer[0] === DASH_DASH[0] && this.#buffer[1] === DASH_DASH[1]) {
+			if (data[0] === 0x2d && data[1] === 0x2d) {
+				// `--`: closing delimiter
 				this.#done = true;
-				this.#buffer = new Uint8Array(0);
 				return parts;
 			}
-			if (this.#buffer[0] === CRLF[0] && this.#buffer[1] === CRLF[1]) {
-				this.#buffer = this.#buffer.slice(2);
+			if (data[0] === CRLF[0] && data[1] === CRLF[1]) {
+				data = data.slice(2);
 				this.#state = 2;
 				continue;
 			}


### PR DESCRIPTION
Based on https://github.com/huggingface/huggingface.js/pull/2265/changes

Removing fallbacks, also keep the request streaming to limit memory footprint


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core Hub Xet download path and changes the CAS reconstruction contract, but behavior is guarded by explicit errors and extensive new tests.
> 
> **Overview**
> Updates **Xet blob downloads** to the v2 reconstruction API and the new `xorbs` schema: each signed URL lists one or more `{ chunks, bytes }` ranges instead of the old `fetch_info` single `range` + `url_range` pair. Reconstruction calls use **`/v2/reconstructions/`** (rewriting v1 link URLs when needed).
> 
> When a fetch entry has **multiple signed byte ranges**, `XetBlob` issues one HTTP request with a combined `Range` header and **requires** a `multipart/byteranges` response. A new **`StreamingMultipartParser`** streams and splits parts without buffering the full body; each part is decoded through shared **`parseChunkHeader` / `decompressChunk` / `decodePartChunks`** helpers with strict checks (part count, chunk counts, `unpacked_length`). If the CDN returns a non-multipart body for a multi-range request, the client **throws** rather than guessing—servers that lack multi-range support are expected to emit separate single-range entries instead.
> 
> Supporting utilities: variadic **`combineUint8Arrays`**, Boyer–Moore **`indexOfSubsequence`**, plus broad **`XetBlob`** and parser tests for happy path and failure modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aefc52de1f43c2790cafef32ecf3352359a78b28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->