### PR TITLE
Add text-to-speech and text-to-audio task helpers for WaveSpeed provider

### DIFF
--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -174,6 +174,8 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 		"image-to-video": new Wavespeed.WavespeedAIImageToVideoTask(),
 		"image-text-to-image": new Wavespeed.WavespeedAIImageTextToImageTask(),
 		"image-text-to-video": new Wavespeed.WavespeedAIImageTextToVideoTask(),
+		"text-to-speech": new Wavespeed.WavespeedAITextToSpeechTask(),
+		"text-to-audio": new Wavespeed.WavespeedAITextToAudioTask(),
 	},
 	"zai-org": {
 		conversational: new Zai.ZaiConversationalTask(),

--- a/packages/inference/src/providers/wavespeed.ts
+++ b/packages/inference/src/providers/wavespeed.ts
@@ -16,6 +16,8 @@ import type {
 	ImageToVideoTaskHelper,
 	ImageTextToImageTaskHelper,
 	ImageTextToVideoTaskHelper,
+	TextToSpeechTaskHelper,
+	TextToAudioTaskHelper,
 } from "./providerHelper.js";
 import { TaskProviderHelper } from "./providerHelper.js";
 import {
@@ -216,6 +218,46 @@ export class WavespeedAITextToImageTask extends WavespeedAITask implements TextT
 }
 
 export class WavespeedAITextToVideoTask extends WavespeedAITask implements TextToVideoTaskHelper {
+	constructor() {
+		super(WAVESPEEDAI_API_BASE_URL);
+	}
+
+	override async getResponse(
+		response: WaveSpeedAISubmitTaskResponse,
+		url?: string,
+		headers?: Record<string, string>,
+		_outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob> {
+		return super.getResponse(response, url, headers, undefined, signal) as Promise<Blob>;
+	}
+}
+
+export class WavespeedAITextToSpeechTask extends WavespeedAITask implements TextToSpeechTaskHelper {
+	constructor() {
+		super(WAVESPEEDAI_API_BASE_URL);
+	}
+
+	override preparePayload(params: BodyParams): Record<string, unknown> {
+		return {
+			...omit(params.args, ["inputs", "parameters"]),
+			...(params.args.parameters ? (params.args.parameters as Record<string, unknown>) : undefined),
+			text: params.args.inputs,
+		};
+	}
+
+	override async getResponse(
+		response: WaveSpeedAISubmitTaskResponse,
+		url?: string,
+		headers?: Record<string, string>,
+		_outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob> {
+		return super.getResponse(response, url, headers, undefined, signal) as Promise<Blob>;
+	}
+}
+
+export class WavespeedAITextToAudioTask extends WavespeedAITask implements TextToAudioTaskHelper {
 	constructor() {
 		super(WAVESPEEDAI_API_BASE_URL);
 	}

--- a/packages/inference/src/tasks/audio/textToSpeech.ts
+++ b/packages/inference/src/tasks/audio/textToSpeech.ts
@@ -1,6 +1,7 @@
 import type { TextToSpeechInput } from "@huggingface/tasks";
 import { resolveProvider } from "../../lib/getInferenceProviderMapping.js";
 import { getProviderHelper } from "../../lib/getProviderHelper.js";
+import { makeRequestOptions } from "../../lib/makeRequestOptions.js";
 import type { BaseArgs, Options } from "../../types.js";
 import { innerRequest } from "../../utils/request.js";
 type TextToSpeechArgs = BaseArgs & TextToSpeechInput;
@@ -19,5 +20,6 @@ export async function textToSpeech(args: TextToSpeechArgs, options?: Options): P
 		...options,
 		task: "text-to-speech",
 	});
-	return providerHelper.getResponse(res, undefined, undefined, undefined, options?.signal);
+	const { url, info } = await makeRequestOptions(args, providerHelper, { ...options, task: "text-to-speech" });
+	return providerHelper.getResponse(res, url, info.headers as Record<string, string>, undefined, options?.signal);
 }

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -2190,6 +2190,20 @@ describe.skip("InferenceClient", () => {
 					status: "live",
 					task: "image-to-video",
 				},
+				"microsoft/VibeVoice-1.5B": {
+					provider: "wavespeed",
+					hfModelId: "microsoft/VibeVoice-1.5B",
+					providerId: "wavespeed-ai/vibevoice",
+					status: "live",
+					task: "text-to-speech",
+				},
+				"ACE-Step/ACE-Step-v1-3.5B": {
+					provider: "wavespeed",
+					hfModelId: "ACE-Step/ACE-Step-v1-3.5B",
+					providerId: "wavespeed-ai/ace-step/prompt-to-audio",
+					status: "live",
+					task: "text-to-audio",
+				},
 			};
 			it(`textToImage - black-forest-labs/FLUX.1-schnell`, async () => {
 				const res = await client.textToImage({
@@ -2291,6 +2305,22 @@ describe.skip("InferenceClient", () => {
 							new Blob([readTestFile("bird_canny.png")], { type: "image/png" }),
 						],
 					},
+				});
+				expect(res).toBeInstanceOf(Blob);
+			});
+			it(`textToSpeech - microsoft/VibeVoice-1.5B`, async () => {
+				const res = await client.textToSpeech({
+					model: "microsoft/VibeVoice-1.5B",
+					provider: "wavespeed",
+					inputs: "Hello, this is a test of the WaveSpeed text to speech integration.",
+				});
+				expect(res).toBeInstanceOf(Blob);
+			});
+			it(`textToAudio - ACE-Step/ACE-Step-v1-3.5B`, async () => {
+				const res = await client.textToAudio({
+					model: "ACE-Step/ACE-Step-v1-3.5B",
+					provider: "wavespeed",
+					inputs: "An upbeat lo-fi hip hop track with a relaxed piano melody.",
 				});
 				expect(res).toBeInstanceOf(Blob);
 			});


### PR DESCRIPTION
## What

Adds `text-to-speech` and `text-to-audio` task support for the `wavespeed` inference provider:

- **`WavespeedAITextToSpeechTask`** — sends the input text as `text` (the field WaveSpeed TTS endpoints such as `wavespeed-ai/vibevoice` and `chatterbox/text-to-speech` expect), mirroring how the fal.ai TTS helper handles the same translation.
- **`WavespeedAITextToAudioTask`** — reuses the base payload (`prompt` = inputs), matching WaveSpeed music/audio endpoints such as `wavespeed-ai/ace-step/prompt-to-audio`.

Both reuse the existing WaveSpeed submit-and-poll response handling already used by the image/video helpers.

## Fix in `textToSpeech()`

`textToSpeech()` called `providerHelper.getResponse(res, undefined, undefined, ...)` without url/headers. That works for providers that return audio synchronously (fal, replicate), but WaveSpeed's helper polls an async task result and requires them. This PR passes url/headers the same way `textToAudio()` already does; providers that ignore these arguments are unaffected.

## Why

WaveSpeed serves several audio models whose HF Hub counterparts currently have no inference provider at all (e.g. `microsoft/VibeVoice-1.5B`, `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice`, `k2-fsa/OmniVoice`, `ACE-Step/Ace-Step1.5`, `MiniMaxAI/MiniMax-Music3`). We'd like to register those model mappings, which requires client support for the tasks first.

## Testing

- `pnpm run check`, `pnpm run lint`, `pnpm run build` pass in `packages/inference`.
- Added `textToSpeech` / `textToAudio` cases to the WaveSpeed block in `InferenceClient.spec.ts`.
- Verified live against the WaveSpeed production API through the new helpers: `textToSpeech` (VibeVoice) returned an `audio/mpeg` blob, `textToAudio` (ACE-Step prompt-to-audio) returned an `audio/wav` blob.

I'm the maintainer on the WaveSpeed side (we operate the `wavespeed` provider). cc @Wauplin @SBrandeis @hanouticelina

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139Zu5TfHzGVyPeatY9HJAR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped provider additions plus aligning textToSpeech with an existing textToAudio pattern; no auth or data-model changes.
> 
> **Overview**
> Adds **WaveSpeed** support for **`text-to-speech`** and **`text-to-audio`**, wiring new task helpers into the provider registry and reusing the existing submit-and-poll **`Blob`** flow used for other WaveSpeed media tasks.
> 
> **`WavespeedAITextToSpeechTask`** maps client `inputs` to the API **`text`** field (for endpoints like VibeVoice); **`WavespeedAITextToAudioTask`** keeps the default **`prompt`**-style payload for music/prompt-to-audio routes. Integration tests cover VibeVoice TTS and ACE-Step text-to-audio.
> 
> **`textToSpeech()`** now passes **request URL and headers** into **`getResponse`**, matching **`textToAudio()`**, so async providers (including WaveSpeed) can poll task status; synchronous providers that ignore those args stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e94f0c989612eda113676a1a340824bcc27fe78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->