### PR TITLE
Add Zimmer to local apps

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -839,6 +839,14 @@ export const LOCAL_APPS = {
 		displayOnModelPage: isToolCallingLocalAgentModel,
 		snippet: snippetOpenClaw,
 	},
+	zimmer: {
+		prettyLabel: "Zimmer",
+		docsUrl: "https://zimmerapp.co/docs",
+		mainTask: "text-generation",
+		displayOnModelPage: (model) => isLlamaCppGgufModel(model) || isMlxModel(model),
+		deeplink: (model, filepath) =>
+			new URL(`zimmer://open_from_hf?model=${model.id}${filepath ? `&file=${filepath}` : ""}`),
+	},
 } satisfies Record<string, LocalApp>;
 
 export type LocalAppKey = keyof typeof LOCAL_APPS;


### PR DESCRIPTION
## Summary

Add **Zimmer** to the local-apps registry for GGUF and MLX models.

## What is Zimmer

A privacy-focused local AI platform and workspace that runs open-weight models locally on **macOS (Apple Silicon)** and **Windows (x64 and ARM64)**. Prompts, documents and answers stay on the user's own machine.

Site: https://zimmerapp.co · Docs: https://zimmerapp.co/docs

## Supported formats

- **GGUF**, via a bundled llama.cpp server (no Python, Docker or terminal toolchain required)
- **MLX**, on Apple Silicon

`displayOnModelPage` is therefore `isLlamaCppGgufModel(model) || isMlxModel(model)` — the same predicate LM Studio uses. I verified Zimmer's visibility matches `lmstudio` exactly for a GGUF model, an MLX model, and a model that is neither.

## Deep-link support

Implemented and shipping as of **v0.3.53**:

```
zimmer://open_from_hf?model={repoId}&file={filename}
```

`file` is optional — omitted on the repo-level entry, in which case Zimmer lets the user pick a quantization. The shape deliberately follows the `lmstudio://open_from_hf` convention already encoded in this file rather than inventing a new one.

The URL scheme is registered on both platforms (`CFBundleURLTypes` on macOS, the installer's protocol registration on Windows), and cold launch is handled on both — macOS via `open-url`, Windows via `argv` on first process.

## Test URL

```
zimmer://open_from_hf?model=unsloth/Qwen3-30B-A3B-GGUF&file=Qwen3-30B-A3B-Q4_K_M.gguf
```

Install Zimmer from https://zimmerapp.co first, then open the URL. It works with the app running or closed.

## Behavior note

**Deep links do not auto-download large files.** They open Zimmer's Model Hub with the quantization highlighted, so the user can review the file size and how it fits their hardware, and confirm, before anything is written to disk. A link from a web page can therefore never start a multi-gigabyte download on its own.

## Checks

Run in `packages/tasks`:

| Check | Result |
| --- | --- |
| `pnpm format:check` | pass |
| `pnpm lint:check` | pass |
| `pnpm check` (tsc) | pass |
| `pnpm test` (vitest) | 22/22 pass |

Happy to adjust anything — naming, placement, or the deeplink shape. Thanks for maintaining this list!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only addition with no auth or runtime logic changes; behavior is gated by existing model predicates and URL construction.
> 
> **Overview**
> Adds **Zimmer** to the `LOCAL_APPS` registry in `local-apps.ts` so it can appear in model pages’ **Use this model** flows for local inference.
> 
> Visibility matches **LM Studio**: `displayOnModelPage` is true for GGUF (`isLlamaCppGgufModel`) and MLX (`isMlxModel`) models. Opening the app uses a **`zimmer://open_from_hf`** deeplink with `model` and optional `file` query params, following the same pattern as `lmstudio://open_from_hf`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb877125be4e39381f17b71ac2ce02ab58818018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->