### PR TITLE
Add MiniMax H3 model library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -613,7 +613,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/MiniMax-AI/MiniMax-H3",
 		docsUrl: "https://huggingface.co/MiniMaxAI/MiniMax-H3",
 		filter: false,
-		countDownloads: `path_extension:"safetensors" OR path_filename:"model_index" OR path_filename:"config"`,
+		countDownloads: `path_extension:"safetensors" OR path_filename:"model_index" OR path_filename:"config" OR path:"modular_model_index.json"`,
 	},
 	hermes: {
 		prettyLabel: "HERMES",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -607,6 +607,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/fudan-generative-vision/hallo",
 		countDownloads: `path:"hallo/net.pth"`,
 	},
+	"minimax-h3": {
+		prettyLabel: "MiniMax H3",
+		repoName: "MiniMax-H3",
+		repoUrl: "https://github.com/MiniMax-AI/MiniMax-H3",
+		docsUrl: "https://huggingface.co/MiniMaxAI/MiniMax-H3",
+		filter: false,
+		countDownloads: `path_extension:"safetensors" OR path_filename:"model_index" OR path_filename:"config"`,
+	},
 	hermes: {
 		prettyLabel: "HERMES",
 		repoName: "HERMES",


### PR DESCRIPTION
Adds a minimax-h3 model library entry for MiniMax-H3 repositories.

MiniMax-H3 style repositories can distribute multiple task-specific checkpoints under subfolders, while users may download subfolders directly. The download counting rule includes safetensors weights and indexed model entry/config files so these workflows are reflected in Hub download stats.

Counting query:

path_extension:"safetensors" OR path_filename:"model_index" OR path_filename:"config"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry entry in `model-libraries.ts`; no runtime or auth changes, only Hub labeling and download analytics.
> 
> **Overview**
> Registers **MiniMax H3** on the Hub as library tag `minimax-h3`, with GitHub/docs links and `filter: false` so it does not appear in the main models library filter until it is popular enough.
> 
> Hub **download stats** for repos tagged with this library use a custom Elasticsearch rule: `.safetensors` weights, `model_index` / `config` filenames, and `modular_model_index.json`, so multi-checkpoint layouts and subfolder downloads are counted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cf37569756c50f044bed87288070659b387cb94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->