### PR TITLE
[Inference Providers] deepinfra: add text-to-video support

### DIFF
--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -71,6 +71,7 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 		"feature-extraction": new DeepInfra.DeepInfraFeatureExtractionTask(),
 		"text-generation": new DeepInfra.DeepInfraTextGenerationTask(),
 		"text-to-speech": new DeepInfra.DeepInfraTextToSpeechTask(),
+		"text-to-video": new DeepInfra.DeepInfraTextToVideoTask(),
 	},
 	"fal-ai": {
 		"audio-to-audio": new FalAI.FalAIAudioToAudioTask(),

--- a/packages/inference/src/providers/deepinfra.ts
+++ b/packages/inference/src/providers/deepinfra.ts
@@ -24,9 +24,15 @@ import type {
 	FeatureExtractionOutput,
 	TextGenerationOutput,
 } from "@huggingface/tasks";
-import { InferenceClientInputError, InferenceClientProviderOutputError } from "../errors.js";
+import {
+	InferenceClientInputError,
+	InferenceClientProviderApiError,
+	InferenceClientProviderOutputError,
+} from "../errors.js";
+import { isUrl } from "../lib/isUrl.js";
 import type { AutomaticSpeechRecognitionArgs } from "../tasks/audio/automaticSpeechRecognition.js";
 import type { BodyParams, RequestArgs } from "../types.js";
+import { delay } from "../utils/delay.js";
 import { omit } from "../utils/omit.js";
 import {
 	type AutomaticSpeechRecognitionTaskHelper,
@@ -35,6 +41,7 @@ import {
 	type FeatureExtractionTaskHelper,
 	TaskProviderHelper,
 	type TextToSpeechTaskHelper,
+	type TextToVideoTaskHelper,
 } from "./providerHelper.js";
 
 /**
@@ -94,6 +101,13 @@ interface DeepInfraEmbeddingsResponse {
 	}>;
 	model: string;
 	object: string;
+}
+
+interface DeepInfraVideoResponse {
+	id?: string;
+	status?: string;
+	data?: Array<{ url?: string }>;
+	error?: string;
 }
 
 export class DeepInfraConversationalTask extends BaseConversationalTask {
@@ -297,6 +311,97 @@ export class DeepInfraFeatureExtractionTask extends TaskProviderHelper implement
 		}
 		throw new InferenceClientProviderOutputError(
 			`Received malformed response from DeepInfra feature-extraction (embeddings) API: ${JSON.stringify(response)}`,
+		);
+	}
+}
+
+export class DeepInfraTextToVideoTask extends TaskProviderHelper implements TextToVideoTaskHelper {
+	constructor() {
+		super("deepinfra", DEEPINFRA_API_BASE_URL);
+	}
+
+	makeRoute(): string {
+		return "v1/openai/videos";
+	}
+
+	preparePayload(params: BodyParams): Record<string, unknown> {
+		// DeepInfra video generation is asynchronous: this POST submits the job and getResponse
+		// polls it. `prompt`/`model` are applied after caller parameters so neither can be overridden.
+		return {
+			...omit(params.args, ["inputs", "parameters"]),
+			...(params.args.parameters as Record<string, unknown> | undefined),
+			prompt: params.args.inputs,
+			model: params.model,
+		};
+	}
+
+	override async getResponse(
+		response: DeepInfraVideoResponse,
+		url?: string,
+		headers?: Record<string, string>,
+		_outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob> {
+		if (!url || !headers) {
+			throw new InferenceClientInputError("URL and headers are required for text-to-video task");
+		}
+		const jobId = response.id;
+		if (!jobId) {
+			throw new InferenceClientProviderOutputError(
+				"Received malformed response from DeepInfra text-to-video API: no job id found in the response",
+			);
+		}
+
+		const parsedUrl = new URL(url);
+		const baseUrl = `${parsedUrl.protocol}//${parsedUrl.host}${
+			parsedUrl.host === "router.huggingface.co" ? "/deepinfra" : ""
+		}`;
+		const statusUrl = `${baseUrl}/v1/openai/videos/${jobId}`;
+
+		let status = response.status ?? "";
+		let job: DeepInfraVideoResponse = response;
+		while (status !== "succeeded" && status !== "failed") {
+			await delay(500, signal);
+			const statusResponse = await fetch(statusUrl, { headers, signal });
+			if (!statusResponse.ok) {
+				throw new InferenceClientProviderApiError(
+					"Failed to fetch text-to-video job status",
+					{ url: statusUrl, method: "GET", headers },
+					{
+						requestId: statusResponse.headers.get("x-request-id") ?? "",
+						status: statusResponse.status,
+						body: await statusResponse.text(),
+					},
+				);
+			}
+			job = (await statusResponse.json()) as DeepInfraVideoResponse;
+			if (typeof job !== "object" || !job || typeof job.status !== "string") {
+				throw new InferenceClientProviderOutputError(
+					"Received malformed response from DeepInfra text-to-video API: failed to read job status",
+				);
+			}
+			status = job.status;
+		}
+
+		if (status === "failed") {
+			throw new InferenceClientProviderOutputError(
+				`DeepInfra text-to-video job failed: ${job.error ?? "unknown error"}`,
+			);
+		}
+
+		if (
+			Array.isArray(job.data) &&
+			job.data.length > 0 &&
+			typeof job.data[0].url === "string" &&
+			isUrl(job.data[0].url)
+		) {
+			const videoResponse = await fetch(job.data[0].url, { signal });
+			return await videoResponse.blob();
+		}
+		throw new InferenceClientProviderOutputError(
+			`Received malformed response from DeepInfra text-to-video API: expected { data: [{ url: string }] }, got instead: ${JSON.stringify(
+				job,
+			)}`,
 		);
 	}
 }

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -1672,6 +1672,9 @@ describe.skip("InferenceClient", () => {
 			const FE_HF_MODEL = "Qwen/Qwen3-Embedding-0.6B";
 			const FE_PROVIDER_ID = "Qwen/Qwen3-Embedding-0.6B";
 
+			const T2V_HF_MODEL = "Wan-AI/Wan2.1-T2V-14B";
+			const T2V_PROVIDER_ID = "Wan-AI/Wan2.1-T2V-14B";
+
 			const setMapping = (task: "conversational" | "text-generation") => {
 				HARDCODED_MODEL_INFERENCE_MAPPING["deepinfra"] = {
 					[HF_MODEL]: {
@@ -1716,6 +1719,18 @@ describe.skip("InferenceClient", () => {
 						providerId: FE_PROVIDER_ID,
 						status: "live",
 						task: "feature-extraction",
+					},
+				};
+			};
+
+			const setTextToVideoMapping = () => {
+				HARDCODED_MODEL_INFERENCE_MAPPING["deepinfra"] = {
+					[T2V_HF_MODEL]: {
+						provider: "deepinfra",
+						hfModelId: T2V_HF_MODEL,
+						providerId: T2V_PROVIDER_ID,
+						status: "live",
+						task: "text-to-video",
 					},
 				};
 			};
@@ -1803,6 +1818,16 @@ describe.skip("InferenceClient", () => {
 				});
 				expect(Array.isArray(res)).toBe(true);
 				expect(res.length).toBeGreaterThan(0);
+			});
+
+			it("textToVideo", async () => {
+				setTextToVideoMapping();
+				const res = await client.textToVideo({
+					model: T2V_HF_MODEL,
+					provider: "deepinfra",
+					inputs: "A cat playing the piano in a jazz club.",
+				});
+				expect(res).toBeInstanceOf(Blob);
 			});
 		},
 		TIMEOUT,


### PR DESCRIPTION
## What

Adds `DeepInfraTextToVideoTask` so the `deepinfra` provider supports `text-to-video`.

DeepInfra's video generation is asynchronous (submit → poll → fetch), so this follows the `novita` text-to-video pattern rather than a thin forwarder:
- `makeRoute`: `v1/openai/videos` (POST submits the job).
- `preparePayload`: forwards `prompt`; applies `prompt`/`model` after caller parameters.
- `getResponse`: reads the job `id`, polls `v1/openai/videos/{id}` (router-aware base URL) until `status` is `succeeded`/`failed`, then fetches `data[0].url` and returns a `Blob`. Throws typed errors on failure/malformed output.

Wired in `getProviderHelper.ts` under `deepinfra`. Existing tasks untouched.

## Test
Added a `textToVideo` integration case to the DeepInfra suite (same skip-gated pattern as the other deepinfra tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)