### PR TITLE
Reword SafetensorParseError JSDoc (review follow-up)

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -182,7 +182,7 @@ function packingFactor(dtype: Dtype, numBits: number | undefined): number {
 
 /**
  * Thrown when a safetensors file or sharded index is malformed (bad header, invalid tensor
- * entry, unsafe shard filename, …) rather than when fetching it fails, so callers can treat
+ * entry, unsafe shard filename, …) rather than a failure when fetching, so callers can treat
  * the failure as permanent — e.g. drop a cached parse result instead of keeping it for retry.
  */
 export class SafetensorParseError extends Error {


### PR DESCRIPTION
Applies @julien-c's suggested rewording of the `SafetensorParseError` JSDoc on #2341, which was merged before the comment landed.

https://github.com/huggingface/huggingface.js/pull/2341#pullrequestreview-4856739341

Doc comment only — no behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no runtime or API impact.
> 
> **Overview**
> **Documentation-only** follow-up on merged safetensors parsing work: the `SafetensorParseError` class JSDoc is rephrased so the contrast reads more clearly — malformed file/index cases are distinguished from **a failure when fetching**, not “when fetching it fails.”
> 
> The intent for callers is unchanged: treat this error as a **permanent** parse problem (e.g. invalidate cache) versus transient network/download issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a815b04ed2382654b49580e6eddb5cda2b97541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->