### PR TITLE
[Inference Providers] fix fal-ai image-text-to-video URL rewrite breaking routed calls

### DIFF
--- a/packages/inference/src/providers/fal-ai.ts
+++ b/packages/inference/src/providers/fal-ai.ts
@@ -37,7 +37,7 @@ import {
 	type TextToVideoTaskHelper,
 	type ImageToVideoTaskHelper,
 } from "./providerHelper.js";
-import { HF_HUB_URL } from "../config.js";
+import { HF_HUB_URL, HF_ROUTER_URL } from "../config.js";
 import type { AutomaticSpeechRecognitionArgs } from "../tasks/audio/automaticSpeechRecognition.js";
 import type { AudioToAudioArgs, AudioToAudioOutput } from "../tasks/audio/audioToAudio.js";
 import {
@@ -221,6 +221,24 @@ function buildLoraPath(modelId: ModelId, adapterWeightsPath: string): string {
 	return `${HF_HUB_URL}/${modelId}/resolve/main/${adapterWeightsPath}`;
 }
 
+/**
+ * Some fal apps expose the image+text variant one path segment deeper than the text-only one
+ * (e.g. `fal-ai/flux-2` and `fal-ai/flux-2/edit`). When the mapping points at the deeper endpoint,
+ * an image-less call drops the last segment to reach the text-only one.
+ *
+ * Only valid when calling fal directly: when routing through huggingface.co, the URL path *is* the
+ * provider model id the router resolves the mapping from, so rewriting it makes the model
+ * unresolvable ("Model not supported by provider fal-ai").
+ */
+function dropEndpointSegmentOnDirectCalls(url: string): string {
+	const urlObj = new URL(url);
+	if (urlObj.origin === HF_ROUTER_URL) {
+		return url;
+	}
+	urlObj.pathname = urlObj.pathname.split("/").slice(0, -1).join("/");
+	return urlObj.toString();
+}
+
 export class FalAITextToImageTask extends FalAiQueueTask implements TextToImageTaskHelper {
 	task: InferenceTask;
 
@@ -368,12 +386,7 @@ export class FalAIImageTextToImageTask extends FalAIImageToImageTask implements 
 			...omit(args, ["inputs", "parameters"]),
 			...(args.parameters as Record<string, unknown>),
 			prompt: args.parameters?.prompt,
-			urlTransform: (url) => {
-				const urlObj = new URL(url);
-				// Strip last path segment: fal-ai/flux-2/edit => fal-ai/flux-2
-				urlObj.pathname = urlObj.pathname.split("/").slice(0, -1).join("/");
-				return urlObj.toString();
-			},
+			urlTransform: dropEndpointSegmentOnDirectCalls,
 		} as RequestArgs;
 	}
 }
@@ -502,11 +515,7 @@ export class FalAIImageTextToVideoTask extends FalAIImageToVideoTask implements 
 			...omit(args, ["inputs", "parameters"]),
 			...(args.parameters as Record<string, unknown>),
 			prompt: args.parameters?.prompt,
-			urlTransform: (url) => {
-				const urlObj = new URL(url);
-				urlObj.pathname = urlObj.pathname.split("/").slice(0, -1).join("/");
-				return urlObj.toString();
-			},
+			urlTransform: dropEndpointSegmentOnDirectCalls,
 		} as RequestArgs;
 	}
 }

--- a/packages/inference/test/fal-ai-url.spec.ts
+++ b/packages/inference/test/fal-ai-url.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { FalAIImageTextToImageTask, FalAIImageTextToVideoTask } from "../src/providers/fal-ai.js";
+import type { AuthMethod } from "../src/types.js";
+
+async function urlFor(
+	helper: FalAIImageTextToImageTask | FalAIImageTextToVideoTask,
+	providerId: string,
+	authMethod: AuthMethod,
+	args: Record<string, unknown>,
+): Promise<string> {
+	const payload = await helper.preparePayloadAsync(args as never);
+	return helper.makeUrl({
+		authMethod,
+		model: providerId,
+		task: helper.task,
+		urlTransform: (payload as { urlTransform?: (url: string) => string }).urlTransform,
+	});
+}
+
+const PROMPT_ONLY = { parameters: { prompt: "a bee on a sunflower" } };
+const WITH_IMAGE = { inputs: new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" }), ...PROMPT_ONLY };
+
+describe("fal-ai request URLs", () => {
+	describe("image-text-to-video", () => {
+		const providerId = "minimax/h3/image-to-video";
+
+		it("keeps the provider model id intact when routed through huggingface.co", async () => {
+			// The router resolves the mapping from the URL path, so dropping a segment makes the model
+			// unresolvable ("Model not supported by provider fal-ai").
+			expect(await urlFor(new FalAIImageTextToVideoTask(), providerId, "hf-token", PROMPT_ONLY)).toBe(
+				"https://router.huggingface.co/fal-ai/minimax/h3/image-to-video?_subdomain=queue",
+			);
+		});
+
+		it("drops the endpoint segment when calling fal directly", async () => {
+			expect(await urlFor(new FalAIImageTextToVideoTask(), providerId, "provider-key", PROMPT_ONLY)).toBe(
+				"https://queue.fal.run/minimax/h3",
+			);
+		});
+
+		it("never rewrites the URL when an image is provided", async () => {
+			expect(await urlFor(new FalAIImageTextToVideoTask(), providerId, "hf-token", WITH_IMAGE)).toBe(
+				"https://router.huggingface.co/fal-ai/minimax/h3/image-to-video?_subdomain=queue",
+			);
+			expect(await urlFor(new FalAIImageTextToVideoTask(), providerId, "provider-key", WITH_IMAGE)).toBe(
+				"https://queue.fal.run/minimax/h3/image-to-video",
+			);
+		});
+	});
+
+	describe("image-text-to-image", () => {
+		const providerId = "fal-ai/flux-2/edit";
+
+		it("keeps the provider model id intact when routed through huggingface.co", async () => {
+			expect(await urlFor(new FalAIImageTextToImageTask(), providerId, "hf-token", PROMPT_ONLY)).toBe(
+				"https://router.huggingface.co/fal-ai/fal-ai/flux-2/edit?_subdomain=queue",
+			);
+		});
+
+		it("drops the /edit segment when calling fal directly", async () => {
+			expect(await urlFor(new FalAIImageTextToImageTask(), providerId, "provider-key", PROMPT_ONLY)).toBe(
+				"https://queue.fal.run/fal-ai/flux-2",
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Problem

`FalAIImageTextToVideoTask.preparePayloadAsync` (and its `image-text-to-image` counterpart) drops the last path segment of the request URL when no image is provided:

```ts
urlTransform: (url) => {
    const urlObj = new URL(url);
    urlObj.pathname = urlObj.pathname.split("/").slice(0, -1).join("/");
    return urlObj.toString();
},
```

The intent is to reach the text-only variant of a fal endpoint (`fal-ai/flux-2/edit` → `fal-ai/flux-2`), which works when calling fal directly.

It does not work when routing through huggingface.co: there, the URL path **is** the provider model id the router resolves the mapping from, so rewriting it makes the model unresolvable. The request fails with `Model not supported by provider fal-ai` before ever reaching fal — and no fal mapping registers the stripped parent path (`fal-ai/flux-2`, `minimax/h3`, … are all absent).

The first model to hit this is `MiniMaxAI/MiniMax-H3` (`minimax/h3/image-to-video`), the first fal `image-text-to-video` mapping. A prompt-only call was sent to `/fal-ai/minimax/h3`:

```
POST https://router.huggingface.co/fal-ai/minimax/h3?_subdomain=queue
→ 400 {"error":"Model not supported by provider fal-ai"}
```

Surfaced in the model page widget, which offers "Enter a prompt, an image, or both", as `Failed to perform inference: Model not supported by provider fal-ai`.

## Fix

Keep the rewrite for direct fal calls (behaviour unchanged) and skip it when the request goes through the router. Both duplicated closures now share one documented helper, so the FLUX.2-specific rationale lives in one place instead of being silently inherited.

## Verification

Live, against `router.huggingface.co` and fal:

| case | before | after |
|---|---|---|
| prompt only | `POST /fal-ai/minimax/h3` → 400 `Model not supported by provider fal-ai` | `POST /fal-ai/minimax/h3/image-to-video` → 422 `image_url: Field required` |
| image + prompt | correct URL already | unchanged, returns `video/mp4, 2256308 bytes` |
| prompt only, direct fal key | `queue.fal.run/minimax/h3` | unchanged |

The 422 is the correct outcome: fal's OpenAPI has `minimax/h3/image-to-video` requiring both `prompt` and `image_url` (prompt-only lives at `minimax/h3/text-to-video`). The fix stops the SDK from corrupting the URL and lets the provider's real error through instead of a misleading routing failure.

`test/fal-ai-url.spec.ts` pins both sides of the guard. Run against the pre-fix code, exactly the two routed assertions fail and the three direct-key/with-image ones pass — so direct-fal behaviour is provably unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted URL-building fix in fal-ai inference with tests; no auth or data-handling changes.
> 
> **Overview**
> **Fixes prompt-only fal-ai `image-text-to-image` and `image-text-to-video` calls when using the Hugging Face router.** Those tasks used to always strip the last URL path segment (e.g. `minimax/h3/image-to-video` → `minimax/h3`) so direct fal calls could hit a text-only endpoint. On `router.huggingface.co` the path is the provider model id used for mapping, so that rewrite caused `Model not supported by provider fal-ai`.
> 
> The change introduces `dropEndpointSegmentOnDirectCalls`, which **only** drops the last segment when the request is **not** routed through the router; router URLs are left unchanged. Direct fal behavior and image+prompt URLs are unchanged. **`test/fal-ai-url.spec.ts`** locks in router vs direct-key URL behavior for both tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d61b9372c998e11576cf79a1edae2f9847335e1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->