### PR TITLE
Fix: map LoRA for I2V tasks in fal-ai

### DIFF
--- a/packages/inference/src/providers/fal-ai.ts
+++ b/packages/inference/src/providers/fal-ai.ts
@@ -447,12 +447,21 @@ export class FalAIImageToVideoTask extends FalAiQueueTask implements ImageToVide
 
 	/** Synchronous case – caller already gave us base64 or a URL */
 	override preparePayload(params: BodyParams): Record<string, unknown> {
-		return {
+		const payload: Record<string, unknown> = {
 			...omit(params.args, ["inputs", "parameters"]),
 			...(params.args.parameters as Record<string, unknown>),
 			// args.inputs is expected to be a base64 data URI or an URL
 			image_url: params.args.image_url,
 		};
+		if (params.mapping?.adapter === "lora" && params.mapping.adapterWeightsPath) {
+			payload.loras = [
+				{
+					path: buildLoraPath(params.mapping.hfModelId, params.mapping.adapterWeightsPath),
+					scale: 1,
+				},
+			];
+		}
+		return payload;
 	}
 
 	/** Asynchronous helper – caller gave us a Blob */


### PR DESCRIPTION
This follows up from https://github.com/huggingface/huggingface.js/pull/2349, which enabled `image-text-to-video` support for the fal-ai inference provider. This PR adds support for the LoRA variants of the mentioned MiniMax H3 model (and future `it2v` models), including any referenced LoRA as the required `loras` array.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that mirrors existing LoRA handling in other fal-ai tasks; only affects requests when LoRA mapping is present.
> 
> **Overview**
> **fal-ai image-to-video** now sends LoRA weights when the HF→provider mapping marks the model as a LoRA adapter, matching behavior already used for text-to-image and image-to-image.
> 
> `FalAIImageToVideoTask.preparePayload` builds the JSON body in a `payload` object and, when `params.mapping.adapter === "lora"` and `adapterWeightsPath` is set, adds a `loras` array with a Hub `resolve/main/...` path via `buildLoraPath` and `scale: 1`. Non-LoRA calls are unchanged aside from the small refactor from an inline return to a mutable payload.
> 
> `FalAIImageTextToVideoTask` subclasses this class, so LoRA-mapped **image-text-to-video** models get the same `loras` field on the synchronous payload path; the Blob-based `preparePayloadAsync` path is not modified in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c479243a64697f3bef5d051db76c1cdaf3e8f15e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->