### PR TITLE
🐛 fix(inference): forward custom fetch through resolveProvider for provider="auto"

### DIFF
--- a/packages/inference/src/lib/getInferenceProviderMapping.ts
+++ b/packages/inference/src/lib/getInferenceProviderMapping.ts
@@ -2,7 +2,13 @@ import type { WidgetType } from "@huggingface/tasks";
 import { HF_HUB_URL } from "../config.js";
 import { HARDCODED_MODEL_INFERENCE_MAPPING } from "../providers/consts.js";
 import { EQUIVALENT_SENTENCE_TRANSFORMERS_TASKS } from "../providers/hf-inference.js";
-import type { InferenceProvider, InferenceProviderMappingEntry, InferenceProviderOrPolicy, ModelId } from "../types.js";
+import type {
+	InferenceProvider,
+	InferenceProviderMappingEntry,
+	InferenceProviderOrPolicy,
+	ModelId,
+	Options,
+} from "../types.js";
 import { typedInclude } from "../utils/typedInclude.js";
 import { InferenceClientHubApiError, InferenceClientInputError } from "../errors.js";
 import { getLogger } from "./logger.js";
@@ -164,6 +170,7 @@ export async function resolveProvider(
 	provider?: InferenceProviderOrPolicy,
 	modelId?: string,
 	endpointUrl?: string,
+	options?: Pick<Options, "fetch">,
 ): Promise<InferenceProvider> {
 	const logger = getLogger();
 	if (endpointUrl) {
@@ -183,7 +190,7 @@ export async function resolveProvider(
 		if (!modelId) {
 			throw new InferenceClientInputError("Specifying a model is required when provider is 'auto'");
 		}
-		const mappings = await fetchInferenceProviderMappingForModel(modelId);
+		const mappings = await fetchInferenceProviderMappingForModel(modelId, undefined, options);
 		provider = mappings[0]?.provider as InferenceProvider | undefined;
 		logger.log("Auto selected provider:", provider);
 	}

--- a/packages/inference/src/tasks/audio/audioClassification.ts
+++ b/packages/inference/src/tasks/audio/audioClassification.ts
@@ -16,7 +16,7 @@ export async function audioClassification(
 	args: AudioClassificationArgs,
 	options?: Options,
 ): Promise<AudioClassificationOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "audio-classification");
 	const payload = preparePayload(args);
 	const { data: res } = await innerRequest<AudioClassificationOutput>(payload, providerHelper, {

--- a/packages/inference/src/tasks/audio/audioToAudio.ts
+++ b/packages/inference/src/tasks/audio/audioToAudio.ts
@@ -39,7 +39,7 @@ export interface AudioToAudioOutput {
  * Example model: speechbrain/sepformer-wham does audio source separation.
  */
 export async function audioToAudio(args: AudioToAudioArgs, options?: Options): Promise<AudioToAudioOutput[]> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "audio-to-audio");
 	const payload = await providerHelper.preparePayloadAsync(args);
 	const { data: res } = await innerRequest<AudioToAudioOutput>(payload, providerHelper, {

--- a/packages/inference/src/tasks/audio/automaticSpeechRecognition.ts
+++ b/packages/inference/src/tasks/audio/automaticSpeechRecognition.ts
@@ -14,7 +14,7 @@ export async function automaticSpeechRecognition(
 	args: AutomaticSpeechRecognitionArgs,
 	options?: Options,
 ): Promise<AutomaticSpeechRecognitionOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "automatic-speech-recognition");
 	const payload = await providerHelper.preparePayloadAsync(args);
 	const { data: res } = await innerRequest<AutomaticSpeechRecognitionOutput>(payload, providerHelper, {

--- a/packages/inference/src/tasks/audio/textToAudio.ts
+++ b/packages/inference/src/tasks/audio/textToAudio.ts
@@ -16,7 +16,7 @@ interface OutputUrlTextToAudioGeneration {
  * Example model: stabilityai/stable-audio-open-1.0
  */
 export async function textToAudio(args: TextToAudioArgs, options?: Options): Promise<Blob> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "text-to-audio");
 	const { data: res } = await innerRequest<Blob | OutputUrlTextToAudioGeneration>(args, providerHelper, {
 		...options,

--- a/packages/inference/src/tasks/audio/textToSpeech.ts
+++ b/packages/inference/src/tasks/audio/textToSpeech.ts
@@ -13,7 +13,7 @@ interface OutputUrlTextToSpeechGeneration {
  * Recommended model: espnet/kan-bayashi_ljspeech_vits
  */
 export async function textToSpeech(args: TextToSpeechArgs, options?: Options): Promise<Blob> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "text-to-speech");
 	const { data: res } = await innerRequest<Blob | OutputUrlTextToSpeechGeneration>(args, providerHelper, {
 		...options,

--- a/packages/inference/src/tasks/custom/request.ts
+++ b/packages/inference/src/tasks/custom/request.ts
@@ -19,7 +19,7 @@ export async function request<T>(
 	logger.warn(
 		"The request method is deprecated and will be removed in a future version of huggingface.js. Use specific task functions instead.",
 	);
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, options?.task);
 	const result = await innerRequest<T>(args, providerHelper, options);
 	return result.data;

--- a/packages/inference/src/tasks/custom/streamingRequest.ts
+++ b/packages/inference/src/tasks/custom/streamingRequest.ts
@@ -19,7 +19,7 @@ export async function* streamingRequest<T>(
 	logger.warn(
 		"The streamingRequest method is deprecated and will be removed in a future version of huggingface.js. Use specific task functions instead.",
 	);
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, options?.task);
 	yield* innerStreamingRequest(args, providerHelper, options);
 }

--- a/packages/inference/src/tasks/cv/imageClassification.ts
+++ b/packages/inference/src/tasks/cv/imageClassification.ts
@@ -15,7 +15,7 @@ export async function imageClassification(
 	args: ImageClassificationArgs,
 	options?: Options,
 ): Promise<ImageClassificationOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "image-classification");
 	const payload = preparePayload(args);
 	const { data: res } = await innerRequest<ImageClassificationOutput>(payload, providerHelper, {

--- a/packages/inference/src/tasks/cv/imageSegmentation.ts
+++ b/packages/inference/src/tasks/cv/imageSegmentation.ts
@@ -15,7 +15,7 @@ export async function imageSegmentation(
 	args: ImageSegmentationArgs,
 	options?: Options,
 ): Promise<ImageSegmentationOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "image-segmentation");
 	const payload = await providerHelper.preparePayloadAsync(args);
 	const { data: res } = await innerRequest<ImageSegmentationOutput>(payload, providerHelper, {

--- a/packages/inference/src/tasks/cv/imageTextToImage.ts
+++ b/packages/inference/src/tasks/cv/imageTextToImage.ts
@@ -11,7 +11,7 @@ export type ImageTextToImageArgs = BaseArgs & ImageTextToImageInput;
  * Recommended model: black-forest-labs/FLUX.2-dev
  */
 export async function imageTextToImage(args: ImageTextToImageArgs, options?: Options): Promise<Blob> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "image-text-to-image");
 	const payload = await providerHelper.preparePayloadAsync(args);
 	const { data: res, requestContext } = await innerRequest<Blob>(payload, providerHelper, {

--- a/packages/inference/src/tasks/cv/imageTextToVideo.ts
+++ b/packages/inference/src/tasks/cv/imageTextToVideo.ts
@@ -11,7 +11,7 @@ export type ImageTextToVideoArgs = BaseArgs & ImageTextToVideoInput;
  * Recommended model: Lightricks/LTX-Video
  */
 export async function imageTextToVideo(args: ImageTextToVideoArgs, options?: Options): Promise<Blob> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "image-text-to-video");
 	const payload = await providerHelper.preparePayloadAsync(args);
 	const { data: res, requestContext } = await innerRequest<Blob>(payload, providerHelper, {

--- a/packages/inference/src/tasks/cv/imageToImage.ts
+++ b/packages/inference/src/tasks/cv/imageToImage.ts
@@ -12,7 +12,7 @@ export type ImageToImageArgs = BaseArgs & ImageToImageInput;
  * Recommended model: lllyasviel/sd-controlnet-depth
  */
 export async function imageToImage(args: ImageToImageArgs, options?: Options): Promise<Blob> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "image-to-image");
 	const payload = await providerHelper.preparePayloadAsync(args);
 	const { data: res } = await innerRequest<Blob>(payload, providerHelper, {

--- a/packages/inference/src/tasks/cv/imageToText.ts
+++ b/packages/inference/src/tasks/cv/imageToText.ts
@@ -10,7 +10,7 @@ export type ImageToTextArgs = BaseArgs & (ImageToTextInput | LegacyImageInput);
  * This task reads some image input and outputs the text caption.
  */
 export async function imageToText(args: ImageToTextArgs, options?: Options): Promise<ImageToTextOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "image-to-text");
 	const payload = await providerHelper.preparePayloadAsync(args, options?.signal);
 	const { data: res } = await innerRequest<ImageToTextOutput>(payload, providerHelper, {

--- a/packages/inference/src/tasks/cv/imageToVideo.ts
+++ b/packages/inference/src/tasks/cv/imageToVideo.ts
@@ -12,7 +12,7 @@ export type ImageToVideoArgs = BaseArgs & ImageToVideoInput;
  * Recommended model: Wan-AI/Wan2.1-I2V-14B-720P
  */
 export async function imageToVideo(args: ImageToVideoArgs, options?: Options): Promise<Blob> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "image-to-video");
 	const payload = await providerHelper.preparePayloadAsync(args);
 	const { data: res } = await innerRequest<Blob>(payload, providerHelper, {

--- a/packages/inference/src/tasks/cv/objectDetection.ts
+++ b/packages/inference/src/tasks/cv/objectDetection.ts
@@ -12,7 +12,7 @@ export type ObjectDetectionArgs = BaseArgs & (ObjectDetectionInput | LegacyImage
  * Recommended model: facebook/detr-resnet-50
  */
 export async function objectDetection(args: ObjectDetectionArgs, options?: Options): Promise<ObjectDetectionOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "object-detection");
 	const payload = preparePayload(args);
 	const { data: res } = await innerRequest<ObjectDetectionOutput>(payload, providerHelper, {

--- a/packages/inference/src/tasks/cv/textToImage.ts
+++ b/packages/inference/src/tasks/cv/textToImage.ts
@@ -35,7 +35,7 @@ export async function textToImage(
 	args: TextToImageArgs,
 	options?: TextToImageOptions,
 ): Promise<Blob | string | Record<string, unknown>> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "text-to-image");
 	const { data: res } = await innerRequest<Record<string, unknown>>(args, providerHelper, {
 		...options,

--- a/packages/inference/src/tasks/cv/textToVideo.ts
+++ b/packages/inference/src/tasks/cv/textToVideo.ts
@@ -13,7 +13,7 @@ export type TextToVideoArgs = BaseArgs & TextToVideoInput;
 export type TextToVideoOutput = Blob;
 
 export async function textToVideo(args: TextToVideoArgs, options?: Options): Promise<TextToVideoOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "text-to-video");
 	const { data: response } = await innerRequest<FalAiQueueOutput | ReplicateOutput | NovitaAsyncAPIOutput>(
 		args,

--- a/packages/inference/src/tasks/cv/zeroShotImageClassification.ts
+++ b/packages/inference/src/tasks/cv/zeroShotImageClassification.ts
@@ -45,7 +45,7 @@ export async function zeroShotImageClassification(
 	args: ZeroShotImageClassificationArgs,
 	options?: Options,
 ): Promise<ZeroShotImageClassificationOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "zero-shot-image-classification");
 	const payload = await preparePayload(args);
 	const { data: res } = await innerRequest<ZeroShotImageClassificationOutput>(payload, providerHelper, {

--- a/packages/inference/src/tasks/multimodal/documentQuestionAnswering.ts
+++ b/packages/inference/src/tasks/multimodal/documentQuestionAnswering.ts
@@ -20,7 +20,7 @@ export async function documentQuestionAnswering(
 	args: DocumentQuestionAnsweringArgs,
 	options?: Options,
 ): Promise<DocumentQuestionAnsweringOutput[number]> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "document-question-answering");
 	const reqArgs: RequestArgs = {
 		...args,

--- a/packages/inference/src/tasks/multimodal/visualQuestionAnswering.ts
+++ b/packages/inference/src/tasks/multimodal/visualQuestionAnswering.ts
@@ -20,7 +20,7 @@ export async function visualQuestionAnswering(
 	args: VisualQuestionAnsweringArgs,
 	options?: Options,
 ): Promise<VisualQuestionAnsweringOutput[number]> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "visual-question-answering");
 	const reqArgs: RequestArgs = {
 		...args,

--- a/packages/inference/src/tasks/nlp/chatCompletion.ts
+++ b/packages/inference/src/tasks/nlp/chatCompletion.ts
@@ -15,13 +15,13 @@ export async function chatCompletion(
 ): Promise<ChatCompletionOutput> {
 	let providerHelper: ConversationalTaskHelper & TaskProviderHelper;
 	if (args.endpointUrl) {
-		const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+		const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 		providerHelper = getProviderHelper(provider, "conversational");
 	} else if (!args.provider || args.provider === "auto") {
 		// Special case: we have a dedicated auto-router for conversational models. No need to fetch provider mapping.
 		providerHelper = new AutoRouterConversationalTask();
 	} else {
-		const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+		const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 		providerHelper = getProviderHelper(provider, "conversational");
 	}
 	const { data: response } = await innerRequest<ChatCompletionOutput>(args, providerHelper, {

--- a/packages/inference/src/tasks/nlp/chatCompletionStream.ts
+++ b/packages/inference/src/tasks/nlp/chatCompletionStream.ts
@@ -15,13 +15,13 @@ export async function* chatCompletionStream(
 ): AsyncGenerator<ChatCompletionStreamOutput> {
 	let providerHelper: ConversationalTaskHelper & TaskProviderHelper;
 	if (args.endpointUrl) {
-		const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+		const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 		providerHelper = getProviderHelper(provider, "conversational");
 	} else if (!args.provider || args.provider === "auto") {
 		// Special case: we have a dedicated auto-router for conversational models. No need to fetch provider mapping.
 		providerHelper = new AutoRouterConversationalTask();
 	} else {
-		const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+		const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 		providerHelper = getProviderHelper(provider, "conversational");
 	}
 	yield* innerStreamingRequest<ChatCompletionStreamOutput>(args, providerHelper, {

--- a/packages/inference/src/tasks/nlp/featureExtraction.ts
+++ b/packages/inference/src/tasks/nlp/featureExtraction.ts
@@ -23,7 +23,7 @@ export async function featureExtraction(
 	args: FeatureExtractionArgs,
 	options?: Options,
 ): Promise<FeatureExtractionOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "feature-extraction");
 	const { data: res } = await innerRequest<FeatureExtractionOutput>(args, providerHelper, {
 		...options,

--- a/packages/inference/src/tasks/nlp/fillMask.ts
+++ b/packages/inference/src/tasks/nlp/fillMask.ts
@@ -10,7 +10,7 @@ export type FillMaskArgs = BaseArgs & FillMaskInput;
  * Tries to fill in a hole with a missing word (token to be precise). That’s the base task for BERT models.
  */
 export async function fillMask(args: FillMaskArgs, options?: Options): Promise<FillMaskOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "fill-mask");
 	const { data: res } = await innerRequest<FillMaskOutput>(args, providerHelper, {
 		...options,

--- a/packages/inference/src/tasks/nlp/questionAnswering.ts
+++ b/packages/inference/src/tasks/nlp/questionAnswering.ts
@@ -14,7 +14,7 @@ export async function questionAnswering(
 	args: QuestionAnsweringArgs,
 	options?: Options,
 ): Promise<QuestionAnsweringOutput[number]> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "question-answering");
 	const { data: res } = await innerRequest<QuestionAnsweringOutput | QuestionAnsweringOutput[number]>(
 		args,

--- a/packages/inference/src/tasks/nlp/sentenceSimilarity.ts
+++ b/packages/inference/src/tasks/nlp/sentenceSimilarity.ts
@@ -13,7 +13,7 @@ export async function sentenceSimilarity(
 	args: SentenceSimilarityArgs,
 	options?: Options,
 ): Promise<SentenceSimilarityOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "sentence-similarity");
 	const { data: res } = await innerRequest<SentenceSimilarityOutput>(args, providerHelper, {
 		...options,

--- a/packages/inference/src/tasks/nlp/summarization.ts
+++ b/packages/inference/src/tasks/nlp/summarization.ts
@@ -10,7 +10,7 @@ export type SummarizationArgs = BaseArgs & SummarizationInput;
  * This task is well known to summarize longer text into shorter text. Be careful, some models have a maximum length of input. That means that the summary cannot handle full books for instance. Be careful when choosing your model.
  */
 export async function summarization(args: SummarizationArgs, options?: Options): Promise<SummarizationOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "summarization");
 	const { data: res } = await innerRequest<SummarizationOutput[]>(args, providerHelper, {
 		...options,

--- a/packages/inference/src/tasks/nlp/tableQuestionAnswering.ts
+++ b/packages/inference/src/tasks/nlp/tableQuestionAnswering.ts
@@ -13,7 +13,7 @@ export async function tableQuestionAnswering(
 	args: TableQuestionAnsweringArgs,
 	options?: Options,
 ): Promise<TableQuestionAnsweringOutput[number]> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "table-question-answering");
 	const { data: res } = await innerRequest<TableQuestionAnsweringOutput | TableQuestionAnsweringOutput[number]>(
 		args,

--- a/packages/inference/src/tasks/nlp/textClassification.ts
+++ b/packages/inference/src/tasks/nlp/textClassification.ts
@@ -13,7 +13,7 @@ export async function textClassification(
 	args: TextClassificationArgs,
 	options?: Options,
 ): Promise<TextClassificationOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "text-classification");
 	const { data: res } = await innerRequest<TextClassificationOutput>(args, providerHelper, {
 		...options,

--- a/packages/inference/src/tasks/nlp/textGeneration.ts
+++ b/packages/inference/src/tasks/nlp/textGeneration.ts
@@ -13,7 +13,7 @@ export async function textGeneration(
 	args: BaseArgs & TextGenerationInput,
 	options?: Options,
 ): Promise<TextGenerationOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "text-generation");
 	const { data: response } = await innerRequest<TextGenerationOutput | TextGenerationOutput[]>(args, providerHelper, {
 		...options,

--- a/packages/inference/src/tasks/nlp/textGenerationStream.ts
+++ b/packages/inference/src/tasks/nlp/textGenerationStream.ts
@@ -91,7 +91,7 @@ export async function* textGenerationStream(
 	args: BaseArgs & TextGenerationInput,
 	options?: Options,
 ): AsyncGenerator<TextGenerationStreamOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "text-generation");
 	yield* innerStreamingRequest<TextGenerationStreamOutput>(args, providerHelper, {
 		...options,

--- a/packages/inference/src/tasks/nlp/tokenClassification.ts
+++ b/packages/inference/src/tasks/nlp/tokenClassification.ts
@@ -13,7 +13,7 @@ export async function tokenClassification(
 	args: TokenClassificationArgs,
 	options?: Options,
 ): Promise<TokenClassificationOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "token-classification");
 	const { data: res } = await innerRequest<TokenClassificationOutput[number] | TokenClassificationOutput>(
 		args,

--- a/packages/inference/src/tasks/nlp/translation.ts
+++ b/packages/inference/src/tasks/nlp/translation.ts
@@ -9,7 +9,7 @@ export type TranslationArgs = BaseArgs & TranslationInput;
  * This task is well known to translate text from one language to another. Recommended model: Helsinki-NLP/opus-mt-ru-en.
  */
 export async function translation(args: TranslationArgs, options?: Options): Promise<TranslationOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "translation");
 	const { data: res } = await innerRequest<TranslationOutput>(args, providerHelper, {
 		...options,

--- a/packages/inference/src/tasks/nlp/zeroShotClassification.ts
+++ b/packages/inference/src/tasks/nlp/zeroShotClassification.ts
@@ -13,7 +13,7 @@ export async function zeroShotClassification(
 	args: ZeroShotClassificationArgs,
 	options?: Options,
 ): Promise<ZeroShotClassificationOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "zero-shot-classification");
 	const { data: res } = await innerRequest<ZeroShotClassificationOutput[number] | ZeroShotClassificationOutput>(
 		args,

--- a/packages/inference/src/tasks/tabular/tabularClassification.ts
+++ b/packages/inference/src/tasks/tabular/tabularClassification.ts
@@ -26,7 +26,7 @@ export async function tabularClassification(
 	args: TabularClassificationArgs,
 	options?: Options,
 ): Promise<TabularClassificationOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "tabular-classification");
 	const { data: res } = await innerRequest<TabularClassificationOutput>(args, providerHelper, {
 		...options,

--- a/packages/inference/src/tasks/tabular/tabularRegression.ts
+++ b/packages/inference/src/tasks/tabular/tabularRegression.ts
@@ -26,7 +26,7 @@ export async function tabularRegression(
 	args: TabularRegressionArgs,
 	options?: Options,
 ): Promise<TabularRegressionOutput> {
-	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl);
+	const provider = await resolveProvider(args.provider, args.model, args.endpointUrl, options);
 	const providerHelper = getProviderHelper(provider, "tabular-regression");
 	const { data: res } = await innerRequest<TabularRegressionOutput>(args, providerHelper, {
 		...options,

--- a/packages/inference/test/resolve-provider-fetch.spec.ts
+++ b/packages/inference/test/resolve-provider-fetch.spec.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveProvider } from "../src/lib/getInferenceProviderMapping.js";
+import { inferenceProviderMappingCache } from "../src/lib/getInferenceProviderMapping.js";
+
+describe("resolveProvider with provider='auto'", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		inferenceProviderMappingCache.clear();
+	});
+
+	it("uses the custom fetch passed in options for the provider-mapping pre-flight call", async () => {
+		const globalFetchMock = vi.fn();
+		vi.stubGlobal("fetch", globalFetchMock);
+
+		const customFetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() =>
+			Promise.resolve(
+				new Response(
+					JSON.stringify({
+						inferenceProviderMapping: [
+							{
+								provider: "hf-inference",
+								hfModelId: "my-model",
+								providerId: "my-model",
+								status: "live",
+								task: "text-classification",
+							},
+						],
+					}),
+					{ headers: { "Content-Type": "application/json" } },
+				),
+			),
+		);
+
+		const provider = await resolveProvider("auto", "my-model", undefined, { fetch: customFetchMock });
+
+		expect(provider).toBe("hf-inference");
+		expect(customFetchMock).toHaveBeenCalledTimes(1);
+		expect(globalFetchMock).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Fixes #2376

## Problem

`InferenceClient` accepts a custom `fetch` (e.g. a proxy-aware fetch) via constructor/task `options`, and it's correctly forwarded to the actual inference HTTP request. However, `resolveProvider()` in `packages/inference/src/lib/getInferenceProviderMapping.ts` did **not** accept/forward `options` when resolving `provider: "auto"`, so its pre-flight call to `fetchInferenceProviderMappingForModel()` always used the native global `fetch`, bypassing any custom fetch/proxy.

This affected ~36 call sites — essentially every task method except `chatCompletion`/`chatCompletionStream`, which dodge it only because `provider: "auto"` + conversational task uses a special-cased router path that skips `resolveProvider` entirely.

## Fix

- `resolveProvider()` now accepts an optional `options` parameter (`Pick<Options, "fetch">`) and forwards it to `fetchInferenceProviderMappingForModel()`.
- Every task function that calls `resolveProvider()` now passes its own `options` through (it was already in scope in each case).
- Added a regression test (`packages/inference/test/resolve-provider-fetch.spec.ts`) asserting that the custom `fetch` passed in `options` is used — and the global `fetch` is *not* used — for the `provider: "auto"` pre-flight lookup.

## Verification

```ts
const client = new InferenceClient(token, { fetch: proxyFetch });
client.textClassification({ model: "...", inputs: "...", provider: "auto" });
```

now routes both the provider-mapping pre-flight call and the inference request through `proxyFetch`.

Ran for `packages/inference`:
- `tsc --noEmit` ✅
- `pnpm test` ✅ (26 passed, 118 skipped — those require `HF_TOKEN`, unrelated to this change)
- `pnpm lint` ✅
- `pnpm run format:check` ✅ (oxfmt)
- `pnpm run build` ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small plumbing change that only forwards an existing fetch option; no new request paths or auth logic.
> 
> **Overview**
> Custom `fetch` (e.g. proxy-aware) is now used for the `provider: "auto"` pre-flight mapping lookup, not just the inference request.
> 
> `resolveProvider()` accepts optional `options` (`Pick<Options, "fetch">`) and passes it to `fetchInferenceProviderMappingForModel()`. All task call sites now forward their existing `options`. A regression test asserts the custom fetch is used and global `fetch` is not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60bf65c0ba4a2dc1b0a21c12e556ef674e974f7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->