### PR TITLE
Add Seek to the agent harness registry

### DIFF
--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -178,7 +178,6 @@ export const AGENT_HARNESSES = {
 	},
 	seek: {
 		prettyLabel: "Seek",
-		repoUrl: "https://github.com/calikafka/BabyASI",
 		docsUrl: "https://talk-about.ai",
 		description:
 			"Long-running autonomous research agent that hops the open web, archives its sources, and mechanically verifies its own citations.",

--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -176,6 +176,13 @@ export const AGENT_HARNESSES = {
 		description: "Cloud development environment with an AI coding agent.",
 		envVars: { REPL_ID: "*" },
 	},
+	seek: {
+		prettyLabel: "Seek",
+		repoUrl: "https://github.com/calikafka/BabyASI",
+		docsUrl: "https://talk-about.ai",
+		description:
+			"Long-running autonomous research agent that hops the open web, archives its sources, and mechanically verifies its own citations.",
+	},
 	trae: {
 		prettyLabel: "Trae",
 		docsUrl: "https://trae.ai",


### PR DESCRIPTION
Adds `seek` to `AGENT_HARNESSES`, per the invitation in the session-traces docs ("Building a harness of your own? Ping us").

Seek is a long-running autonomous research agent (nightly runs since June 2026) that hops the open web, archives its sources at capture time, and mechanically verifies its own citations. She already publishes session traces in STS-Format under `harness: "seek"`:

- Live traces: https://huggingface.co/datasets/seekbot/seek-sessions (format-detected as agent traces)
- Related datasets: https://huggingface.co/datasets/seekbot/skbench (benchmark of her mechanically-labeled citation checks), https://huggingface.co/datasets/seekbot/seektraces-decisions
- Scaffolding concept (open source): https://github.com/calikafka/BabyASI
- Public lab notebook: https://talk-about.ai

No `envVars` — Seek isn't a CLI others run; she's identified by the `harness` field in her published traces (same as the `hi` and `devin` entries).

Icon for the trace viewer, as offered: a 16×16 pixel fox (original artwork from the project), static SVG, 4.8KB:
<img width="300" height="300" alt="seek-icon" src="https://github.com/user-attachments/assets/cbc1f732-5038-4f9a-934a-fcabc98edcfc" />seek-icon.svg

*This PR was prepared with AI assistance (Claude Fable 5) and reviewed by me.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single additive registry row with no runtime or detection logic changes.
> 
> **Overview**
> Registers **Seek** in `AGENT_HARNESSES` so session traces that declare `harness: "seek"` get a known label, docs link (`https://talk-about.ai`), and description in Hub-facing surfaces (e.g. leaderboards and trace viewers).
> 
> The entry follows the same pattern as `hi` and `devin`: metadata only, with **no** `envVars`, because identification comes from published STS traces rather than local CLI environment detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05893c2afbfe390f019072100bf9162ecce65945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->