### PR TITLE
Fix fal video LoRA payload mapping

### DIFF
--- a/packages/inference/src/providers/fal-ai.ts
+++ b/packages/inference/src/providers/fal-ai.ts
@@ -447,12 +447,23 @@ export class FalAIImageToVideoTask extends FalAiQueueTask implements ImageToVide
 
 	/** Synchronous case – caller already gave us base64 or a URL */
 	override preparePayload(params: BodyParams): Record<string, unknown> {
-		return {
+		const payload: Record<string, unknown> = {
 			...omit(params.args, ["inputs", "parameters"]),
 			...(params.args.parameters as Record<string, unknown>),
 			// args.inputs is expected to be a base64 data URI or an URL
 			image_url: params.args.image_url,
 		};
+
+		if (params.mapping?.adapter === "lora" && params.mapping.adapterWeightsPath) {
+			payload.loras = [
+				{
+					path: buildLoraPath(params.mapping.hfModelId, params.mapping.adapterWeightsPath),
+					scale: 1,
+				},
+			];
+		}
+
+		return payload;
 	}
 
 	/** Asynchronous helper – caller gave us a Blob */

--- a/packages/inference/test/fal-ai-payload.spec.ts
+++ b/packages/inference/test/fal-ai-payload.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { makeRequestOptionsFromResolvedModel } from "../src/lib/makeRequestOptions.js";
+import { FalAIImageTextToVideoTask } from "../src/providers/fal-ai.js";
+import type { InferenceProviderMappingEntry, RequestArgs } from "../src/types.js";
+
+const LORA_MAPPING = {
+	provider: "fal-ai",
+	hfModelId: "example/video-lora",
+	providerId: "minimax/h3/image-to-video/lora",
+	status: "live",
+	task: "image-to-video",
+	adapter: "lora",
+	adapterWeightsPath: "adapter.safetensors",
+} satisfies InferenceProviderMappingEntry;
+
+const NON_LORA_MAPPING = {
+	provider: "fal-ai",
+	hfModelId: "example/base-video-model",
+	providerId: "minimax/h3/image-to-video",
+	status: "live",
+	task: "image-to-video",
+} satisfies InferenceProviderMappingEntry;
+
+async function requestPayload(
+	args: Parameters<FalAIImageTextToVideoTask["preparePayloadAsync"]>[0],
+	mapping: InferenceProviderMappingEntry,
+): Promise<Record<string, unknown>> {
+	const helper = new FalAIImageTextToVideoTask();
+	const preparedArgs = await helper.preparePayloadAsync(args);
+	const { info } = makeRequestOptionsFromResolvedModel(
+		mapping.providerId,
+		helper,
+		preparedArgs as RequestArgs,
+		mapping,
+		{ task: "image-text-to-video" },
+	);
+	return JSON.parse(info.body as string) as Record<string, unknown>;
+}
+
+describe("fal-ai image-text-to-video request payloads", () => {
+	it("adds LoRA mapping data to an inherited prompt-only request", async () => {
+		await expect(requestPayload({ parameters: { prompt: "A bee takes flight" } }, LORA_MAPPING)).resolves.toEqual({
+			prompt: "A bee takes flight",
+			loras: [
+				{
+					path: "https://huggingface.co/example/video-lora/resolve/main/adapter.safetensors",
+					scale: 1,
+				},
+			],
+		});
+	});
+
+	it("adds LoRA mapping data when an image is present", async () => {
+		const inputs = new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" });
+
+		await expect(
+			requestPayload({ inputs, parameters: { prompt: "A bee takes flight" } }, LORA_MAPPING),
+		).resolves.toEqual({
+			prompt: "A bee takes flight",
+			image_url: "data:image/png;base64,AQID",
+			loras: [
+				{
+					path: "https://huggingface.co/example/video-lora/resolve/main/adapter.safetensors",
+					scale: 1,
+				},
+			],
+		});
+	});
+
+	it("does not add LoRA data for a non-LoRA mapping", async () => {
+		await expect(requestPayload({ parameters: { prompt: "A bee takes flight" } }, NON_LORA_MAPPING)).resolves.toEqual({
+			prompt: "A bee takes flight",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add fal LoRA adapter metadata to image/video request payloads.

The fal `image-text-to-video` helper already receives `adapter` and `adapterWeightsPath` from the inference-provider mapping, but its inherited video payload builder did not convert them into fal's required `loras` input. As a result, registered video LoRA models could reach the routed endpoint without their required adapter payload and fail with `Model not supported by provider fal-ai`.

## Fix

- Build a `loras` array in `FalAIImageToVideoTask.preparePayload` when the mapping identifies a LoRA adapter.
- Resolve the adapter weights to the corresponding Hugging Face `resolve/main` URL.
- Use scale `1`, matching existing fal text-to-image and image-to-image behavior.
- Cover both prompt-only and image-present `image-text-to-video` requests through the inherited helper.
- Preserve non-LoRA payload behavior.

The fal `minimax/h3/image-to-video/lora` endpoint intentionally permits an omitted `image_url`; prompt-only requests are supported by the same endpoint, so no endpoint switching is needed.

## Validation

- `pnpm --filter @huggingface/inference test -- fal-ai-payload.spec.ts` — 28 passed, 118 configured skips
- `pnpm --filter @huggingface/inference check` — passed
- `pnpm --filter @huggingface/inference lint:check` — passed
- `pnpm --filter @huggingface/inference format:check` — passed
- `git diff --check` — passed
