### PR TITLE
fix(mcp-client): preserve model reasoning between tool rounds

### DIFF
--- a/packages/mcp-client/src/McpClient.ts
+++ b/packages/mcp-client/src/McpClient.ts
@@ -138,10 +138,10 @@ export class McpClient {
 			},
 		);
 
-		const message = {
+		const message: ChatCompletionInputMessage & { reasoning_content?: string } = {
 			role: "unknown",
 			content: "",
-		} satisfies ChatCompletionInputMessage;
+		};
 		const finalToolCalls: Record<number, ChatCompletionStreamOutputDeltaToolCall> = {};
 		let numOfChunks = 0;
 
@@ -160,6 +160,9 @@ export class McpClient {
 			}
 			if (delta.content) {
 				message.content += delta.content;
+			}
+			if (typeof delta.reasoning_content === "string") {
+				message.reasoning_content = (message.reasoning_content ?? "") + delta.reasoning_content;
 			}
 			for (const toolCall of delta.tool_calls ?? []) {
 				// aggregating chunks into an encoded arguments JSON object
@@ -187,8 +190,11 @@ export class McpClient {
 
 		const assistantMessage: ChatCompletionInputMessage = {
 			role: "assistant",
-			content: message.content,
 		};
+
+		if (message.reasoning_content !== undefined) {
+			assistantMessage.reasoning_content = message.reasoning_content;
+		}
 
 		const finalToolCallValues = Object.values(finalToolCalls);
 
@@ -201,6 +207,12 @@ export class McpClient {
 					arguments: toolCall.function.arguments,
 				},
 			}));
+			
+			if (message.content !== "") {
+				assistantMessage.content = message.content;
+			}
+		} else {
+			assistantMessage.content = message.content;
 		}
 		messages.push(assistantMessage);
 


### PR DESCRIPTION
Fixes #2334

**Description**
When using the `McpClient` with reasoning-enabled models (like Kimi K2/K3), the model's reasoning/thinking content was previously dropped between tool-calling rounds. This broke the requirement that some models have for preserving thinking history across turns. Furthermore, some backends return a 400 error if an empty `content` string is sent alongside `tool_calls`.

This PR:
- Captures `reasoning_content` from the streamed chunks in `McpClient`.
- Appends `reasoning_content` to the `assistantMessage` that gets pushed into the message history for subsequent rounds.
- Conditionally omits the `content` property entirely if it is empty and there are `tool_calls` present to prevent API 400 errors.

**Testing**
All unit tests in `mcp-client` pass successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to assistant message assembly in the MCP client loop; no auth or data-path changes, with behavior aligned to reasoning-model API expectations.
> 
> **Overview**
> **`McpClient.processSingleTurnWithTools`** now keeps **reasoning model** history intact across MCP tool rounds by aggregating streamed **`reasoning_content`** and copying it onto the assistant message pushed into **`messages`** for the next completion.
> 
> When the model returns **`tool_calls`** with no visible text, **`content`** is **omitted** instead of sending an empty string, avoiding **400** responses from some inference backends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac15be068e3ddc48c25e110fa213cc2455d5aa48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->