### PR TITLE
fix(tasks-gen): await fixture writes during generation

### DIFF
--- a/packages/tasks-gen/scripts/generate-snippets-fixtures.ts
+++ b/packages/tasks-gen/scripts/generate-snippets-fixtures.ts
@@ -451,15 +451,15 @@ if (import.meta.vitest) {
 	await fs.rm(path.join(rootDirFinder(), "snippets-fixtures"), { recursive: true, force: true });
 
 	console.debug("  🏭 Generating new fixtures...");
-	TEST_CASES.forEach(({ testName, task, model, providers, lora, opts }) => {
+	for (const { testName, task, model, providers, lora, opts } of TEST_CASES) {
 		console.debug(`      ${testName} (${providers.join(", ")})`);
-		inferenceSnippetLanguages.forEach(async (language) => {
-			providers.forEach(async (provider) => {
+		for (const language of inferenceSnippetLanguages) {
+			for (const provider of providers) {
 				const generatedSnippets = generateInferenceSnippet(model, language, provider, task, lora, opts);
 				await saveExpectedInferenceSnippet(testName, language, provider, generatedSnippets);
-			});
-		});
-	});
+			}
+		}
+	}
 	console.log("✅ All done!");
 	console.log("👉 Please check the generated fixtures before committing them.");
 }


### PR DESCRIPTION
The generation branch of `generate-snippets-fixtures.ts` writes fixtures inside `forEach(async ...)`:

```ts
inferenceSnippetLanguages.forEach(async (language) => {
    providers.forEach(async (provider) => {
        const generatedSnippets = generateInferenceSnippet(...);
        await saveExpectedInferenceSnippet(...);
    });
});
```

`forEach` ignores the returned promises, so the `await` inside only suspends its own callback. Two consequences:

1. **"✅ All done!" prints before anything is written.** Execution falls straight through to the log lines while the writes are still pending, so the script tells you to review fixtures that may not exist yet.
2. **Write failures escape.** A rejection from `saveExpectedInferenceSnippet` becomes an unhandled rejection instead of failing the script, so a partial regeneration can look like a success.

That second point matters more than usual here, because immediately beforehand the script does:

```ts
await fs.rm(path.join(rootDirFinder(), "snippets-fixtures"), { recursive: true, force: true });
```

The old fixtures are deleted up front, so an early exit or a swallowed write error leaves the tree with fixtures missing rather than merely stale.

This converts the three loops to `for...of` so the awaits are actually sequenced and any failure propagates. The file is already a top-level-`await` module, so no wrapper is needed.

The `import.meta.vitest` branch above uses `forEach` without `async` and is correct as-is; I left it alone.

Verified: `oxfmt --check` passes and the file transpiles cleanly. I did not run the generator itself, since it deletes and rewrites the whole fixtures directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only fixture generator control-flow fix; no runtime, auth, or data-path changes.
> 
> **Overview**
> Fixes snippet fixture generation so writes actually complete before the script reports success.
> 
> The generation path in `generate-snippets-fixtures.ts` used nested `forEach(async …)` after deleting `snippets-fixtures`. `forEach` does not await those callbacks, so “All done!” could print while writes were still pending, and save failures became unhandled rejections—leaving a wiped, incomplete fixture tree. Nested loops are now `for...of` so `await saveExpectedInferenceSnippet` is sequenced and errors fail the script. The vitest branch is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b10bbd4ae1ecd5edf507dd02bf7066419639c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->