### PR TITLE
[hub] Plateau-seeking concurrency controller for parallel xet downloads

### DIFF
--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -374,7 +374,7 @@ describe("XetBlob", () => {
 			let pacer = Promise.resolve();
 			const takeSlot = () => (pacer = pacer.then(() => new Promise<void>((resolve) => setTimeout(resolve, 1))));
 			const PIECE = 512;
-			const released = new Promise<void>((resolve) => setTimeout(resolve, 150));
+			const released = new Promise<void>((resolve) => setTimeout(resolve, 250));
 
 			let stat: Record<string, unknown> | undefined;
 			const blob = new XetBlob({

--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -365,6 +365,52 @@ describe("XetBlob", () => {
 			expect(Math.max(...history)).toBeLessThan(4);
 		});
 
+		it("walks back down after a zero-rate climb (stalled start)", async () => {
+			// Responses stall long enough for the zero-rate heuristic to climb several levels
+			// without measuring them, then stream on a bandwidth-capped link. The controller
+			// must re-measure the skipped levels on the way down instead of being stuck at the
+			// stall peak forever.
+			const fixture = makeParallelFixture(16, 1024, 32);
+			let pacer = Promise.resolve();
+			const takeSlot = () => (pacer = pacer.then(() => new Promise<void>((resolve) => setTimeout(resolve, 1))));
+			const PIECE = 512;
+			const released = new Promise<void>((resolve) => setTimeout(resolve, 150));
+
+			let stat: Record<string, unknown> | undefined;
+			const blob = new XetBlob({
+				hash: "test",
+				size: fixture.wholeText.length,
+				refreshUrl: "https://huggingface.co",
+				parallelDownloads: { maxConcurrency: 4, controllerTickMs: 30, onStat: (s) => (stat = s) },
+				fetch: async function (_url) {
+					const url = new URL(_url as string);
+					if (url.hostname !== "xorb.co") {
+						return makeFetch(fixture)(_url as string);
+					}
+					await released;
+					const data = fixture.xorbData[Number(url.pathname.slice(1))];
+					let offset = 0;
+					return new Response(
+						new ReadableStream({
+							async pull(controller) {
+								await takeSlot();
+								controller.enqueue(data.subarray(offset, offset + PIECE));
+								offset += PIECE;
+								if (offset >= data.byteLength) {
+									controller.close();
+								}
+							},
+						}),
+					);
+				},
+			});
+
+			expect(await blob.text()).toBe(fixture.wholeText);
+			const history = (stat?.targetHistory ?? []) as number[];
+			expect(Math.max(...history)).toBeGreaterThanOrEqual(3); // the stall climbed
+			expect(history[history.length - 1]).toBeLessThan(Math.max(...history)); // …and came back down
+		});
+
 		it("propagates fetch errors", async () => {
 			const fixture = makeParallelFixture(3);
 

--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -203,26 +203,32 @@ describe("XetBlob", () => {
 	describe("parallelDownloads", () => {
 		// Build a file spread over `xorbCount` distinct xorbs (2 chunks each), served by one URL per
 		// xorb so the entry fetches are independent and can overlap.
-		function makeParallelFixture(xorbCount: number) {
+		function makeParallelFixture(xorbCount: number, chunkLength = 12, chunksPerXorb = 2) {
 			const contents = Array(xorbCount)
 				.fill(0)
-				.map((_, i) => [`chunk-${i}-a-`, `chunk-${i}-b!`] as const);
-			const xorbData = contents.map(([a, b]) => combineUint8Arrays(makeChunk(a), makeChunk(b)));
-			const wholeText = contents.map(([a, b]) => a + b).join("");
+				.map((_, i) =>
+					Array(chunksPerXorb)
+						.fill(0)
+						.map((_, j) => `chunk-${i}-${j}-`.padEnd(chunkLength, "x")),
+				);
+			const xorbData = contents.map((chunks) => combineUint8Arrays(...chunks.map((chunk) => makeChunk(chunk))));
+			const wholeText = contents.map((chunks) => chunks.join("")).join("");
 
 			const reconstructionInfo: ReconstructionInfo = {
-				terms: contents.map(([a, b], i) => ({
+				terms: contents.map((chunks, i) => ({
 					hash: `xorb${i}`,
-					range: { start: 0, end: 2 },
-					unpacked_length: a.length + b.length,
+					range: { start: 0, end: chunksPerXorb },
+					unpacked_length: sum(chunks.map((chunk) => chunk.length)),
 				})),
 				xorbs: Object.fromEntries(
-					contents.map(([, ,], i) => [
+					contents.map((_, i) => [
 						`xorb${i}`,
 						[
 							{
 								url: `https://xorb.co/${i}`,
-								ranges: [{ chunks: { start: 0, end: 2 }, bytes: { start: 0, end: xorbData[i].byteLength - 1 } }],
+								ranges: [
+									{ chunks: { start: 0, end: chunksPerXorb }, bytes: { start: 0, end: xorbData[i].byteLength - 1 } },
+								],
 							},
 						],
 					]),
@@ -272,7 +278,9 @@ describe("XetBlob", () => {
 				hash: "test",
 				size: fixture.wholeText.length,
 				refreshUrl: "https://huggingface.co",
-				parallelDownloads: { maxConcurrency: 4, onStat: (s) => (stat = s) },
+				// Fast controller ticks: with the responses gated, no bytes flow, so each tick
+				// probes one connection up (latency-bound heuristic) until the ceiling.
+				parallelDownloads: { maxConcurrency: 4, controllerTickMs: 5, onStat: (s) => (stat = s) },
 				fetch: makeFetch(fixture, {
 					gate: released,
 					onXorbRequest: () => {
@@ -307,6 +315,54 @@ describe("XetBlob", () => {
 
 			expect(await blob.text()).toBe(fixture.wholeText);
 			expect(stat?.maxActive).toBe(1);
+		});
+
+		it("settles back to serial on a bandwidth-capped link", async () => {
+			// Simulate a saturated link: a shared pacer caps aggregate throughput no matter how
+			// many streams are open, so extra connections never improve the byte rate and the
+			// controller should spend most of the download at concurrency 1.
+			const fixture = makeParallelFixture(16, 1024, 32);
+			let pacer = Promise.resolve();
+			const takeSlot = () => (pacer = pacer.then(() => new Promise<void>((resolve) => setTimeout(resolve, 1))));
+			const PIECE = 512;
+
+			let stat: Record<string, unknown> | undefined;
+			const blob = new XetBlob({
+				hash: "test",
+				size: fixture.wholeText.length,
+				refreshUrl: "https://huggingface.co",
+				parallelDownloads: { maxConcurrency: 4, controllerTickMs: 30, onStat: (s) => (stat = s) },
+				fetch: async function (_url) {
+					const url = new URL(_url as string);
+					if (url.hostname !== "xorb.co") {
+						return makeFetch(fixture)(_url as string);
+					}
+					const data = fixture.xorbData[Number(url.pathname.slice(1))];
+					let offset = 0;
+					return new Response(
+						new ReadableStream({
+							async pull(controller) {
+								await takeSlot();
+								controller.enqueue(data.subarray(offset, offset + PIECE));
+								offset += PIECE;
+								if (offset >= data.byteLength) {
+									controller.close();
+								}
+							},
+						}),
+					);
+				},
+			});
+
+			expect(await blob.text()).toBe(fixture.wholeText);
+			const history = (stat?.targetHistory ?? []) as number[];
+			expect(history.length).toBeGreaterThan(10);
+			// Probes are allowed (that's how the plateau is found), but the controller must
+			// settle near serial rather than ratchet up: most ticks at 1-2 (under event-loop
+			// contention the mock's entry-transition gaps let 2 genuinely beat 1), and the
+			// ceiling is never reached.
+			expect(history.filter((t) => t <= 2).length).toBeGreaterThan(history.length * 0.6);
+			expect(Math.max(...history)).toBeLessThan(4);
 		});
 
 		it("propagates fetch errors", async () => {

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -35,9 +35,10 @@ type XetBlobCreateOptions = {
 	/**
 	 * Fetch xorb data with multiple parallel requests, instead of one at a time.
 	 *
-	 * Concurrency is tuned automatically (starting at 2, between 1 and `maxConcurrency`),
-	 * increasing while aggregate throughput improves and backing off on rate-limits or when
-	 * extra connections stop helping. Memory is bounded: at most `maxInFlightBytes` of
+	 * Concurrency is tuned automatically (starting serially, between 1 and `maxConcurrency`):
+	 * extra connections are added one at a time and only kept while they improve aggregate
+	 * throughput, so an already-saturated link stays at (or near) serial speed. Rate-limits
+	 * always back off. Memory is bounded: at most `maxInFlightBytes` of
 	 * downloaded-but-not-yet-consumed data is held (by default derived from the file's
 	 * reconstruction, between 64MB and 256MB).
 	 *
@@ -62,6 +63,10 @@ export interface ParallelDownloadOptions {
 	 * @internal Instrumentation callback for tests and benchmarks, called once per download.
 	 */
 	onStat?: (stat: Record<string, unknown>) => void;
+	/**
+	 * @internal Concurrency controller tick interval, for tests and benchmarks.
+	 */
+	controllerTickMs?: number;
 }
 
 // Browsers get a lower concurrency ceiling: connections may share an HTTP/2 session, and
@@ -73,6 +78,11 @@ export interface ParallelDownloadOptions {
 const PARALLEL_DEFAULT_MAX_CONCURRENCY = isFrontend ? 4 : 8;
 const PARALLEL_MIN_IN_FLIGHT_BYTES = 64 * 1024 * 1024;
 const PARALLEL_MAX_IN_FLIGHT_BYTES = 256 * 1024 * 1024;
+const PARALLEL_CONTROLLER_TICK_MS = 500;
+/** An extra connection is kept only if aggregate throughput improves by at least this factor. */
+const PARALLEL_PROBE_KEEP_MARGIN = 1.05;
+/** Ticks between upward re-probes once a concurrency plateau has been found (~5s). */
+const PARALLEL_PLATEAU_HOLD_TICKS = 10;
 
 /** Simple broadcast notifier: `wait()` resolves at the next `notifyAll()`. */
 class Notifier {
@@ -840,7 +850,7 @@ export class XetBlob extends Blob {
 			const state = {
 				nextEntry: 0,
 				neededEntry: 0,
-				target: Math.min(2, maxConcurrency),
+				target: 1,
 				error: undefined as unknown,
 				finished: false,
 				inFlightBytes: 0,
@@ -1112,30 +1122,57 @@ export class XetBlob extends Blob {
 			};
 			const workersDone = Promise.allSettled(Array.from({ length: maxConcurrency }, (_, i) => runWorker(i)));
 
-			// ---- Adaptive concurrency controller (AIMD-style, throughput-driven)
+			// ---- Adaptive concurrency controller (plateau-seeking, throughput-driven)
 			//
-			// Every 500ms, compare aggregate decode throughput with the (decaying) best observed:
-			// grow while extra connections keep improving it, back off on rate-limits or when
-			// throughput regresses. This detects bandwidth saturation even when every request
-			// succeeds, so capped links settle at low concurrency instead of adding contention.
+			// Starts serial and probes one extra connection at a time, keeping a per-level
+			// average of aggregate decode throughput. A probe is kept only when the new level
+			// actually improves aggregate throughput; otherwise back off to the plateau and
+			// hold there, re-probing only occasionally in case conditions changed. On an
+			// already-saturated link this settles back to serial — the worst case is a brief
+			// probe — while unsaturated paths keep ramping. Ticks where nothing flowed probe
+			// up regardless: the bottleneck is latency, which extra connections hide. Rate
+			// limits (429s) always step down.
+			const levelRate = new Map<number, number>();
 			let lastBytes = 0;
-			let lastRate = 0;
 			let last429 = 0;
+			let settleTicks = 1; // measurements skipped while the latest target change takes effect
+			let holdTicks = 0; // plateau hold: no upward probes while positive
 			const controller = setInterval(() => {
 				const rate = state.decodedBytes - lastBytes;
 				lastBytes = state.decodedBytes;
+				holdTicks = Math.max(0, holdTicks - 1);
 				if (state.count429 > last429) {
 					last429 = state.count429;
 					state.target = Math.max(1, state.target - 1);
-				} else if (rate > lastRate * 1.05) {
+					settleTicks = 1;
+					holdTicks = PARALLEL_PLATEAU_HOLD_TICKS;
+				} else if (rate === 0) {
+					// Nothing decoded during the tick: latency-bound (TTFB) or stalled, so an
+					// extra connection cannot reduce aggregate throughput.
 					state.target = Math.min(maxConcurrency, state.target + 1);
-				} else if (rate > 0 && rate < lastRate * 0.7) {
-					state.target = Math.max(1, state.target - 1);
+					settleTicks = 1;
+				} else if (settleTicks > 0) {
+					settleTicks--;
+				} else if (state.claimed >= state.target) {
+					// Enough work for every connection during the tick (workers hold their claim
+					// between entries): a valid throughput sample for the current level.
+					const ewma = ((levelRate.get(state.target) ?? rate) + rate) / 2;
+					levelRate.set(state.target, ewma);
+					const below = levelRate.get(state.target - 1);
+					if (below !== undefined && ewma < below * PARALLEL_PROBE_KEEP_MARGIN) {
+						// The extra connection doesn't pay for itself: back off and hold.
+						levelRate.delete(state.target);
+						state.target--;
+						settleTicks = 1;
+						holdTicks = PARALLEL_PLATEAU_HOLD_TICKS;
+					} else if (holdTicks === 0 && state.target < maxConcurrency) {
+						state.target++;
+						settleTicks = 1;
+					}
 				}
-				lastRate = Math.max(rate, lastRate * 0.9);
 				state.targetHistory.push(state.target);
 				notifier.notifyAll();
-			}, 500);
+			}, opts.controllerTickMs ?? PARALLEL_CONTROLLER_TICK_MS);
 
 			// ---- In-order consumer
 			try {

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -1154,9 +1154,10 @@ export class XetBlob extends Blob {
 					state.target = Math.max(1, state.target - 1);
 					settleTicks = 1;
 					holdTicks = PARALLEL_PLATEAU_HOLD_TICKS;
-				} else if (rate === 0) {
+				} else if (rate === 0 && state.nextEntry < plan.length) {
 					// Nothing decoded during the tick: latency-bound (TTFB) or stalled, so an
-					// extra connection cannot reduce aggregate throughput.
+					// extra connection cannot reduce aggregate throughput. (Pointless once no
+					// unclaimed entries remain — an extra worker would have nothing to fetch.)
 					state.target = Math.min(maxConcurrency, state.target + 1);
 					settleTicks = 1;
 				} else if (settleTicks > 0) {

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -858,6 +858,7 @@ export class XetBlob extends Blob {
 				active: 0,
 				claimed: 0,
 				maxActive: 0,
+				activeHighWater: 0,
 				count429: 0,
 				targetHistory: [] as number[],
 			};
@@ -1086,6 +1087,7 @@ export class XetBlob extends Blob {
 						}
 						state.active++;
 						state.maxActive = Math.max(state.maxActive, state.active);
+						state.activeHighWater = Math.max(state.activeHighWater, state.active);
 						let lastError: unknown;
 						// One tally across attempts: commits skip already-populated ranges, so bytes
 						// committed by a failed attempt (possibly consumed and freed by the reader in
@@ -1140,6 +1142,12 @@ export class XetBlob extends Blob {
 			const controller = setInterval(() => {
 				const rate = state.decodedBytes - lastBytes;
 				lastBytes = state.decodedBytes;
+				// Highest number of simultaneously active connections during the tick: after a
+				// down-step, the retired worker keeps draining its entry for a while, and those
+				// ticks must not be credited to the lower level (an inflated baseline would
+				// suppress legitimate climbs later).
+				const tickHighWater = state.activeHighWater;
+				state.activeHighWater = state.active;
 				holdTicks = Math.max(0, holdTicks - 1);
 				if (state.count429 > last429) {
 					last429 = state.count429;
@@ -1153,9 +1161,10 @@ export class XetBlob extends Blob {
 					settleTicks = 1;
 				} else if (settleTicks > 0) {
 					settleTicks--;
-				} else if (state.claimed >= state.target) {
+				} else if (state.claimed >= state.target && tickHighWater <= state.target) {
 					// Enough work for every connection during the tick (workers hold their claim
-					// between entries): a valid throughput sample for the current level.
+					// between entries) and no extra connections still draining: a valid
+					// throughput sample for the current level.
 					const ewma = ((levelRate.get(state.target) ?? rate) + rate) / 2;
 					levelRate.set(state.target, ewma);
 					const below = levelRate.get(state.target - 1);

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -1159,7 +1159,14 @@ export class XetBlob extends Blob {
 					const ewma = ((levelRate.get(state.target) ?? rate) + rate) / 2;
 					levelRate.set(state.target, ewma);
 					const below = levelRate.get(state.target - 1);
-					if (below !== undefined && ewma < below * PARALLEL_PROBE_KEEP_MARGIN) {
+					if (state.target > 1 && below === undefined) {
+						// The level below was never measured (skipped by a zero-rate climb): step
+						// down to establish its baseline, keeping this level's average for the way
+						// back up. Repeats until a measured level (or 1) is reached, so stall-climbs
+						// always have a path back down.
+						state.target--;
+						settleTicks = 1;
+					} else if (below !== undefined && ewma < below * PARALLEL_PROBE_KEEP_MARGIN) {
 						// The extra connection doesn't pay for itself: back off and hold.
 						levelRate.delete(state.target);
 						state.target--;


### PR DESCRIPTION
Follow-up to #2350 (and the discussion in #2337): fixes the adaptive concurrency controller's behavior on bandwidth-saturated links.

## Problem

The AIMD controller compared each 500ms tick's throughput against its own **decayed best**, which inflates during ramp-up (TCP slow start makes every early tick look like an improvement). It therefore ratcheted toward the ceiling even on links where extra connections add nothing but contention — and it started at 2, so short downloads never converged back down. Measured in browsers on a capped residential line: parallel up to **20–33% slower than serial**.

## Fix

The controller is now **plateau-seeking**:

- **Starts serial** (target = 1), so the worst case on a saturated link is ≈ serial by construction, and downloads that finish within a tick never leave serial.
- Keeps a **per-concurrency-level EWMA** of aggregate decode throughput; samples are only taken on ticks where every connection had work, and the tick following a target change is skipped (ramp contamination — the old controller's main sin).
- A probe to level *n* is **kept only if it beats level *n*−1 by ≥5%**; otherwise it backs off to the plateau and holds for ~5s before re-probing (conditions change).
- Ticks where **nothing flowed** still probe up — the bottleneck is latency (TTFB/stall), which extra connections can only hide. Levels skipped by such climbs are re-measured on the way back down (a level with no baseline below it steps down instead of probing up), so stall-climbs always have a path back to the plateau.
- 429s still step down immediately.

No public API change: `parallelDownloads` stays `boolean | { maxConcurrency, maxInFlightBytes }`, default on. (New `@internal controllerTickMs` for tests, alongside the existing `onStat`.)

## Benchmarks

Node, real downloads (`SmolLM2-135M-Instruct` 269MB / `Qwen2.5-0.5B-Instruct` 988MB), interleaved serial / old / new. `targets=` shows the controller's concurrency over time.

**Residential ~capped link (the regression case):**

```
### SmolLM2-135M model.safetensors (269MB)
serial      10.1s  26.7MB/s
old-aimd    10.9s  24.8MB/s  targets=[3,4,4,5,5,4,3,2,3,3,…] max=5
new         7.3s   36.8MB/s  targets=[1,2,2,3,3,3,3,3,3,3,3,3,3]
### Qwen2.5-0.5B model.safetensors (988MB)
serial      24.1s / 21.4s
old-aimd    19.1s / 18.9s   climbs to 8
new         20.1s / 19.4s   settles at 3-4
```

The new controller no longer loses to serial anywhere, and on this link it actually beats it: with the CDN currently capping `multipart/byteranges` responses to ~15–25MB/s per stream, a couple of parallel streams is the only client-side mitigation, and the plateau finds exactly the level where that stops paying.

**EU VPS (fast path, high CDN variance during the runs):** new ≈ old on average (Qwen 3-run means: old 18.4s, new 18.6s, serial 23.3s); the ladder still climbs to 8 when each step genuinely improves aggregate throughput.

## Tests

- New: `settles back to serial on a bandwidth-capped link` — a shared pacer caps aggregate throughput regardless of open streams; asserts the controller spends most ticks at 1–2 and never reaches the ceiling (the old controller ratchets to the ceiling and stays).
- Parallel fixture generalized to n chunks per xorb; the ramp-dependent test drives the controller with fast ticks.

Compared with xet-core's `adaptive_concurrency` (success-ratio EWMA + RTT regression): same spirit, but this controller optimizes observed aggregate goodput directly, which also detects bandwidth saturation when every request succeeds with good RTT — the case that motivated this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes adaptive download concurrency for all default parallel Xet fetches; behavior is well-tested but affects performance paths across browsers and Node.
> 
> **Overview**
> Replaces the **AIMD-style** parallel xorb download controller in `XetBlob` with a **plateau-seeking** algorithm so bandwidth-saturated links no longer ratchet toward max concurrency and run slower than serial.
> 
> **Controller behavior:** initial `target` is **1** (was 2). Each tick compares per-level EWMA decode throughput; an extra connection is kept only if it beats the level below by **≥5%** (`PARALLEL_PROBE_KEEP_MARGIN`). Zero-byte ticks still probe up (latency-bound); skipped levels are stepped down on the way back after stalled starts. Samples use `activeHighWater` so draining workers after a down-step do not inflate baselines. After finding a plateau, upward probes pause for ~5s (`PARALLEL_PLATEAU_HOLD_TICKS`). 429 handling is unchanged.
> 
> **API/docs:** Public `parallelDownloads` options are unchanged; docs now describe serial start and saturation-aware tuning. Adds internal **`controllerTickMs`** for tests (default 500ms).
> 
> **Tests:** `makeParallelFixture` supports configurable chunk size/count; existing ramp test uses fast ticks. New cases assert settling near serial under a shared bandwidth pacer and walking down after a zero-rate stall climb.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff85e85269816b3e2cf54c27e5dab3fe2984e9c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->