### PR TITLE
Cactus Needle 2

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -206,8 +206,8 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
       prettyLabel: "Needle",
       repoName: "needle",
       repoUrl: "https://github.com/cactus-compute/needle",
-      countDownloads: `path:"macos-arm64/needle" OR path:"linux-x86_64/needle" OR path:"linux-arm64/needle" OR path:"linux-armv7/needle" OR path:"linux-riscv64/needle"path:"linux-mipsel/needle" OR path:"android-arm64/needle" OR path:"android-armv7/needle" OR path:"android-riscv64/needle" OR path_extension:"exe" OR (path_filename:"libneedle" AND path_extension:"a") OR path_extension:"whl" OR path_extension:"wasm" OR path_extension:"cact"`,
-  },
+      countDownloads: `path:"macos-arm64/needle" OR path:"linux-x86_64/needle" OR path:"linux-arm64/needle" OR path:"linux-armv7/needle" OR path:"linux-riscv64/needle" OR path:"linux-mipsel/needle" OR path:"android-arm64/needle" OR path:"android-armv7/needle" OR path:"android-riscv64/needle" OR path_extension:"exe" OR (path_filename:"libneedle" AND path_extension:"a") OR path_extension:"whl" OR path_extension:"wasm" OR path_extension:"cact"`,
+	},
 	cancertathomev2: {
 		prettyLabel: "Cancer@HomeV2",
 		repoName: "Cancer@HomeV2",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -202,6 +202,12 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path:"boltzgen1_diverse.ckpt"`,
 	},
+	"cactus-needle": {
+      prettyLabel: "Needle",
+      repoName: "needle",
+      repoUrl: "https://github.com/cactus-compute/needle",
+      countDownloads: `path:"macos-arm64/needle" OR path:"linux-x86_64/needle" OR path:"linux-arm64/needle" OR path:"linux-armv7/needle" OR path:"linux-riscv64/needle"path:"linux-mipsel/needle" OR path:"android-arm64/needle" OR path:"android-armv7/needle" OR path:"android-riscv64/needle" OR path_extension:"exe" OR (path_filename:"libneedle" AND path_extension:"a") OR path_extension:"whl" OR path_extension:"wasm" OR path_extension:"cact"`,
+  },
 	cancertathomev2: {
 		prettyLabel: "Cancer@HomeV2",
 		repoName: "Cancer@HomeV2",


### PR DESCRIPTION
An on-device model shipped as per-platform binaries: github.com/cactus-compute/needle, the HF repo goes public at launch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single additive entry in the model libraries registry; no auth, infra, or runtime behavior changes.
> 
> **Overview**
> Registers **Cactus Needle** on the Hub as library tag `cactus-needle`, with UI label **Needle** and a link to [cactus-compute/needle](https://github.com/cactus-compute/needle).
> 
> Download counting uses a custom Elasticsearch query aimed at on-device artifacts: per-platform `needle` binaries (macOS/Linux/Android paths), `.exe`, static `libneedle.a`, wheels, WASM, and `.cact` files. Like neighboring entries, it omits `filter: true`, so it will not appear in the popular-library models filter until that is enabled later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10a5497a94478b179c01085efe069669bc75c7b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->