### PR TITLE
Fix silent Node exit during polling, Buffer input crashes, broken JS snippets, and ambiguous WaveSpeed LoRA paths

### DIFF
--- a/packages/inference/src/providers/wavespeed.ts
+++ b/packages/inference/src/providers/wavespeed.ts
@@ -76,12 +76,17 @@ interface WaveSpeedAISubmitTaskResponse {
 }
 
 async function buildImagesField(
-	inputs: Blob | ArrayBuffer,
+	inputs: Blob | ArrayBuffer | ArrayBufferView,
 	hasImages: unknown,
 ): Promise<{ base: string; images: string[] }> {
-	const base = base64FromBytes(
-		new Uint8Array(inputs instanceof ArrayBuffer ? inputs : await (inputs as Blob).arrayBuffer()),
-	);
+	// Accept Blob, ArrayBuffer and ArrayBufferView (e.g. a Node Buffer from fs.readFileSync)
+	const bytes =
+		inputs instanceof ArrayBuffer
+			? new Uint8Array(inputs)
+			: ArrayBuffer.isView(inputs)
+				? new Uint8Array(inputs.buffer, inputs.byteOffset, inputs.byteLength)
+				: new Uint8Array(await inputs.arrayBuffer());
+	const base = base64FromBytes(bytes);
 	const images =
 		Array.isArray(hasImages) && hasImages.every((value): value is string => typeof value === "string")
 			? hasImages
@@ -244,7 +249,7 @@ export class WavespeedAIImageToImageTask extends WavespeedAITask implements Imag
 	async preparePayloadAsync(args: ImageToImageArgs): Promise<RequestArgs> {
 		const hasImages =
 			(args as { images?: unknown }).images ?? (args.parameters as Record<string, unknown> | undefined)?.images;
-		const { base, images } = await buildImagesField(args.inputs as Blob | ArrayBuffer, hasImages);
+		const { base, images } = await buildImagesField(args.inputs as Blob | ArrayBuffer | ArrayBufferView, hasImages);
 		return { ...args, inputs: args.parameters?.prompt, image: base, images };
 	}
 
@@ -267,7 +272,7 @@ export class WavespeedAIImageToVideoTask extends WavespeedAITask implements Imag
 	async preparePayloadAsync(args: ImageToVideoArgs): Promise<RequestArgs> {
 		const hasImages =
 			(args as { images?: unknown }).images ?? (args.parameters as Record<string, unknown> | undefined)?.images;
-		const { base, images } = await buildImagesField(args.inputs as Blob | ArrayBuffer, hasImages);
+		const { base, images } = await buildImagesField(args.inputs as Blob | ArrayBuffer | ArrayBufferView, hasImages);
 		return { ...args, inputs: args.parameters?.prompt, image: base, images };
 	}
 

--- a/packages/inference/src/providers/wavespeed.ts
+++ b/packages/inference/src/providers/wavespeed.ts
@@ -5,6 +5,7 @@ import type { TextToVideoArgs } from "../tasks/cv/textToVideo.js";
 import type { ImageToVideoArgs } from "../tasks/cv/imageToVideo.js";
 import type { BodyParams, OutputType, RequestArgs, UrlParams } from "../types.js";
 import type { ImageTextToVideoArgs } from "../tasks/cv/imageTextToVideo.js";
+import { HF_HUB_URL } from "../config.js";
 import { dataUrlFromBlob } from "../utils/dataUrlFromBlob.js";
 import { delay } from "../utils/delay.js";
 import { omit } from "../utils/omit.js";
@@ -116,7 +117,11 @@ abstract class WavespeedAITask extends TaskProviderHelper {
 		if (params.mapping?.adapter === "lora") {
 			payload.loras = [
 				{
-					path: params.mapping.hfModelId,
+					// Point at the exact weights file when the mapping specifies one — a bare
+					// repo id is ambiguous for repos that contain several LoRA files.
+					path: params.mapping.adapterWeightsPath
+						? `${HF_HUB_URL}/${params.mapping.hfModelId}/resolve/main/${params.mapping.adapterWeightsPath}`
+						: params.mapping.hfModelId,
 					scale: 1, // Default scale value
 				},
 			];
@@ -282,7 +287,9 @@ const TRANSPARENT_1PX_PNG_BASE64 =
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
 
 function getTransparentPngBlob(): Blob {
-	const bytes = Uint8Array.from(Buffer.from(TRANSPARENT_1PX_PNG_BASE64, "base64"));
+	const bytes = globalThis.Buffer
+		? Uint8Array.from(globalThis.Buffer.from(TRANSPARENT_1PX_PNG_BASE64, "base64"))
+		: Uint8Array.from(globalThis.atob(TRANSPARENT_1PX_PNG_BASE64), (c) => c.charCodeAt(0));
 	return new Blob([bytes], { type: "image/png" });
 }
 

--- a/packages/inference/src/snippets/templates/js/fetch/imageToImage.jinja
+++ b/packages/inference/src/snippets/templates/js/fetch/imageToImage.jinja
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 const image = fs.readFileSync("{{inputs.asObj.inputs}}");
 
 async function query(data) {

--- a/packages/inference/src/snippets/templates/js/fetch/imageToVideo.jinja
+++ b/packages/inference/src/snippets/templates/js/fetch/imageToVideo.jinja
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 const image = fs.readFileSync("{{inputs.asObj.inputs}}");
 
 async function query(data) {

--- a/packages/inference/src/snippets/templates/js/huggingface.js/basicAudio.jinja
+++ b/packages/inference/src/snippets/templates/js/huggingface.js/basicAudio.jinja
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient("{{ accessToken }}");

--- a/packages/inference/src/snippets/templates/js/huggingface.js/basicImage.jinja
+++ b/packages/inference/src/snippets/templates/js/huggingface.js/basicImage.jinja
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient("{{ accessToken }}");

--- a/packages/inference/src/snippets/templates/js/huggingface.js/imageToImage.jinja
+++ b/packages/inference/src/snippets/templates/js/huggingface.js/imageToImage.jinja
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient("{{ accessToken }}");

--- a/packages/inference/src/snippets/templates/js/huggingface.js/imageToVideo.jinja
+++ b/packages/inference/src/snippets/templates/js/huggingface.js/imageToVideo.jinja
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient("{{ accessToken }}");

--- a/packages/inference/src/utils/delay.ts
+++ b/packages/inference/src/utils/delay.ts
@@ -13,7 +13,6 @@ export function delay(ms: number, signal?: AbortSignal): Promise<void> {
 			cleanup();
 			resolve();
 		}, ms);
-		timeout.unref?.();
 
 		if (!signal) {
 			return;

--- a/packages/tasks-gen/snippets-fixtures/automatic-speech-recognition/js/huggingface.js/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/automatic-speech-recognition/js/huggingface.js/0.hf-inference.js
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient(process.env.HF_TOKEN);

--- a/packages/tasks-gen/snippets-fixtures/image-classification/js/huggingface.js/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/image-classification/js/huggingface.js/0.hf-inference.js
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient(process.env.HF_TOKEN);

--- a/packages/tasks-gen/snippets-fixtures/image-to-image/js/fetch/0.fal-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/image-to-image/js/fetch/0.fal-ai.js
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 const image = fs.readFileSync("cat.png");
 
 async function query(data) {

--- a/packages/tasks-gen/snippets-fixtures/image-to-image/js/fetch/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/image-to-image/js/fetch/0.hf-inference.js
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 const image = fs.readFileSync("cat.png");
 
 async function query(data) {

--- a/packages/tasks-gen/snippets-fixtures/image-to-image/js/fetch/0.replicate.js
+++ b/packages/tasks-gen/snippets-fixtures/image-to-image/js/fetch/0.replicate.js
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 const image = fs.readFileSync("cat.png");
 
 async function query(data) {

--- a/packages/tasks-gen/snippets-fixtures/image-to-image/js/huggingface.js/0.fal-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/image-to-image/js/huggingface.js/0.fal-ai.js
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient(process.env.HF_TOKEN);

--- a/packages/tasks-gen/snippets-fixtures/image-to-image/js/huggingface.js/0.hf-inference.js
+++ b/packages/tasks-gen/snippets-fixtures/image-to-image/js/huggingface.js/0.hf-inference.js
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient(process.env.HF_TOKEN);

--- a/packages/tasks-gen/snippets-fixtures/image-to-image/js/huggingface.js/0.replicate.js
+++ b/packages/tasks-gen/snippets-fixtures/image-to-image/js/huggingface.js/0.replicate.js
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient(process.env.HF_TOKEN);

--- a/packages/tasks-gen/snippets-fixtures/image-to-video/js/fetch/0.fal-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/image-to-video/js/fetch/0.fal-ai.js
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 const image = fs.readFileSync("cat.png");
 
 async function query(data) {

--- a/packages/tasks-gen/snippets-fixtures/image-to-video/js/huggingface.js/0.fal-ai.js
+++ b/packages/tasks-gen/snippets-fixtures/image-to-video/js/huggingface.js/0.fal-ai.js
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 import { InferenceClient } from "@huggingface/inference";
 
 const client = new InferenceClient(process.env.HF_TOKEN);


### PR DESCRIPTION
Five small, related fixes found while testing the WaveSpeed provider integration — happy to split if preferred.

## 1. `delay()` unrefs its timer → Node scripts exit silently mid-generation

`delay()` calls `timeout.unref?.()` (introduced with the abort-signal work in #2112). During the wait between two polls (used by the wavespeed, fal queue, novita, together and zai-org helpers), the pending `fetch` has completed and the unref'd timer is the process's only remaining handle — so the event loop drains and **a plain Node script exits silently with code 0 in the middle of a generation** (Node prints "Detected unsettled top-level await" when the await is top-level; inside a function it just dies quietly).

Repro before the fix (any polling provider):

```ts
const img = await client.textToImage({ provider: "wavespeed", model: "...", inputs: "..." });
console.log("never reached — process exits during the first 500ms poll gap");
```

Fix: don't unref. The abort listener still runs `clearTimeout`, so an aborted call cannot keep the process alive — the unref isn't needed for #2112's purpose.

## 2. `getTransparentPngBlob()` uses bare `Buffer` → crashes in browsers

`Buffer.from(...)` is referenced without a guard in `providers/wavespeed.ts`, so the `image-text-to-image` / `image-text-to-video` no-image fallback throws `ReferenceError: Buffer is not defined` in browsers. Fixed with the same `globalThis.Buffer` / `atob` pattern already used by `base64FromBytes()`.

## 3. WaveSpeed LoRA payload sends only the repo id → ambiguous for multi-file repos

The LoRA payload used `path: params.mapping.hfModelId`. WaveSpeed accepts either a HF repo id or a direct URL; a bare repo id is ambiguous for repos that contain several LoRA files (e.g. `lightx2v/Wan2.2-Distill-Loras`). When the mapping provides `adapterWeightsPath`, we now point at the exact weights file via `{HF_HUB_URL}/{repo}/resolve/main/{path}`, the same approach as the fal.ai helper. Repos without `adapterWeightsPath` behave as before. (Verified live, including a repo with a non-ASCII weights filename.)

## 4. `buildImagesField()` rejects the Buffer the snippets tell users to pass

The generated JS snippets call `fs.readFileSync()` and pass the result — a Buffer, i.e. an `ArrayBufferView`, neither a Blob nor an ArrayBuffer — so the WaveSpeed image paths threw `TypeError: inputs.arrayBuffer is not a function` before submitting. Accept Blob / ArrayBuffer / ArrayBufferView. (Same class of bug that Codex flagged on the new code in #2381; this fixes the pre-existing instance.)

## 5. Six JS snippet templates use `fs` without importing it

`js/huggingface.js/{imageToImage,imageToVideo,basicImage,basicAudio}.jinja` and `js/fetch/{imageToImage,imageToVideo}.jinja` reference `fs.readFileSync` but never import `fs`, so every copy-pasted example fails with `ReferenceError: fs is not defined`. Added `import fs from "node:fs"` and regenerated the snippet fixtures.

## Testing

- `pnpm run check`, `pnpm run lint`, `pnpm run build` pass in `packages/inference`; snippet fixtures regenerated via `pnpm --filter tasks-gen generate-snippets-fixtures`.
- Verified live against the WaveSpeed production API: a LoRA `textToImage` call with `adapterWeightsPath` set completes end-to-end through the new resolve-URL path, and the Node process now survives the polling gaps without a keepalive timer (previously it exited silently).

I'm the maintainer on the WaveSpeed side (we operate the `wavespeed` provider). Related: #2379 adds text-to-speech / text-to-audio task helpers, #2381 adds the video-to-video task. cc @Wauplin @SBrandeis @hanouticelina

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139Zu5TfHzGVyPeatY9HJAR
