### PR TITLE
Add ExtractBench to evaluation frameworks

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -167,4 +167,10 @@ export const EVALUATION_FRAMEWORKS = {
 			"MMMU is a new benchmark designed to evaluate multimodal models on massive multi-discipline tasks demanding college-level subject knowledge and deliberate reasoning.",
 		url: "https://mmmu-benchmark.github.io/",
 	},
+	extractbench: {
+		name: "extractbench",
+		description:
+			"ExtractBench is a benchmark for schema-guided data extraction from enterprise documents, scoring schema-valid JSON extraction and evidence grounding without an LLM judge.",
+		url: "https://github.com/run-llama/ExtractBench",
+	},
 } as const;


### PR DESCRIPTION
## Summary
- Adds `extractbench` to `EVALUATION_FRAMEWORKS` in `packages/tasks/src/eval.ts`.
- Matches the `evaluation_framework: extractbench` key already declared in the `eval.yaml` on [llamaindex/ExtractBench](https://huggingface.co/datasets/llamaindex/ExtractBench).
- ExtractBench evaluates schema-guided data extraction from enterprise documents (deterministic scoring: value F1, word/page-level grounding F1), no LLM-as-judge. Repo: https://github.com/run-llama/ExtractBench

## Test plan
- [x] Ran `oxfmt` on the changed file to match formatting conventions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata entry in a static framework catalog; no runtime logic, auth, or data-path changes.
> 
> **Overview**
> Registers **ExtractBench** in `EVALUATION_FRAMEWORKS` (`packages/tasks/src/eval.ts`) so benchmark datasets can declare `evaluation_framework: extractbench` in `eval.yaml` with a supported name, description, and repo link.
> 
> ExtractBench is described as schema-guided extraction from enterprise documents, with deterministic scoring (schema-valid JSON and evidence grounding) and no LLM-as-judge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 078849837a2a232522bb8f7347dcb27391012b2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->