### PR TITLE
docs(tasks): include device_map auto in pipeline example

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.spec.ts
+++ b/packages/tasks/src/model-libraries-snippets.spec.ts
@@ -1,8 +1,34 @@
 import { describe, expect, it } from "vitest";
 import type { ModelData } from "./model-data.js";
-import { llama_cpp_python } from "./model-libraries-snippets.js";
+import { llama_cpp_python, transformers } from "./model-libraries-snippets.js";
 
 describe("model-libraries-snippets", () => {
+	it("transformers pipeline and auto snippets include device_map auto", async () => {
+		const model: ModelData = {
+			id: "distilbert/distilbert-base-uncased-finetuned-sst-2-english",
+			pipeline_tag: "text-classification",
+			tags: [],
+			inference: "",
+			transformersInfo: {
+				auto_model: "AutoModelForSequenceClassification",
+				processor: "AutoTokenizer",
+				pipeline_tag: "text-classification",
+			},
+		};
+		const snippet = transformers(model);
+
+		expect(snippet[0]).toEqual(`# Use a pipeline as a high-level helper
+from transformers import pipeline
+
+pipe = pipeline("text-classification", model="distilbert/distilbert-base-uncased-finetuned-sst-2-english", device_map="auto")`);
+
+		expect(snippet[1]).toEqual(`# Load model directly
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+
+tokenizer = AutoTokenizer.from_pretrained("distilbert/distilbert-base-uncased-finetuned-sst-2-english")
+model = AutoModelForSequenceClassification.from_pretrained("distilbert/distilbert-base-uncased-finetuned-sst-2-english", device_map="auto")`);
+	});
+
 	it("llama_cpp_python conversational", async () => {
 		const model: ModelData = {
 			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1889,7 +1889,7 @@ export const transformers = (model: ModelData): string[] => {
 		pipelineSnippet.push(
 			"from transformers import pipeline",
 			"",
-			`pipe = pipeline("${model.pipeline_tag}", model="${model.id}"` + remote_code_snippet + ")",
+			`pipe = pipeline("${model.pipeline_tag}", model="${model.id}"` + remote_code_snippet + ', device_map="auto")',
 		);
 
 		if (model.tags.includes("conversational")) {


### PR DESCRIPTION
## Summary

Updates the pipeline usage snippet to include `device_map: "auto"` support where appropriate.

## Why

The example should reflect practical configuration used for multi-device execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only snippet and test changes in `packages/tasks` with no runtime or API impact.
> 
> **Overview**
> Updates generated **Transformers** usage snippets so the high-level `pipeline(...)` example includes `device_map="auto"`, matching the existing direct `from_pretrained` examples on model pages.
> 
> Adds a Vitest case for a text-classification model that locks in both the pipeline and auto-load snippet strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eae3dcdb6a09bf825ca07be9454337ce65e67fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->