### PR TITLE
[Inference] Bound 503 retries with backoff and release the stalled body

### DIFF
--- a/packages/inference/src/utils/request.ts
+++ b/packages/inference/src/utils/request.ts
@@ -5,6 +5,12 @@ import type { EventSourceMessage } from "../vendor/fetch-event-source/parse.js";
 import { getLines, getMessages } from "../vendor/fetch-event-source/parse.js";
 import { InferenceClientProviderApiError } from "../errors.js";
 import type { JsonObject } from "../vendor/type-fest/basic.js";
+import { delay } from "./delay.js";
+
+/** Number of times a 503 (provider warming up / loading the model) response is retried before the error is surfaced. */
+const MAX_503_RETRIES = 5;
+/** Base delay between 503 retries, in ms. Multiplied by the attempt number for a simple linear backoff. */
+const RETRY_DELAY_503_MS = 1000;
 
 export interface ResponseWrapper<T> {
 	data: T;
@@ -45,14 +51,17 @@ export async function innerRequest<T>(
 		/** Is chat completion compatible */
 		chatCompletion?: boolean;
 	},
+	attempt = 0,
 ): Promise<ResponseWrapper<T>> {
 	const { url, info } = await makeRequestOptions(args, providerHelper, options);
 	const response = await (options?.fetch ?? fetch)(url, info);
 
 	const requestContext: ResponseWrapper<T>["requestContext"] = { url, info };
 
-	if (options?.retry_on_error !== false && response.status === 503) {
-		return innerRequest(args, providerHelper, options);
+	if (options?.retry_on_error !== false && response.status === 503 && attempt < MAX_503_RETRIES) {
+		await response.body?.cancel().catch(() => {});
+		await delay(RETRY_DELAY_503_MS * (attempt + 1), options?.signal);
+		return innerRequest(args, providerHelper, options, attempt + 1);
 	}
 
 	if (!response.ok) {
@@ -131,12 +140,15 @@ export async function* innerStreamingRequest<T>(
 		/** Is chat completion compatible */
 		chatCompletion?: boolean;
 	},
+	attempt = 0,
 ): AsyncGenerator<T> {
 	const { url, info } = await makeRequestOptions({ ...args, stream: true }, providerHelper, options);
 	const response = await (options?.fetch ?? fetch)(url, info);
 
-	if (options?.retry_on_error !== false && response.status === 503) {
-		return yield* innerStreamingRequest(args, providerHelper, options);
+	if (options?.retry_on_error !== false && response.status === 503 && attempt < MAX_503_RETRIES) {
+		await response.body?.cancel().catch(() => {});
+		await delay(RETRY_DELAY_503_MS * (attempt + 1), options?.signal);
+		return yield* innerStreamingRequest(args, providerHelper, options, attempt + 1);
 	}
 	if (!response.ok) {
 		if (response.headers.get("Content-Type")?.startsWith("application/json")) {

--- a/packages/inference/test/request-retry.spec.ts
+++ b/packages/inference/test/request-retry.spec.ts
@@ -1,0 +1,391 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HFInferenceTask } from "../src/providers/hf-inference.js";
+import { innerRequest, innerStreamingRequest } from "../src/utils/request.js";
+import type { RequestArgs } from "../src/types.js";
+
+const itWithFakeTimers = typeof window !== "undefined" && typeof window.document !== "undefined" ? it.skip : it;
+
+const providerHelper = new HFInferenceTask();
+const args: RequestArgs = { endpointUrl: "https://example.com/model", inputs: "hello" };
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+function eventStreamResponse(): Response {
+	return new Response(null, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+}
+
+/**
+ * Models a single reusable connection, like a real HTTP/1.1 keep-alive socket: the first 503
+ * response's body is left open (a stalled provider that sent headers but never finished the
+ * body), and any later fetch call blocks until that body is released via `cancel()`. If the
+ * retry never releases it, the next request can never acquire the connection.
+ */
+function createSingleConnectionFetch(finalResponse: () => Response) {
+	let connectionFree = true;
+	let releaseWaiter: (() => void) | undefined;
+	let fetchInvocations = 0;
+	let serverRequests = 0;
+	let cancelCalls = 0;
+
+	const acquireConnection = () => {
+		if (connectionFree) {
+			connectionFree = false;
+			return Promise.resolve();
+		}
+		return new Promise<void>((resolve) => {
+			releaseWaiter = () => {
+				connectionFree = false;
+				resolve();
+			};
+		});
+	};
+
+	const releaseConnection = () => {
+		connectionFree = true;
+		releaseWaiter?.();
+		releaseWaiter = undefined;
+	};
+
+	const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(async () => {
+		fetchInvocations++;
+		await acquireConnection();
+		serverRequests++;
+		if (serverRequests === 1) {
+			const stalledBody = new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(new TextEncoder().encode('{"error":"loading"'));
+					// deliberately never closed: the provider stalls mid-body
+				},
+				cancel() {
+					cancelCalls++;
+					releaseConnection();
+				},
+			});
+			return new Response(stalledBody, { status: 503, headers: { "Content-Type": "application/json" } });
+		}
+		releaseConnection();
+		return finalResponse();
+	});
+
+	return { fetchMock, stats: () => ({ fetchInvocations, serverRequests, cancelCalls }) };
+}
+
+function serverGoneWithRejectingCancel(): Response {
+	const response = jsonResponse({ error: "loading" }, 503);
+	// simulate cancel() rejecting (e.g. body already errored/closed) to make sure that doesn't
+	// override the 503 retry handling
+	if (response.body) {
+		response.body.cancel = () => Promise.reject(new Error("already closed"));
+	}
+	return response;
+}
+
+async function drain<T>(gen: AsyncGenerator<T>): Promise<T[]> {
+	const out: T[] = [];
+	for await (const item of gen) {
+		out.push(item);
+	}
+	return out;
+}
+
+describe("innerRequest 503 retry backoff", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	itWithFakeTimers("retries a bounded number of times, then surfaces the error", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() =>
+			Promise.resolve(jsonResponse({ error: "loading" }, 503)),
+		);
+
+		const assertion = expect(innerRequest(args, providerHelper, { fetch: fetchMock })).rejects.toThrow();
+		await vi.runAllTimersAsync();
+		await assertion;
+
+		// 1 initial request + 5 retries
+		expect(fetchMock).toHaveBeenCalledTimes(6);
+	});
+
+	itWithFakeTimers("waits with increasing delay between 503 retries", async () => {
+		vi.useFakeTimers();
+		let calls = 0;
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() => {
+			calls++;
+			return Promise.resolve(jsonResponse({ error: "loading" }, 503));
+		});
+
+		innerRequest(args, providerHelper, { fetch: fetchMock }).catch(() => {});
+
+		await vi.advanceTimersByTimeAsync(0);
+		expect(calls).toBe(1);
+
+		await vi.advanceTimersByTimeAsync(999);
+		expect(calls).toBe(1);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(calls).toBe(2);
+
+		await vi.advanceTimersByTimeAsync(1999);
+		expect(calls).toBe(2);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(calls).toBe(3);
+	});
+
+	itWithFakeTimers("aborts during the retry delay instead of issuing another request", async () => {
+		vi.useFakeTimers();
+		const controller = new AbortController();
+		let calls = 0;
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() => {
+			calls++;
+			return Promise.resolve(jsonResponse({ error: "loading" }, 503));
+		});
+
+		const assertion = expect(
+			innerRequest(args, providerHelper, { fetch: fetchMock, signal: controller.signal }),
+		).rejects.toThrow(/aborted/i);
+
+		await vi.advanceTimersByTimeAsync(0);
+		expect(calls).toBe(1);
+
+		controller.abort();
+		await assertion;
+
+		expect(calls).toBe(1);
+	});
+
+	it("does not retry when retry_on_error is false", async () => {
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() =>
+			Promise.resolve(jsonResponse({ error: "loading" }, 503)),
+		);
+
+		await expect(innerRequest(args, providerHelper, { fetch: fetchMock, retry_on_error: false })).rejects.toThrow();
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns a successful response as-is without retrying", async () => {
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() =>
+			Promise.resolve(jsonResponse({ ok: true })),
+		);
+
+		const { data } = await innerRequest(args, providerHelper, { fetch: fetchMock });
+
+		expect(data).toEqual({ ok: true });
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	itWithFakeTimers("recovers once the provider stops returning 503", async () => {
+		vi.useFakeTimers();
+		let calls = 0;
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() => {
+			calls++;
+			return Promise.resolve(calls === 1 ? jsonResponse({ error: "loading" }, 503) : jsonResponse({ ok: true }));
+		});
+
+		const requestPromise = innerRequest(args, providerHelper, { fetch: fetchMock });
+		await vi.runAllTimersAsync();
+		const { data } = await requestPromise;
+
+		expect(data).toEqual({ ok: true });
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("innerStreamingRequest 503 retry backoff", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	itWithFakeTimers("retries a bounded number of times, then surfaces the error", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() =>
+			Promise.resolve(jsonResponse({ error: "loading" }, 503)),
+		);
+
+		const assertion = expect(
+			drain(innerStreamingRequest(args, providerHelper, { fetch: fetchMock })),
+		).rejects.toThrow();
+		await vi.runAllTimersAsync();
+		await assertion;
+
+		expect(fetchMock).toHaveBeenCalledTimes(6);
+	});
+
+	itWithFakeTimers("aborts during the retry delay instead of issuing another request", async () => {
+		vi.useFakeTimers();
+		const controller = new AbortController();
+		let calls = 0;
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() => {
+			calls++;
+			return Promise.resolve(jsonResponse({ error: "loading" }, 503));
+		});
+
+		const assertion = expect(
+			drain(innerStreamingRequest(args, providerHelper, { fetch: fetchMock, signal: controller.signal })),
+		).rejects.toThrow(/aborted/i);
+
+		await vi.advanceTimersByTimeAsync(0);
+		expect(calls).toBe(1);
+
+		controller.abort();
+		await assertion;
+
+		expect(calls).toBe(1);
+	});
+
+	it("does not retry when retry_on_error is false", async () => {
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() =>
+			Promise.resolve(jsonResponse({ error: "loading" }, 503)),
+		);
+
+		await expect(
+			drain(innerStreamingRequest(args, providerHelper, { fetch: fetchMock, retry_on_error: false })),
+		).rejects.toThrow();
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns a successful stream as-is without retrying", async () => {
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() =>
+			Promise.resolve(eventStreamResponse()),
+		);
+
+		await drain(innerStreamingRequest(args, providerHelper, { fetch: fetchMock }));
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	itWithFakeTimers("recovers once the provider stops returning 503", async () => {
+		vi.useFakeTimers();
+		let calls = 0;
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() => {
+			calls++;
+			return Promise.resolve(calls === 1 ? jsonResponse({ error: "loading" }, 503) : eventStreamResponse());
+		});
+
+		const genPromise = drain(innerStreamingRequest(args, providerHelper, { fetch: fetchMock }));
+		await vi.runAllTimersAsync();
+		await genPromise;
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("503 response body release", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	itWithFakeTimers("releases a stalled 503 body so a single-connection retry can proceed (innerRequest)", async () => {
+		vi.useFakeTimers();
+		const { fetchMock, stats } = createSingleConnectionFetch(() => jsonResponse({ ok: true }));
+
+		const requestPromise = innerRequest(args, providerHelper, { fetch: fetchMock });
+		let settled = false;
+		requestPromise.then(() => (settled = true));
+
+		// the first response settles and its body is cancelled before the retry delay starts
+		await vi.advanceTimersByTimeAsync(0);
+		expect(stats()).toEqual({ fetchInvocations: 1, serverRequests: 1, cancelCalls: 1 });
+
+		// the retry delay elapses; without releasing the stalled body, the second fetch call
+		// can never acquire the (single) connection and the request hangs forever
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(settled).toBe(true);
+		expect(stats()).toEqual({ fetchInvocations: 2, serverRequests: 2, cancelCalls: 1 });
+
+		const { data } = await requestPromise;
+		expect(data).toEqual({ ok: true });
+	});
+
+	itWithFakeTimers(
+		"releases a stalled 503 body so a single-connection retry can proceed (innerStreamingRequest)",
+		async () => {
+			vi.useFakeTimers();
+			const { fetchMock, stats } = createSingleConnectionFetch(() => eventStreamResponse());
+
+			const genPromise = drain(innerStreamingRequest(args, providerHelper, { fetch: fetchMock }));
+			let settled = false;
+			genPromise.then(() => (settled = true));
+
+			await vi.advanceTimersByTimeAsync(0);
+			expect(stats()).toEqual({ fetchInvocations: 1, serverRequests: 1, cancelCalls: 1 });
+
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(settled).toBe(true);
+			expect(stats()).toEqual({ fetchInvocations: 2, serverRequests: 2, cancelCalls: 1 });
+
+			await genPromise;
+		},
+	);
+
+	itWithFakeTimers("still retries when cancelling the 503 body rejects (innerRequest)", async () => {
+		vi.useFakeTimers();
+		let calls = 0;
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() => {
+			calls++;
+			return Promise.resolve(calls === 1 ? serverGoneWithRejectingCancel() : jsonResponse({ ok: true }));
+		});
+
+		const requestPromise = innerRequest(args, providerHelper, { fetch: fetchMock });
+		await vi.runAllTimersAsync();
+		const { data } = await requestPromise;
+
+		expect(data).toEqual({ ok: true });
+		expect(calls).toBe(2);
+	});
+
+	itWithFakeTimers("still retries when cancelling the 503 body rejects (innerStreamingRequest)", async () => {
+		vi.useFakeTimers();
+		let calls = 0;
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() => {
+			calls++;
+			return Promise.resolve(calls === 1 ? serverGoneWithRejectingCancel() : eventStreamResponse());
+		});
+
+		const genPromise = drain(innerStreamingRequest(args, providerHelper, { fetch: fetchMock }));
+		await vi.runAllTimersAsync();
+		await genPromise;
+
+		expect(calls).toBe(2);
+	});
+
+	itWithFakeTimers("does not throw when the 503 response has no body to cancel (innerRequest)", async () => {
+		vi.useFakeTimers();
+		let calls = 0;
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() => {
+			calls++;
+			return Promise.resolve(
+				calls === 1
+					? new Response(null, { status: 503, headers: { "Content-Type": "application/json" } })
+					: jsonResponse({ ok: true }),
+			);
+		});
+
+		const requestPromise = innerRequest(args, providerHelper, { fetch: fetchMock });
+		await vi.runAllTimersAsync();
+		const { data } = await requestPromise;
+
+		expect(data).toEqual({ ok: true });
+		expect(calls).toBe(2);
+	});
+
+	itWithFakeTimers("does not throw when the 503 response has no body to cancel (innerStreamingRequest)", async () => {
+		vi.useFakeTimers();
+		let calls = 0;
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() => {
+			calls++;
+			return Promise.resolve(
+				calls === 1
+					? new Response(null, { status: 503, headers: { "Content-Type": "application/json" } })
+					: eventStreamResponse(),
+			);
+		});
+
+		const genPromise = drain(innerStreamingRequest(args, providerHelper, { fetch: fetchMock }));
+		await vi.runAllTimersAsync();
+		await genPromise;
+
+		expect(calls).toBe(2);
+	});
+});


### PR DESCRIPTION
## Problem

`innerRequest` and `innerStreamingRequest` retry immediately and without limit on a 503 response:

```ts
if (options?.retry_on_error !== false && response.status === 503) {
    return innerRequest(args, providerHelper, options);
}
```

A provider stuck warming up (or any endpoint that always returns 503) grows an unbounded recursive promise/generator chain with no delay between attempts. In practice this doesn't stack-overflow, it keeps allocating until the process runs out of heap and crashes, which is harder to diagnose than a clean error.

The retry also never reads or cancels the previous response's body before recursing. A client limited to a single connection (a real HTTP/1.1 keep-alive socket, or any fetch implementation that only allows one in-flight request) can't reuse that connection for the retry until the prior body is drained or cancelled, so the retry just hangs.

## Fix

- Cap retries at 5 attempts, after which the 503 is surfaced as a normal error.
- Add a linear backoff between attempts (1s times the attempt number), which respects `options.signal` so an abort during the delay rejects immediately instead of waiting it out.
- Cancel the 503 response body before scheduling each retry.

Visible behavior change: the first retry now waits 1s instead of firing immediately. The backoff constant is easy to tune if a different value is preferred.

## Verification

`packages/inference/test/request-retry.spec.ts` (new), covering both `innerRequest` and `innerStreamingRequest`:

- retries stop at the cap and surface the error (6 total attempts: 1 + 5 retries)
- delay between retries increases and is respected before the next attempt fires
- aborting during the delay rejects without issuing another request
- `retry_on_error: false` skips retries entirely
- a 200 response is returned without retrying
- recovery once the provider stops returning 503
- the 503 body is released before the retry, reproduced against a fetch mock that models a single reusable connection: the retry can only proceed once the prior body is cancelled, otherwise the second request never acquires the connection and the whole call hangs
- cancelling the body still retries correctly if `cancel()` itself rejects
- no throw when the 503 response has no body to cancel

Full suite: `pnpm --filter @huggingface/inference test` passes (42 passed, 118 skipped without `HF_TOKEN`, unrelated to this change). `tsc --noEmit`, `eslint`, and `oxfmt --check` are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core HTTP retry behavior for all inference calls on 503; bounded retries and added delay alter failure timing and warmup recovery, though behavior is well-tested and fixes unbounded retry/memory issues.
> 
> **Overview**
> **503 handling** in `innerRequest` and `innerStreamingRequest` no longer retries immediately and without limit. Retries are capped at **5** (six total attempts), separated by **linear backoff** (1s × attempt index) via `delay`, and honor **`options.signal`** during the wait.
> 
> Before each retry, the **503 response body is cancelled** (errors from `cancel()` are ignored) so keep-alive / single-connection clients can issue the next fetch instead of hanging on an unread body.
> 
> **User-visible change:** the first 503 retry waits ~1s instead of firing instantly. `retry_on_error: false` still disables retries.
> 
> Adds **`request-retry.spec.ts`** with coverage for caps, backoff timing, abort during delay, opt-out, recovery, and single-connection body release for both code paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 459f44b2df1540b4a5643fa6d89e1baa2328ea8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
