### PR TITLE
Add protoAgent local-app snippet

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -249,6 +249,46 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		expect(snippet[2].content).toContain('openclaw agent --local --agent main --message "Hello from Hugging Face"');
 	});
 
+	it("protoagent", async () => {
+		const { snippet: snippetFunc } = LOCAL_APPS.protoagent;
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			gguf: { total: 1, context_length: 4096, chat_template: "{% if tools %}" },
+			inference: "",
+		};
+		const snippet = snippetFunc(model);
+
+		expect(snippet[0].content).toContain(`llama serve -hf bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`);
+		expect(snippet[1].setup).toContain("uv tool install protolabs-agent");
+		expect(snippet[1].content).toContain(
+			"protoagent model use --base-url http://127.0.0.1:8080/v1 --model bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}",
+		);
+		expect(snippet[2].content).toContain("protoagent up");
+	});
+
+	it("protoagent - mlx", async () => {
+		const { snippet: snippetFunc } = LOCAL_APPS.protoagent;
+		const model: ModelData = {
+			id: "mlx-community/Llama-3.2-3B-Instruct-mlx",
+			tags: ["mlx", "conversational"],
+			pipeline_tag: "text-generation",
+			config: {
+				tokenizer_config: {
+					chat_template: "{% if tools %}...{% endif %}",
+				},
+			},
+			inference: "",
+		};
+		const snippet = snippetFunc(model);
+
+		expect(snippet[0].setup).toContain("uv tool install mlx-lm");
+		expect(snippet[1].content).toContain(
+			"protoagent model use --base-url http://127.0.0.1:8080/v1 --model mlx-community/Llama-3.2-3B-Instruct-mlx",
+		);
+		expect(snippet[2].content).toContain("protoagent up");
+	});
+
 	it("docker model runner", async () => {
 		const { snippet: snippetFunc } = LOCAL_APPS["docker-model-runner"];
 		const model: ModelData = {

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -546,6 +546,23 @@ const snippetHermesAgent = (model: ModelData, filepath?: string): LocalAppSnippe
 	];
 };
 
+const snippetProtoagent = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
+	const modelId = isMlxModel(model) ? model.id : `${model.id}${getQuantTag(filepath)}`;
+	const serverStep = getLocalServerStep(model, filepath);
+	return [
+		serverStep,
+		{
+			title: "Point protoAgent at the local server",
+			setup: ["# Install protoAgent:", "uv tool install protolabs-agent"].join("\n"),
+			content: [
+				"# Point protoAgent at the local server:",
+				`protoagent model use --base-url http://127.0.0.1:8080/v1 --model ${modelId}`,
+			].join("\n"),
+		},
+		{ title: "Run protoAgent", content: "protoagent up" },
+	];
+};
+
 const snippetOpenClaw = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 	const isMLX = isMlxModel(model);
 	const providerId = isMLX ? "mlx-lm" : "llama-cpp";
@@ -838,6 +855,13 @@ export const LOCAL_APPS = {
 		mainTask: "text-generation",
 		displayOnModelPage: isToolCallingLocalAgentModel,
 		snippet: snippetOpenClaw,
+	},
+	protoagent: {
+		prettyLabel: "protoAgent",
+		docsUrl: "https://github.com/protoLabsAI/protoAgent/blob/main/docs/guides/cli.md#point-at-a-local-model",
+		mainTask: "text-generation",
+		displayOnModelPage: isToolCallingLocalAgentModel,
+		snippet: snippetProtoagent,
 	},
 } satisfies Record<string, LocalApp>;
 


### PR DESCRIPTION
[protoAgent](https://github.com/protoLabsAI/protoAgent) is a LangGraph agent runtime with an operator console, A2A, and drop-in plugins. It's now installable from PyPI (`uv tool install protolabs-agent`), so it can point at a locally-served model the same way Hermes Agent and OpenClaw do.

- Added `snippetProtoagent` next to `snippetHermesAgent` — same shape: start the local server, point protoAgent at it via `protoagent model use --base-url ... --model ...`, then `protoagent up`.
- Added a `protoagent` `LOCAL_APPS` entry (gated on `isToolCallingLocalAgentModel`, same as the other agentic-CLI entries — protoAgent drives tools on every turn, and a non-tool-calling model 400s at the endpoint with "does not support tools").
- Docs link points at protoAgent's own ["Point at a local model"](https://github.com/protoLabsAI/protoAgent/blob/main/docs/guides/cli.md#point-at-a-local-model) guide section, which already documents this exact one-liner as the intended copy-paste target for a HF model card.
- Added `protoagent` / `protoagent - mlx` tests mirroring the existing `hermes-agent` test shape — `pnpm vitest run local-apps.spec.ts` passes (22/22), `tsc --noEmit` and `eslint`/`oxfmt` are clean.