### PR TITLE
Switch from secret to OIDC auth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ jobs:
   node:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      id-token: write # needed to mint the OIDC token exchanged for a short-lived HF token (trusted publishers)
+      contents: read
 
     steps:
       - uses: actions/checkout@v3
@@ -40,14 +43,25 @@ jobs:
           pnpm install --frozen-lockfile --filter ...[${{ steps.since.outputs.SINCE }}]...
           pnpm --filter ...[${{ steps.since.outputs.SINCE }}]... build
 
+      - name: Install the hf CLI
+        run: |
+          curl -LsSf https://hf.co/cli/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Exchange OIDC token for a short-lived HF token (trusted publisher)
+        env:
+          HF_OIDC_RESOURCE: coyotte508 # HF username whose user-publisher is configured under https://huggingface.co/settings/authentication#ci-cd-access
+        run: echo "HF_TOKEN=$(hf auth token)" >> "$GITHUB_ENV"
+
       - name: Test
         run: pnpm --filter ...[${{ steps.since.outputs.SINCE }}] test
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   browser:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      id-token: write # needed to mint the OIDC token exchanged for a short-lived HF token (trusted publishers)
+      contents: read
 
     steps:
       - uses: actions/checkout@v3
@@ -80,14 +94,25 @@ jobs:
           pnpm install --frozen-lockfile --filter ...[${{ steps.since.outputs.SINCE }}]...
           pnpm --filter ...[${{ steps.since.outputs.SINCE }}]... build
 
+      - name: Install the hf CLI
+        run: |
+          curl -LsSf https://hf.co/cli/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Exchange OIDC token for a short-lived HF token (trusted publisher)
+        env:
+          HF_OIDC_RESOURCE: coyotte508 # HF username whose user-publisher is configured under https://huggingface.co/settings/authentication#ci-cd-access
+        run: echo "HF_TOKEN=$(hf auth token)" >> "$GITHUB_ENV"
+
       - name: Test in browser
         run: pnpm --filter ...[${{ steps.since.outputs.SINCE }}] test:browser
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      id-token: write # needed to mint the OIDC token exchanged for a short-lived HF token (trusted publishers)
+      contents: read
 
     steps:
       - uses: actions/checkout@v3
@@ -99,6 +124,16 @@ jobs:
           node-version: "20"
           cache: "pnpm"
           cache-dependency-path: "**/pnpm-lock.yaml"
+
+      - name: Install the hf CLI
+        run: |
+          curl -LsSf https://hf.co/cli/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Exchange OIDC token for a short-lived HF token (trusted publisher)
+        env:
+          HF_OIDC_RESOURCE: coyotte508 # HF username whose user-publisher is configured under https://huggingface.co/settings/authentication#ci-cd-access
+        run: echo "HF_TOKEN=$(hf auth token)" >> "$GITHUB_ENV"
 
       - name: E2E - start mock npm registry
         run: |
@@ -129,7 +164,7 @@ jobs:
           pnpm i --ignore-workspace --registry http://localhost:4874/
           pnpm start
         env:
-          token: ${{ secrets.HF_TOKEN }}
+          token: $HF_TOKEN
 
       - name: E2E test - svelte app build
         working-directory: e2e/svelte
@@ -146,4 +181,3 @@ jobs:
         run: deno run --allow-read --allow-net --allow-env=HF_TOKEN index.ts
         env:
           NPM_CONFIG_REGISTRY: http://localhost:4874/
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,15 @@ jobs:
       - name: Exchange OIDC token for a short-lived HF token (trusted publisher)
         env:
           HF_OIDC_RESOURCE: coyotte508 # HF username whose user-publisher is configured under https://huggingface.co/settings/authentication#ci-cd-access
-        run: echo "HF_TOKEN=$(hf auth token)" >> "$GITHUB_ENV"
+        run: |
+          # Validate the token shape before writing it to GITHUB_ENV: a single-line "hf_..." value
+          # cannot smuggle extra KEY=VALUE lines into the env file, whatever the CLI outputs.
+          token="$(hf auth token)" || { echo "::warning::OIDC token exchange failed, tests will run unauthenticated"; exit 0; }
+          if ! [[ "$token" =~ ^hf_[A-Za-z0-9._-]+$ ]]; then
+            echo "::warning::Unexpected token format from OIDC exchange, ignoring it"
+            exit 0
+          fi
+          echo "HF_TOKEN=$token" >> "$GITHUB_ENV"
 
       - name: Test
         run: pnpm --filter ...[${{ steps.since.outputs.SINCE }}] test
@@ -102,7 +110,15 @@ jobs:
       - name: Exchange OIDC token for a short-lived HF token (trusted publisher)
         env:
           HF_OIDC_RESOURCE: coyotte508 # HF username whose user-publisher is configured under https://huggingface.co/settings/authentication#ci-cd-access
-        run: echo "HF_TOKEN=$(hf auth token)" >> "$GITHUB_ENV"
+        run: |
+          # Validate the token shape before writing it to GITHUB_ENV: a single-line "hf_..." value
+          # cannot smuggle extra KEY=VALUE lines into the env file, whatever the CLI outputs.
+          token="$(hf auth token)" || { echo "::warning::OIDC token exchange failed, tests will run unauthenticated"; exit 0; }
+          if ! [[ "$token" =~ ^hf_[A-Za-z0-9._-]+$ ]]; then
+            echo "::warning::Unexpected token format from OIDC exchange, ignoring it"
+            exit 0
+          fi
+          echo "HF_TOKEN=$token" >> "$GITHUB_ENV"
 
       - name: Test in browser
         run: pnpm --filter ...[${{ steps.since.outputs.SINCE }}] test:browser
@@ -133,7 +149,15 @@ jobs:
       - name: Exchange OIDC token for a short-lived HF token (trusted publisher)
         env:
           HF_OIDC_RESOURCE: coyotte508 # HF username whose user-publisher is configured under https://huggingface.co/settings/authentication#ci-cd-access
-        run: echo "HF_TOKEN=$(hf auth token)" >> "$GITHUB_ENV"
+        run: |
+          # Validate the token shape before writing it to GITHUB_ENV: a single-line "hf_..." value
+          # cannot smuggle extra KEY=VALUE lines into the env file, whatever the CLI outputs.
+          token="$(hf auth token)" || { echo "::warning::OIDC token exchange failed, tests will run unauthenticated"; exit 0; }
+          if ! [[ "$token" =~ ^hf_[A-Za-z0-9._-]+$ ]]; then
+            echo "::warning::Unexpected token format from OIDC exchange, ignoring it"
+            exit 0
+          fi
+          echo "HF_TOKEN=$token" >> "$GITHUB_ENV"
 
       - name: E2E - start mock npm registry
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,9 +186,8 @@ jobs:
         working-directory: e2e/ts
         run: |
           pnpm i --ignore-workspace --registry http://localhost:4874/
-          pnpm start
-        env:
-          token: $HF_TOKEN
+          # shell expands $HF_TOKEN here (an env: map would pass the literal string "$HF_TOKEN")
+          token="$HF_TOKEN" pnpm start
 
       - name: E2E test - svelte app build
         working-directory: e2e/svelte

--- a/packages/hub/src/consts.ts
+++ b/packages/hub/src/consts.ts
@@ -1,1 +1,4 @@
+/**
+ * Base URL of the Hugging Face Hub.
+ */
 export const HUB_URL = "https://huggingface.co";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI authentication now depends on Hugging Face trusted-publisher/OIDC configuration; misconfiguration or exchange failures cause tests to run without credentials rather than failing the job outright.
> 
> **Overview**
> CI no longer injects **`secrets.HF_TOKEN`** into the **node**, **browser**, and **e2e** jobs in `.github/workflows/test.yml`. Each job now requests **`id-token: write`** and **`contents: read`**, installs the **hf CLI**, and exchanges the GitHub OIDC identity for a short-lived Hub token via **`HF_OIDC_RESOURCE`** (trusted publisher for user `coyotte508`). The token is written to **`GITHUB_ENV`** only after a strict **`hf_...`** regex check so malformed CLI output cannot poison the env file; exchange failures log a warning and tests continue **unauthenticated**.
> 
> E2E steps that previously passed the secret explicitly now rely on that job-level **`HF_TOKEN`**: the TypeScript smoke test uses shell expansion (`token="$HF_TOKEN" pnpm start`), and the Deno step drops the per-step **`HF_TOKEN`** env mapping while still allowing **`HF_TOKEN`** from the environment.
> 
> A one-line JSDoc comment was added above **`HUB_URL`** in `packages/hub/src/consts.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8885fe60ef988a7db07d8f3f8d221ac8837d0aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->