### PR TITLE
[hub] Remove the lower browser cap on the in-flight download budget

### DIFF
--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -39,7 +39,7 @@ type XetBlobCreateOptions = {
 	 * increasing while aggregate throughput improves and backing off on rate-limits or when
 	 * extra connections stop helping. Memory is bounded: at most `maxInFlightBytes` of
 	 * downloaded-but-not-yet-consumed data is held (by default derived from the file's
-	 * reconstruction: 64-256MB in Node, 64MB in browsers).
+	 * reconstruction, between 64MB and 256MB).
 	 *
 	 * Pass `false` to download serially, or an object to tune the ceiling/budget.
 	 *
@@ -64,11 +64,15 @@ export interface ParallelDownloadOptions {
 	onStat?: (stat: Record<string, unknown>) => void;
 }
 
-// Browsers get a lower ceiling and a fixed budget: connections may share an HTTP/2 session,
-// and tab/worker memory is scarcer than in Node.
+// Browsers get a lower concurrency ceiling: connections may share an HTTP/2 session, and
+// tab/worker memory is scarcer than in Node. The byte budget derivation is identical
+// everywhere — a cap below ~3x the entry size degrades below serial performance (entries
+// reserve their estimated size before fetching), and since entries max out at one xorb
+// (~64MB compressed) the derivation self-limits at ~192MB; actual browser memory is further
+// bounded by the lower ceiling.
 const PARALLEL_DEFAULT_MAX_CONCURRENCY = isFrontend ? 4 : 8;
 const PARALLEL_MIN_IN_FLIGHT_BYTES = 64 * 1024 * 1024;
-const PARALLEL_MAX_IN_FLIGHT_BYTES = isFrontend ? 64 * 1024 * 1024 : 256 * 1024 * 1024;
+const PARALLEL_MAX_IN_FLIGHT_BYTES = 256 * 1024 * 1024;
 
 /** Simple broadcast notifier: `wait()` resolves at the next `notifyAll()`. */
 class Notifier {


### PR DESCRIPTION
Follow-up to #2350, found by testing the published prerelease (`2.15.0-parallel-dl.1`) in a browser via a static Space: the flat 64MB browser budget fits fewer than two typical xorb entry reservations (~40–50MB compressed), so parallel degraded below serial (13.5s vs 8.2s on SmolLM2) — the same budget-below-3×-entry-size pathology the VPS benchmarks in #2350 demonstrated.

Fix: use the same reconstruction-derived budget everywhere, `clamp(3 × largest entry, 64MB, 256MB)`. The cap never artificially clips in browsers: entries max out at one xorb (~64MB compressed), so the derivation self-limits at ~192MB, and actual browser memory stays bounded by the lower concurrency ceiling (4). The environment distinction now lives in a single knob (the ceiling) instead of two.

With ~40MB entries this restores the ~120MB budget that produced the 2.8× browser win in the #2350 benchmarks (`maxActive=3`, ~200MB peak heap).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-constant change in Xet parallel download tuning with clearer docs; browser memory remains limited by lower max concurrency.
> 
> **Overview**
> **Parallel Xet downloads in browsers** no longer use a fixed **64MB** in-flight byte ceiling. `PARALLEL_MAX_IN_FLIGHT_BYTES` is **256MB** in all environments, so the default budget follows the same reconstruction rule everywhere: **3× largest xorb entry**, clamped to **[64MB, 256MB]**.
> 
> That fixes browser parallel mode falling **below serial** when typical ~40–50MB entries need ~120MB of budget to reserve more than one fetch at a time. **Browser vs Node** now differs only on **concurrency** (4 vs 8); comments and JSDoc describe the unified budget and why memory stays bounded in tabs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b038b2439ffe94392289b8ee42fcfc34b0a25e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->