### PR TITLE
Update LTX model library snippets for LTX-2.5 and DFR

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -1031,83 +1031,288 @@ import soundfile as sf
 sf.write('output.wav', audio, 24000)`,
 ];
 
-export const ltx = (model: ModelData): string[] => {
-	const localDir = `models/${nameWithoutNamespace(model.id)}`;
-	const install = `# Install the LTX-2 pipelines
+/**
+ * Detect LTX-2.5 (split weights + Gemma 4 TE file) vs LTX-2.3
+ * (monolith checkpoint + separate Gemma 3 root). Prefer explicit tags / ids /
+ * base_model refs; fall back to 2.3 for unmarked legacy cards.
+ */
+function _isLtx25Model(model: ModelData): boolean {
+	const refs: string[] = [model.id, ...(model.tags ?? [])];
+	const base = model.cardData?.base_model;
+	if (Array.isArray(base)) {
+		refs.push(...base);
+	} else if (base) {
+		refs.push(base);
+	}
+	return refs.some((ref) => /ltx[-_]?2\.5/i.test(ref));
+}
+
+const _LTX_I2V_HINT = `# For image-to-video, add: --image path/to/image.jpg 0 0.8`;
+const _LTX_GEMMA3_ROOT = "models/gemma-3-12b";
+const _LTX_DEFAULT_PROMPT = "A beautiful sunset over the ocean";
+
+function _ltxInstall(is25: boolean): string {
+	// natten is only needed for the LTX-2.5 diffusion VAE (skipped automatically on Windows/macOS).
+	return `# Install the LTX-2 pipelines
 git clone https://github.com/Lightricks/LTX-2.git
 cd LTX-2
-uv sync --frozen`;
+uv sync ${is25 ? "--extra natten" : "--frozen"}`;
+}
 
-	// Every pipeline needs the Gemma text encoder, which lives in a separate repo.
-	const download = `# Download the weights from this repo, plus the Gemma text encoder
-hf download ${model.id} --local-dir ${localDir}
-hf download google/gemma-3-12b-it-qat-q4_0-unquantized --local-dir models/gemma-3-12b`;
+function _ltxRun(
+	module: string,
+	args: string[],
+	comment: string,
+	options?: { hint?: boolean; footer?: string },
+): string {
+	const body = `uv run python -m ltx_pipelines.${module} \\\n    ${args.join(" \\\n    ")}`;
+	const parts = [`# ${comment}`, body];
+	if (options?.footer) {
+		parts.push(options.footer);
+	}
+	if (options?.hint) {
+		parts.push(_LTX_I2V_HINT);
+	}
+	return parts.join("\n");
+}
 
-	// Add "--image <path> <frame_idx> <strength>" to any command below to condition on
-	// an image (e.g. "--image image.jpg 0 0.8"), turning text-to-video into image-to-video.
-	const imageToVideoHint = `# For image-to-video, add: --image path/to/image.jpg 0 0.8`;
+interface Ltx25SplitPaths {
+	transformer: string;
+	textEncoder: string;
+	videoVae: string;
+	audioVae: string;
+	spatialUpsampler: string;
+	temporalUpsampler?: string;
+}
 
-	const tags = model.tags ?? [];
+const _LTX_DETAILING_LORA_REPO = "Lightricks/LTX-2.5-22b-IC-LoRA-Pixel-Spatial-Upscaler";
+const _LTX_DETAILING_LORA_FILE = "ltx-2.5-22b-ic-lora-pixel-spatial-upscaler-x2-1.0.safetensors";
 
-	// IC-LoRA: video-to-video / image-to-video with a control (reference) signal.
-	// Checked before "lora" because an IC-LoRA repo may carry both tags.
+function _ltx25SplitArgs(paths: Ltx25SplitPaths): string[] {
+	const args = [
+		`--transformer-path ${paths.transformer}`,
+		`--text-encoder-path ${paths.textEncoder}`,
+		`--video-vae-path ${paths.videoVae}`,
+		`--audio-vae-path ${paths.audioVae}`,
+		`--spatial-upsampler-path ${paths.spatialUpsampler}`,
+	];
+	if (paths.temporalUpsampler) {
+		args.push(`--temporal-upsampler-path ${paths.temporalUpsampler}`);
+	}
+	return args;
+}
+
+function _ltx25RepoPaths(localDir: string): { distilled: Ltx25SplitPaths; dfr: Ltx25SplitPaths } {
+	const shared = {
+		transformer: `${localDir}/diffusion_models/<distilled-transformer>.safetensors`,
+		textEncoder: `${localDir}/text_encoders/gemma4-12b-with-proj-ltx-2.5-bf16.safetensors`,
+		videoVae: `${localDir}/vae/<video-vae>.safetensors`,
+		audioVae: `${localDir}/vae/<audio-vae>.safetensors`,
+		spatialUpsampler: `${localDir}/latent_upscale_models/<spatial-upsampler>.safetensors`,
+	};
+	return {
+		distilled: shared,
+		// DFR runs on the distilled transformer; detailing IC-LoRA is required separately.
+		dfr: {
+			...shared,
+			temporalUpsampler: `${localDir}/latent_upscale_models/<temporal-upsampler>.safetensors`,
+		},
+	};
+}
+
+function _ltx25BasePlaceholderPaths(): Ltx25SplitPaths {
+	return {
+		transformer: "path/to/distilled-transformer.safetensors",
+		textEncoder: "path/to/gemma4-12b-with-proj-ltx-2.5-bf16.safetensors",
+		videoVae: "path/to/video-vae.safetensors",
+		audioVae: "path/to/audio-vae.safetensors",
+		spatialUpsampler: "path/to/spatial-upsampler.safetensors",
+	};
+}
+
+function _ltx25Download(modelId: string, localDir: string, kind: "base" | "adapter"): string {
+	if (kind === "adapter") {
+		return `# Download the adapter weights from this repo
+# (base components come from Lightricks/LTX-2.5 — see Files and versions)
+hf download ${modelId} --local-dir ${localDir}`;
+	}
+	const detailingDir = `models/${_LTX_DETAILING_LORA_REPO.split("/")[1]}`;
+	return `# Download weights from this repo
+# Substitute filenames from this repo's "Files and versions" if they differ
+hf download ${modelId} \\
+    diffusion_models/<distilled-transformer>.safetensors \\
+    text_encoders/gemma4-12b-with-proj-ltx-2.5-bf16.safetensors \\
+    vae/<video-vae>.safetensors \\
+    vae/<audio-vae>.safetensors \\
+    latent_upscale_models/<spatial-upsampler>.safetensors \\
+    latent_upscale_models/<temporal-upsampler>.safetensors \\
+    --local-dir ${localDir}
+# DFR requires the detailing IC-LoRA (separate repo; strength is fixed at 0.5)
+hf download ${_LTX_DETAILING_LORA_REPO} --local-dir ${detailingDir}`;
+}
+
+function _ltx23Download(modelId: string, localDir: string): string {
+	return `# Download the weights from this repo, plus the Gemma text encoder
+hf download ${modelId} --local-dir ${localDir}
+hf download google/gemma-3-12b-it-qat-q4_0-unquantized --local-dir ${_LTX_GEMMA3_ROOT}`;
+}
+
+function _ltx25Snippets(model: ModelData, localDir: string, tags: string[]): string[] {
+	const install = _ltxInstall(true);
+	const loraArg = `--lora ${localDir}/<weights>.safetensors 1.0`;
+	const basePaths = _ltx25BasePlaceholderPaths();
+
+	if (tags.includes("ic-lora")) {
+		return [
+			install,
+			_ltx25Download(model.id, localDir, "adapter"),
+			_ltxRun(
+				"ic_lora",
+				[
+					..._ltx25SplitArgs(basePaths),
+					loraArg,
+					"--video-conditioning reference.mp4 1.0",
+					`--prompt "your prompt here"`,
+					"--output-path output.mp4",
+				],
+				"Video-to-video with the IC-LoRA (runs on the distilled LTX-2.5 base)",
+			),
+		];
+	}
+
+	if (tags.includes("lora")) {
+		return [
+			install,
+			_ltx25Download(model.id, localDir, "adapter"),
+			_ltxRun(
+				"distilled",
+				[..._ltx25SplitArgs(basePaths), loraArg, `--prompt "your prompt here"`, "--output-path output.mp4"],
+				"Text/image-to-video with the LoRA on the distilled LTX-2.5 pipeline",
+				{ hint: true },
+			),
+		];
+	}
+
+	const { distilled, dfr } = _ltx25RepoPaths(localDir);
+	const detailingDir = `models/${_LTX_DETAILING_LORA_REPO.split("/")[1]}`;
+	return [
+		install,
+		_ltx25Download(model.id, localDir, "base"),
+		_ltxRun(
+			"distilled",
+			[
+				..._ltx25SplitArgs(distilled),
+				"--num-frames 121",
+				`--prompt "${_LTX_DEFAULT_PROMPT}"`,
+				"--output-path output.mp4",
+			],
+			"Distilled LTX-2.5 pipeline (fast)",
+			{ hint: true },
+		),
+		_ltxRun(
+			"dfr_pipeline",
+			[
+				..._ltx25SplitArgs(dfr),
+				`--detailing-lora ${detailingDir}/${_LTX_DETAILING_LORA_FILE}`,
+				"--spatial-upscalings 1",
+				"--temporal-upscalings 1",
+				"--height 1088",
+				"--width 1920",
+				"--num-frames 121",
+				`--prompt "${_LTX_DEFAULT_PROMPT}"`,
+				"--output-path output.mp4",
+			],
+			"DFR pipeline (higher detail fidelity; optional temporal 2x/4x)",
+			{
+				footer: "# For 4K: --spatial-upscalings 2 --width 3840 --height 2176",
+				hint: true,
+			},
+		),
+	];
+}
+
+function _ltx23Snippets(model: ModelData, localDir: string, tags: string[]): string[] {
+	const install = _ltxInstall(false);
+	const download = _ltx23Download(model.id, localDir);
+	const loraArg = `--lora ${localDir}/<weights>.safetensors 1.0`;
+	const gemma = `--gemma-root ${_LTX_GEMMA3_ROOT}`;
+
 	if (tags.includes("ic-lora")) {
 		return [
 			install,
 			download,
-			`# Video-to-video with the IC-LoRA (runs on the distilled base model)
-uv run python -m ltx_pipelines.ic_lora \\
-    --distilled-checkpoint-path path/to/distilled_checkpoint.safetensors \\
-    --spatial-upsampler-path path/to/spatial_upsampler.safetensors \\
-    --gemma-root models/gemma-3-12b \\
-    --lora ${localDir}/<weights>.safetensors 1.0 \\
-    --video-conditioning reference.mp4 1.0 \\
-    --prompt "your prompt here" \\
-    --output-path output.mp4`,
+			_ltxRun(
+				"ic_lora",
+				[
+					"--distilled-checkpoint-path path/to/distilled_checkpoint.safetensors",
+					"--spatial-upsampler-path path/to/spatial_upsampler.safetensors",
+					gemma,
+					loraArg,
+					"--video-conditioning reference.mp4 1.0",
+					`--prompt "your prompt here"`,
+					"--output-path output.mp4",
+				],
+				"Video-to-video with the IC-LoRA (runs on the distilled base model)",
+			),
 		];
 	}
 
-	// Standard LoRA applied on top of the base pipeline.
 	if (tags.includes("lora")) {
 		return [
 			install,
 			download,
-			`# Text/image-to-video with the LoRA on the HQ two-stage base pipeline
-uv run python -m ltx_pipelines.ti2vid_two_stages_hq \\
-    --checkpoint-path path/to/checkpoint.safetensors \\
-    --distilled-lora path/to/distilled_lora.safetensors 0.8 \\
-    --spatial-upsampler-path path/to/spatial_upsampler.safetensors \\
-    --gemma-root models/gemma-3-12b \\
-    --lora ${localDir}/<weights>.safetensors 1.0 \\
-    --prompt "your prompt here" \\
-    --output-path output.mp4
-${imageToVideoHint}`,
+			_ltxRun(
+				"ti2vid_two_stages_hq",
+				[
+					"--checkpoint-path path/to/checkpoint.safetensors",
+					"--distilled-lora path/to/distilled_lora.safetensors 0.8",
+					"--spatial-upsampler-path path/to/spatial_upsampler.safetensors",
+					gemma,
+					loraArg,
+					`--prompt "your prompt here"`,
+					"--output-path output.mp4",
+				],
+				"Text/image-to-video with the LoRA on the HQ two-stage base pipeline",
+				{ hint: true },
+			),
 		];
 	}
 
-	// Base model: the fast (distilled) and HQ (two-stage) pipelines. Substitute the
-	// .safetensors filenames with the ones listed under this repo's "Files and versions".
 	return [
 		install,
 		download,
-		`# Fast pipeline (distilled model, no distilled LoRA needed)
-uv run python -m ltx_pipelines.distilled \\
-    --distilled-checkpoint-path ${localDir}/<distilled-checkpoint>.safetensors \\
-    --spatial-upsampler-path ${localDir}/<spatial-upsampler>.safetensors \\
-    --gemma-root models/gemma-3-12b \\
-    --prompt "A beautiful sunset over the ocean" \\
-    --output-path output.mp4
-${imageToVideoHint}`,
-		`# HQ pipeline (two-stage, higher quality)
-uv run python -m ltx_pipelines.ti2vid_two_stages_hq \\
-    --checkpoint-path ${localDir}/<checkpoint>.safetensors \\
-    --distilled-lora ${localDir}/<distilled-lora>.safetensors 0.8 \\
-    --spatial-upsampler-path ${localDir}/<spatial-upsampler>.safetensors \\
-    --gemma-root models/gemma-3-12b \\
-    --prompt "A beautiful sunset over the ocean" \\
-    --output-path output.mp4
-${imageToVideoHint}`,
+		_ltxRun(
+			"distilled",
+			[
+				`--distilled-checkpoint-path ${localDir}/<distilled-checkpoint>.safetensors`,
+				`--spatial-upsampler-path ${localDir}/<spatial-upsampler>.safetensors`,
+				gemma,
+				`--prompt "${_LTX_DEFAULT_PROMPT}"`,
+				"--output-path output.mp4",
+			],
+			"Fast pipeline (distilled model, no distilled LoRA needed)",
+			{ hint: true },
+		),
+		_ltxRun(
+			"ti2vid_two_stages_hq",
+			[
+				`--checkpoint-path ${localDir}/<checkpoint>.safetensors`,
+				`--distilled-lora ${localDir}/<distilled-lora>.safetensors 0.8`,
+				`--spatial-upsampler-path ${localDir}/<spatial-upsampler>.safetensors`,
+				gemma,
+				`--prompt "${_LTX_DEFAULT_PROMPT}"`,
+				"--output-path output.mp4",
+			],
+			"HQ pipeline (two-stage, higher quality)",
+			{ hint: true },
+		),
 	];
+}
+
+export const ltx = (model: ModelData): string[] => {
+	const localDir = `models/${nameWithoutNamespace(model.id)}`;
+	const tags = model.tags ?? [];
+	return _isLtx25Model(model) ? _ltx25Snippets(model, localDir, tags) : _ltx23Snippets(model, localDir, tags);
 };
 
 export const lightning_ir = (model: ModelData): string[] => {

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -804,7 +804,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		countDownloads: `path_extension:"pt"`,
 	},
 	ltx: {
-		prettyLabel: "LTX.io",
+		prettyLabel: "LTX-2",
 		repoName: "LTX-2",
 		repoUrl: "https://github.com/Lightricks/LTX-2",
 		docsUrl: "https://github.com/Lightricks/LTX-2",


### PR DESCRIPTION
## Summary
- Rename the LTX library pretty label from `LTX.io` to `LTX`
- Add LTX-2.5-friendly Hub snippets using split-pack loading (`--transformer-path`, text encoder, VAEs), with distilled + DFR pipelines
- Keep LTX-2.3 backward compatible (monolith checkpoints + Gemma 3 `--gemma-root`, distilled + HQ)
- Detect 2.5 via model id / tags / `base_model`; cover LoRA and IC-LoRA variants for both generations

## Test plan
- [x] `pnpm --filter tasks lint:check`
- [x] `pnpm --filter tasks check`
- [x] `pnpm --filter tasks format:check`
- [x] `pnpm --filter tasks test`
- [ ] Spot-check generated snippets for `Lightricks/LTX-2.5` and `Lightricks/LTX-2.3` (and a 2.5/2.3 LoRA)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect displayed install/run snippets and library labeling on model pages, with no runtime or API impact; wrong 2.5 vs 2.3 detection could show misleading commands to users.
> 
> **Overview**
> Updates the **LTX** model library UI label from `LTX.io` to **LTX-2** and rewrites the `ltx` Hub code snippets so they match both **LTX-2.5** and legacy **LTX-2.3** layouts.
> 
> **LTX-2.5** models are detected from `model.id`, tags, or `base_model` (e.g. `ltx-2.5`). Snippets use split checkpoint paths (`--transformer-path`, VAEs, upsamplers, bundled Gemma 4 text encoder), `uv sync --extra natten`, multi-file `hf download` (plus a separate detailing IC-LoRA repo for **DFR**), and examples for **distilled**, **DFR**, **LoRA**, and **IC-LoRA** pipelines. **LTX-2.3** keeps monolith checkpoints and `google/gemma-3-12b` `--gemma-root` with the same tag-based LoRA / IC-LoRA / base flows, now built through shared `_ltxRun` helpers and optional image-to-video hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4ec92eb77316e078ef86166befa38b5d43894f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->