### PR TITLE
🐛 blob: use a Range probe instead of HEAD in WebBlob.create

### DIFF
--- a/packages/blob/src/utils/WebBlob.spec.ts
+++ b/packages/blob/src/utils/WebBlob.spec.ts
@@ -8,10 +8,14 @@ describe("WebBlob", () => {
 	let contentType: string;
 
 	beforeAll(async () => {
-		const response = await fetch(resourceUrl, { method: "HEAD" });
-		size = Number(response.headers.get("content-length"));
+		// Compute the reference size from the response body itself; in browsers
+		// `Content-Length` is not reliably exposed when the response is gzipped
+		// on the fly by CloudFront.
+		const response = await fetch(resourceUrl);
+		const blob = await response.blob();
+		size = blob.size;
+		fullText = await blob.text();
 		contentType = response.headers.get("content-type") || "";
-		fullText = await (await fetch(resourceUrl)).text();
 	});
 
 	it("should create a WebBlob with a slice on the entire resource", async () => {
@@ -79,6 +83,39 @@ describe("WebBlob", () => {
 
 		const streamText = await new Response(slice.stream()).text();
 		expect(streamText).toBe(expectedText);
+	});
+
+	it("should get the size from the range probe when Content-Length is missing", async () => {
+		const totalSize = 1_500_000;
+		const requests: Array<{ method: string; range: string | null }> = [];
+		// A response that lost `Content-Length`/`Accept-Ranges` to on-the-fly gzip,
+		// as served from a CloudFront cache in the browser.
+		const customFetch: typeof fetch = (_input, init) => {
+			requests.push({ method: init?.method ?? "GET", range: new Headers(init?.headers).get("Range") });
+
+			return Promise.resolve(
+				new Response(new Uint8Array(1), {
+					status: 206,
+					headers: { "content-type": "text/plain", "content-range": `bytes 0-0/${totalSize}` },
+				}),
+			);
+		};
+
+		const webBlob = await WebBlob.create(resourceUrl, { fetch: customFetch });
+
+		expect(webBlob).toBeInstanceOf(WebBlob);
+		expect(webBlob.size).toBe(totalSize);
+		expect(requests).toEqual([{ method: "GET", range: "bytes=0-0" }]);
+	});
+
+	it("should buffer the whole body when the server ignores the range probe", async () => {
+		const customFetch: typeof fetch = () =>
+			Promise.resolve(new Response("hello", { status: 200, headers: { "content-type": "text/plain" } }));
+
+		const webBlob = await WebBlob.create(resourceUrl, { fetch: customFetch, cacheBelow: 0 });
+
+		expect(webBlob).not.toBeInstanceOf(WebBlob);
+		expect(await webBlob.text()).toBe("hello");
 	});
 
 	it("should throw a TypeError on negative start/end", () => {

--- a/packages/blob/src/utils/WebBlob.ts
+++ b/packages/blob/src/utils/WebBlob.ts
@@ -19,17 +19,52 @@ interface WebBlobCreateOptions {
 export class WebBlob extends Blob {
 	static async create(url: URL, opts?: WebBlobCreateOptions): Promise<Blob> {
 		const customFetch = opts?.fetch ?? fetch;
-		const response = await customFetch(url, { method: "HEAD" });
 
-		const size = Number(response.headers.get("content-length"));
-		const contentType = response.headers.get("content-type") || "";
-		const supportRange = response.headers.get("accept-ranges") === "bytes";
+		// Probe with `Range: bytes=0-0` rather than `HEAD` to learn the file size
+		// and confirm range support in a single round trip.
+		//
+		// In browsers, when CloudFront gzips a response on the fly (typical for
+		// small text/JSON files behind `/api/resolve-cache/...`), the cached
+		// response loses both `Content-Length` and `Accept-Ranges`. Subsequent
+		// HEAD requests served from that cache inherit the missing headers, so
+		// the lib could not tell either the file size or whether ranges were
+		// supported, and silently fell back to buffering the whole blob in RAM.
+		//
+		// Range responses are never content-encoded, so `Content-Range`
+		// (carrying the total size) always survives, regardless of the cached
+		// encoding state.
+		const probe = await customFetch(url, {
+			headers: {
+				Range: "bytes=0-0",
+			},
+		});
 
-		if (!supportRange || size < (opts?.cacheBelow ?? 1_000_000)) {
-			return await (await customFetch(url)).blob();
+		if (!probe.ok) {
+			throw new Error(`Failed to fetch ${url}: ${probe.status} ${probe.statusText}`);
 		}
 
-		return new WebBlob(url, 0, size, contentType, true, customFetch);
+		const contentType = probe.headers.get("content-type") || "";
+
+		// 206 → server honored the range request; total size is in `Content-Range`.
+		if (probe.status === 206) {
+			const totalSize = Number(probe.headers.get("content-range")?.split("/").pop());
+			await probe.body?.cancel();
+
+			if (Number.isFinite(totalSize) && totalSize >= (opts?.cacheBelow ?? 1_000_000)) {
+				return new WebBlob(url, 0, totalSize, contentType, true, customFetch);
+			}
+
+			// Small file (or unknown total) → buffer it in RAM.
+			const full = await customFetch(url);
+			if (!full.ok) {
+				throw new Error(`Failed to fetch ${url}: ${full.status} ${full.statusText}`);
+			}
+			return full.blob();
+		}
+
+		// 200 → server ignored `Range`; we've already started downloading the
+		// full body, so just consume it.
+		return probe.blob();
 	}
 
 	private url: URL;


### PR DESCRIPTION
Fixes #2366

## What

`packages/hub` fixed this in #2118 by probing with `Range: bytes=0-0` instead of `HEAD`; `packages/blob` was left on the old code. This copies that fix over.

The `HEAD` probe takes the size from `Content-Length`, which CloudFront drops when it gzips a response on the fly, so in browsers `WebBlob.create` ended up with `size = 0` and handed back an empty blob. A range probe gets the total size from `Content-Range`, which survives whatever encoding the cache happens to hold.

`create()` is now the same as hub's apart from two things: no `accessToken` (this package's options don't have one), and a plain `Error` on a failed response since `packages/blob` has no `createApiError`.

## Why CI didn't catch it

`test.yml` tests only the packages changed since the merge base, and `packages/blob` hadn't been touched since January, so its browser specs never ran. #2365 touched the package last week and the browser job went red for exactly this, not for anything in that PR.

## Tests

The `beforeAll` change also comes from #2118: it took the reference size from a `HEAD` request too, so the spec was measuring the same unreliable header it was asserting against.

Two new tests inject a `fetch` so they don't depend on the CDN's cache state:

- 206 without `Content-Length` → size comes from `Content-Range`. Fails before this change (`create` returns a 1-byte buffered blob instead of a `WebBlob`).
- server ignores the range and answers 200 → body is buffered.

Results:

- `packages/blob`: `pnpm test` 10/10, `pnpm test:browser` 7/7 — the latter was `2 failed | 3 passed` before
- `packages/dduf` (the only dependent, reaches this through `createBlob`): `pnpm test` and `pnpm test:browser` both pass
- `lint:check`, `check` (tsc) and `format:check` clean

## Disclosure

This fix was prepared with AI assistance; every change and test result was reproduced and reviewed locally before submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fetch-probe change in blob utilities with regression tests; no auth or data-model changes.
> 
> **Overview**
> **`WebBlob.create`** no longer uses a **`HEAD`** request to read **`Content-Length`** and **`Accept-Ranges`**. It issues a **`GET`** with **`Range: bytes=0-0`**, derives total size from **`Content-Range`** on **206**, cancels the probe body for large files, and either returns a lazy **`WebBlob`** or buffers via a full fetch when below **`cacheBelow`**. If the server answers **200** and ignores the range, it returns **`probe.blob()`** instead of starting a second download.
> 
> Browser specs now size the fixture from the downloaded body (not **`HEAD`**), and add injected-**`fetch`** cases for missing **`Content-Length`** on **206** and for range-ignored **200** responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d293532699d28f93067fc25b16b9c34e83e5bfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->