### PR TITLE
Add OpenDDE to model libraries

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1342,6 +1342,13 @@ openasr transcribe audio.wav --model ${modelId}`,
 	];
 };
 
+export const opendde = (): string[] => [
+	`# pip install 'opendde[gpu]'
+# Checkpoints are fetched from the Hub into $OPENDDE_ROOT_DIR (default ~/.cache/opendde)
+opendde doctor
+opendde pred -i examples/input.json -o ./output -n opendde_v1`,
+];
+
 export const paddlenlp = (model: ModelData): string[] => {
 	if (model.config?.architectures?.[0]) {
 		const architecture = model.config.architectures[0];

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1093,6 +1093,15 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: false,
 		countDownloads: `path_extension:"oasr"`,
 	},
+	opendde: {
+		prettyLabel: "OpenDDE",
+		repoName: "OpenDDE",
+		repoUrl: "https://github.com/aurekaresearch/OpenDDE",
+		docsUrl: "https://huggingface.co/aurekaresearch/OpenDDE/blob/main/docs/inference_instructions.md",
+		snippets: snippets.opendde,
+		filter: false,
+		countDownloads: `path_extension:"pt"`,
+	},
 	openpeerllm: {
 		prettyLabel: "OpenPeerLLM",
 		repoName: "OpenPeerLLM",


### PR DESCRIPTION
Adds [OpenDDE](https://github.com/aurekaresearch/OpenDDE) to the model libraries.

OpenDDE is an open-source, all-atom biomolecular foundation model that turns co-folding into a scalable engine for structure prediction, design, and optimization in drug discovery (proteins, DNA, RNA, ligands, ions).

- PyPI: https://pypi.org/project/opendde/ (`pip install opendde`, Apache-2.0)
- Code: https://github.com/aurekaresearch/OpenDDE
- Docs: https://huggingface.co/aurekaresearch/OpenDDE/blob/main/docs/inference_instructions.md
- Weights: https://huggingface.co/aurekaresearch/OpenDDE

### `countDownloads`

The `opendde` package resolves its checkpoints straight from the Hub and fetches them with a plain HTTP GET against the `resolve` endpoint (see [`opendde/config/model_manifest.py`](https://github.com/aurekaresearch/OpenDDE/blob/main/opendde/config/model_manifest.py)):

```
https://huggingface.co/aurekaresearch/OpenDDE/resolve/<revision>/opendde.pt
```

It never requests `config.json`, so the default query files don't reflect real usage. `path_extension:"pt"` matches the two released checkpoints (`opendde.pt`, `opendde_abag.pt`) and future ones, while excluding the large non-weight assets that live in the same repo (`common/components.cif`, `common/components.cif.rdkit_mol.pkl`), so downloads aren't double counted.

`library_name: opendde` is already set on the model card.

`filter: false` since this is a single-repo library.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive registry and snippet-only changes with no auth, API, or shared runtime impact.
> 
> **Overview**
> Registers **OpenDDE** (`library_name: opendde`) so Hub model pages show install/inference guidance and download stats align with how weights are fetched.
> 
> A new `opendde` entry in `MODEL_LIBRARIES_UI_ELEMENTS` points at the Aureka Research repo and docs, uses **`filter: false`** (single-repo library), and sets **`countDownloads`** to `path_extension:"pt"` because the CLI pulls `.pt` checkpoints via Hub `resolve` rather than standard `config.json` files.
> 
> Model pages get a static CLI snippet (`pip install 'opendde[gpu]'`, `opendde doctor`, `opendde pred …`) via a new `opendde()` export in `model-libraries-snippets.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ba985e9fe9169562f066faa4abc8f2cbfac779b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->