### PR TITLE
🐛 peft snippet: load speech seq2seq base models with AutoModelForSpeechSeq2Seq

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.spec.ts
+++ b/packages/tasks/src/model-libraries-snippets.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ModelData } from "./model-data.js";
-import { llama_cpp_python } from "./model-libraries-snippets.js";
+import { llama_cpp_python, peft } from "./model-libraries-snippets.js";
 
 describe("model-libraries-snippets", () => {
 	it("llama_cpp_python conversational", async () => {
@@ -54,5 +54,42 @@ output = llm(
 	echo=True
 )
 print(output)`);
+	});
+
+	it("peft text seq2seq adapter", async () => {
+		const model: ModelData = {
+			id: "smangrul/twitter_complaints_bigscience_T0_3B_LORA_SEQ_2_SEQ_LM",
+			tags: ["peft"],
+			inference: "",
+			config: {
+				peft: { base_model_name_or_path: "bigscience/T0_3B", task_type: "SEQ_2_SEQ_LM" },
+			},
+		};
+		const snippet = peft(model);
+
+		expect(snippet.join("\n")).toEqual(`from peft import PeftModel
+from transformers import AutoModelForSeq2SeqLM
+
+base_model = AutoModelForSeq2SeqLM.from_pretrained("bigscience/T0_3B")
+model = PeftModel.from_pretrained(base_model, "smangrul/twitter_complaints_bigscience_T0_3B_LORA_SEQ_2_SEQ_LM")`);
+	});
+
+	it("peft speech seq2seq adapter (whisper)", async () => {
+		const model: ModelData = {
+			id: "nazarkozak/whisper-small-disfluent-verbatim-lora",
+			pipeline_tag: "automatic-speech-recognition",
+			tags: ["peft"],
+			inference: "",
+			config: {
+				peft: { base_model_name_or_path: "openai/whisper-small", task_type: "SEQ_2_SEQ_LM" },
+			},
+		};
+		const snippet = peft(model);
+
+		expect(snippet.join("\n")).toEqual(`from peft import PeftModel
+from transformers import AutoModelForSpeechSeq2Seq
+
+base_model = AutoModelForSpeechSeq2Seq.from_pretrained("openai/whisper-small")
+model = PeftModel.from_pretrained(base_model, "nazarkozak/whisper-small-disfluent-verbatim-lora")`);
 	});
 });

--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -2025,12 +2025,13 @@ const pipe = await pipeline('${model.pipeline_tag}', '${model.id}');`,
 	];
 };
 
-const peftTask = (peftTaskType?: string) => {
+const peftTask = (peftTaskType?: string, pipelineTag?: ModelData["pipeline_tag"]) => {
 	switch (peftTaskType) {
 		case "CAUSAL_LM":
 			return "CausalLM";
 		case "SEQ_2_SEQ_LM":
-			return "Seq2SeqLM";
+			// Speech seq2seq base models (e.g. Whisper) cannot be loaded with AutoModelForSeq2SeqLM
+			return pipelineTag === "automatic-speech-recognition" ? "SpeechSeq2Seq" : "Seq2SeqLM";
 		case "TOKEN_CLS":
 			return "TokenClassification";
 		case "SEQ_CLS":
@@ -2042,7 +2043,7 @@ const peftTask = (peftTaskType?: string) => {
 
 export const peft = (model: ModelData): string[] => {
 	const { base_model_name_or_path: peftBaseModel, task_type: peftTaskType } = model.config?.peft ?? {};
-	const pefttask = peftTask(peftTaskType);
+	const pefttask = peftTask(peftTaskType, model.pipeline_tag);
 	if (!pefttask) {
 		return [`Task type is invalid.`];
 	}


### PR DESCRIPTION
The `peft` snippet picks the `transformers` auto class purely from the adapter's `task_type`. Whisper LoRA adapters have `task_type: SEQ_2_SEQ_LM` in their `adapter_config.json`, so the model page generates:

```python
base_model = AutoModelForSeq2SeqLM.from_pretrained("openai/whisper-small")
```

which fails with:

```
ValueError: Unrecognized configuration class WhisperConfig for AutoModelForSeq2SeqLM
```

This is what #1903 reported (the report was about a PEFT adapter page, not the plain Whisper notebook, which is why the snippet looked fine when checked against `openai/whisper-small` itself).

## Fix

Use the model's `pipeline_tag` to disambiguate: for `automatic-speech-recognition` adapters, generate `AutoModelForSpeechSeq2Seq` instead. Text seq2seq adapters are unchanged.

Real-world example hitting the bug today: [`nazarkozak/whisper-small-disfluent-verbatim-lora`](https://huggingface.co/nazarkozak/whisper-small-disfluent-verbatim-lora) (`base_model_name_or_path: openai/whisper-small`, `task_type: SEQ_2_SEQ_LM`, `pipeline_tag: automatic-speech-recognition`) — used as the test fixture.

## Tests

Added two cases to `model-libraries-snippets.spec.ts`: a Whisper adapter (new behavior) and a T0 text adapter (unchanged behavior).

Fixes #1903

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to PEFT snippet generation plus unit tests; no runtime inference or auth paths affected.
> 
> **Overview**
> Fixes broken **PEFT** usage snippets on Whisper (and similar) adapter model pages where `task_type` is `SEQ_2_SEQ_LM` but the base model is speech seq2seq, not text seq2seq.
> 
> `peftTask` now takes `pipeline_tag` and maps `SEQ_2_SEQ_LM` to **`SpeechSeq2Seq`** when `pipeline_tag` is `automatic-speech-recognition`, so generated code uses `AutoModelForSpeechSeq2Seq` instead of `AutoModelForSeq2SeqLM`. Text seq2seq PEFT adapters are unchanged.
> 
> Tests cover a T0 text adapter (still `AutoModelForSeq2SeqLM`) and a Whisper LoRA adapter (`AutoModelForSpeechSeq2Seq`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fc23966007113d3fdb02190ad686fe3beab4ed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->