### PR TITLE
Add Montreal Forced Aligner to model libraries

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1013,7 +1013,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner",
 		docsUrl: "https://montreal-forced-aligner.readthedocs.io",
 		filter: false,
-		countDownloads: `path_extension:"zip"`,
+		countDownloads: `path:"acoustic/final.mdl" OR path_extension:"zip"`,
 	},
 	moshi: {
 		prettyLabel: "Moshi",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1007,6 +1007,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.mobilint,
 		filter: false,
 	},
+	"montreal-forced-aligner": {
+		prettyLabel: "Montreal Forced Aligner",
+		repoName: "Montreal Forced Aligner",
+		repoUrl: "https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner",
+		docsUrl: "https://montreal-forced-aligner.readthedocs.io",
+		filter: false,
+		countDownloads: `path_extension:"zip"`,
+	},
 	moshi: {
 		prettyLabel: "Moshi",
 		repoName: "Moshi",


### PR DESCRIPTION
Hello, and thank you for maintaining this registry.

### What this does

Adds a `montreal-forced-aligner` entry to `MODEL_LIBRARIES_UI_ELEMENTS` so that downloads are counted for Montreal Forced Aligner models hosted on the Hub.

### Why

The Montreal Forced Aligner project publishes its official model zoo on the Hub under [MontrealCorpusTools](https://huggingface.co/MontrealCorpusTools). All 22 of those repositories currently display "Downloads are not tracked for this model", as do community MFA models, because there is no registry entry to count against. This happens even when the model card correctly sets `library_name: montreal-forced-aligner`, so repository owners have no way to resolve it from their side.

### Download query

MFA acoustic models and pronunciation dictionaries are distributed as `.zip` archives, for example `english_mfa.zip`, so `path_extension:"zip"` matches the artifact that users actually download.

### Notes

* `filter: false` is used, since there is no existing Hub filter for this library.
* I have not added a snippet, as MFA is used through its command line interface rather than a Python loading call. Happy to add one if you would prefer.
* Very happy to adjust the entry shape, the download query, or add a changeset if that is required. Please let me know.

Thank you for your time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single additive registry entry with no runtime logic changes; only affects how downloads are attributed for repos tagged with this library.
> 
> **Overview**
> Registers **Montreal Forced Aligner** in `MODEL_LIBRARIES_UI_ELEMENTS` under the key `montreal-forced-aligner`, so Hub models with that `library_name` can show download stats instead of “Downloads are not tracked for this model.”
> 
> The entry wires up labels, repo/docs URLs, **`filter: false`** (no models-page library filter), and a **`countDownloads`** Elasticsearch query that counts `acoustic/final.mdl` and **`.zip`** artifacts (typical MFA acoustic models and pronunciation dictionaries). No usage snippet is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc2a88e0fbb1e5617f2c7b202633ee0ad4a47f67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->