### PR TITLE
[Inference Providers] deepinfra: add feature-extraction support

### DIFF
--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -68,6 +68,7 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 	deepinfra: {
 		"automatic-speech-recognition": new DeepInfra.DeepInfraAutomaticSpeechRecognitionTask(),
 		conversational: new DeepInfra.DeepInfraConversationalTask(),
+		"feature-extraction": new DeepInfra.DeepInfraFeatureExtractionTask(),
 		"text-generation": new DeepInfra.DeepInfraTextGenerationTask(),
 		"text-to-speech": new DeepInfra.DeepInfraTextToSpeechTask(),
 	},

--- a/packages/inference/src/providers/deepinfra.ts
+++ b/packages/inference/src/providers/deepinfra.ts
@@ -19,7 +19,11 @@ model to DeepInfra, please open an issue on the present repo
 * Thanks!
 */
 
-import type { AutomaticSpeechRecognitionOutput, TextGenerationOutput } from "@huggingface/tasks";
+import type {
+	AutomaticSpeechRecognitionOutput,
+	FeatureExtractionOutput,
+	TextGenerationOutput,
+} from "@huggingface/tasks";
 import { InferenceClientInputError, InferenceClientProviderOutputError } from "../errors.js";
 import type { AutomaticSpeechRecognitionArgs } from "../tasks/audio/automaticSpeechRecognition.js";
 import type { BodyParams, RequestArgs } from "../types.js";
@@ -28,6 +32,7 @@ import {
 	type AutomaticSpeechRecognitionTaskHelper,
 	BaseConversationalTask,
 	BaseTextGenerationTask,
+	type FeatureExtractionTaskHelper,
 	TaskProviderHelper,
 	type TextToSpeechTaskHelper,
 } from "./providerHelper.js";
@@ -79,6 +84,16 @@ interface DeepInfraAudioTranscriptionSegment {
 interface DeepInfraAudioTranscriptionResponse {
 	text: string;
 	segments?: DeepInfraAudioTranscriptionSegment[];
+}
+
+interface DeepInfraEmbeddingsResponse {
+	data: Array<{
+		embedding: number[];
+		index: number;
+		object: string;
+	}>;
+	model: string;
+	object: string;
 }
 
 export class DeepInfraConversationalTask extends BaseConversationalTask {
@@ -244,6 +259,44 @@ export class DeepInfraTextToSpeechTask extends TaskProviderHelper implements Tex
 		}
 		throw new InferenceClientProviderOutputError(
 			`Received malformed response from DeepInfra text-to-speech API: ${JSON.stringify(response)}`,
+		);
+	}
+}
+
+export class DeepInfraFeatureExtractionTask extends TaskProviderHelper implements FeatureExtractionTaskHelper {
+	constructor() {
+		super("deepinfra", DEEPINFRA_API_BASE_URL);
+	}
+
+	makeRoute(): string {
+		return "v1/openai/embeddings";
+	}
+
+	preparePayload(params: BodyParams): Record<string, unknown> {
+		// `model` is applied last so caller parameters cannot override the mapped provider model.
+		return {
+			...omit(params.args, ["inputs", "parameters"]),
+			...(params.args.parameters as Record<string, unknown> | undefined),
+			input: params.args.inputs,
+			model: params.model,
+		};
+	}
+
+	async getResponse(response: DeepInfraEmbeddingsResponse): Promise<FeatureExtractionOutput> {
+		if (
+			typeof response === "object" &&
+			response !== null &&
+			"data" in response &&
+			Array.isArray(response.data) &&
+			response.data.every(
+				(item): item is DeepInfraEmbeddingsResponse["data"][number] =>
+					typeof item === "object" && !!item && Array.isArray(item.embedding),
+			)
+		) {
+			return response.data.map((item) => item.embedding);
+		}
+		throw new InferenceClientProviderOutputError(
+			`Received malformed response from DeepInfra feature-extraction (embeddings) API: ${JSON.stringify(response)}`,
 		);
 	}
 }

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -1669,6 +1669,9 @@ describe.skip("InferenceClient", () => {
 			const TTS_HF_MODEL = "hexgrad/Kokoro-82M";
 			const TTS_PROVIDER_ID = "hexgrad/Kokoro-82M";
 
+			const FE_HF_MODEL = "Qwen/Qwen3-Embedding-0.6B";
+			const FE_PROVIDER_ID = "Qwen/Qwen3-Embedding-0.6B";
+
 			const setMapping = (task: "conversational" | "text-generation") => {
 				HARDCODED_MODEL_INFERENCE_MAPPING["deepinfra"] = {
 					[HF_MODEL]: {
@@ -1701,6 +1704,18 @@ describe.skip("InferenceClient", () => {
 						providerId: TTS_PROVIDER_ID,
 						status: "live",
 						task: "text-to-speech",
+					},
+				};
+			};
+
+			const setFeatureExtractionMapping = () => {
+				HARDCODED_MODEL_INFERENCE_MAPPING["deepinfra"] = {
+					[FE_HF_MODEL]: {
+						provider: "deepinfra",
+						hfModelId: FE_HF_MODEL,
+						providerId: FE_PROVIDER_ID,
+						status: "live",
+						task: "feature-extraction",
 					},
 				};
 			};
@@ -1777,6 +1792,17 @@ describe.skip("InferenceClient", () => {
 					parameters: { voice: "af_bella" },
 				});
 				expect(res).toBeInstanceOf(Blob);
+			});
+
+			it("featureExtraction", async () => {
+				setFeatureExtractionMapping();
+				const res = await client.featureExtraction({
+					model: FE_HF_MODEL,
+					provider: "deepinfra",
+					inputs: "Hello from DeepInfra feature extraction.",
+				});
+				expect(Array.isArray(res)).toBe(true);
+				expect(res.length).toBeGreaterThan(0);
 			});
 		},
 		TIMEOUT,


### PR DESCRIPTION
## What

Adds `feature-extraction` (embeddings) support to the **deepinfra** inference provider.

## Details

- New `DeepInfraFeatureExtractionTask` in `packages/inference/src/providers/deepinfra.ts`.
- Targets DeepInfra's OpenAI-compatible endpoint `POST /v1/openai/embeddings` and returns the list of embedding vectors (`response.data.map((item) => item.embedding)`).
- `model` is applied **last** in the payload so caller parameters cannot override the mapped provider model (consistent with the deepinfra TTS/ASR tasks, #2304 / #2241).
- Registered under `deepinfra -> feature-extraction` in `getProviderHelper.ts`.

Mirrors the existing `TogetherFeatureExtractionTask` (same OpenAI-compatible embeddings shape). Python counterpart: huggingface_hub#4656.

## Tests

Added a `featureExtraction` integration case to the deepinfra block in `InferenceClient.spec.ts`, mirroring the existing `textToSpeech` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider task following existing Together/DeepInfra OpenAI embeddings patterns; no changes to auth or shared inference routing beyond a new task registration.
> 
> **Overview**
> Adds **feature-extraction** for the **deepinfra** provider so `InferenceClient.featureExtraction` can route to DeepInfra embedding models.
> 
> A new `DeepInfraFeatureExtractionTask` calls DeepInfra’s OpenAI-compatible **`POST /v1/openai/embeddings`**, maps HF `inputs` to `input`, merges optional `parameters`, and sets **`model` last** so callers cannot override the mapped provider model (same pattern as DeepInfra TTS/ASR). Responses are normalized to `FeatureExtractionOutput` by extracting `data[].embedding` vectors, with validation and malformed-response errors aligned with other DeepInfra tasks.
> 
> The task is registered under **`deepinfra` → `feature-extraction`** in `getProviderHelper.ts`. An integration test in the DeepInfra block exercises `featureExtraction` with a hardcoded model mapping, mirroring existing DeepInfra provider tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d8bb26c9f2e6e1df26c2c922283cc2e070792e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->