### PR TITLE
🐛 Add missing throw in FileBlob/WebBlob/XetBlob slice() negative-argument guards

### DIFF
--- a/packages/blob/src/utils/FileBlob.spec.ts
+++ b/packages/blob/src/utils/FileBlob.spec.ts
@@ -42,4 +42,11 @@ describe("FileBlob", () => {
 		const result = await slice.stream().getReader().read();
 		expect(new TextDecoder().decode(result.value)).toBe(expectedText);
 	});
+
+	it("should throw a TypeError on negative start/end", async () => {
+		const fileBlob = await FileBlob.create("package.json");
+
+		expect(() => fileBlob.slice(-5)).toThrow(TypeError);
+		expect(() => fileBlob.slice(0, -1)).toThrow(TypeError);
+	});
 });

--- a/packages/blob/src/utils/FileBlob.ts
+++ b/packages/blob/src/utils/FileBlob.ts
@@ -66,7 +66,7 @@ export class FileBlob extends Blob {
 	 */
 	override slice(start = 0, end = this.size): FileBlob {
 		if (start < 0 || end < 0) {
-			new TypeError("Unsupported negative start/end on FileBlob.slice");
+			throw new TypeError("Unsupported negative start/end on FileBlob.slice");
 		}
 
 		const slice = new FileBlob(this.path, this.start + start, Math.min(this.start + end, this.end));

--- a/packages/blob/src/utils/WebBlob.spec.ts
+++ b/packages/blob/src/utils/WebBlob.spec.ts
@@ -80,4 +80,11 @@ describe("WebBlob", () => {
 		const streamText = await new Response(slice.stream()).text();
 		expect(streamText).toBe(expectedText);
 	});
+
+	it("should throw a TypeError on negative start/end", () => {
+		const webBlob = new WebBlob(resourceUrl, 0, 100, "text/plain", true, fetch);
+
+		expect(() => webBlob.slice(-5)).toThrow(TypeError);
+		expect(() => webBlob.slice(0, -1)).toThrow(TypeError);
+	});
 });

--- a/packages/blob/src/utils/WebBlob.ts
+++ b/packages/blob/src/utils/WebBlob.ts
@@ -60,7 +60,7 @@ export class WebBlob extends Blob {
 
 	override slice(start = 0, end = this.size): WebBlob {
 		if (start < 0 || end < 0) {
-			new TypeError("Unsupported negative start/end on FileBlob.slice");
+			throw new TypeError("Unsupported negative start/end on WebBlob.slice");
 		}
 
 		const slice = new WebBlob(

--- a/packages/gguf/src/utils/FileBlob.ts
+++ b/packages/gguf/src/utils/FileBlob.ts
@@ -66,7 +66,7 @@ export class FileBlob extends Blob {
 	 */
 	override slice(start = 0, end = this.size): FileBlob {
 		if (start < 0 || end < 0) {
-			new TypeError("Unsupported negative start/end on FileBlob.slice");
+			throw new TypeError("Unsupported negative start/end on FileBlob.slice");
 		}
 
 		const newStart = Math.min(this.start + start, this.end);

--- a/packages/hub/src/utils/FileBlob.spec.ts
+++ b/packages/hub/src/utils/FileBlob.spec.ts
@@ -42,4 +42,11 @@ describe("FileBlob", () => {
 		const result = await slice.stream().getReader().read();
 		expect(new TextDecoder().decode(result.value)).toBe(expectedText);
 	});
+
+	it("should throw a TypeError on negative start/end", async () => {
+		const fileBlob = await FileBlob.create("package.json");
+
+		expect(() => fileBlob.slice(-5)).toThrow(TypeError);
+		expect(() => fileBlob.slice(0, -1)).toThrow(TypeError);
+	});
 });

--- a/packages/hub/src/utils/FileBlob.ts
+++ b/packages/hub/src/utils/FileBlob.ts
@@ -66,7 +66,7 @@ export class FileBlob extends Blob {
 	 */
 	override slice(start = 0, end = this.size): FileBlob {
 		if (start < 0 || end < 0) {
-			new TypeError("Unsupported negative start/end on FileBlob.slice");
+			throw new TypeError("Unsupported negative start/end on FileBlob.slice");
 		}
 
 		const slice = new FileBlob(this.path, this.start + start, Math.min(this.start + end, this.end));

--- a/packages/hub/src/utils/WebBlob.spec.ts
+++ b/packages/hub/src/utils/WebBlob.spec.ts
@@ -96,4 +96,11 @@ describe("WebBlob", () => {
 		const streamText = await new Response(slice.stream()).text();
 		expect(streamText).toBe(expectedText);
 	});
+
+	it("should throw a TypeError on negative start/end", () => {
+		const webBlob = new WebBlob(resourceUrl, 0, 100, "text/plain", true, fetch, undefined);
+
+		expect(() => webBlob.slice(-5)).toThrow(TypeError);
+		expect(() => webBlob.slice(0, -1)).toThrow(TypeError);
+	});
 });

--- a/packages/hub/src/utils/WebBlob.ts
+++ b/packages/hub/src/utils/WebBlob.ts
@@ -111,7 +111,7 @@ export class WebBlob extends Blob {
 
 	override slice(start = 0, end = this.size): WebBlob {
 		if (start < 0 || end < 0) {
-			new TypeError("Unsupported negative start/end on WebBlob.slice");
+			throw new TypeError("Unsupported negative start/end on WebBlob.slice");
 		}
 
 		const slice = new WebBlob(

--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -1496,6 +1496,17 @@ describe("XetBlob", () => {
 			});
 		});
 	});
+
+	it("should throw a TypeError on negative start/end", () => {
+		const blob = new XetBlob({
+			hash: "test",
+			size: 100,
+			refreshUrl: "https://huggingface.co",
+		});
+
+		expect(() => blob.slice(-5)).toThrow(TypeError);
+		expect(() => blob.slice(0, -1)).toThrow(TypeError);
+	});
 });
 
 function makeChunk(content: string) {

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -359,7 +359,7 @@ export class XetBlob extends Blob {
 
 	override slice(start = 0, end = this.size): XetBlob {
 		if (start < 0 || end < 0) {
-			new TypeError("Unsupported negative start/end on XetBlob.slice");
+			throw new TypeError("Unsupported negative start/end on XetBlob.slice");
 		}
 
 		const slice = this.#clone();


### PR DESCRIPTION
Fixes #2364

## What

The `slice()` negative-argument guards in `FileBlob`, `WebBlob` and `XetBlob` construct a `TypeError` but never `throw` it, making the guard dead code. Negative arguments then flow into the range arithmetic and produce invalid blobs (`size: -1`), invalid `Range: bytes=-5-99` requests (servers ignore them and return the full body — silent wrong data), or downstream `RangeError`s. See #2364 for full repros.

This PR adds the missing `throw` in all 6 copies of the pattern:

- `packages/blob/src/utils/FileBlob.ts`
- `packages/blob/src/utils/WebBlob.ts` (also fixes the copy-pasted message: `FileBlob.slice` → `WebBlob.slice`)
- `packages/gguf/src/utils/FileBlob.ts`
- `packages/hub/src/utils/FileBlob.ts`
- `packages/hub/src/utils/WebBlob.ts`
- `packages/hub/src/utils/XetBlob.ts`

All 6 are the same copy-pasted guard, so they're fixed together in this one scoped PR. `SplicedBlob.slice()` already `throw`s — this makes the sibling classes consistent with it and with their JSDoc ("The slice method does not supports negative start/end").

## Regression tests

Added one `should throw a TypeError on negative start/end` test next to the existing `slice()` tests in each spec file that exists (`blob`/`FileBlob`, `blob`/`WebBlob`, `hub`/`FileBlob`, `hub`/`WebBlob`, `hub`/`XetBlob`). All 5 fail before the fix and pass after:

```
# before fix
Tests  5 failed   (AssertionError: expected function to throw an error, but it didn't)
# after fix
Tests  5 passed
```

`packages/gguf`'s `FileBlob` has no existing spec file, so no new test file was added for it to keep the diff minimal — its guard is the same one-line fix, exercised by the gguf local-file parsing test.

## Test results

- `@huggingface/blob`: full suite, **8/8 passed**
- `@huggingface/hub`: `FileBlob.spec.ts` + `SplicedBlob.spec.ts` + `WebBlob.spec.ts` **62/62 passed**; `XetBlob.spec.ts` **36/36 passed** (network-dependent cases in this file are flaky on my connection; one fully green run included)
- `@huggingface/gguf`: `should parse a local file` (the FileBlob path) passes; the full suite's remote-download cases time out on my connection **both with and without this change** (verified against a clean checkout)
- `lint:check` and `check` (tsc) pass for all three packages; `pnpm -r format` produces no diff
- Not run locally: the rest of the hub suite (unrelated to blobs), browser tests, e2e

## Disclosure

This fix was prepared with AI assistance; every change and test result was reproduced and reviewed locally before submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, behavior-aligning bugfix with targeted tests; only callers passing negative slice indices see a new throw instead of corrupt slices or wrong HTTP ranges.
> 
> **Overview**
> Fixes **dead validation** in `FileBlob`, `WebBlob`, and `XetBlob` `slice()` implementations across `blob`, `gguf`, and `hub`: guards that documented “no negative start/end” only did `new TypeError(...)` without **`throw`**, so invalid indices still produced bad ranges (e.g. negative `size`, malformed `Range` headers, or silent full-body fetches).
> 
> Each affected guard now **`throw`s** a `TypeError`; **`WebBlob`** in `packages/blob` also corrects the message from `FileBlob.slice` to **`WebBlob.slice`**. Regression tests assert `slice(-5)` and `slice(0, -1)` throw in the five existing spec files (`gguf` gets the same one-line fix without a new spec).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64dfb7797448d8ae75bdaf5b06c2f43068bb3ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->