### PR TITLE
Fix: honor abort signal during in-flight MCP tool calls

### DIFF
--- a/packages/mcp-client/src/McpClient.ts
+++ b/packages/mcp-client/src/McpClient.ts
@@ -205,6 +205,9 @@ export class McpClient {
 		messages.push(assistantMessage);
 
 		for (const toolCall of finalToolCallValues) {
+			if (opts.abortSignal?.aborted) {
+				throw new Error("AbortError");
+			}
 			const toolName = toolCall.function.name ?? "unknown";
 			/// TODO(Fix upstream type so this is always a string)^
 			const toolMessage: ChatCompletionInputMessageTool = {
@@ -235,9 +238,17 @@ export class McpClient {
 			const client = this.clients.get(toolName);
 			if (client) {
 				try {
-					const result = await client.callTool({ name: toolName, arguments: toolArgs, signal: opts.abortSignal });
+					const result = await client.callTool({ name: toolName, arguments: toolArgs }, undefined, {
+						signal: opts.abortSignal,
+					});
+					if (opts.abortSignal?.aborted) {
+						throw new Error("AbortError");
+					}
 					toolMessage.content = ResultFormatter.format(result);
 				} catch (error) {
+					if (opts.abortSignal?.aborted) {
+						throw new Error("AbortError");
+					}
 					toolMessage.content = `Error: MCP tool call failed with error message: ${error}`;
 				}
 			} else {

--- a/packages/mcp-client/test/McpClient.abort.spec.ts
+++ b/packages/mcp-client/test/McpClient.abort.spec.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from "vitest";
+import { Agent } from "../src";
+import type { ChatCompletionInputMessage } from "@huggingface/tasks";
+
+/**
+ * Builds a fake `chatCompletionStream` that always resolves a single tool_call
+ * for `toolName`, and calls `onStreamEnd` (if given) right after the last chunk
+ * is yielded, i.e. after the streaming loop's own abort check has already run
+ * once and won't run again before control moves into the tool-execution loop.
+ */
+function fakeStream(toolName: string, onStreamEnd?: () => void) {
+	let callCount = 0;
+	return {
+		callCount: () => callCount,
+		fn: function chatCompletionStream() {
+			callCount++;
+			const id = `call_${callCount}`;
+			async function* gen() {
+				yield {
+					choices: [
+						{
+							delta: {
+								role: "assistant",
+								tool_calls: [{ index: 0, id, function: { name: toolName, arguments: "{}" } }],
+							},
+						},
+					],
+				};
+				onStreamEnd?.();
+			}
+			return gen();
+		},
+	};
+}
+
+function makeAgent() {
+	const agent = new Agent({ provider: "auto", model: "fake/fake-model", apiKey: "sk-fake", servers: [] });
+	return agent;
+}
+
+async function drain(gen: AsyncGenerator<unknown>, maxSteps = 6) {
+	const yielded: unknown[] = [];
+	for (let i = 0; i < maxSteps; i++) {
+		const { value, done } = await gen.next();
+		if (done) {
+			break;
+		}
+		yielded.push(value);
+	}
+	return yielded;
+}
+
+describe("McpClient abort handling", () => {
+	it("stops the agent loop without starting another LLM turn when the tool call is aborted", async () => {
+		const controller = new AbortController();
+		const stream = fakeStream("myTool", () => controller.abort());
+		const agent = makeAgent();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).client = { chatCompletionStream: stream.fn };
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).clients.set("myTool", {
+			callTool: async (_params: unknown, _resultSchema: unknown, options?: { signal?: AbortSignal }) => {
+				if (options?.signal?.aborted) {
+					throw new DOMException("The operation was aborted", "AbortError");
+				}
+				return { content: [{ type: "text", text: "tool ran" }] };
+			},
+		});
+
+		const yielded = await drain(agent.run("do the thing", { abortSignal: controller.signal }));
+
+		// only the assistant's tool_call chunk was yielded; the aborted tool call
+		// never produced a "tool" message and no second LLM turn was started
+		expect(yielded).toHaveLength(1);
+		expect(stream.callCount()).toBe(1);
+	});
+
+	it("does not disguise an aborted tool call as a normal tool failure message", async () => {
+		const controller = new AbortController();
+		const stream = fakeStream("myTool", () => controller.abort());
+		const agent = makeAgent();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).client = { chatCompletionStream: stream.fn };
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).clients.set("myTool", {
+			callTool: async (_params: unknown, _resultSchema: unknown, options?: { signal?: AbortSignal }) => {
+				if (options?.signal?.aborted) {
+					throw new DOMException("The operation was aborted", "AbortError");
+				}
+				return { content: [{ type: "text", text: "tool ran" }] };
+			},
+		});
+
+		await drain(agent.run("do the thing", { abortSignal: controller.signal }));
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const messages = (agent as any).messages as ChatCompletionInputMessage[];
+		const toolMessages = messages.filter((m) => m.role === "tool");
+		expect(toolMessages).toHaveLength(0);
+	});
+
+	it("passes the abort signal into the SDK call so a still-pending tool call settles as soon as it fires", async () => {
+		const controller = new AbortController();
+		const stream = fakeStream("myTool");
+		const agent = makeAgent();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).client = { chatCompletionStream: stream.fn };
+		let receivedSignal: AbortSignal | undefined;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).clients.set("myTool", {
+			// never resolves on its own; only settles if the SDK actually forwards
+			// the signal and something listens for its abort event
+			callTool: (_params: unknown, _resultSchema: unknown, options?: { signal?: AbortSignal }) => {
+				receivedSignal = options?.signal;
+				return new Promise((_resolve, reject) => {
+					options?.signal?.addEventListener("abort", () => {
+						reject(new DOMException("The operation was aborted", "AbortError"));
+					});
+				});
+			},
+		});
+
+		const iterator = agent.run("do the thing", { abortSignal: controller.signal })[Symbol.asyncIterator]();
+		await iterator.next(); // assistant chunk
+
+		const pending = iterator.next(); // resumes into the tool call, which now hangs
+		await Promise.resolve(); // let the generator run up to its awaited callTool()
+		expect(receivedSignal).toBe(controller.signal);
+
+		controller.abort();
+		const result = await pending;
+
+		expect(result.done).toBe(true);
+	});
+
+	it("stops the agent loop even when the tool ignores the abort signal and resolves normally", async () => {
+		const controller = new AbortController();
+		const stream = fakeStream("myTool");
+		const agent = makeAgent();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).client = { chatCompletionStream: stream.fn };
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).clients.set("myTool", {
+			// a tool that doesn't check `signal` at all and resolves after the
+			// caller has already aborted (e.g. it was too far along to cancel)
+			callTool: async () => {
+				controller.abort();
+				return { content: [{ type: "text", text: "tool ran despite abort" }] };
+			},
+		});
+
+		const yielded = await drain(agent.run("do the thing", { abortSignal: controller.signal }));
+
+		expect(yielded).toHaveLength(1);
+		expect(stream.callCount()).toBe(1);
+	});
+
+	it("does not start the next tool call in the same turn once aborted between yields", async () => {
+		// two tool calls in a single turn; abort lands right after the first
+		// tool's message is yielded to the caller and before the second tool
+		// is ever invoked
+		const controller = new AbortController();
+		const stream = {
+			callCount: () => 1,
+			fn: function chatCompletionStream() {
+				async function* gen() {
+					yield {
+						choices: [
+							{
+								delta: {
+									role: "assistant",
+									tool_calls: [
+										{ index: 0, id: "call_a", function: { name: "toolA", arguments: "{}" } },
+										{ index: 1, id: "call_b", function: { name: "toolB", arguments: "{}" } },
+									],
+								},
+							},
+						],
+					};
+				}
+				return gen();
+			},
+		};
+		const agent = makeAgent();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).client = { chatCompletionStream: stream.fn };
+		let toolBCalled = false;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).clients.set("toolA", {
+			callTool: async () => ({ content: [{ type: "text", text: "a ran" }] }),
+		});
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).clients.set("toolB", {
+			callTool: async () => {
+				toolBCalled = true;
+				return { content: [{ type: "text", text: "b ran" }] };
+			},
+		});
+
+		const iterator = agent.run("do the thing", { abortSignal: controller.signal })[Symbol.asyncIterator]();
+		await iterator.next(); // assistant chunk
+		const toolAMessage = await iterator.next(); // toolA's tool message
+		expect((toolAMessage.value as { name?: string }).name).toBe("toolA");
+
+		controller.abort();
+		const afterAbort = await iterator.next();
+
+		expect(afterAbort.done).toBe(true);
+		expect(toolBCalled).toBe(false);
+	});
+
+	it("leaves a normal (non-aborted) successful tool call flow unchanged", async () => {
+		const stream = fakeStream("task_complete");
+		const agent = makeAgent();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).client = { chatCompletionStream: stream.fn };
+
+		const yielded = await drain(agent.run("do the thing"));
+
+		expect(stream.callCount()).toBe(1);
+		expect(yielded.some((v) => (v as { role?: string }).role === "tool")).toBe(true);
+	});
+
+	it("still surfaces a real (non-abort) tool error as a normal tool failure message and continues the loop", async () => {
+		let turn = 0;
+		const stream = {
+			callCount: () => turn,
+			fn: function chatCompletionStream() {
+				turn++;
+				const toolName = turn === 1 ? "myTool" : "task_complete";
+				const id = `call_${turn}`;
+				async function* gen() {
+					yield {
+						choices: [
+							{
+								delta: {
+									role: "assistant",
+									tool_calls: [{ index: 0, id, function: { name: toolName, arguments: "{}" } }],
+								},
+							},
+						],
+					};
+				}
+				return gen();
+			},
+		};
+		const agent = makeAgent();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).client = { chatCompletionStream: stream.fn };
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(agent as any).clients.set("myTool", {
+			callTool: async () => {
+				throw new Error("boom");
+			},
+		});
+
+		const yielded = await drain(agent.run("do the thing"));
+
+		const toolMessage = yielded.find((v) => (v as { role?: string }).role === "tool") as
+			| { content?: string }
+			| undefined;
+		expect(toolMessage?.content).toContain("MCP tool call failed");
+		expect(stream.callCount()).toBe(2);
+	});
+});


### PR DESCRIPTION
## Problem

`McpClient.processSingleTurnWithTools` accepts an `abortSignal` and checks it in a few places, but the actual MCP tool call ignores it. `client.callTool` was called with `signal` on the request params object:

```ts
await client.callTool({ name: toolName, arguments: toolArgs, signal: opts.abortSignal });
```

The installed `@modelcontextprotocol/sdk` signature is `callTool(params, resultSchema?, options?)`, where `signal` lives on the third argument (`RequestOptions`). Putting it on `params` means it's never forwarded to the transport, so aborting mid-tool-call has no effect on the in-flight request. It keeps running, and cancellation only takes effect a turn later, once the result comes back and the post-call abort check fires.

## Fix

Pass the signal through `RequestOptions` instead:

```ts
await client.callTool({ name: toolName, arguments: toolArgs }, undefined, {
	signal: opts.abortSignal,
});
```

Also added abort checks at the top of the tool-call loop and in the catch block (the existing check only ran right after the `callTool` await), so an abort landing between two tool calls in the same turn, or during a tool call that rejects for another reason, still ends the turn cleanly instead of continuing or surfacing as a normal tool-failure message.

## Tests

`McpClient.abort.spec.ts` covers: a pending tool call actually receiving the signal through the SDK (fails without the params/options fix), abort landing between two tool calls in one turn, a tool that resolves normally after the caller already aborted, and that a real non-abort tool error still surfaces normally. Checked each of the three abort-check locations individually by reverting it in isolation: each has a test that fails without it.

`pnpm vitest run` in `packages/mcp-client`: 22/22 passed. `tsc` and `eslint` clean.

---

One thing this doesn't touch: when a tool call is aborted mid-turn, the assistant message with its `tool_calls` is already pushed to `messages`, but the matching `tool` response never gets appended, leaving the message list with a `tool_calls` entry that has no corresponding `tool` message, which most providers reject on the next turn. Is there a preferred way to handle this, e.g. drop the dangling assistant message, or push a synthetic cancelled `tool` message?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to MCP client tool execution and cancellation; no auth or data-path changes, with dedicated test coverage.
> 
> **Overview**
> **Fixes cancellation during MCP tool execution** by passing `opts.abortSignal` through the SDK’s third `callTool` argument (`RequestOptions`) instead of on the params object, so in-flight tool requests can actually be aborted.
> 
> **Tightens abort handling in the tool loop**: checks `abortSignal` before each tool call, after `callTool` returns, and in the catch path so aborts stop the turn cleanly (no fake tool-failure messages, no second tool in the same turn, no extra LLM turn).
> 
> Adds **`McpClient.abort.spec.ts`** with Vitest coverage for signal forwarding, mid-turn abort between tools, tools that ignore abort, and unchanged non-abort error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29ffca326c4d33e20d5d025d94555f8e0ce7441e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->