### PR TITLE
Add range-edit support for efficient file appends

### DIFF
--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -82,24 +82,39 @@ for await (const progressEvent of await hub.uploadFilesWithProgress({
   console.log(progressEvent);
 }
 
-// Edit a file by adding prefix & suffix
-await commit({
+// Edit a file in place. When the original content is the blob returned by
+// `downloadFile` for a xet-backed file, the unchanged data is NOT re-downloaded:
+// the modified ranges (plus their chunk neighborhood) are the only parts fetched,
+// re-chunked and hashed. Editing a 1TB bucket file downloads ~nothing; for
+// models/datasets the unchanged data is streamed once for the new sha256.
+const originalFile = await hub.downloadFile({ repo, path: "myfile.bin", accessToken: "hf_..." });
+await hub.commit({
   repo,
   accessToken: "hf_...",
+  title: "edit myfile.bin",
   operations: [{
-    type: "edit",
+    operation: "edit",
+    path: "myfile.bin",
     originalContent: originalFile,
     edits: [{
+      // Replace bytes [0, 4) with a new prefix
       start: 0,
-      end: 0,
-      content: new Blob(["prefix"])
+      end: 4,
+      content: new Blob(["new prefix"])
     }, {
-      start: originalFile.length,
-      end: originalFile.length,
+      // Append at the end (start === end === size inserts without replacing)
+      start: originalFile.size,
+      end: originalFile.size,
       content: new Blob(["suffix"])
     }]
   }]
-})
+});
+
+// Repeatedly appending to the same file? Pass the same `rangeEditCache` to each
+// commit: the partial merkle state is kept in memory and appends skip the
+// storage-metadata API calls entirely.
+const rangeEditCache = new Map();
+await hub.commit({ repo, accessToken: "hf_...", title: "append", rangeEditCache, operations: [/* edit op appending to the file */] });
 
 await hub.deleteFile({repo, accessToken: "hf_...", path: "myfile.bin"});
 
@@ -222,6 +237,8 @@ When uploading large files, you may want to run the `commit` calls inside a work
 Remote resources and local files should be passed as `URL` whenever it's possible so they can be lazy loaded in chunks to reduce RAM usage. Passing a `File` inside the browser's context is fine, because it natively behaves as a `Blob`.
 
 Under the hood, `@huggingface/hub` uses a lazy blob implementation to load the file.
+
+When **editing** an existing file, prefer an `edit` commit operation with the blob returned by `downloadFile` as `originalContent` over re-uploading the whole content: for xet-backed files, only the edited regions are downloaded, re-chunked and hashed — the rest of the file is reused server-side. For repeated appends to the same file, pass a shared `rangeEditCache` (`new Map()`) to the successive `commit` calls to also skip the storage-metadata round-trips.
 
 ## Dependencies
 

--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -82,11 +82,7 @@ for await (const progressEvent of await hub.uploadFilesWithProgress({
   console.log(progressEvent);
 }
 
-// Edit a file in place. When the original content is the blob returned by
-// `downloadFile` for a xet-backed file, the unchanged data is NOT re-downloaded:
-// the modified ranges (plus their chunk neighborhood) are the only parts fetched,
-// re-chunked and hashed. Editing a 1TB bucket file downloads ~nothing; for
-// models/datasets the unchanged data is streamed once for the new sha256.
+// Edit a file in place, without downloading/uploading its unchanged data
 const originalFile = await hub.downloadFile({ repo, path: "myfile.bin", accessToken: "hf_..." });
 await hub.commit({
   repo,
@@ -97,24 +93,18 @@ await hub.commit({
     path: "myfile.bin",
     originalContent: originalFile,
     edits: [{
-      // Replace bytes [0, 4) with a new prefix
+      // Replace bytes [0, 4)
       start: 0,
       end: 4,
       content: new Blob(["new prefix"])
     }, {
-      // Append at the end (start === end === size inserts without replacing)
+      // Append at the end
       start: originalFile.size,
       end: originalFile.size,
       content: new Blob(["suffix"])
     }]
   }]
 });
-
-// Repeatedly appending to the same file? Pass the same `rangeEditCache` to each
-// commit: the partial merkle state is kept in memory and appends skip the
-// storage-metadata API calls entirely.
-const rangeEditCache = new Map();
-await hub.commit({ repo, accessToken: "hf_...", title: "append", rangeEditCache, operations: [/* edit op appending to the file */] });
 
 await hub.deleteFile({repo, accessToken: "hf_...", path: "myfile.bin"});
 
@@ -129,7 +119,7 @@ await hub.deleteRepo({ repo, accessToken: "hf_..." });
 
 ## CLI usage
 
-You can use `@huggingface/hub` in CLI mode to upload files and folders to your repo. 
+You can use `@huggingface/hub` in CLI mode to upload files and folders to your repo.
 
 ```console
 npx @huggingface/hub upload coyotte508/test-model .
@@ -238,7 +228,7 @@ Remote resources and local files should be passed as `URL` whenever it's possibl
 
 Under the hood, `@huggingface/hub` uses a lazy blob implementation to load the file.
 
-When **editing** an existing file, prefer an `edit` commit operation with the blob returned by `downloadFile` as `originalContent` over re-uploading the whole content: for xet-backed files, only the edited regions are downloaded, re-chunked and hashed — the rest of the file is reused server-side. For repeated appends to the same file, pass a shared `rangeEditCache` (`new Map()`) to the successive `commit` calls to also skip the storage-metadata round-trips.
+To edit an existing file, prefer an `edit` commit operation with the blob returned by `downloadFile` as `originalContent`: only the edited regions are downloaded, re-chunked and hashed. For repeated appends to the same file, pass a shared `rangeEditCache: new Map()` to the `commit` calls to also skip the storage-metadata round-trips.
 
 ## Dependencies
 

--- a/packages/hub/scripts/test-range-edit.ts
+++ b/packages/hub/scripts/test-range-edit.ts
@@ -1,0 +1,295 @@
+/**
+ * Integration test for range-edit uploads (`CommitEditFile` with a `XetBlob` original).
+ *
+ * Creates a private repo, uploads a file, then edits/appends it via `commit` edit
+ * operations whose `originalContent` is the `XetBlob` returned by `downloadFile`. The
+ * unchanged parts of the file are not re-chunked: the CAS `/v2/file-chunk-hashes` API
+ * provides partial merkle data instead. After each edit the file is re-downloaded and
+ * compared byte-for-byte. The repo is deleted at the end.
+ *
+ * Usage: HF_TOKEN=hf_... pnpm --filter @huggingface/hub exec tsx scripts/test-range-edit.ts
+ */
+
+import { commit, createRepo, deleteRepo, downloadFile, whoAmI } from "../src";
+import type { RepoDesignation } from "../src";
+
+const accessToken = process.env.HF_TOKEN;
+if (!accessToken) {
+	console.error("Set HF_TOKEN to run this script");
+	process.exit(1);
+}
+
+/** Deterministic pseudo-random bytes (splitmix64) */
+function randomBytes(seed: bigint, length: number): Uint8Array {
+	const out = new Uint8Array(length);
+	const view = new DataView(out.buffer);
+	let state = seed;
+	let i = 0;
+	for (; i + 8 <= length; i += 8) {
+		state = (state + 0x9e3779b97f4a7c15n) & 0xffffffffffffffffn;
+		let z = state;
+		z = ((z ^ (z >> 30n)) * 0xbf58476d1ce4e5b9n) & 0xffffffffffffffffn;
+		z = ((z ^ (z >> 27n)) * 0x94d049bb133111ebn) & 0xffffffffffffffffn;
+		z ^= z >> 31n;
+		view.setBigUint64(i, z, true);
+	}
+	for (; i < length; i++) {
+		out[i] = i & 0xff;
+	}
+	return out;
+}
+
+interface FetchStats {
+	fileChunkHashesCalls: number;
+	xorbUploads: number;
+	casDataBytesDownloaded: number;
+}
+
+function instrumentedFetch(stats: FetchStats): typeof fetch {
+	return async (input, init) => {
+		const url = String(typeof input === "object" && "url" in input ? input.url : input);
+		const resp = await fetch(input, init);
+
+		if (url.includes("/v2/file-chunk-hashes/")) {
+			stats.fileChunkHashesCalls++;
+		}
+		if (url.includes("/xorbs/") && init?.method === "POST") {
+			stats.xorbUploads++;
+		}
+		// Presigned xorb data downloads (transfer URLs) — count bytes
+		if ((url.includes("transfer.xethub") || url.includes("/xorbs/")) && (!init?.method || init.method === "GET")) {
+			const length = resp.headers.get("Content-Length");
+			if (length) {
+				stats.casDataBytesDownloaded += parseInt(length);
+			}
+		}
+		return resp;
+	};
+}
+
+async function expectContent(repo: RepoDesignation, path: string, expected: Uint8Array, label: string) {
+	const blob = await downloadFile({ repo, path, accessToken });
+	if (!blob) {
+		throw new Error(`${label}: file ${path} not found`);
+	}
+	const actual = new Uint8Array(await blob.arrayBuffer());
+	if (actual.length !== expected.length) {
+		throw new Error(`${label}: size mismatch: ${actual.length} !== ${expected.length}`);
+	}
+	for (let i = 0; i < actual.length; i++) {
+		if (actual[i] !== expected[i]) {
+			throw new Error(`${label}: content mismatch at byte ${i}`);
+		}
+	}
+	console.log(`✅ ${label}: content matches (${expected.length} bytes)`);
+}
+
+function splice(data: Uint8Array, start: number, end: number, insert: Uint8Array): Uint8Array {
+	const out = new Uint8Array(data.length - (end - start) + insert.length);
+	out.set(data.subarray(0, start), 0);
+	out.set(insert, start);
+	out.set(data.subarray(end), start + insert.length);
+	return out;
+}
+
+async function main() {
+	const user = await whoAmI({ accessToken });
+	const repoName = `${user.name}/range-edit-test-${Date.now()}`;
+	const repo: RepoDesignation = { type: "model", name: repoName };
+
+	console.log(`Creating repo ${repoName}...`);
+	await createRepo({ repo, accessToken, private: true });
+
+	try {
+		// 1. Initial upload: 8MB of pseudo-random data
+		let expected = randomBytes(42n, 8 * 1024 * 1024);
+		console.log("Uploading initial 8MB file...");
+		await commit({
+			repo,
+			accessToken,
+			title: "initial upload",
+			operations: [{ operation: "addOrUpdate", path: "data.bin", content: new Blob([expected]) }],
+		});
+		await expectContent(repo, "data.bin", expected, "initial upload");
+
+		// 2. Mid-file edit via range-edit path
+		{
+			const stats: FetchStats = { fileChunkHashesCalls: 0, xorbUploads: 0, casDataBytesDownloaded: 0 };
+			const original = await downloadFile({ repo, path: "data.bin", accessToken, fetch: instrumentedFetch(stats) });
+			if (!original) {
+				throw new Error("original not found");
+			}
+			console.log(`original blob: ${original.constructor.name}, hash: ${"hash" in original ? original.hash : "n/a"}`);
+
+			const insert = randomBytes(1000n, 1000);
+			expected = splice(expected, 2_000_000, 2_001_000, insert);
+			await commit({
+				repo,
+				accessToken,
+				fetch: instrumentedFetch(stats),
+				title: "mid-file edit",
+				operations: [
+					{
+						operation: "edit",
+						path: "data.bin",
+						originalContent: original,
+						edits: [{ content: new Blob([insert]), start: 2_000_000, end: 2_001_000 }],
+					},
+				],
+			});
+			console.log(
+				`   file-chunk-hashes calls: ${stats.fileChunkHashesCalls}, xorb uploads: ${stats.xorbUploads}, CAS bytes downloaded: ${stats.casDataBytesDownloaded}`,
+			);
+			if (stats.fileChunkHashesCalls === 0) {
+				throw new Error("Expected the range-edit path (file-chunk-hashes) to be used");
+			}
+			await expectContent(repo, "data.bin", expected, "mid-file edit");
+		}
+
+		// 3. Second round: edit the composed file (exercises reused terms + gapVerification)
+		{
+			const stats: FetchStats = { fileChunkHashesCalls: 0, xorbUploads: 0, casDataBytesDownloaded: 0 };
+			const original = await downloadFile({ repo, path: "data.bin", accessToken });
+			if (!original) {
+				throw new Error("original not found");
+			}
+			const insert = randomBytes(2000n, 500);
+			expected = splice(expected, 6_000_000, 6_000_100, insert);
+			await commit({
+				repo,
+				accessToken,
+				fetch: instrumentedFetch(stats),
+				title: "second-round edit",
+				operations: [
+					{
+						operation: "edit",
+						path: "data.bin",
+						originalContent: original,
+						edits: [{ content: new Blob([insert]), start: 6_000_000, end: 6_000_100 }],
+					},
+				],
+			});
+			console.log(
+				`   file-chunk-hashes calls: ${stats.fileChunkHashesCalls}, xorb uploads: ${stats.xorbUploads}, CAS bytes downloaded: ${stats.casDataBytesDownloaded}`,
+			);
+			await expectContent(repo, "data.bin", expected, "second-round edit");
+		}
+
+		// 4. Append
+		{
+			const stats: FetchStats = { fileChunkHashesCalls: 0, xorbUploads: 0, casDataBytesDownloaded: 0 };
+			const original = await downloadFile({ repo, path: "data.bin", accessToken });
+			if (!original) {
+				throw new Error("original not found");
+			}
+			const appended = randomBytes(3000n, 300_000);
+			const size = expected.length;
+			expected = splice(expected, size, size, appended);
+			await commit({
+				repo,
+				accessToken,
+				fetch: instrumentedFetch(stats),
+				title: "append",
+				operations: [
+					{
+						operation: "edit",
+						path: "data.bin",
+						originalContent: original,
+						edits: [{ content: new Blob([appended]), start: size, end: size }],
+					},
+				],
+			});
+			console.log(
+				`   file-chunk-hashes calls: ${stats.fileChunkHashesCalls}, xorb uploads: ${stats.xorbUploads}, CAS bytes downloaded: ${stats.casDataBytesDownloaded}`,
+			);
+			await expectContent(repo, "data.bin", expected, "append");
+		}
+
+		// 5. Header edit (the GGUF use case: replace the first bytes)
+		{
+			const stats: FetchStats = { fileChunkHashesCalls: 0, xorbUploads: 0, casDataBytesDownloaded: 0 };
+			const original = await downloadFile({ repo, path: "data.bin", accessToken });
+			if (!original) {
+				throw new Error("original not found");
+			}
+			const newHeader = randomBytes(4000n, 2048);
+			expected = splice(expected, 0, 1024, newHeader);
+			await commit({
+				repo,
+				accessToken,
+				fetch: instrumentedFetch(stats),
+				title: "header edit",
+				operations: [
+					{
+						operation: "edit",
+						path: "data.bin",
+						originalContent: original,
+						edits: [{ content: new Blob([newHeader]), start: 0, end: 1024 }],
+					},
+				],
+			});
+			console.log(
+				`   file-chunk-hashes calls: ${stats.fileChunkHashesCalls}, xorb uploads: ${stats.xorbUploads}, CAS bytes downloaded: ${stats.casDataBytesDownloaded}`,
+			);
+			await expectContent(repo, "data.bin", expected, "header edit (grow)");
+		}
+
+		// 6. Cached appends: repeated appends to the same file must not call the CAS
+		// metadata APIs at all (the partial merkle state is kept in memory).
+		{
+			const rangeEditCache = new Map();
+			let logContent = randomBytes(5000n, 3 * 1024 * 1024);
+			console.log("Uploading log.bin (3MB) with a range-edit cache...");
+			await commit({
+				repo,
+				accessToken,
+				rangeEditCache,
+				title: "log initial",
+				operations: [{ operation: "addOrUpdate", path: "log.bin", content: new Blob([logContent]) }],
+			});
+
+			for (let round = 0; round < 3; round++) {
+				const stats: FetchStats = { fileChunkHashesCalls: 0, xorbUploads: 0, casDataBytesDownloaded: 0 };
+				const original = await downloadFile({ repo, path: "log.bin", accessToken });
+				if (!original) {
+					throw new Error("log.bin not found");
+				}
+				const appended = randomBytes(BigInt(6000 + round), 200_000);
+				const size = logContent.length;
+				logContent = splice(logContent, size, size, appended);
+				await commit({
+					repo,
+					accessToken,
+					rangeEditCache,
+					fetch: instrumentedFetch(stats),
+					title: `append round ${round}`,
+					operations: [
+						{
+							operation: "edit",
+							path: "log.bin",
+							originalContent: original,
+							edits: [{ content: new Blob([appended]), start: size, end: size }],
+						},
+					],
+				});
+				console.log(
+					`   round ${round}: file-chunk-hashes calls: ${stats.fileChunkHashesCalls}, xorb uploads: ${stats.xorbUploads}`,
+				);
+				if (stats.fileChunkHashesCalls !== 0) {
+					throw new Error("Cached append should not call file-chunk-hashes");
+				}
+			}
+			await expectContent(repo, "log.bin", logContent, "cached appends (3 rounds)");
+		}
+
+		console.log("\n🎉 All range-edit integration tests passed");
+	} finally {
+		console.log(`Deleting repo ${repoName}...`);
+		await deleteRepo({ repo, accessToken });
+	}
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/packages/hub/src/lib/commit.ts
+++ b/packages/hub/src/lib/commit.ts
@@ -27,6 +27,9 @@ import type { XetTokenParams } from "../utils/uploadShards";
 import { uploadShards } from "../utils/uploadShards";
 import { splitAsyncGenerator } from "../utils/splitAsyncGenerator";
 import { SplicedBlob } from "../utils/SplicedBlob";
+import type { RangeEditCache } from "../utils/rangeEdit";
+
+export type { RangeEditCache, RangeEditCacheEntry } from "../utils/rangeEdit";
 
 const CONCURRENT_SHAS = 5;
 const CONCURRENT_LFS_UPLOADS = 5;
@@ -47,9 +50,22 @@ export interface CommitFile {
 }
 
 /**
- * Opitmized when only the beginning or the end of the file is replaced
+ * Edit an existing file by replacing byte ranges of its original content.
  *
- * todo: handle other cases
+ * When `originalContent` is a {@link XetBlob} (as returned by {@link downloadFile} for
+ * xet-backed files), the unchanged parts of the file are neither downloaded nor re-chunked:
+ * the CAS server provides chunk-aligned edit windows and partial merkle data
+ * (`GET /v2/file-chunk-hashes`), so only the modified regions (plus their chunk-boundary
+ * neighborhood) are fetched, re-chunked and hashed.
+ *
+ * - For buckets (no sha256 involved), this means edits and appends require **no download of
+ *   the unchanged data at all**.
+ * - For models/datasets/spaces, the unchanged data is still streamed **once** to compute the
+ *   new file's sha256 (required by the LFS protocol), instead of twice (sha256 + chunking).
+ *
+ * With any other Blob as `originalContent`, the whole content is re-chunked locally and
+ * unchanged chunks are deduplicated against the remote (upload is skipped, but the content
+ * is read in full).
  */
 export interface CommitEditFile {
 	operation: "edit";
@@ -149,6 +165,15 @@ export type CommitParams = {
 	 * Use xet protocol: https://huggingface.co/blog/xet-on-the-hub to upload, rather than a basic S3 PUT
 	 */
 	useXet?: boolean;
+	/**
+	 * In-memory cache for repeated edits/appends to the same files (create one with `new Map()`).
+	 *
+	 * When the same cache instance is passed to successive `commit` calls, appending to a file
+	 * uploaded by a previous call (via an `edit` operation inserting at the end of the file)
+	 * skips the CAS metadata API calls entirely: the partial merkle state of the unchanged
+	 * data is kept in memory.
+	 */
+	rangeEditCache?: RangeEditCache;
 	// Credentials are optional due to custom fetch functions or cookie auth
 } & Partial<CredentialsParams>;
 
@@ -449,6 +474,7 @@ export async function* commitIter(params: CommitParams): AsyncGenerator<CommitPr
 									// todo: maybe leave empty if PR?
 									rev: params.branch ?? "main",
 									isPullRequest: params.isPullRequest,
+									rangeEditCache: params.rangeEditCache,
 									yieldCallback: (event) => yieldCallback({ ...event, state: "uploading" }),
 								})) {
 									if (event.event === "file") {
@@ -841,6 +867,7 @@ export async function* commitIterBucket(params: CommitParams): AsyncGenerator<Co
 							repo: repoId,
 							xetParams,
 							rev: params.branch ?? "main",
+							rangeEditCache: params.rangeEditCache,
 							yieldCallback: (event) => yieldCallback({ ...event, state: "uploading" }),
 						})) {
 							if (event.event === "file") {

--- a/packages/hub/src/lib/download-file.ts
+++ b/packages/hub/src/lib/download-file.ts
@@ -77,6 +77,7 @@ export async function downloadFile(
 		return new XetBlob({
 			refreshUrl: info.xet.refreshUrl.href,
 			reconstructionUrl: info.xet.reconstructionUrl.href,
+			hash: info.xet.hash,
 			fetch: params.fetch,
 			accessToken,
 			size: info.size,

--- a/packages/hub/src/utils/createXorbs.ts
+++ b/packages/hub/src/utils/createXorbs.ts
@@ -1,10 +1,20 @@
-import { bg4_split_bytes, XET_CHUNK_HEADER_BYTES, XetChunkCompressionScheme } from "./XetBlob";
+import { bg4_split_bytes, XET_CHUNK_HEADER_BYTES, XetChunkCompressionScheme, XetBlob } from "./XetBlob";
 import { compress as lz4_compress } from "../vendor/lz4js";
 import { ChunkCache } from "./ChunkCache";
 import { xetWriteToken, type XetWriteTokenParams } from "./xetWriteToken";
 import type { ShardData } from "./shardParser";
 import { parseShardData } from "./shardParser";
 import { SplicedBlob } from "./SplicedBlob";
+import {
+	buildFreshFileCachePayload,
+	buildRangeEditCachePayload,
+	composeRepresentation,
+	computeComposedFileHash,
+	planRangeEdit,
+	windowSegments,
+} from "./rangeEdit";
+import type { RangeEditCache, RangeEditCachePayload, RangeEditPlan } from "./rangeEdit";
+import { sum } from "./sum";
 import {
 	createChunker,
 	nextBlock,
@@ -133,6 +143,8 @@ export async function* createXorbs(
 	fileSources: AsyncGenerator<{ content: Blob; path: string; sha256?: string }>,
 	params: XetWriteTokenParams & {
 		yieldCallback?: (event: { event: "fileProgress"; path: string; progress: number }) => void;
+		/** When provided, appends/tail edits of files uploaded earlier through this cache skip the CAS metadata calls */
+		rangeEditCache?: RangeEditCache;
 	},
 ): AsyncGenerator<
 	| XorbEvent
@@ -151,6 +163,8 @@ export async function* createXorbs(
 				length: number;
 				rangeHash: string;
 			}>;
+			/** Present when a range-edit cache is active: state for future appends to this file */
+			rangeEditCachePayload?: RangeEditCachePayload;
 	  },
 	void,
 	undefined
@@ -187,9 +201,14 @@ export async function* createXorbs(
 			length: number;
 			rangeHash: string;
 		}>;
+		rangeEditCachePayload?: RangeEditCachePayload;
 	}> = [];
 
 	const remoteXorbHashes: string[] = [""]; // starts at index 1 (to simplify implem a bit)
+
+	/** Local xorb ids stay numeric; negative ids map to remote xorb hashes; string ids are already remote hashes */
+	const resolveXorbId = (xorbId: number | string): number | string =>
+		typeof xorbId === "string" ? xorbId : xorbId >= 0 ? xorbId : remoteXorbHashes[-xorbId];
 
 	for await (const fileSource of fileSources) {
 		params.yieldCallback?.({
@@ -209,12 +228,45 @@ export async function* createXorbs(
 			alreadyDoneFileSha256s.add(fileSource.sha256);
 		}
 
-		const chunker = createChunker(TARGET_CHUNK_SIZE);
 		{
 			xorb.fileSize[fileSource.path] = fileSource.content.size;
 
+			// When editing an existing xet file, ask the CAS server for the chunk-aligned
+			// windows that need re-chunking and partial merkle data for the rest, so only
+			// the modified regions of the file are downloaded and processed.
+			let rangeEditPlan: RangeEditPlan | undefined;
+			if (
+				fileSource.content instanceof SplicedBlob &&
+				fileSource.content.originalBlob instanceof XetBlob &&
+				fileSource.content.originalBlob.hash !== undefined &&
+				fileSource.content.originalBlob.size > 0
+			) {
+				rangeEditPlan = await planRangeEdit(fileSource.content, fileSource.content.originalBlob, params);
+			}
+
+			// Prime the chunk cache with the original file's dedup info (one query on its first
+			// chunk returns the whole shard, ie the chunk => xorb mapping of the original file),
+			// so unchanged window bytes dedup against the original xorbs instead of re-uploading.
+			if (rangeEditPlan !== undefined) {
+				await loadDedupInfoToCache(
+					(fileSource.content as SplicedBlob).originalBlob.slice(0, MAX_CHUNK_SIZE),
+					remoteXorbHashes,
+					params,
+					chunkCache,
+					computeHmacHex,
+					{
+						maxChunks: 1,
+						isAtBeginning: true,
+					},
+				);
+			}
+
 			// Load dedup info for the first chunk of the file, if it's potentially modified by the splice
-			if (fileSource.content instanceof SplicedBlob && fileSource.content.firstSpliceIndex < MAX_CHUNK_SIZE) {
+			if (
+				rangeEditPlan === undefined &&
+				fileSource.content instanceof SplicedBlob &&
+				fileSource.content.firstSpliceIndex < MAX_CHUNK_SIZE
+			) {
 				await loadDedupInfoToCache(
 					fileSource.content.originalBlob.slice(0, MAX_CHUNK_SIZE),
 					remoteXorbHashes,
@@ -229,10 +281,9 @@ export async function* createXorbs(
 			}
 			let bytesSinceRemoteDedup = Infinity;
 			let bytesSinceLastProgressEvent = 0;
-			let isFirstFileChunk = true;
+			let dedupNextChunk = true;
 			const sourceChunks: Array<Uint8Array> = [];
 
-			const reader = fileSource.content.stream().getReader();
 			let processedBytes = 0;
 			let dedupedBytes = 0; // Track bytes that were deduplicated
 			// Needed to compute the final file hash
@@ -248,9 +299,9 @@ export async function* createXorbs(
 
 			const addChunks = async function* (chunks: Array<{ hash: string; length: number; dedup: boolean }>) {
 				for (const chunk of chunks) {
-					if (isFirstFileChunk) {
+					if (dedupNextChunk) {
 						chunk.dedup = true;
-						isFirstFileChunk = false;
+						dedupNextChunk = false;
 					}
 					let chunkIndex = xorb.chunks.length;
 					let chunkXorbId = xorbId;
@@ -305,7 +356,7 @@ export async function* createXorbs(
 							for (const event of pendingFileEvents) {
 								event.representation = event.representation.map((rep) => ({
 									...rep,
-									xorbId: (rep.xorbId as number) >= 0 ? rep.xorbId : remoteXorbHashes[-rep.xorbId],
+									xorbId: resolveXorbId(rep.xorbId),
 								}));
 								yield event;
 							}
@@ -358,7 +409,7 @@ export async function* createXorbs(
 						for (const event of pendingFileEvents) {
 							event.representation = event.representation.map((rep) => ({
 								...rep,
-								xorbId: (rep.xorbId as number) >= 0 ? rep.xorbId : remoteXorbHashes[-rep.xorbId],
+								xorbId: resolveXorbId(rep.xorbId),
 							}));
 							yield event;
 						}
@@ -367,31 +418,105 @@ export async function* createXorbs(
 				}
 			};
 
-			while (true) {
-				const { done, value } = await reader.read();
-				if (done) {
-					yield* addChunks(finalizeChunker(chunker));
-					break;
+			/** Stream a blob's data into the chunker, yielding xorb events as they fill up */
+			const pumpBlob = async function* (chunker: ReturnType<typeof createChunker>, blob: Blob) {
+				const reader = blob.stream().getReader();
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) {
+						break;
+					}
+					processedBytes += value.length;
+					sourceChunks.push(value);
+					yield* addChunks(addDataToChunker(value, chunker));
 				}
-				processedBytes += value.length;
-				sourceChunks.push(value);
-				yield* addChunks(addDataToChunker(value, chunker));
+			};
+
+			let fileRepresentation: Array<{
+				xorbId: number | string;
+				indexStart: number;
+				indexEnd: number;
+				length: number;
+				rangeHash: string;
+			}>;
+			let fileHashHex: string;
+			let dedupRatio: number;
+			let rangeEditCachePayload: RangeEditCachePayload | undefined;
+
+			if (rangeEditPlan !== undefined) {
+				const originalBlob = (fileSource.content as SplicedBlob).originalBlob;
+				// Index ranges of each window's chunks within fileChunks / chunkMetadata
+				const windowBounds: Array<[number, number]> = [];
+
+				for (const window of rangeEditPlan.windows) {
+					const chunker = createChunker(TARGET_CHUNK_SIZE);
+					dedupNextChunk = true;
+					const startIndex = fileChunks.length;
+
+					for (const segment of windowSegments(window, originalBlob)) {
+						yield* pumpBlob(chunker, segment);
+					}
+					yield* addChunks(finalizeChunker(chunker));
+
+					windowBounds.push([startIndex, fileChunks.length]);
+				}
+
+				// The reused (non-window) bytes are neither downloaded nor uploaded: count
+				// them as processed & uploaded right away for progress reporting.
+				const windowNewBytes = sum(rangeEditPlan.windows.map((window) => window.newSize));
+				const reusedBytes = fileSource.content.size - windowNewBytes;
+				processedBytes += reusedBytes;
+				xorb.fileUploadedBytes[fileSource.path] = (xorb.fileUploadedBytes[fileSource.path] ?? 0) + reusedBytes;
+				xorb.fileProcessedBytes[fileSource.path] = processedBytes;
+
+				// Build the window representations only now: remote dedup backtracking during a
+				// later window can still remap chunk metadata of an earlier one.
+				const windowRepresentations = windowBounds.map(([start, end]) =>
+					buildFileRepresentation(
+						chunkMetadata.slice(start, end),
+						fileChunks.slice(start, end),
+						computeVerificationHashHex,
+					),
+				);
+				fileRepresentation = composeRepresentation(rangeEditPlan, windowRepresentations);
+				fileHashHex = computeComposedFileHash(
+					rangeEditPlan,
+					windowBounds.map(([start, end]) => fileChunks.slice(start, end)),
+				);
+				dedupRatio = fileSource.content.size > 0 ? (reusedBytes + dedupedBytes) / fileSource.content.size : 0;
+				if (params.rangeEditCache) {
+					rangeEditCachePayload = buildRangeEditCachePayload(
+						rangeEditPlan,
+						windowBounds.map(([start, end]) => fileChunks.slice(start, end)),
+						fileRepresentation,
+					);
+				}
+			} else {
+				const chunker = createChunker(TARGET_CHUNK_SIZE);
+				yield* pumpBlob(chunker, fileSource.content);
+				yield* addChunks(finalizeChunker(chunker));
+
+				fileRepresentation = buildFileRepresentation(chunkMetadata, fileChunks, computeVerificationHashHex);
+				fileHashHex = computeFileHashHex(fileChunks);
+				dedupRatio = fileSource.content.size > 0 ? dedupedBytes / fileSource.content.size : 0;
+				if (params.rangeEditCache) {
+					rangeEditCachePayload = buildFreshFileCachePayload(fileChunks, fileRepresentation);
+				}
 			}
 
-			const fileRepresentation = buildFileRepresentation(chunkMetadata, fileChunks, computeVerificationHashHex);
 			xorb.immutableData = {
 				chunkIndex: xorb.chunks.length,
 				offset: xorb.offset,
 			};
-			const dedupRatio = fileSource.content.size > 0 ? dedupedBytes / fileSource.content.size : 0;
 
 			pendingFileEvents.push({
 				event: "file" as const,
 				path: fileSource.path,
-				hash: computeFileHashHex(fileChunks),
+				hash: fileHashHex,
 				sha256: fileSource.sha256,
 				dedupRatio,
 				representation: fileRepresentation,
+				rangeEditCachePayload,
 			});
 		}
 	}
@@ -403,7 +528,7 @@ export async function* createXorbs(
 	for (const event of pendingFileEvents) {
 		event.representation = event.representation.map((rep) => ({
 			...rep,
-			xorbId: (rep.xorbId as number) >= 0 ? rep.xorbId : remoteXorbHashes[-rep.xorbId],
+			xorbId: resolveXorbId(rep.xorbId),
 		}));
 		yield event;
 	}

--- a/packages/hub/src/utils/rangeEdit.spec.ts
+++ b/packages/hub/src/utils/rangeEdit.spec.ts
@@ -1,0 +1,635 @@
+import { describe, expect, it } from "vitest";
+import { MerkleHashSubtree, fileHash, hashToHex, hexToBytes, verificationHash } from "@huggingface/xetchunk-wasm";
+import type { MerkleHashSubtreeJson } from "@huggingface/xetchunk-wasm";
+import {
+	addToRangeEditCache,
+	assignEditsToWindows,
+	buildFreshFileCachePayload,
+	buildRangeEditCachePayload,
+	composeRepresentation,
+	computeComposedFileHash,
+	planRangeEditFromCache,
+	snapAndCoalesceDirtyRanges,
+	windowSegments,
+} from "./rangeEdit";
+import type { OriginalTerm, RangeEditCache, RangeEditPlan, RepresentationEntry } from "./rangeEdit";
+import { SplicedBlob } from "./SplicedBlob";
+
+interface TestChunk {
+	hash: string;
+	length: number;
+}
+
+/** Deterministic pseudo-random 32-byte hash from a seed (splitmix64-based). */
+function chunkOf(seed: number, length: number): TestChunk {
+	const bytes = new Uint8Array(32);
+	const view = new DataView(bytes.buffer);
+	let state = BigInt(seed) & 0xffffffffffffffffn;
+	for (let i = 0; i < 4; i++) {
+		state = (state + 0x9e3779b97f4a7c15n) & 0xffffffffffffffffn;
+		let z = state;
+		z = ((z ^ (z >> 30n)) * 0xbf58476d1ce4e5b9n) & 0xffffffffffffffffn;
+		z = ((z ^ (z >> 27n)) * 0x94d049bb133111ebn) & 0xffffffffffffffffn;
+		z ^= z >> 31n;
+		view.setBigUint64(i * 8, z, true);
+	}
+	return { hash: hashToHex(bytes), length };
+}
+
+/** Stable chunk size for TARGET_CHUNK_SIZE=64KB: within [2*8KB, 128KB-8KB) */
+const STABLE_SIZE = 20_000;
+/** Unstable chunk size (>= max - min = 120KB) */
+const UNSTABLE_SIZE = 125_000;
+
+/**
+ * TS mirror of the server's `ChunkWindowBuilder` (xetcas PR #987 / xet-core
+ * `chunk_window_builder.rs`): computes windows, gap hash subtrees and per-stable-term
+ * verification hashes for a synthetic original file. Used to simulate
+ * `GET /v2/file-chunk-hashes` responses in tests.
+ */
+function buildServerResponse(
+	chunks: TestChunk[],
+	terms: OriginalTerm[],
+	dirtyRanges: Array<[number, number]>,
+): {
+	windows: Array<{ start: number; end: number }>;
+	hashRanges: Array<MerkleHashSubtreeJson | null>;
+	gapVerification: string[];
+} {
+	const isStable = (size: number) => size >= 16_384 && size < 122_880;
+
+	let dirtyIdx = 0;
+	let inDirtyZone = false;
+	let gapIsFirst = true;
+	let cursor = 0;
+	let gapChunks: TestChunk[] = [];
+	const windows: Array<{ start: number; end: number }> = [];
+	const hashRanges: Array<MerkleHashSubtreeJson | null> = [];
+	let tailPrevSize: number | undefined;
+
+	const toSubtree = (chunksIn: TestChunk[], atStart: boolean, atEnd: boolean): MerkleHashSubtreeJson | null => {
+		const subtree = MerkleHashSubtree.fromChunks(
+			atStart,
+			chunksIn.map((c) => ({ hash: hexToBytes(c.hash), length: c.length })),
+			atEnd,
+		);
+		return subtree.isEmpty ? null : subtree.toJSON();
+	};
+
+	const overlapsDirtyAt = (idx: number, byteStart: number, byteEnd: number) =>
+		idx < dirtyRanges.length && byteEnd > dirtyRanges[idx][0] && byteStart < dirtyRanges[idx][1];
+	const mergeAhead = (byteEnd: number) => {
+		while (dirtyIdx + 1 < dirtyRanges.length && byteEnd > dirtyRanges[dirtyIdx + 1][0]) {
+			dirtyIdx++;
+		}
+	};
+
+	for (const chunk of chunks) {
+		const byteStart = cursor;
+		const byteEnd = cursor + chunk.length;
+		const overlapsDirty = overlapsDirtyAt(dirtyIdx, byteStart, byteEnd);
+
+		if (!inDirtyZone) {
+			if (overlapsDirty) {
+				hashRanges.push(toSubtree(gapChunks, gapIsFirst, false));
+				gapChunks = [];
+				windows.push({ start: cursor, end: byteEnd });
+				mergeAhead(byteEnd);
+				inDirtyZone = true;
+				tailPrevSize = undefined;
+			} else {
+				gapChunks.push(chunk);
+			}
+		} else if (overlapsDirty || overlapsDirtyAt(dirtyIdx + 1, byteStart, byteEnd)) {
+			if (!overlapsDirty) {
+				dirtyIdx++;
+			}
+			windows[windows.length - 1].end = byteEnd;
+			mergeAhead(byteEnd);
+			tailPrevSize = undefined;
+		} else {
+			windows[windows.length - 1].end = byteEnd;
+			const stable = tailPrevSize !== undefined && isStable(tailPrevSize) && isStable(chunk.length);
+			tailPrevSize = chunk.length;
+			if (stable) {
+				dirtyIdx++;
+				gapIsFirst = false;
+				inDirtyZone = false;
+				tailPrevSize = undefined;
+			}
+		}
+		cursor = byteEnd;
+	}
+
+	hashRanges.push(toSubtree(gapChunks, gapIsFirst, true));
+
+	// gap verification per stable term (fully outside every final window)
+	const gapVerification: string[] = [];
+	let acc = 0;
+	let windowIdx = 0;
+	let chunkIdx = 0;
+	for (const term of terms) {
+		const termStart = acc;
+		const termEnd = acc + term.unpackedLength;
+		acc = termEnd;
+		const termChunkCount = term.range.end - term.range.start;
+		const termChunks = chunks.slice(chunkIdx, chunkIdx + termChunkCount);
+		chunkIdx += termChunkCount;
+		while (windowIdx < windows.length && windows[windowIdx].end <= termStart) {
+			windowIdx++;
+		}
+		const overlaps = windowIdx < windows.length && windows[windowIdx].start < termEnd;
+		if (!overlaps) {
+			gapVerification.push(hashToHex(verificationHash(termChunks.map((c) => hexToBytes(c.hash)))));
+		}
+	}
+
+	return { windows, hashRanges, gapVerification };
+}
+
+/** Build a synthetic original file: `chunkCounts[i]` chunks per term, all in one xorb. */
+function makeOriginal(chunkCounts: number[], chunkSize: (i: number) => number) {
+	const chunks: TestChunk[] = [];
+	const terms: OriginalTerm[] = [];
+	const segByteStarts = [0];
+	let chunkIdx = 0;
+	for (const count of chunkCounts) {
+		let termBytes = 0;
+		const rangeStart = chunkIdx;
+		for (let i = 0; i < count; i++) {
+			const chunk = chunkOf(chunkIdx, chunkSize(chunkIdx));
+			chunks.push(chunk);
+			termBytes += chunk.length;
+			chunkIdx++;
+		}
+		terms.push({
+			hash: "a".repeat(64),
+			unpackedLength: termBytes,
+			range: { start: rangeStart, end: chunkIdx },
+		});
+		segByteStarts.push(segByteStarts[segByteStarts.length - 1] + termBytes);
+	}
+	return { chunks, terms, segByteStarts, size: segByteStarts[segByteStarts.length - 1] };
+}
+
+describe("rangeEdit", () => {
+	describe("snapAndCoalesceDirtyRanges", () => {
+		const segByteStarts = [0, 100, 250, 400, 500];
+
+		it("snaps an edit to enclosing term boundaries", () => {
+			expect(snapAndCoalesceDirtyRanges([{ start: 120, end: 130 }], segByteStarts, 500)).toEqual([[100, 250]]);
+		});
+
+		it("keeps already-aligned ranges", () => {
+			expect(snapAndCoalesceDirtyRanges([{ start: 100, end: 250 }], segByteStarts, 500)).toEqual([[100, 250]]);
+		});
+
+		it("snaps a pure insert to the term containing it", () => {
+			expect(snapAndCoalesceDirtyRanges([{ start: 120, end: 120 }], segByteStarts, 500)).toEqual([[100, 250]]);
+		});
+
+		it("snaps a pure insert on a boundary to the following term", () => {
+			expect(snapAndCoalesceDirtyRanges([{ start: 250, end: 250 }], segByteStarts, 500)).toEqual([[250, 400]]);
+		});
+
+		it("snaps an append (insert at EOF) to the last term", () => {
+			expect(snapAndCoalesceDirtyRanges([{ start: 500, end: 500 }], segByteStarts, 500)).toEqual([[400, 500]]);
+		});
+
+		it("coalesces overlapping/adjacent snapped ranges", () => {
+			expect(
+				snapAndCoalesceDirtyRanges(
+					[
+						{ start: 120, end: 130 },
+						{ start: 200, end: 260 },
+						{ start: 450, end: 460 },
+					],
+					segByteStarts,
+					500,
+				),
+			).toEqual([[100, 500]]);
+		});
+	});
+
+	describe("assignEditsToWindows", () => {
+		const segByteStarts = [0, 100, 250, 400, 500];
+
+		it("assigns edits to their windows and computes sizes", () => {
+			const editA = { insert: new Blob(["x".repeat(20)]), start: 120, end: 130 };
+			const editB = { insert: new Blob([]), start: 420, end: 450 };
+			const windows = assignEditsToWindows(
+				[
+					{ start: 100, end: 250 },
+					{ start: 400, end: 500 },
+				],
+				[editA, editB],
+				500,
+				segByteStarts,
+			);
+			expect(windows).toHaveLength(2);
+			expect(windows[0].edits).toEqual([editA]);
+			expect(windows[0].newSize).toBe(150 + 20 - 10);
+			expect(windows[0].effectiveEnd).toBe(250);
+			expect(windows[1].edits).toEqual([editB]);
+			expect(windows[1].newSize).toBe(100 - 30);
+		});
+
+		it("extends a mid-term window end to the next term boundary", () => {
+			const edit = { insert: new Blob(["y".repeat(10)]), start: 120, end: 130 };
+			// Server extended the window past the requested [100, 250) to 300 (inside term [250, 400))
+			const windows = assignEditsToWindows([{ start: 100, end: 300 }], [edit], 500, segByteStarts);
+			expect(windows[0].end).toBe(300);
+			expect(windows[0].effectiveEnd).toBe(400);
+			expect(windows[0].newSize).toBe(300);
+			expect(windows[0].hashSplitSize).toBe(200);
+		});
+
+		it("assigns an append to the last window only when it ends at EOF", () => {
+			const append = { insert: new Blob(["z".repeat(50)]), start: 500, end: 500 };
+			const windows = assignEditsToWindows([{ start: 400, end: 500 }], [append], 500, segByteStarts);
+			expect(windows[0].edits).toEqual([append]);
+			expect(windows[0].newSize).toBe(150);
+		});
+
+		it("throws when an edit is not assigned to any window", () => {
+			expect(() =>
+				assignEditsToWindows(
+					[{ start: 0, end: 100 }],
+					[{ insert: new Blob(["a"]), start: 300, end: 310 }],
+					500,
+					segByteStarts,
+				),
+			).toThrow();
+		});
+	});
+
+	describe("windowSegments", () => {
+		it("interleaves original slices and edit inserts up to effectiveEnd", async () => {
+			const original = new Blob(["0123456789"]);
+			const window = {
+				start: 2,
+				end: 6,
+				effectiveEnd: 8,
+				edits: [{ insert: new Blob(["AB"]), start: 4, end: 5 }],
+				newSize: 7,
+				hashSplitSize: 5,
+			};
+			const segments = windowSegments(window, original);
+			const text = (await Promise.all(segments.map((segment) => segment.text()))).join("");
+			expect(text).toBe("23AB567");
+		});
+
+		it("handles appends (insert at EOF)", async () => {
+			const original = new Blob(["0123456789"]);
+			const window = {
+				start: 5,
+				end: 10,
+				effectiveEnd: 10,
+				edits: [{ insert: new Blob(["APPEND"]), start: 10, end: 10 }],
+				newSize: 11,
+				hashSplitSize: 11,
+			};
+			const text = (await Promise.all(windowSegments(window, original).map((segment) => segment.text()))).join("");
+			expect(text).toBe("56789APPEND");
+		});
+	});
+
+	describe("end-to-end hash & representation composition", () => {
+		/**
+		 * Simulates the full flow against the mirrored server logic:
+		 * 1. Build a synthetic original file (chunks split into terms).
+		 * 2. Apply edits, get windows/gaps from the simulated server.
+		 * 3. Simulate the client's re-chunking of each window.
+		 * 4. Verify the composed hash equals `fileHash` of the final chunk list, and the
+		 *    representation splices reused terms and window entries correctly.
+		 */
+		function run(opts: {
+			chunkCounts: number[];
+			chunkSize?: (i: number) => number;
+			/** Replace original chunk indexes [start, end) with the given new chunks */
+			edit: { chunkStart: number; chunkEnd: number; newChunks: TestChunk[] };
+		}) {
+			const { chunks, terms, segByteStarts, size } = makeOriginal(
+				opts.chunkCounts,
+				opts.chunkSize ?? (() => STABLE_SIZE),
+			);
+
+			// Byte range of the edited chunks
+			const editStart = chunks.slice(0, opts.edit.chunkStart).reduce((sum, c) => sum + c.length, 0);
+			const editEnd = chunks.slice(0, opts.edit.chunkEnd).reduce((sum, c) => sum + c.length, 0);
+			const newBytes = opts.edit.newChunks.reduce((sum, c) => sum + c.length, 0);
+			const edits = [{ insert: new Blob([new Uint8Array(newBytes)]), start: editStart, end: editEnd }];
+
+			const dirtyRanges = snapAndCoalesceDirtyRanges(edits, segByteStarts, size);
+			const server = buildServerResponse(chunks, terms, dirtyRanges);
+			const windows = assignEditsToWindows(server.windows, edits, size, segByteStarts);
+
+			const plan: RangeEditPlan = {
+				originalHash: "f".repeat(64),
+				originalSize: size,
+				newSize: size - (editEnd - editStart) + newBytes,
+				terms,
+				segByteStarts,
+				windows,
+				hashRanges: server.hashRanges,
+				gapVerification: server.gapVerification,
+			};
+
+			// Simulate the client's re-chunking of each window: original chunks are reproduced
+			// outside the edited byte range (the chunker resets at chunk boundaries and provably
+			// re-syncs by window.end), the edited region yields the new chunks.
+			const finalChunks: TestChunk[] = [];
+			const chunkStartBytes: number[] = [];
+			let acc = 0;
+			for (const chunk of chunks) {
+				chunkStartBytes.push(acc);
+				acc += chunk.length;
+			}
+			const windowChunks: TestChunk[][] = plan.windows.map((window) => {
+				const result: TestChunk[] = [];
+				for (let i = 0; i < chunks.length; i++) {
+					const start = chunkStartBytes[i];
+					if (start < window.start || start >= window.effectiveEnd) {
+						continue;
+					}
+					if (start === editStart) {
+						result.push(...opts.edit.newChunks);
+					}
+					if (start >= editStart && start < editEnd) {
+						continue; // replaced
+					}
+					result.push(chunks[i]);
+				}
+				return result;
+			});
+
+			// Final full chunk list (for the ground-truth hash)
+			for (let i = 0; i < chunks.length; i++) {
+				if (chunkStartBytes[i] === editStart) {
+					finalChunks.push(...opts.edit.newChunks);
+				}
+				if (chunkStartBytes[i] >= editStart && chunkStartBytes[i] < editEnd) {
+					continue;
+				}
+				finalChunks.push(chunks[i]);
+			}
+
+			const expectedHash = hashToHex(
+				fileHash(finalChunks.map((chunk) => ({ hash: hexToBytes(chunk.hash), length: chunk.length }))),
+			);
+			const composedHash = computeComposedFileHash(plan, windowChunks);
+			expect(composedHash).toBe(expectedHash);
+
+			// Representation: fake one rep entry per window, check term splicing
+			const windowReps = windowChunks.map((wc, i) => [
+				{
+					xorbId: i,
+					indexStart: 0,
+					indexEnd: wc.length,
+					length: wc.reduce((sum, c) => sum + c.length, 0),
+					rangeHash: "b".repeat(64),
+				},
+			]);
+			const representation = composeRepresentation(plan, windowReps);
+
+			return { plan, representation, windows, server };
+		}
+
+		it("mid-file edit with stable chunks (window extends past the requested term)", () => {
+			// 5 terms x 4 stable chunks; edit chunks 6-7 (term 1)
+			const { plan, representation, windows } = run({
+				chunkCounts: [4, 4, 4, 4, 4],
+				edit: { chunkStart: 6, chunkEnd: 7, newChunks: [chunkOf(1000, 17_000), chunkOf(1001, 21_000)] },
+			});
+
+			// Server extends the window 2 chunks past the requested [term1] range → mid-term 2
+			expect(windows).toHaveLength(1);
+			expect(windows[0].end).toBeGreaterThan(plan.segByteStarts[2]);
+			expect(windows[0].end).toBeLessThan(plan.segByteStarts[3]);
+			expect(windows[0].effectiveEnd).toBe(plan.segByteStarts[3]);
+
+			// Representation: term 0 reused, window rep, terms 3..4 reused
+			expect(representation).toHaveLength(4);
+			expect(representation[0].indexStart).toBe(0);
+			expect(representation[0].indexEnd).toBe(4);
+			expect(representation[0].rangeHash).toBe(plan.gapVerification[0]);
+			expect(representation[1].xorbId).toBe(0); // the window rep
+			expect(representation[2].indexStart).toBe(12);
+			expect(representation[3].indexEnd).toBe(20);
+			expect(plan.gapVerification).toHaveLength(3);
+		});
+
+		it("edit at the start of the file", () => {
+			const { representation, windows, plan } = run({
+				chunkCounts: [4, 4, 4],
+				edit: { chunkStart: 0, chunkEnd: 2, newChunks: [chunkOf(2000, 30_000)] },
+			});
+			expect(windows[0].start).toBe(0);
+			expect(representation[0].xorbId).toBe(0);
+			expect(plan.hashRanges[0]).toBeNull();
+		});
+
+		it("edit of the last term (window ends at EOF, no extension)", () => {
+			const { windows, representation, plan } = run({
+				chunkCounts: [4, 4, 4],
+				edit: { chunkStart: 10, chunkEnd: 12, newChunks: [chunkOf(3000, 40_000)] },
+			});
+			expect(windows[0].end).toBe(plan.originalSize);
+			expect(windows[0].effectiveEnd).toBe(plan.originalSize);
+			expect(plan.hashRanges[plan.hashRanges.length - 1]).toBeNull();
+			expect(representation).toHaveLength(3); // terms 0,1 reused + window
+		});
+
+		it("append (new chunks after the last original chunk)", () => {
+			const { chunks, terms, segByteStarts, size } = makeOriginal([4, 4], () => STABLE_SIZE);
+			const appended = [chunkOf(4000, 25_000), chunkOf(4001, 33_000)];
+			const appendBytes = appended.reduce((sum, c) => sum + c.length, 0);
+			const edits = [{ insert: new Blob([new Uint8Array(appendBytes)]), start: size, end: size }];
+
+			const dirtyRanges = snapAndCoalesceDirtyRanges(edits, segByteStarts, size);
+			expect(dirtyRanges).toEqual([[segByteStarts[1], size]]);
+			const server = buildServerResponse(chunks, terms, dirtyRanges);
+			const windows = assignEditsToWindows(server.windows, edits, size, segByteStarts);
+			expect(windows[0].end).toBe(size);
+
+			const plan: RangeEditPlan = {
+				originalHash: "f".repeat(64),
+				originalSize: size,
+				newSize: size + appendBytes,
+				terms,
+				segByteStarts,
+				windows,
+				hashRanges: server.hashRanges,
+				gapVerification: server.gapVerification,
+			};
+
+			// Window re-chunks term 1's chunks + the appended chunks
+			const windowChunks = [[...chunks.slice(4), ...appended]];
+			const finalChunks = [...chunks, ...appended];
+			const expectedHash = hashToHex(
+				fileHash(finalChunks.map((chunk) => ({ hash: hexToBytes(chunk.hash), length: chunk.length }))),
+			);
+			expect(computeComposedFileHash(plan, windowChunks)).toBe(expectedHash);
+
+			const representation = composeRepresentation(plan, [
+				[
+					{
+						xorbId: 0,
+						indexStart: 0,
+						indexEnd: 6,
+						length: windowChunks[0].reduce((sum, c) => sum + c.length, 0),
+						rangeHash: "b".repeat(64),
+					},
+				],
+			]);
+			expect(representation).toHaveLength(2);
+			expect(representation[0].xorbId).toBe(terms[0].hash);
+			expect(representation[0].rangeHash).toBe(plan.gapVerification[0]);
+		});
+
+		it("edit with unstable following chunks (window extends to EOF)", () => {
+			const { windows, plan, representation } = run({
+				chunkCounts: [3, 3, 3],
+				chunkSize: () => UNSTABLE_SIZE,
+				edit: { chunkStart: 3, chunkEnd: 4, newChunks: [chunkOf(5000, 50_000)] },
+			});
+			// No stable pair after the dirty zone → extension runs to EOF
+			expect(windows[0].end).toBe(plan.originalSize);
+			expect(representation).toHaveLength(2); // term 0 reused + window
+			expect(plan.gapVerification).toHaveLength(1);
+		});
+
+		it("cached appends: plan synthesized without API data matches ground truth across rounds", () => {
+			// Fresh file: 10 chunks in two terms ([0..6) xorb A, [6..10) xorb B)
+			const fileChunks = Array.from({ length: 10 }, (_, i) => chunkOf(100 + i, STABLE_SIZE));
+			const rangeHashOf = (chunks: TestChunk[]) => hashToHex(verificationHash(chunks.map((c) => hexToBytes(c.hash))));
+			let representation: RepresentationEntry[] = [
+				{
+					xorbId: "a".repeat(64),
+					indexStart: 0,
+					indexEnd: 6,
+					length: 6 * STABLE_SIZE,
+					rangeHash: rangeHashOf(fileChunks.slice(0, 6)),
+				},
+				{
+					xorbId: "c".repeat(64),
+					indexStart: 0,
+					indexEnd: 4,
+					length: 4 * STABLE_SIZE,
+					rangeHash: rangeHashOf(fileChunks.slice(6)),
+				},
+			];
+
+			const cache: RangeEditCache = new Map();
+			let payload = buildFreshFileCachePayload(fileChunks, representation);
+			expect(payload).toBeDefined();
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			expect(payload?.lastTermChunks).toEqual(fileChunks.slice(6));
+
+			let currentChunks = [...fileChunks];
+			let currentHash = "e".repeat(64);
+			let size = currentChunks.reduce((sum, c) => sum + c.length, 0);
+
+			const storeCacheEntry = () => {
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				const p = payload!;
+				addToRangeEditCache(cache, currentHash, {
+					size: p.size,
+					terms: representation.map((rep) => ({
+						hash: rep.xorbId as string,
+						unpackedLength: rep.length,
+						range: { start: rep.indexStart, end: rep.indexEnd },
+						rangeHash: rep.rangeHash,
+					})),
+					openSubtree: p.openSubtree,
+					lastTermChunks: p.lastTermChunks,
+				});
+			};
+			storeCacheEntry();
+
+			for (let round = 0; round < 3; round++) {
+				// Append: re-chunking the last term + appended data merges the term's last chunk
+				// (previously cut by finalize) with the appended bytes into fresh chunks.
+				const appendBytes = 36_000;
+				const lastTermChunkCount =
+					representation[representation.length - 1].indexEnd - representation[representation.length - 1].indexStart;
+				const lastTerm = currentChunks.slice(currentChunks.length - lastTermChunkCount);
+				const lastChunkLength = lastTerm[lastTerm.length - 1].length;
+				const newTailChunks = [
+					chunkOf(500 + round * 10, 25_000),
+					chunkOf(501 + round * 10, lastChunkLength + appendBytes - 25_000),
+				];
+				const spliced = SplicedBlob.create(new Blob([new Uint8Array(size)]), [
+					{ insert: new Blob([new Uint8Array(appendBytes)]), start: size, end: size },
+				]);
+
+				const plan = planRangeEditFromCache(spliced, currentHash, size, cache);
+				expect(plan).toBeDefined();
+				if (!plan) {
+					throw new Error("unreachable");
+				}
+				expect(plan.windows).toHaveLength(1);
+				expect(plan.newSize).toBe(size + appendBytes);
+
+				const windowChunks = [...lastTerm.slice(0, -1), ...newTailChunks];
+				const nextChunks = [...currentChunks.slice(0, currentChunks.length - lastTermChunkCount), ...windowChunks];
+				const newSize = nextChunks.reduce((sum, c) => sum + c.length, 0);
+				expect(newSize).toBe(size + appendBytes);
+
+				const expected = hashToHex(fileHash(nextChunks.map((c) => ({ hash: hexToBytes(c.hash), length: c.length }))));
+				expect(computeComposedFileHash(plan, [windowChunks])).toBe(expected);
+
+				// Representation: all terms except the last are reused via their cached rangeHashes
+				const windowRep = [
+					{
+						xorbId: `${round}`.repeat(64).slice(0, 64),
+						indexStart: 0,
+						indexEnd: windowChunks.length,
+						length: windowChunks.reduce((sum, c) => sum + c.length, 0),
+						rangeHash: rangeHashOf(windowChunks),
+					},
+				];
+				const composed = composeRepresentation(plan, [windowRep]);
+				expect(composed).toHaveLength(representation.length);
+				expect(composed.slice(0, -1)).toEqual(
+					representation.slice(0, -1).map((rep) => ({
+						xorbId: rep.xorbId,
+						indexStart: rep.indexStart,
+						indexEnd: rep.indexEnd,
+						length: rep.length,
+						rangeHash: rep.rangeHash,
+					})),
+				);
+
+				// Next round: cache from this round's payload
+				payload = buildRangeEditCachePayload(plan, [windowChunks], composed);
+				expect(payload).toBeDefined();
+				representation = composed;
+				currentChunks = nextChunks;
+				currentHash = expected + round; // any unique key
+				size = newSize;
+				storeCacheEntry();
+			}
+		});
+
+		it("throws when window chunks do not re-sync at the hash split point", () => {
+			const { chunks, terms, segByteStarts, size } = makeOriginal([4, 4, 4], () => STABLE_SIZE);
+			const edits = [{ insert: new Blob([new Uint8Array(100)]), start: 0, end: 100 }];
+			const dirtyRanges = snapAndCoalesceDirtyRanges(edits, segByteStarts, size);
+			const server = buildServerResponse(chunks, terms, dirtyRanges);
+			const windows = assignEditsToWindows(server.windows, edits, size, segByteStarts);
+			const plan: RangeEditPlan = {
+				originalHash: "f".repeat(64),
+				originalSize: size,
+				newSize: size,
+				terms,
+				segByteStarts,
+				windows,
+				hashRanges: server.hashRanges,
+				gapVerification: server.gapVerification,
+			};
+			// One big chunk covering the whole window: no boundary at the split point
+			expect(() => computeComposedFileHash(plan, [[chunkOf(6000, windows[0].newSize)]])).toThrow(/re-sync/);
+		});
+	});
+});

--- a/packages/hub/src/utils/rangeEdit.ts
+++ b/packages/hub/src/utils/rangeEdit.ts
@@ -1,0 +1,709 @@
+import { MerkleHashSubtree, hashToHex, hexToBytes, hmac } from "@huggingface/xetchunk-wasm";
+import type { MerkleHashSubtreeJson } from "@huggingface/xetchunk-wasm";
+import type { ReconstructionInfo, XetBlob } from "./XetBlob";
+import type { SplicedBlob } from "./SplicedBlob";
+import { xetWriteToken, type XetWriteTokenParams } from "./xetWriteToken";
+
+/**
+ * In-memory state of a file previously written through the range-edit path, keyed by its
+ * xet hash. Lets a subsequent append (or edit of the file's last term) skip the
+ * reconstruction and file-chunk-hashes API calls entirely: the partial merkle state and
+ * verification hashes are already known.
+ *
+ * Pass the same {@link RangeEditCache} instance to successive `commit` calls that append to
+ * the same file to avoid calling the CAS metadata APIs on every append.
+ */
+export type RangeEditCache = Map<string, RangeEditCacheEntry>;
+
+export interface RangeEditCacheEntry {
+	/** Total file size in bytes */
+	size: number;
+	/** The file's terms, in order, with their verification range hashes */
+	terms: Array<OriginalTerm & { rangeHash: string }>;
+	/**
+	 * Partial merkle state of all chunks except the last term's
+	 * (`at_start: true, at_end: false`); `null` when the file has a single term.
+	 */
+	openSubtree: MerkleHashSubtreeJson | null;
+	/** The last term's chunks (hash + length) */
+	lastTermChunks: Array<{ hash: string; length: number }>;
+}
+
+const RANGE_EDIT_CACHE_MAX_ENTRIES = 10;
+
+export function addToRangeEditCache(cache: RangeEditCache, xetHash: string, entry: RangeEditCacheEntry): void {
+	cache.delete(xetHash);
+	cache.set(xetHash, entry);
+	while (cache.size > RANGE_EDIT_CACHE_MAX_ENTRIES) {
+		const oldest = cache.keys().next().value;
+		if (oldest === undefined) {
+			break;
+		}
+		cache.delete(oldest);
+	}
+}
+
+/**
+ * Support for editing xet files without downloading the parts of the file that
+ * are not modified, using the CAS APIs:
+ *
+ * - `GET /v2/reconstructions/{file_id}`: the original file's term/segment layout.
+ * - `GET /v2/file-chunk-hashes/{file_id}` with the `X-Range-Dirty` header: chunk-aligned
+ *   windows to re-chunk, {@link MerkleHashSubtree} summaries of the untouched gaps and
+ *   verification hashes for the untouched terms.
+ *
+ * This mirrors xet-core's `upload_ranges` (`xet_data/src/processing/range_upload.rs`).
+ */
+
+/** One chunk-aligned dirty window of a file, returned by `GET /v2/file-chunk-hashes/{file_id}`. */
+export interface ChunkWindow {
+	/** `[start, end)` in original-file byte offsets, expanded outward to stable chunk boundaries */
+	dirtyByteRange: [number, number];
+}
+
+/** Response shape of `GET /v2/file-chunk-hashes/{file_id}` */
+export interface FileChunkHashesResponse {
+	totalChunks: number;
+	fileSize: number;
+	windows: ChunkWindow[];
+	/**
+	 * `windows.length + 1` entries: partial merkle summaries of the clean gaps before,
+	 * between and after the windows. `null` when the gap is empty.
+	 */
+	hashRanges: Array<MerkleHashSubtreeJson | null>;
+	/**
+	 * One verification range hash per **stable original term** (a term that lies entirely
+	 * outside every window, in term order). These become the `rangeHash` of reused terms.
+	 */
+	gapVerification: string[];
+}
+
+export interface OriginalTerm {
+	/** Xorb hash (hex) */
+	hash: string;
+	/** Unpacked byte length of the term */
+	unpackedLength: number;
+	/** Chunk index range within the xorb, end-exclusive */
+	range: { start: number; end: number };
+}
+
+/** A splice operation in original-file coordinates, assigned to a window */
+export interface RangeEditOperation {
+	insert: Blob;
+	start: number;
+	end: number;
+}
+
+export interface RangeEditWindow {
+	/** Window start, in original-file byte offsets. Always a term boundary. */
+	start: number;
+	/**
+	 * Window end as returned by the server, in original-file byte offsets. Always a chunk
+	 * boundary (the server extends the requested range until the chunker provably re-syncs),
+	 * but **not necessarily a term boundary**.
+	 */
+	end: number;
+	/**
+	 * Window end extended to the next term boundary (or file end), in original-file byte
+	 * offsets. The server's stable-boundary extension can make `end` land in the middle of
+	 * a term; that term can then neither be reused (no verification hash is provided for a
+	 * partially-covered term) nor partially referenced. So the client re-chunks up to the
+	 * next term boundary: since the chunker has provably re-synced by `end` and resets its
+	 * state at every chunk boundary, the chunks produced for `[end, effectiveEnd)` are
+	 * bit-identical to the original file's chunks there — keeping the composed hash
+	 * consistent with the server's gap subtrees, which cover `[end, …)`.
+	 */
+	effectiveEnd: number;
+	/** The splice operations that land inside this window, sorted by start */
+	edits: RangeEditOperation[];
+	/** Size of the window data `[start, effectiveEnd)` after edits are applied */
+	newSize: number;
+	/**
+	 * Size of the window data `[start, end)` after edits are applied. When computing the
+	 * composed file hash, the window's chunk list must be split at this length: chunks
+	 * before it pair with the server's gap subtrees (which start at `end`), chunks after it
+	 * are original-file chunks only used for the shard representation.
+	 */
+	hashSplitSize: number;
+}
+
+export interface RangeEditPlan {
+	/** Xet hash of the original file */
+	originalHash: string;
+	originalSize: number;
+	/** New total file size */
+	newSize: number;
+	/** The original file's terms (segments), in order */
+	terms: OriginalTerm[];
+	/** `terms.length + 1` entries; `segByteStarts[i]` is the first byte of term `i` */
+	segByteStarts: number[];
+	windows: RangeEditWindow[];
+	hashRanges: Array<MerkleHashSubtreeJson | null>;
+	gapVerification: string[];
+}
+
+/**
+ * Plan a range edit for a {@link SplicedBlob} whose original content is a {@link XetBlob}.
+ *
+ * Returns `undefined` when the server cannot provide the needed metadata (eg the original
+ * file is not registered in the repo the write token is scoped to) — callers should then
+ * fall back to processing the blob in full.
+ */
+export async function planRangeEdit(
+	spliced: SplicedBlob,
+	original: XetBlob,
+	params: XetWriteTokenParams & { rangeEditCache?: RangeEditCache },
+): Promise<RangeEditPlan | undefined> {
+	const originalHash = original.hash;
+	const originalSize = original.size;
+	if (!originalHash || originalSize === 0 || original.start !== 0) {
+		return undefined;
+	}
+
+	// Appends (and edits confined to the file's last term) can be planned entirely from
+	// the in-memory state of a previous range-edit upload — no API call needed.
+	if (params.rangeEditCache) {
+		const cached = planRangeEditFromCache(spliced, originalHash, originalSize, params.rangeEditCache);
+		if (cached) {
+			return cached;
+		}
+	}
+
+	const token = await xetWriteToken(params);
+
+	// 1. Fetch the original file's term layout
+	const reconstructionResp = await (params.fetch ?? fetch)(`${token.casUrl}/v2/reconstructions/${originalHash}`, {
+		headers: { Authorization: `Bearer ${token.accessToken}` },
+	});
+	if (!reconstructionResp.ok) {
+		return undefined;
+	}
+	const reconstruction = (await reconstructionResp.json()) as ReconstructionInfo;
+	const terms: OriginalTerm[] = reconstruction.terms.map((term) => ({
+		hash: term.hash,
+		unpackedLength: term.unpacked_length,
+		range: { start: term.range.start, end: term.range.end },
+	}));
+
+	const segByteStarts: number[] = [0];
+	let acc = 0;
+	for (const term of terms) {
+		acc += term.unpackedLength;
+		segByteStarts.push(acc);
+	}
+	if (acc !== originalSize) {
+		throw new Error(
+			`Original file size mismatch: reconstruction reports ${acc} bytes but the blob is ${originalSize} bytes`,
+		);
+	}
+
+	// 2. Snap the dirty ranges to term boundaries and coalesce them
+	const edits = spliced.spliceOperations;
+	const dirtyRanges = snapAndCoalesceDirtyRanges(edits, segByteStarts, originalSize);
+	if (dirtyRanges.length === 0) {
+		return undefined;
+	}
+
+	// 3. Ask the server for windows + gap hash data
+	const rangeHeader = "bytes=" + dirtyRanges.map(([start, end]) => `${start}-${end - 1}`).join(",");
+	const resp = await (params.fetch ?? fetch)(`${token.casUrl}/v2/file-chunk-hashes/${originalHash}`, {
+		headers: {
+			Authorization: `Bearer ${token.accessToken}`,
+			"X-Range-Dirty": rangeHeader,
+		},
+	});
+	if (!resp.ok) {
+		return undefined;
+	}
+	const chunkHashes = (await resp.json()) as FileChunkHashesResponse;
+
+	if (chunkHashes.windows.length === 0) {
+		throw new Error("Server returned no windows for range edit");
+	}
+	if (chunkHashes.hashRanges.length !== chunkHashes.windows.length + 1) {
+		throw new Error(
+			`Server returned ${chunkHashes.hashRanges.length} hashRanges, expected ${chunkHashes.windows.length + 1}`,
+		);
+	}
+
+	// 4. Assign the edits to the windows
+	const windows = assignEditsToWindows(
+		chunkHashes.windows.map((w) => ({ start: w.dirtyByteRange[0], end: w.dirtyByteRange[1] })),
+		edits,
+		originalSize,
+		segByteStarts,
+	);
+
+	return {
+		originalHash,
+		originalSize,
+		newSize: spliced.size,
+		terms,
+		segByteStarts,
+		windows,
+		hashRanges: chunkHashes.hashRanges,
+		gapVerification: chunkHashes.gapVerification,
+	};
+}
+
+/**
+ * Plan an edit purely from cached file state, without any API call. Only possible when
+ * every edit lands within the file's last term (the common case being an append), since the
+ * cache keeps the partial merkle state of everything before it plus the last term's chunks.
+ */
+export function planRangeEditFromCache(
+	spliced: SplicedBlob,
+	originalHash: string,
+	originalSize: number,
+	cache: RangeEditCache,
+): RangeEditPlan | undefined {
+	const entry = cache.get(originalHash);
+	if (!entry || entry.size !== originalSize || entry.terms.length === 0) {
+		return undefined;
+	}
+
+	const edits = spliced.spliceOperations;
+	if (edits.length === 0) {
+		return undefined;
+	}
+
+	const lastTerm = entry.terms[entry.terms.length - 1];
+	const lastTermStart = originalSize - lastTerm.unpackedLength;
+
+	// All edits must be confined to the last term (appends have start === end === size)
+	for (const edit of edits) {
+		const editStart = edit.start === edit.end && edit.start === originalSize ? originalSize : edit.start;
+		if (editStart < lastTermStart) {
+			return undefined;
+		}
+	}
+
+	const segByteStarts: number[] = [0];
+	let acc = 0;
+	for (const term of entry.terms) {
+		acc += term.unpackedLength;
+		segByteStarts.push(acc);
+	}
+
+	const windows = assignEditsToWindows(
+		[{ start: lastTermStart, end: originalSize }],
+		edits,
+		originalSize,
+		segByteStarts,
+	);
+
+	return {
+		originalHash,
+		originalSize,
+		newSize: spliced.size,
+		terms: entry.terms,
+		segByteStarts,
+		windows,
+		hashRanges: [entry.openSubtree, null],
+		gapVerification: entry.terms.slice(0, -1).map((term) => term.rangeHash),
+	};
+}
+
+/**
+ * Snap each edit's dirty range to the enclosing term boundaries, then sort and coalesce.
+ *
+ * Snapping to *term* boundaries (rather than chunk boundaries) lets us swap whole terms
+ * during composition. Term edges are chunk edges, so the server's chunk-aligned windows
+ * come back identical to the snapped ranges.
+ */
+export function snapAndCoalesceDirtyRanges(
+	edits: Array<{ start: number; end: number }>,
+	segByteStarts: number[],
+	originalSize: number,
+): Array<[number, number]> {
+	const nSegs = segByteStarts.length - 1;
+
+	/** Largest term-start byte that is `<= byte` */
+	const snapStart = (byte: number): number => {
+		let idx = 0;
+		while (idx + 1 < segByteStarts.length && segByteStarts[idx + 1] <= byte) {
+			idx++;
+		}
+		return segByteStarts[idx];
+	};
+	/** Smallest term-start byte that is `>= byte` */
+	const snapEnd = (byte: number): number => {
+		let idx = 0;
+		while (idx < segByteStarts.length && segByteStarts[idx] < byte) {
+			idx++;
+		}
+		return segByteStarts[Math.min(idx, segByteStarts.length - 1)];
+	};
+
+	const snapped: Array<[number, number]> = [];
+	for (const edit of edits) {
+		if (edit.start === edit.end) {
+			// Pure insert: pick the term containing the insert position. At end-of-file,
+			// fall back to the last term.
+			if (edit.start === originalSize) {
+				snapped.push([segByteStarts[nSegs - 1], segByteStarts[nSegs]]);
+			} else {
+				snapped.push([snapStart(edit.start), snapEnd(edit.start + 1)]);
+			}
+		} else {
+			snapped.push([snapStart(edit.start), snapEnd(edit.end)]);
+		}
+	}
+
+	snapped.sort((a, b) => a[0] - b[0]);
+	const coalesced: Array<[number, number]> = [];
+	for (const range of snapped) {
+		const last = coalesced[coalesced.length - 1];
+		if (last && range[0] <= last[1]) {
+			last[1] = Math.max(last[1], range[1]);
+			continue;
+		}
+		coalesced.push([range[0], range[1]]);
+	}
+	return coalesced;
+}
+
+/**
+ * Assign each edit to exactly one window, and compute each window's effective end (the
+ * server's window end extended to the next term boundary, see
+ * {@link RangeEditWindow.effectiveEnd}).
+ *
+ * A pure insert at exactly `window.end` belongs to that window only when
+ * `window.end === originalSize` (no later window can take it); anywhere else it belongs to
+ * the next window starting at that byte.
+ *
+ * Throws when an edit cannot be assigned (the server returned narrower windows than
+ * requested), since silently dropping it would produce a corrupt file.
+ */
+export function assignEditsToWindows(
+	windows: Array<{ start: number; end: number }>,
+	edits: RangeEditOperation[],
+	originalSize: number,
+	segByteStarts: number[],
+): RangeEditWindow[] {
+	let editIdx = 0;
+	const result: RangeEditWindow[] = [];
+
+	for (const [windowIdx, window] of windows.entries()) {
+		const assigned: RangeEditOperation[] = [];
+		while (editIdx < edits.length) {
+			const edit = edits[editIdx];
+			const belongsHere =
+				edit.start === edit.end
+					? edit.start < window.end || (edit.start === window.end && window.end === originalSize)
+					: edit.end <= window.end;
+			if (!belongsHere) {
+				break;
+			}
+			if (edit.start < window.start) {
+				throw new Error(
+					`Edit at [${edit.start}, ${edit.end}) starts before its window [${window.start}, ${window.end})`,
+				);
+			}
+			assigned.push(edit);
+			editIdx++;
+		}
+
+		let removed = 0;
+		let added = 0;
+		for (const edit of assigned) {
+			removed += edit.end - edit.start;
+			added += edit.insert.size;
+		}
+
+		// Extend the window to the next term boundary >= window.end. The last entry of
+		// segByteStarts is the file size and windows are clamped to it, so this always exists.
+		const effectiveEnd = segByteStarts.find((segStart) => segStart >= window.end);
+		if (effectiveEnd === undefined) {
+			throw new Error(`Window end ${window.end} exceeds the file size ${segByteStarts[segByteStarts.length - 1]}`);
+		}
+		const nextWindowStart = windows[windowIdx + 1]?.start;
+		if (nextWindowStart !== undefined && effectiveEnd > nextWindowStart) {
+			throw new Error(
+				`Window [${window.start}, ${window.end}) extends to term boundary ${effectiveEnd}, overlapping the next window at ${nextWindowStart}`,
+			);
+		}
+
+		result.push({
+			start: window.start,
+			end: window.end,
+			effectiveEnd,
+			edits: assigned,
+			newSize: effectiveEnd - window.start + added - removed,
+			hashSplitSize: window.end - window.start + added - removed,
+		});
+	}
+
+	if (editIdx !== edits.length) {
+		throw new Error(`${edits.length - editIdx} edits were not assigned to any window`);
+	}
+
+	return result;
+}
+
+/**
+ * The sequence of blobs whose concatenation is the new content of a window
+ * (`[start, effectiveEnd)` with the edits applied): original slices between edits, and the
+ * edits' insert blobs.
+ */
+export function windowSegments(window: RangeEditWindow, original: Blob): Blob[] {
+	const segments: Blob[] = [];
+	let cursor = window.start;
+	for (const edit of window.edits) {
+		if (cursor < edit.start) {
+			segments.push(original.slice(cursor, edit.start));
+		}
+		if (edit.insert.size > 0) {
+			segments.push(edit.insert);
+		}
+		cursor = edit.end;
+	}
+	if (cursor < window.effectiveEnd) {
+		segments.push(original.slice(cursor, window.effectiveEnd));
+	}
+	return segments;
+}
+
+export interface RepresentationEntry {
+	xorbId: number | string;
+	indexStart: number;
+	indexEnd: number;
+	length: number;
+	rangeHash: string;
+}
+
+/**
+ * Splice the windows' representations into the original term list: original terms outside
+ * every window are reused as-is (their `rangeHash` comes from `gapVerification`), terms
+ * covered by a window are replaced by the window's freshly-built representation.
+ */
+export function composeRepresentation(
+	plan: RangeEditPlan,
+	windowRepresentations: RepresentationEntry[][],
+): RepresentationEntry[] {
+	const representation: RepresentationEntry[] = [];
+	const nSegs = plan.terms.length;
+	let segIdx = 0;
+	let gapIdx = 0;
+
+	const reuseTerm = (idx: number): void => {
+		const rangeHash = plan.gapVerification[gapIdx];
+		if (rangeHash === undefined) {
+			throw new Error(`Ran out of gapVerification entries at stable term ${idx}`);
+		}
+		gapIdx++;
+		representation.push({
+			xorbId: plan.terms[idx].hash,
+			indexStart: plan.terms[idx].range.start,
+			indexEnd: plan.terms[idx].range.end,
+			length: plan.terms[idx].unpackedLength,
+			rangeHash,
+		});
+	};
+
+	for (let i = 0; i < plan.windows.length; i++) {
+		const window = plan.windows[i];
+		while (segIdx < nSegs && plan.segByteStarts[segIdx] < window.start) {
+			if (plan.segByteStarts[segIdx + 1] > window.start) {
+				throw new Error(
+					`Window starting at ${window.start} straddles term ${segIdx} (${plan.segByteStarts[segIdx]}..${plan.segByteStarts[segIdx + 1]})`,
+				);
+			}
+			reuseTerm(segIdx);
+			segIdx++;
+		}
+		// Terms covered by [window.start, window.effectiveEnd) are replaced by the window's
+		// representation. effectiveEnd is a term boundary, so no term is partially covered.
+		while (segIdx < nSegs && plan.segByteStarts[segIdx] < window.effectiveEnd) {
+			segIdx++;
+		}
+		representation.push(...windowRepresentations[i]);
+	}
+	while (segIdx < nSegs) {
+		reuseTerm(segIdx);
+		segIdx++;
+	}
+	if (gapIdx < plan.gapVerification.length) {
+		throw new Error(
+			`Server returned ${plan.gapVerification.length} gapVerification entries but only ${gapIdx} stable terms were emitted`,
+		);
+	}
+
+	return representation;
+}
+
+const ZERO_KEY = new Uint8Array(32);
+
+/**
+ * Index into `chunks` such that the chunks before it sum to exactly `size` bytes.
+ * Throws when `size` does not land on a chunk boundary.
+ */
+function chunkSplitIndex(chunks: Array<{ hash: string; length: number }>, size: number, context: string): number {
+	let cumulative = 0;
+	let index = 0;
+	while (index < chunks.length && cumulative < size) {
+		cumulative += chunks[index].length;
+		index++;
+	}
+	if (cumulative !== size) {
+		throw new Error(`${context}: expected a chunk boundary at ${size} bytes, got ${cumulative}`);
+	}
+	return index;
+}
+
+/**
+ * Data attached to a file event so {@link addToRangeEditCache} can be fed once local xorb
+ * ids are resolved to hashes (in `uploadShards`).
+ */
+export interface RangeEditCachePayload {
+	size: number;
+	openSubtree: MerkleHashSubtreeJson | null;
+	lastTermChunks: Array<{ hash: string; length: number }>;
+}
+
+/**
+ * Build the cache payload after a range-edit upload: the last term's chunks plus an open
+ * subtree over everything before them. Returns `undefined` when the file's last term is a
+ * reused original term (its chunks are unknown).
+ */
+export function buildRangeEditCachePayload(
+	plan: RangeEditPlan,
+	windowChunks: Array<Array<{ hash: string; length: number }>>,
+	representation: RepresentationEntry[],
+): RangeEditCachePayload | undefined {
+	// The trailing gap must be empty, ie the last window ends the file — otherwise the last
+	// term is a reused original term whose chunks we don't know.
+	if (plan.hashRanges[plan.hashRanges.length - 1] !== null) {
+		return undefined;
+	}
+	const lastRep = representation[representation.length - 1];
+	const lastWindow = windowChunks[windowChunks.length - 1];
+	if (!lastRep || !lastWindow) {
+		return undefined;
+	}
+	const lastTermChunkCount = lastRep.indexEnd - lastRep.indexStart;
+	if (lastTermChunkCount <= 0 || lastTermChunkCount > lastWindow.length) {
+		return undefined;
+	}
+	const lastTermChunks = lastWindow.slice(lastWindow.length - lastTermChunkCount);
+
+	const hashRanges = plan.hashRanges.map((json) => (json === null ? null : MerkleHashSubtree.fromJSON(json)));
+	const firstWindowAtStart = hashRanges[0] === null;
+	const sequence: MerkleHashSubtree[] = [];
+	for (let i = 0; i < plan.windows.length; i++) {
+		const gap = hashRanges[i];
+		if (gap !== null && gap !== undefined) {
+			sequence.push(gap);
+		}
+		const splitIndex = chunkSplitIndex(windowChunks[i], plan.windows[i].hashSplitSize, "buildRangeEditCachePayload");
+		let chunks = windowChunks[i].slice(0, splitIndex);
+		if (i === plan.windows.length - 1) {
+			// Exclude the last term's chunks from the open subtree
+			chunks = chunks.slice(0, chunks.length - lastTermChunkCount);
+		}
+		if (chunks.length > 0 || (i === 0 && firstWindowAtStart)) {
+			sequence.push(
+				MerkleHashSubtree.fromChunks(
+					i === 0 && firstWindowAtStart,
+					chunks.map((chunk) => ({ hash: hexToBytes(chunk.hash), length: chunk.length })),
+					false,
+				),
+			);
+		}
+	}
+
+	const openSubtree = sequence.length > 0 ? MerkleHashSubtree.merge(sequence) : null;
+	return {
+		size: plan.newSize,
+		openSubtree: openSubtree && !openSubtree.isEmpty ? openSubtree.toJSON() : null,
+		lastTermChunks,
+	};
+}
+
+/**
+ * Build the cache payload after a full (non-edit) upload of a file, so that subsequent
+ * appends can skip the CAS metadata calls too.
+ */
+export function buildFreshFileCachePayload(
+	fileChunks: Array<{ hash: string; length: number }>,
+	representation: RepresentationEntry[],
+): RangeEditCachePayload | undefined {
+	const lastRep = representation[representation.length - 1];
+	if (!lastRep) {
+		return undefined;
+	}
+	const lastTermChunkCount = lastRep.indexEnd - lastRep.indexStart;
+	if (lastTermChunkCount <= 0 || lastTermChunkCount > fileChunks.length) {
+		return undefined;
+	}
+	const lastTermChunks = fileChunks.slice(fileChunks.length - lastTermChunkCount);
+	const rest = fileChunks.slice(0, fileChunks.length - lastTermChunkCount);
+	const openSubtree =
+		rest.length > 0
+			? MerkleHashSubtree.fromChunks(
+					true,
+					rest.map((chunk) => ({ hash: hexToBytes(chunk.hash), length: chunk.length })),
+					false,
+				).toJSON()
+			: null;
+	return {
+		size: fileChunks.reduce((sum, chunk) => sum + chunk.length, 0),
+		openSubtree,
+		lastTermChunks,
+	};
+}
+
+/**
+ * Compute the new file hash by merging the gap subtrees with subtrees built from the
+ * windows' freshly-computed chunks: `[gap0, window0, gap1, window1, ..., gapN]`.
+ */
+export function computeComposedFileHash(
+	plan: RangeEditPlan,
+	windowChunks: Array<Array<{ hash: string; length: number }>>,
+): string {
+	// Empty content is the one exception: `file_hash([])` short-circuits to the zero hash
+	// without HMAC.
+	if (plan.newSize === 0) {
+		return "0".repeat(64);
+	}
+
+	const hashRanges = plan.hashRanges.map((json) => (json === null ? null : MerkleHashSubtree.fromJSON(json)));
+	const trailingGap = hashRanges[hashRanges.length - 1];
+	const firstWindowAtStart = hashRanges[0] === null;
+	const lastWindowAtEnd = trailingGap === null;
+	const lastIdx = plan.windows.length - 1;
+
+	const mergeSequence: MerkleHashSubtree[] = [];
+	for (let i = 0; i < plan.windows.length; i++) {
+		const gap = hashRanges[i];
+		if (gap !== null) {
+			mergeSequence.push(gap);
+		}
+		// The server's gap subtrees cover the original chunks from `window.end` onwards, so
+		// only the window chunks up to `hashSplitSize` participate in the merge; the chunks
+		// past it re-produce original chunks already accounted for by the following gap.
+		const window = plan.windows[i];
+		const splitIndex = chunkSplitIndex(
+			windowChunks[i],
+			window.hashSplitSize,
+			`Window [${window.start}, ${window.end}) chunk boundaries did not re-sync at the window end`,
+		);
+		mergeSequence.push(
+			MerkleHashSubtree.fromChunks(
+				i === 0 && firstWindowAtStart,
+				windowChunks[i].slice(0, splitIndex).map((chunk) => ({ hash: hexToBytes(chunk.hash), length: chunk.length })),
+				i === lastIdx && lastWindowAtEnd,
+			),
+		);
+	}
+	if (trailingGap !== null && trailingGap !== undefined) {
+		mergeSequence.push(trailingGap);
+	}
+
+	const merged = MerkleHashSubtree.merge(mergeSequence);
+	const aggregated = merged.finalHash();
+	if (aggregated === undefined) {
+		throw new Error("Merged subtree is not fully closed; cannot derive the file hash");
+	}
+	return hashToHex(hmac(aggregated, ZERO_KEY));
+}

--- a/packages/hub/src/utils/uploadShards.ts
+++ b/packages/hub/src/utils/uploadShards.ts
@@ -1,6 +1,8 @@
 import { createApiError } from "../error";
 import type { RepoId } from "../types/public";
 import { createXorbs } from "./createXorbs";
+import { addToRangeEditCache } from "./rangeEdit";
+import type { RangeEditCache } from "./rangeEdit";
 import { sum } from "./sum";
 import { xetWriteToken } from "./xetWriteToken";
 
@@ -68,6 +70,12 @@ interface UploadShardsParams {
 	rev: string;
 	isPullRequest?: boolean;
 	yieldCallback?: (event: { event: "fileProgress"; path: string; progress: number }) => void;
+	/**
+	 * When provided, files written through this cache can later be appended to (or have
+	 * their last term edited) without any CAS metadata API call: the partial merkle state
+	 * needed is kept in memory. See {@link RangeEditCache}.
+	 */
+	rangeEditCache?: RangeEditCache;
 }
 
 /**
@@ -172,6 +180,21 @@ export async function* uploadShards(
 					sha256: output.sha256,
 					dedupRatio: output.dedupRatio,
 				}; // Maybe wait until shard is uploaded before yielding.
+
+				if (params.rangeEditCache && output.rangeEditCachePayload) {
+					// Local xorb ids can only be resolved here, where the xorb hashes are known
+					addToRangeEditCache(params.rangeEditCache, output.hash, {
+						size: output.rangeEditCachePayload.size,
+						terms: output.representation.map((rep) => ({
+							hash: typeof rep.xorbId === "number" ? xorbHashes[rep.xorbId] : rep.xorbId,
+							unpackedLength: rep.length,
+							range: { start: rep.indexStart, end: rep.indexEnd },
+							rangeHash: rep.rangeHash,
+						})),
+						openSubtree: output.rangeEditCachePayload.openSubtree,
+						lastTermChunks: output.rangeEditCachePayload.lastTermChunks,
+					});
+				}
 
 				if (seenFileXetHashes.has(output.hash)) {
 					break;

--- a/packages/xetchunk-wasm/README.md
+++ b/packages/xetchunk-wasm/README.md
@@ -48,6 +48,10 @@ All hash functions return `Uint8Array` (32 bytes). Use `hashToHex()` to convert 
 - **`hmac(hash: Uint8Array, key: Uint8Array): Uint8Array`** — BLAKE3 keyed hash (matches Rust `DataHash::hmac`).
 - **`verificationHash(chunkHashes: Uint8Array[]): Uint8Array`** — Range verification hash (matches Rust `range_hash_from_chunks`).
 
+### Partial merkle state
+
+- **`MerkleHashSubtree`** — Compact (O(log n)) partially-aggregated merkle state over a contiguous range of chunks, matching Rust's [`MerkleHashSubtree`](https://github.com/huggingface/xet-core/blob/main/xet_core_structures/src/merklehash/merkle_hash_subtree.rs). Build with `MerkleHashSubtree.fromChunks(atStart, chunks, atEnd)`, combine adjacent ranges with `mergeInto()` / `MerkleHashSubtree.merge()`, and read the aggregated hash with `finalHash()` once the range covers the whole file (apply `hmac(hash, zeroKey)` to get the file hash). `toJSON()` / `fromJSON()` are byte-compatible with serde's human-readable serialization, ie with the `hashRanges` entries of the CAS server's `GET /v2/file-chunk-hashes` responses. Useful for editing or appending to a file without knowing all of its chunk hashes.
+
 ### Utilities
 
 - **`hashToHex(hash: Uint8Array): string`** — Convert 32-byte hash to hex string.

--- a/packages/xetchunk-wasm/src/index.ts
+++ b/packages/xetchunk-wasm/src/index.ts
@@ -1,3 +1,10 @@
 export { createChunker, finalize, nextBlock, getChunks, hashToHex, hexToBytes, type Chunk } from "./xet-chunker.js";
 export { xorbHash } from "./xorb-hash.js";
 export { fileHash, hmac, verificationHash } from "./hash-utils.js";
+export {
+	MerkleHashSubtree,
+	findStableStart,
+	findStableEnd,
+	type MerkleHashSubtreeJson,
+	type SubtreeNode,
+} from "./merkle-hash-subtree.js";

--- a/packages/xetchunk-wasm/src/merkle-hash-subtree.ts
+++ b/packages/xetchunk-wasm/src/merkle-hash-subtree.ts
@@ -1,0 +1,522 @@
+import type { Chunk } from "./xet-chunker.js";
+import { hashToHex, hexToBytes } from "./xet-chunker.js";
+import { isNaturalCut, mergedHashOfSequence } from "./xorb-hash.js";
+
+/**
+ * TypeScript port of Rust's `MerkleHashSubtree`
+ * (xet-core: `xet_core_structures/src/merklehash/merkle_hash_subtree.rs`).
+ *
+ * Compact representation of a contiguous range of chunk hashes with O(log n)
+ * storage — a "hump" of partially-aggregated merkle nodes. Adjacent ranges can
+ * be merged without reconstructing the full chunk list, and once a subtree
+ * covers the whole file (`atStart && atEnd`), `finalHash()` equals
+ * `aggregated_node_hash(all_chunks)` (i.e. the xorb hash of the chunk list;
+ * apply `hmac(hash, zeroKey)` to get the file hash).
+ *
+ * The JSON form (`toJSON`/`fromJSON`) is byte-compatible with serde's
+ * human-readable serialization, which is what the CAS server returns in
+ * `GET /v2/file-chunk-hashes` responses (`hashRanges` entries):
+ *
+ * ```json
+ * {
+ *   "nodes": [{ "hash": "<64 hex chars>", "size": 123 }],
+ *   "levels": [[leftCount, rightCount]],
+ *   "at_start": true,
+ *   "at_end": false
+ * }
+ * ```
+ */
+
+/** A node of the aggregation tree: at level 0 a chunk, above that a merged group. */
+export type SubtreeNode = Chunk;
+
+/** Serde-compatible JSON shape (human-readable form). */
+export interface MerkleHashSubtreeJson {
+	nodes: Array<{ hash: string; size: number }>;
+	levels: Array<[number, number]>;
+	at_start: boolean;
+	at_end: boolean;
+}
+
+/** Groups always have at least 2 nodes. */
+const MIN_GROUP_SIZE = 2;
+/** Groups have at most 2*BF+1 = 9 nodes. */
+const MAX_GROUP_SIZE = 9;
+
+/**
+ * Find the next cut point in a sequence of nodes at which to break,
+ * mirroring Rust's `next_merge_cut`. Returns the group length starting at
+ * `start` within `nodes` (bounded by `end`, exclusive).
+ */
+function nextMergeCut(nodes: SubtreeNode[], start: number, end: number): number {
+	const len = end - start;
+	if (len <= MIN_GROUP_SIZE) {
+		return len;
+	}
+
+	const lim = Math.min(MAX_GROUP_SIZE, len);
+	for (let i = MIN_GROUP_SIZE; i < lim; i++) {
+		if (isNaturalCut(nodes[start + i].hash)) {
+			return i + 1;
+		}
+	}
+
+	return lim;
+}
+
+function validGap(gap: number): boolean {
+	return gap > MIN_GROUP_SIZE && gap < MAX_GROUP_SIZE - 1;
+}
+
+/**
+ * Find the first stable group boundary scanning left-to-right.
+ *
+ * A position `m` is "stable" if it is always a group boundary regardless of
+ * what nodes precede this slice: three consecutive natural-cut positions
+ * `c0 < c1 < c2` with both gaps in `(MIN_GROUP_SIZE, MAX_GROUP_SIZE - 1)`
+ * make `c1 + 1` stable.
+ *
+ * Returns `undefined` when the slice is too short or lacks the pattern.
+ */
+export function findStableStart(nodes: SubtreeNode[]): number | undefined {
+	if (nodes.length < MIN_GROUP_SIZE + 1) {
+		return undefined;
+	}
+
+	let prevPrevCut: number | undefined;
+	let prevCut: number | undefined;
+
+	for (let pos = 0; pos < nodes.length; pos++) {
+		if (!isNaturalCut(nodes[pos].hash)) {
+			continue;
+		}
+
+		if (
+			prevCut !== undefined &&
+			validGap(pos - prevCut) &&
+			prevPrevCut !== undefined &&
+			validGap(prevCut - prevPrevCut)
+		) {
+			return prevCut + 1;
+		}
+
+		prevPrevCut = prevCut;
+		prevCut = pos;
+	}
+
+	return undefined;
+}
+
+/**
+ * Find the last stable group boundary scanning right-to-left; the mirror of
+ * {@link findStableStart}. Everything from the returned index onward is the
+ * unstable suffix that cannot yet be merged.
+ */
+export function findStableEnd(nodes: SubtreeNode[]): number | undefined {
+	if (nodes.length < MIN_GROUP_SIZE + 1) {
+		return undefined;
+	}
+
+	let nextNextCut: number | undefined;
+	let nextCut: number | undefined;
+
+	for (let pos = nodes.length - 1; pos >= 0; pos--) {
+		if (!isNaturalCut(nodes[pos].hash)) {
+			continue;
+		}
+
+		if (
+			nextCut !== undefined &&
+			validGap(nextCut - pos) &&
+			nextNextCut !== undefined &&
+			validGap(nextNextCut - nextCut)
+		) {
+			return nextCut + 1;
+		}
+
+		nextNextCut = nextCut;
+		nextCut = pos;
+	}
+
+	return undefined;
+}
+
+/**
+ * The core per-level operation, mirroring Rust's `split_and_promote`:
+ * partitions `nodes` into `[prefixLen, suffixLen]`, appending merged group
+ * nodes of the stable middle region to `promoted`.
+ */
+function splitAndPromote(
+	nodes: SubtreeNode[],
+	atStart: boolean,
+	atEnd: boolean,
+	promoted: SubtreeNode[],
+): [number, number] {
+	if (nodes.length <= 1) {
+		return [nodes.length, 0];
+	}
+
+	let stableStart: number;
+	if (atStart) {
+		stableStart = 0;
+	} else {
+		const idx = findStableStart(nodes);
+		if (idx === undefined) {
+			return [nodes.length, 0];
+		}
+		stableStart = idx;
+	}
+
+	let stableEnd: number;
+	if (atEnd) {
+		stableEnd = nodes.length;
+	} else {
+		const idx = findStableEnd(nodes.slice(stableStart));
+		if (idx === undefined) {
+			return [nodes.length, 0];
+		}
+		stableEnd = stableStart + idx;
+	}
+
+	if (stableStart >= stableEnd) {
+		return [nodes.length, 0];
+	}
+
+	let pos = stableStart;
+	while (pos < stableEnd) {
+		const cutLen = nextMergeCut(nodes, pos, stableEnd);
+		promoted.push(mergedHashOfSequence(nodes.slice(pos, pos + cutLen)));
+		pos += cutLen;
+	}
+
+	return [stableStart, nodes.length - stableEnd];
+}
+
+interface Hump {
+	leftLevels: SubtreeNode[][];
+	rightLevels: SubtreeNode[][];
+}
+
+/**
+ * Flatten per-level left/right arrays into the storage layout used by Rust:
+ * all left-side nodes ascending by level, then all right-side nodes
+ * descending by level.
+ */
+function flattenHump(hump: Hump): { nodes: SubtreeNode[]; levels: Array<[number, number]> } {
+	const nodes: SubtreeNode[] = [];
+	for (const left of hump.leftLevels) {
+		nodes.push(...left);
+	}
+	for (let level = hump.rightLevels.length - 1; level >= 0; level--) {
+		nodes.push(...hump.rightLevels[level]);
+	}
+	const levels = hump.leftLevels.map((left, i) => [left.length, hump.rightLevels[i].length] satisfies [number, number]);
+	return { nodes, levels };
+}
+
+/** Mirror of Rust's `build_hump`. */
+function buildHump(chunks: SubtreeNode[], atStart: boolean, atEnd: boolean): Hump {
+	const leftLevels: SubtreeNode[][] = [];
+	const rightLevels: SubtreeNode[][] = [];
+
+	let current = chunks;
+	let allLeftsEmpty = true;
+	let allRightsEmpty = true;
+
+	// eslint-disable-next-line no-constant-condition
+	while (true) {
+		const levelAtStart = atStart && allLeftsEmpty;
+		const levelAtEnd = atEnd && allRightsEmpty;
+
+		const promoted: SubtreeNode[] = [];
+		const [prefixLen, suffixLen] = splitAndPromote(current, levelAtStart, levelAtEnd, promoted);
+
+		leftLevels.push(current.slice(0, prefixLen));
+		rightLevels.push(current.slice(current.length - suffixLen));
+
+		if (prefixLen > 0) {
+			allLeftsEmpty = false;
+		}
+		if (suffixLen > 0) {
+			allRightsEmpty = false;
+		}
+
+		if (promoted.length === 0) {
+			break;
+		}
+		if (promoted.length === 1) {
+			leftLevels.push(promoted);
+			rightLevels.push([]);
+			break;
+		}
+
+		current = promoted;
+	}
+
+	return { leftLevels, rightLevels };
+}
+
+export class MerkleHashSubtree {
+	private nodes: SubtreeNode[];
+	/** Per-level `[leftCount, rightCount]` pairs indexing into `nodes`. */
+	private levels: Array<[number, number]>;
+	private leftOffsets: number[];
+	private rightOffsets: number[];
+	/** True if this range begins at chunk 0 of the full sequence. */
+	public atStart: boolean;
+	/** True if this range ends at the last chunk of the full sequence. */
+	public atEnd: boolean;
+
+	private constructor(nodes: SubtreeNode[], levels: Array<[number, number]>, atStart: boolean, atEnd: boolean) {
+		this.nodes = nodes;
+		this.levels = levels;
+		this.atStart = atStart;
+		this.atEnd = atEnd;
+		[this.leftOffsets, this.rightOffsets] = computeOffsets(levels);
+	}
+
+	/**
+	 * Create a subtree from a contiguous run of level-0 chunks.
+	 *
+	 * - `atStart`: `chunks[0]` is the first chunk of the entire file.
+	 * - `atEnd`: the last element of `chunks` is the file's final chunk.
+	 */
+	static fromChunks(atStart: boolean, chunks: SubtreeNode[], atEnd: boolean): MerkleHashSubtree {
+		const { nodes, levels } = flattenHump(buildHump(chunks, atStart, atEnd));
+		return new MerkleHashSubtree(nodes, levels, atStart, atEnd);
+	}
+
+	get numNodes(): number {
+		return this.nodes.length;
+	}
+
+	get numLevels(): number {
+		return this.levels.length;
+	}
+
+	get isEmpty(): boolean {
+		return this.nodes.length === 0;
+	}
+
+	private leftAt(level: number): SubtreeNode[] {
+		if (level >= this.levels.length) {
+			return [];
+		}
+		const start = this.leftOffsets[level];
+		return this.nodes.slice(start, start + this.levels[level][0]);
+	}
+
+	private rightAt(level: number): SubtreeNode[] {
+		if (level >= this.levels.length) {
+			return [];
+		}
+		const start = this.rightOffsets[level];
+		return this.nodes.slice(start, start + this.levels[level][1]);
+	}
+
+	/**
+	 * Merge an adjacent subtree (the right neighbor) into this one, in place.
+	 * After the call, `this` covers the combined range: it keeps its own
+	 * `atStart` and takes `other`'s `atEnd`.
+	 *
+	 * Throws if `this.atEnd` (nothing can follow the end) or `other.atStart`
+	 * (the start cannot appear on the right side of a merge).
+	 */
+	mergeInto(other: MerkleHashSubtree): void {
+		if (this.atEnd) {
+			throw new Error("Cannot merge into a subtree that is already at the end");
+		}
+		if (other.atStart) {
+			throw new Error("Cannot merge a subtree that is at the start on the right side");
+		}
+
+		const combinedAtStart = this.atStart;
+		const combinedAtEnd = other.atEnd;
+
+		const maxLevels = Math.max(this.numLevels, other.numLevels);
+
+		const leftLevels: SubtreeNode[][] = [];
+		const rightLevels: SubtreeNode[][] = [];
+		let carry: SubtreeNode[] = [];
+		let allLeftsEmpty = true;
+		let allRightsEmpty = true;
+
+		for (let level = 0; level < maxLevels; level++) {
+			const full = [
+				...this.leftAt(level),
+				...this.rightAt(level),
+				...carry,
+				...other.leftAt(level),
+				...other.rightAt(level),
+			];
+
+			const levelAtStart = combinedAtStart && allLeftsEmpty;
+			const levelAtEnd = combinedAtEnd && allRightsEmpty;
+
+			const promoted: SubtreeNode[] = [];
+			const [prefixLen, suffixLen] = splitAndPromote(full, levelAtStart, levelAtEnd, promoted);
+
+			leftLevels.push(full.slice(0, prefixLen));
+			rightLevels.push(full.slice(full.length - suffixLen));
+
+			if (prefixLen > 0) {
+				allLeftsEmpty = false;
+			}
+			if (suffixLen > 0) {
+				allRightsEmpty = false;
+			}
+
+			carry = promoted;
+		}
+
+		while (carry.length > 0) {
+			if (carry.length === 1) {
+				leftLevels.push(carry);
+				rightLevels.push([]);
+				carry = [];
+			} else {
+				const promoted: SubtreeNode[] = [];
+				const [prefixLen, suffixLen] = splitAndPromote(
+					carry,
+					combinedAtStart && allLeftsEmpty,
+					combinedAtEnd && allRightsEmpty,
+					promoted,
+				);
+
+				leftLevels.push(carry.slice(0, prefixLen));
+				rightLevels.push(carry.slice(carry.length - suffixLen));
+
+				if (prefixLen > 0) {
+					allLeftsEmpty = false;
+				}
+				if (suffixLen > 0) {
+					allRightsEmpty = false;
+				}
+
+				carry = promoted;
+			}
+		}
+
+		// Trim empty trailing levels
+		while (
+			leftLevels.length > 1 &&
+			leftLevels[leftLevels.length - 1].length === 0 &&
+			rightLevels[rightLevels.length - 1].length === 0
+		) {
+			leftLevels.pop();
+			rightLevels.pop();
+		}
+
+		const { nodes, levels } = flattenHump({ leftLevels, rightLevels });
+		this.nodes = nodes;
+		this.levels = levels;
+		[this.leftOffsets, this.rightOffsets] = computeOffsets(levels);
+		this.atStart = combinedAtStart;
+		this.atEnd = combinedAtEnd;
+	}
+
+	/**
+	 * Merge multiple adjacent ranges left-to-right.
+	 * Returns an empty fully-closed range when `ranges` is empty.
+	 */
+	static merge(ranges: MerkleHashSubtree[]): MerkleHashSubtree {
+		if (ranges.length === 0) {
+			return MerkleHashSubtree.fromChunks(true, [], true);
+		}
+		const result = ranges[0].clone();
+		for (let i = 1; i < ranges.length; i++) {
+			result.mergeInto(ranges[i]);
+		}
+		return result;
+	}
+
+	clone(): MerkleHashSubtree {
+		return new MerkleHashSubtree(
+			[...this.nodes],
+			this.levels.map((l) => [...l] satisfies [number, number]),
+			this.atStart,
+			this.atEnd,
+		);
+	}
+
+	/**
+	 * The final aggregated hash — only available when both boundaries are
+	 * known (`atStart && atEnd`). Equals `xorbHash(allChunks)`; apply
+	 * `hmac(hash, zeroKey)` to obtain the file hash.
+	 *
+	 * Returns `undefined` when either boundary is unknown.
+	 */
+	finalHash(): Uint8Array | undefined {
+		if (!this.atStart || !this.atEnd) {
+			return undefined;
+		}
+
+		if (this.nodes.length === 0) {
+			return new Uint8Array(32);
+		}
+
+		const top = this.levels.length - 1;
+		const topLeft = this.leftAt(top);
+		if (topLeft.length !== 1 || this.rightAt(top).length !== 0) {
+			throw new Error("Invariant violation: fully-closed hump should have a single node at the top level");
+		}
+		return topLeft[0].hash;
+	}
+
+	/** Total byte length covered by this subtree. */
+	get totalLength(): number {
+		let total = 0;
+		for (let level = 0; level < this.levels.length; level++) {
+			for (const node of this.leftAt(level)) {
+				total += node.length;
+			}
+			for (const node of this.rightAt(level)) {
+				total += node.length;
+			}
+		}
+		return total;
+	}
+
+	/** Serde-human-readable-compatible JSON (what the CAS server produces/accepts). */
+	toJSON(): MerkleHashSubtreeJson {
+		return {
+			nodes: this.nodes.map((node) => ({ hash: hashToHex(node.hash), size: node.length })),
+			levels: this.levels.map((l) => [...l] satisfies [number, number]),
+			at_start: this.atStart,
+			at_end: this.atEnd,
+		};
+	}
+
+	static fromJSON(json: MerkleHashSubtreeJson): MerkleHashSubtree {
+		return new MerkleHashSubtree(
+			json.nodes.map((node) => ({ hash: hexToBytes(node.hash), length: node.size })),
+			json.levels.map((l) => [l[0], l[1]] satisfies [number, number]),
+			json.at_start,
+			json.at_end,
+		);
+	}
+}
+
+/** Pre-compute left and right offset arrays from levels (mirror of Rust's `compute_offsets`). */
+function computeOffsets(levels: Array<[number, number]>): [number[], number[]] {
+	const leftOffsets: number[] = [];
+	const rightOffsets: number[] = [];
+
+	let cumulativeLeft = 0;
+	for (const [leftCount] of levels) {
+		leftOffsets.push(cumulativeLeft);
+		cumulativeLeft += leftCount;
+	}
+
+	const totalLeft = cumulativeLeft;
+	let cumulativeRightAfter = 0;
+	for (const [, rightCount] of levels) {
+		cumulativeRightAfter += rightCount;
+	}
+	for (const [, rightCount] of levels) {
+		cumulativeRightAfter -= rightCount;
+		rightOffsets.push(totalLeft + cumulativeRightAfter);
+	}
+
+	return [leftOffsets, rightOffsets];
+}

--- a/packages/xetchunk-wasm/src/xorb-hash.ts
+++ b/packages/xetchunk-wasm/src/xorb-hash.ts
@@ -13,6 +13,16 @@ const INDEX_OF_LAST_BYTE_OF_LAST_U64_IN_CHUNK_HASH = 3 * 8;
 
 const nodeHasher = Hasher.newKeyed(BLAKE3_NODE_KEY);
 
+/**
+ * @internal
+ *
+ * `hash % 4 === 0` in Rust's `is_natural_cut`, where `%` operates on the
+ * little-endian u64 at byte offset 24 — so only the low byte matters.
+ */
+export function isNaturalCut(hash: Uint8Array): boolean {
+	return hash[INDEX_OF_LAST_BYTE_OF_LAST_U64_IN_CHUNK_HASH] % MEAN_CHUNK_PER_NODE === 0;
+}
+
 export function xorbHash(chunks: Chunk[]): Uint8Array {
 	if (chunks.length === 0) {
 		return new Uint8Array(32);
@@ -46,10 +56,12 @@ export function xorbHash(chunks: Chunk[]): Uint8Array {
 }
 
 /**
+ * @internal
+ *
  * Matches Rust's `merged_hash_of_sequence`: serializes each entry as
  * "{hash_hex} : {length_decimal}\n" then hashes with BLAKE3_NODE_KEY.
  */
-function mergedHashOfSequence(chunks: Chunk[]): Chunk {
+export function mergedHashOfSequence(chunks: Chunk[]): Chunk {
 	let text = "";
 	let totalLength = 0;
 	for (const chunk of chunks) {

--- a/packages/xetchunk-wasm/tests/merkle-hash-subtree.test.ts
+++ b/packages/xetchunk-wasm/tests/merkle-hash-subtree.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Hasher } from "@huggingface/blake3-jit";
+import { MerkleHashSubtree, hashToHex, xorbHash, fileHash } from "../src/index.js";
+import type { Chunk, MerkleHashSubtreeJson } from "../src/index.js";
+
+/** Same DATA_KEY as Rust's `compute_data_hash` / the chunker's BLAKE3_DATA_KEY. */
+const BLAKE3_DATA_KEY = new Uint8Array([
+	102, 151, 245, 119, 91, 149, 80, 222, 49, 53, 203, 172, 165, 151, 24, 28, 157, 228, 33, 16, 155, 235, 43, 88, 180,
+	208, 176, 75, 147, 173, 242, 41,
+]);
+
+const dataHasher = Hasher.newKeyed(BLAKE3_DATA_KEY);
+
+/** Mirror of the fixture generator: chunk(i) = (compute_data_hash(le_bytes(i)), 100 + (i*37) % 1000) */
+function fixtureChunk(i: number): Chunk {
+	const bytes = new Uint8Array(8);
+	new DataView(bytes.buffer).setBigUint64(0, BigInt(i), true);
+	return {
+		hash: dataHasher.reset().update(bytes).finalize(32),
+		length: 100 + ((i * 37) % 1000),
+	};
+}
+
+function fixtureChunks(n: number): Chunk[] {
+	return Array.from({ length: n }, (_, i) => fixtureChunk(i));
+}
+
+interface Fixture {
+	description: string;
+	cases: Array<{
+		n: number;
+		full: MerkleHashSubtreeJson;
+		finalHash: string;
+		xorbHash: string;
+		fileHash: string;
+		splits: Array<{
+			points: number[];
+			parts: MerkleHashSubtreeJson[];
+			mergedFinalHash: string;
+		}>;
+	}>;
+}
+
+const fixture: Fixture = JSON.parse(
+	readFileSync(join(dirname(fileURLToPath(import.meta.url)), "subtree-fixture.json"), "utf8"),
+);
+
+describe("MerkleHashSubtree", () => {
+	describe("Rust reference fixture", () => {
+		for (const testCase of fixture.cases) {
+			it(`matches Rust for n=${testCase.n}`, () => {
+				const chunks = fixtureChunks(testCase.n);
+
+				// Sanity check that our chunk derivation matches xorbHash/fileHash reference
+				expect(hashToHex(xorbHash(chunks))).toBe(testCase.xorbHash);
+				expect(hashToHex(fileHash(chunks))).toBe(testCase.fileHash);
+
+				// Full closed subtree: serde-compatible JSON + final hash
+				const full = MerkleHashSubtree.fromChunks(true, chunks, true);
+				expect(full.toJSON()).toEqual(testCase.full);
+				const finalHash = full.finalHash();
+				expect(finalHash).toBeDefined();
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				expect(hashToHex(finalHash!)).toBe(testCase.finalHash);
+
+				for (const split of testCase.splits) {
+					const bounds = [0, ...split.points, testCase.n];
+
+					// Build each part in TS and compare against Rust's serialization
+					const tsParts: MerkleHashSubtree[] = [];
+					for (let i = 0; i + 1 < bounds.length; i++) {
+						const part = MerkleHashSubtree.fromChunks(
+							bounds[i] === 0,
+							chunks.slice(bounds[i], bounds[i + 1]),
+							bounds[i + 1] === testCase.n,
+						);
+						expect(part.toJSON()).toEqual(split.parts[i]);
+						tsParts.push(part);
+					}
+
+					// Merge TS-built parts
+					const merged = MerkleHashSubtree.merge(tsParts);
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					expect(hashToHex(merged.finalHash()!)).toBe(split.mergedFinalHash);
+
+					// Merge parts deserialized from Rust JSON (simulates server-provided hashRanges)
+					const rustParts = split.parts.map((json) => MerkleHashSubtree.fromJSON(json));
+					const mergedFromRust = MerkleHashSubtree.merge(rustParts);
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					expect(hashToHex(mergedFromRust.finalHash()!)).toBe(split.mergedFinalHash);
+
+					// Mixed: alternate TS-built / Rust-deserialized parts
+					const mixed = tsParts.map((part, i) => (i % 2 === 0 ? part : rustParts[i]));
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					expect(hashToHex(MerkleHashSubtree.merge(mixed).finalHash()!)).toBe(split.mergedFinalHash);
+				}
+			});
+		}
+	});
+
+	describe("properties", () => {
+		/** Simple deterministic PRNG (mulberry32) for reproducible property tests. */
+		function prng(seed: number): () => number {
+			let state = seed >>> 0;
+			return () => {
+				state = (state + 0x6d2b79f5) >>> 0;
+				let t = state;
+				t = Math.imul(t ^ (t >>> 15), t | 1);
+				t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+				return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+			};
+		}
+
+		function randomChunks(rand: () => number, n: number): Chunk[] {
+			return Array.from({ length: n }, () => {
+				const bytes = new Uint8Array(8);
+				new DataView(bytes.buffer).setBigUint64(0, BigInt(Math.floor(rand() * Number.MAX_SAFE_INTEGER)), true);
+				return {
+					hash: dataHasher.reset().update(bytes).finalize(32),
+					length: 100 + Math.floor(rand() * 9900),
+				};
+			});
+		}
+
+		it("merging arbitrary partitions equals xorbHash of the whole", () => {
+			const rand = prng(42);
+			for (let iter = 0; iter < 30; iter++) {
+				const n = 1 + Math.floor(rand() * 2000);
+				const chunks = randomChunks(rand, n);
+				const expected = hashToHex(xorbHash(chunks));
+
+				// Random partition into up to 8 parts
+				const numCuts = Math.floor(rand() * 7);
+				const cuts = Array.from({ length: numCuts }, () => 1 + Math.floor(rand() * (n - 1))).sort((a, b) => a - b);
+				const bounds = [0, ...new Set(cuts), n];
+
+				const parts = [];
+				for (let i = 0; i + 1 < bounds.length; i++) {
+					parts.push(
+						MerkleHashSubtree.fromChunks(bounds[i] === 0, chunks.slice(bounds[i], bounds[i + 1]), bounds[i + 1] === n),
+					);
+				}
+				const merged = MerkleHashSubtree.merge(parts);
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				expect(hashToHex(merged.finalHash()!)).toBe(expected);
+			}
+		});
+
+		it("streaming append: incremental merges match xorbHash", () => {
+			const rand = prng(1337);
+			const chunks = randomChunks(rand, 5000);
+
+			// Simulates an append session: keep a running subtree, append in batches
+			const running = MerkleHashSubtree.fromChunks(true, chunks.slice(0, 100), false);
+			let pos = 100;
+			while (pos < chunks.length) {
+				const batchSize = 1 + Math.floor(rand() * 400);
+				const end = Math.min(pos + batchSize, chunks.length);
+				running.mergeInto(MerkleHashSubtree.fromChunks(false, chunks.slice(pos, end), end === chunks.length));
+				pos = end;
+			}
+
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			expect(hashToHex(running.finalHash()!)).toBe(hashToHex(xorbHash(chunks)));
+
+			// O(log n) storage
+			expect(running.numNodes).toBeLessThan(1000);
+		});
+
+		it("JSON round-trip preserves merge behavior", () => {
+			const rand = prng(7);
+			const chunks = randomChunks(rand, 800);
+			const a = MerkleHashSubtree.fromChunks(true, chunks.slice(0, 300), false);
+			const b = MerkleHashSubtree.fromChunks(false, chunks.slice(300), true);
+
+			const a2 = MerkleHashSubtree.fromJSON(JSON.parse(JSON.stringify(a.toJSON())));
+			const b2 = MerkleHashSubtree.fromJSON(JSON.parse(JSON.stringify(b.toJSON())));
+
+			expect(a2.toJSON()).toEqual(a.toJSON());
+
+			a2.mergeInto(b2);
+			a.mergeInto(b);
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			expect(hashToHex(a2.finalHash()!)).toBe(hashToHex(a.finalHash()!));
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			expect(hashToHex(a.finalHash()!)).toBe(hashToHex(xorbHash(chunks)));
+		});
+
+		it("rejects invalid merges", () => {
+			const chunks = randomChunks(prng(9), 50);
+			const closed = MerkleHashSubtree.fromChunks(true, chunks, true);
+			const open = MerkleHashSubtree.fromChunks(false, chunks, false);
+			const atStart = MerkleHashSubtree.fromChunks(true, chunks, false);
+
+			expect(() => closed.mergeInto(open)).toThrow();
+			expect(() => atStart.clone().mergeInto(atStart)).toThrow();
+			expect(open.finalHash()).toBeUndefined();
+		});
+
+		it("empty merge returns the zero hash", () => {
+			const merged = MerkleHashSubtree.merge([]);
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			expect(hashToHex(merged.finalHash()!)).toBe("0".repeat(64));
+		});
+
+		it("totalLength sums covered bytes", () => {
+			const chunks = randomChunks(prng(3), 500);
+			const expected = chunks.reduce((sum, c) => sum + c.length, 0);
+			expect(MerkleHashSubtree.fromChunks(true, chunks, true).totalLength).toBe(expected);
+			expect(MerkleHashSubtree.fromChunks(false, chunks, false).totalLength).toBe(expected);
+		});
+	});
+});

--- a/packages/xetchunk-wasm/tests/subtree-fixture.json
+++ b/packages/xetchunk-wasm/tests/subtree-fixture.json
@@ -1,0 +1,4160 @@
+{
+	"cases": [
+		{
+			"fileHash": "0000000000000000000000000000000000000000000000000000000000000000",
+			"finalHash": "0000000000000000000000000000000000000000000000000000000000000000",
+			"full": { "at_end": true, "at_start": true, "levels": [[0, 0]], "nodes": [] },
+			"n": 0,
+			"splits": [],
+			"xorbHash": "0000000000000000000000000000000000000000000000000000000000000000"
+		},
+		{
+			"fileHash": "264e113f74142fe2156701c7515230dcd8d56625277a704eb675c5d3b169e592",
+			"finalHash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [[1, 0]],
+				"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+			},
+			"n": 1,
+			"splits": [],
+			"xorbHash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a"
+		},
+		{
+			"fileHash": "d1c706f62da40fd66ace2a18871665d2ef2cb29107c077aeb9c90292265f5794",
+			"finalHash": "0c74c33a49c40c0c41ec342d37dee4312ca96c6005c0f1b80e48b72b65a55ca4",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [
+					[0, 0],
+					[1, 0]
+				],
+				"nodes": [{ "hash": "0c74c33a49c40c0c41ec342d37dee4312ca96c6005c0f1b80e48b72b65a55ca4", "size": 237 }]
+			},
+			"n": 2,
+			"splits": [
+				{
+					"mergedFinalHash": "0c74c33a49c40c0c41ec342d37dee4312ca96c6005c0f1b80e48b72b65a55ca4",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }]
+						}
+					],
+					"points": [1]
+				}
+			],
+			"xorbHash": "0c74c33a49c40c0c41ec342d37dee4312ca96c6005c0f1b80e48b72b65a55ca4"
+		},
+		{
+			"fileHash": "3005fa4dc4ed2d5d6a5f5377d1854cdf0057c76187183fc4da1a4610892271a2",
+			"finalHash": "1dabfedde0a609e0b32dd29697432c092d71c80b32b67a8bf77f79b7dac83e7f",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [
+					[0, 0],
+					[1, 0]
+				],
+				"nodes": [{ "hash": "1dabfedde0a609e0b32dd29697432c092d71c80b32b67a8bf77f79b7dac83e7f", "size": 411 }]
+			},
+			"n": 3,
+			"splits": [
+				{
+					"mergedFinalHash": "1dabfedde0a609e0b32dd29697432c092d71c80b32b67a8bf77f79b7dac83e7f",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }
+							]
+						}
+					],
+					"points": [1]
+				},
+				{
+					"mergedFinalHash": "1dabfedde0a609e0b32dd29697432c092d71c80b32b67a8bf77f79b7dac83e7f",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }]
+						}
+					],
+					"points": [1, 2]
+				},
+				{
+					"mergedFinalHash": "1dabfedde0a609e0b32dd29697432c092d71c80b32b67a8bf77f79b7dac83e7f",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }]
+						}
+					],
+					"points": [1, 2]
+				}
+			],
+			"xorbHash": "1dabfedde0a609e0b32dd29697432c092d71c80b32b67a8bf77f79b7dac83e7f"
+		},
+		{
+			"fileHash": "a6003e30c3c051b70c8b46f0161c438a99e353fda5ce94a9326ea25fce90476f",
+			"finalHash": "fa19b0b0cebd0464bbde37267168dd472cba994de801f82ba4978533e6b4836e",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [
+					[0, 0],
+					[0, 0],
+					[1, 0]
+				],
+				"nodes": [{ "hash": "fa19b0b0cebd0464bbde37267168dd472cba994de801f82ba4978533e6b4836e", "size": 622 }]
+			},
+			"n": 4,
+			"splits": [
+				{
+					"mergedFinalHash": "fa19b0b0cebd0464bbde37267168dd472cba994de801f82ba4978533e6b4836e",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 }
+							]
+						}
+					],
+					"points": [2]
+				},
+				{
+					"mergedFinalHash": "fa19b0b0cebd0464bbde37267168dd472cba994de801f82ba4978533e6b4836e",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 }
+							]
+						}
+					],
+					"points": [1, 2]
+				},
+				{
+					"mergedFinalHash": "fa19b0b0cebd0464bbde37267168dd472cba994de801f82ba4978533e6b4836e",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 }]
+						}
+					],
+					"points": [1, 3]
+				}
+			],
+			"xorbHash": "fa19b0b0cebd0464bbde37267168dd472cba994de801f82ba4978533e6b4836e"
+		},
+		{
+			"fileHash": "3ed9ae4d4b6f4c4ecb3d52b546fca99963aa6ff9f60b40ea9b49f3ae3544a76c",
+			"finalHash": "a67891eae209a439c77812201e8b79e1bf3c9cfd6dd2d5a483ad75e23ee011d3",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [
+					[0, 0],
+					[0, 0],
+					[1, 0]
+				],
+				"nodes": [{ "hash": "a67891eae209a439c77812201e8b79e1bf3c9cfd6dd2d5a483ad75e23ee011d3", "size": 870 }]
+			},
+			"n": 5,
+			"splits": [
+				{
+					"mergedFinalHash": "a67891eae209a439c77812201e8b79e1bf3c9cfd6dd2d5a483ad75e23ee011d3",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[3, 0]],
+							"nodes": [
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 }
+							]
+						}
+					],
+					"points": [2]
+				},
+				{
+					"mergedFinalHash": "a67891eae209a439c77812201e8b79e1bf3c9cfd6dd2d5a483ad75e23ee011d3",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 }
+							]
+						}
+					],
+					"points": [1, 3]
+				},
+				{
+					"mergedFinalHash": "a67891eae209a439c77812201e8b79e1bf3c9cfd6dd2d5a483ad75e23ee011d3",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[3, 0]],
+							"nodes": [
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 }]
+						}
+					],
+					"points": [1, 4]
+				}
+			],
+			"xorbHash": "a67891eae209a439c77812201e8b79e1bf3c9cfd6dd2d5a483ad75e23ee011d3"
+		},
+		{
+			"fileHash": "349c3fb8edcc399caad678b3d7ac71eaf5a9168b9b90900ea8f7fdcc5c00f645",
+			"finalHash": "36a6aba50eed432fa0687efd3d0c9134f0cdeec6370b34dcf090779328c8cfb5",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [
+					[0, 0],
+					[0, 0],
+					[1, 0]
+				],
+				"nodes": [{ "hash": "36a6aba50eed432fa0687efd3d0c9134f0cdeec6370b34dcf090779328c8cfb5", "size": 1836 }]
+			},
+			"n": 8,
+			"splits": [
+				{
+					"mergedFinalHash": "36a6aba50eed432fa0687efd3d0c9134f0cdeec6370b34dcf090779328c8cfb5",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[4, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[4, 0]],
+							"nodes": [
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 }
+							]
+						}
+					],
+					"points": [4]
+				},
+				{
+					"mergedFinalHash": "36a6aba50eed432fa0687efd3d0c9134f0cdeec6370b34dcf090779328c8cfb5",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[3, 0]],
+							"nodes": [
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[3, 0]],
+							"nodes": [
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 }
+							]
+						}
+					],
+					"points": [2, 5]
+				},
+				{
+					"mergedFinalHash": "36a6aba50eed432fa0687efd3d0c9134f0cdeec6370b34dcf090779328c8cfb5",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[6, 0]],
+							"nodes": [
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 }]
+						}
+					],
+					"points": [1, 7]
+				}
+			],
+			"xorbHash": "36a6aba50eed432fa0687efd3d0c9134f0cdeec6370b34dcf090779328c8cfb5"
+		},
+		{
+			"fileHash": "b09338d5dd46f20f98e332e6c3ae1b0fb957c38e3a0da53651f342ef545c5272",
+			"finalHash": "ea131c2b69f28823bdbb36f1d1d637a546ec237c7b842cf6584fea9a35ac7dde",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [
+					[0, 0],
+					[0, 0],
+					[1, 0]
+				],
+				"nodes": [{ "hash": "ea131c2b69f28823bdbb36f1d1d637a546ec237c7b842cf6584fea9a35ac7dde", "size": 2232 }]
+			},
+			"n": 9,
+			"splits": [
+				{
+					"mergedFinalHash": "ea131c2b69f28823bdbb36f1d1d637a546ec237c7b842cf6584fea9a35ac7dde",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[4, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[5, 0]],
+							"nodes": [
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 }
+							]
+						}
+					],
+					"points": [4]
+				},
+				{
+					"mergedFinalHash": "ea131c2b69f28823bdbb36f1d1d637a546ec237c7b842cf6584fea9a35ac7dde",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[3, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[3, 0]],
+							"nodes": [
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[3, 0]],
+							"nodes": [
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 }
+							]
+						}
+					],
+					"points": [3, 6]
+				},
+				{
+					"mergedFinalHash": "ea131c2b69f28823bdbb36f1d1d637a546ec237c7b842cf6584fea9a35ac7dde",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[7, 0]],
+							"nodes": [
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 }]
+						}
+					],
+					"points": [1, 8]
+				}
+			],
+			"xorbHash": "ea131c2b69f28823bdbb36f1d1d637a546ec237c7b842cf6584fea9a35ac7dde"
+		},
+		{
+			"fileHash": "093c6ca04903a21795d5421780bb02f833f1ffedca9192c552fd0a20df8d8a9f",
+			"finalHash": "ec27dc852fa67e32b8da49bb3d2568a78476ef1c07bb87a4de256544788fd114",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [
+					[0, 0],
+					[0, 0],
+					[1, 0]
+				],
+				"nodes": [{ "hash": "ec27dc852fa67e32b8da49bb3d2568a78476ef1c07bb87a4de256544788fd114", "size": 2665 }]
+			},
+			"n": 10,
+			"splits": [
+				{
+					"mergedFinalHash": "ec27dc852fa67e32b8da49bb3d2568a78476ef1c07bb87a4de256544788fd114",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[5, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[5, 0]],
+							"nodes": [
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 }
+							]
+						}
+					],
+					"points": [5]
+				},
+				{
+					"mergedFinalHash": "ec27dc852fa67e32b8da49bb3d2568a78476ef1c07bb87a4de256544788fd114",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[3, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[3, 0]],
+							"nodes": [
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[4, 0]],
+							"nodes": [
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 }
+							]
+						}
+					],
+					"points": [3, 6]
+				},
+				{
+					"mergedFinalHash": "ec27dc852fa67e32b8da49bb3d2568a78476ef1c07bb87a4de256544788fd114",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[8, 0]],
+							"nodes": [
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 }]
+						}
+					],
+					"points": [1, 9]
+				},
+				{
+					"mergedFinalHash": "ec27dc852fa67e32b8da49bb3d2568a78476ef1c07bb87a4de256544788fd114",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[5, 0]],
+							"nodes": [
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 }]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 }]
+						}
+					],
+					"points": [1, 2, 3, 8, 9]
+				},
+				{
+					"mergedFinalHash": "ec27dc852fa67e32b8da49bb3d2568a78476ef1c07bb87a4de256544788fd114",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[2, 0]],
+							"nodes": [
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 }
+							]
+						}
+					],
+					"points": [2, 4, 6, 8]
+				}
+			],
+			"xorbHash": "ec27dc852fa67e32b8da49bb3d2568a78476ef1c07bb87a4de256544788fd114"
+		},
+		{
+			"fileHash": "b5090f40b1956b9e8b9cdcc33f4633da4b360489f09746b67c9faf0320a31bfe",
+			"finalHash": "ca08626a2d031715d057f37bdad3b7e9de0471a607cfa7b90e45519c92d812a8",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [
+					[0, 0],
+					[0, 0],
+					[1, 0]
+				],
+				"nodes": [{ "hash": "ca08626a2d031715d057f37bdad3b7e9de0471a607cfa7b90e45519c92d812a8", "size": 6732 }]
+			},
+			"n": 17,
+			"splits": [
+				{
+					"mergedFinalHash": "ca08626a2d031715d057f37bdad3b7e9de0471a607cfa7b90e45519c92d812a8",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[8, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[9, 0]],
+							"nodes": [
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "1fb2574032f0a157e8cd6d203d5a9120325031e7650505698fd8eb4c1779520d", "size": 470 },
+								{ "hash": "feff7301b82cade94b660b8f8ce65188eb689a6cf33cb57c74364733622e9af3", "size": 507 },
+								{ "hash": "6232edecc5ddff3735e666e9298a51e02c2a39e07929b7d79b6cbe4d7ef22195", "size": 544 },
+								{ "hash": "42f12f79321fd74a37dba135a2f71eff92fac2697380e264acad133462c5ee87", "size": 581 },
+								{ "hash": "3ec91f614691ab39da5b0ac300064c3c0cdd1186a82c17b790db17b5e943db67", "size": 618 },
+								{ "hash": "f5a6eb781dbfb23f51d36d4aa5611089e1ccfe8e14c80eb32142be9a3bbe8e04", "size": 655 },
+								{ "hash": "d5cac48a9c1b16950b1c31fa898ab41718515519b8aa031537ed8e39090d888c", "size": 692 }
+							]
+						}
+					],
+					"points": [8]
+				},
+				{
+					"mergedFinalHash": "ca08626a2d031715d057f37bdad3b7e9de0471a607cfa7b90e45519c92d812a8",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[5, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[6, 0]],
+							"nodes": [
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "1fb2574032f0a157e8cd6d203d5a9120325031e7650505698fd8eb4c1779520d", "size": 470 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[6, 0]],
+							"nodes": [
+								{ "hash": "feff7301b82cade94b660b8f8ce65188eb689a6cf33cb57c74364733622e9af3", "size": 507 },
+								{ "hash": "6232edecc5ddff3735e666e9298a51e02c2a39e07929b7d79b6cbe4d7ef22195", "size": 544 },
+								{ "hash": "42f12f79321fd74a37dba135a2f71eff92fac2697380e264acad133462c5ee87", "size": 581 },
+								{ "hash": "3ec91f614691ab39da5b0ac300064c3c0cdd1186a82c17b790db17b5e943db67", "size": 618 },
+								{ "hash": "f5a6eb781dbfb23f51d36d4aa5611089e1ccfe8e14c80eb32142be9a3bbe8e04", "size": 655 },
+								{ "hash": "d5cac48a9c1b16950b1c31fa898ab41718515519b8aa031537ed8e39090d888c", "size": 692 }
+							]
+						}
+					],
+					"points": [5, 11]
+				},
+				{
+					"mergedFinalHash": "ca08626a2d031715d057f37bdad3b7e9de0471a607cfa7b90e45519c92d812a8",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[15, 0]],
+							"nodes": [
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "1fb2574032f0a157e8cd6d203d5a9120325031e7650505698fd8eb4c1779520d", "size": 470 },
+								{ "hash": "feff7301b82cade94b660b8f8ce65188eb689a6cf33cb57c74364733622e9af3", "size": 507 },
+								{ "hash": "6232edecc5ddff3735e666e9298a51e02c2a39e07929b7d79b6cbe4d7ef22195", "size": 544 },
+								{ "hash": "42f12f79321fd74a37dba135a2f71eff92fac2697380e264acad133462c5ee87", "size": 581 },
+								{ "hash": "3ec91f614691ab39da5b0ac300064c3c0cdd1186a82c17b790db17b5e943db67", "size": 618 },
+								{ "hash": "f5a6eb781dbfb23f51d36d4aa5611089e1ccfe8e14c80eb32142be9a3bbe8e04", "size": 655 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "d5cac48a9c1b16950b1c31fa898ab41718515519b8aa031537ed8e39090d888c", "size": 692 }]
+						}
+					],
+					"points": [1, 16]
+				},
+				{
+					"mergedFinalHash": "ca08626a2d031715d057f37bdad3b7e9de0471a607cfa7b90e45519c92d812a8",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[12, 0]],
+							"nodes": [
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "1fb2574032f0a157e8cd6d203d5a9120325031e7650505698fd8eb4c1779520d", "size": 470 },
+								{ "hash": "feff7301b82cade94b660b8f8ce65188eb689a6cf33cb57c74364733622e9af3", "size": 507 },
+								{ "hash": "6232edecc5ddff3735e666e9298a51e02c2a39e07929b7d79b6cbe4d7ef22195", "size": 544 },
+								{ "hash": "42f12f79321fd74a37dba135a2f71eff92fac2697380e264acad133462c5ee87", "size": 581 },
+								{ "hash": "3ec91f614691ab39da5b0ac300064c3c0cdd1186a82c17b790db17b5e943db67", "size": 618 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "f5a6eb781dbfb23f51d36d4aa5611089e1ccfe8e14c80eb32142be9a3bbe8e04", "size": 655 }]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "d5cac48a9c1b16950b1c31fa898ab41718515519b8aa031537ed8e39090d888c", "size": 692 }]
+						}
+					],
+					"points": [1, 2, 3, 15, 16]
+				},
+				{
+					"mergedFinalHash": "ca08626a2d031715d057f37bdad3b7e9de0471a607cfa7b90e45519c92d812a8",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[3, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[3, 0]],
+							"nodes": [
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[4, 0]],
+							"nodes": [
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[3, 0]],
+							"nodes": [
+								{ "hash": "1fb2574032f0a157e8cd6d203d5a9120325031e7650505698fd8eb4c1779520d", "size": 470 },
+								{ "hash": "feff7301b82cade94b660b8f8ce65188eb689a6cf33cb57c74364733622e9af3", "size": 507 },
+								{ "hash": "6232edecc5ddff3735e666e9298a51e02c2a39e07929b7d79b6cbe4d7ef22195", "size": 544 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[4, 0]],
+							"nodes": [
+								{ "hash": "42f12f79321fd74a37dba135a2f71eff92fac2697380e264acad133462c5ee87", "size": 581 },
+								{ "hash": "3ec91f614691ab39da5b0ac300064c3c0cdd1186a82c17b790db17b5e943db67", "size": 618 },
+								{ "hash": "f5a6eb781dbfb23f51d36d4aa5611089e1ccfe8e14c80eb32142be9a3bbe8e04", "size": 655 },
+								{ "hash": "d5cac48a9c1b16950b1c31fa898ab41718515519b8aa031537ed8e39090d888c", "size": 692 }
+							]
+						}
+					],
+					"points": [3, 6, 10, 13]
+				}
+			],
+			"xorbHash": "ca08626a2d031715d057f37bdad3b7e9de0471a607cfa7b90e45519c92d812a8"
+		},
+		{
+			"fileHash": "0e259486bde322fe43b1cb52ae8ae4a8c70afa112171a9beb397ddf1e412be91",
+			"finalHash": "1009a140180541d45df1997890de68c41987d04fe3273d6fbfd3128bfda9abfc",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [
+					[0, 0],
+					[0, 0],
+					[0, 0],
+					[1, 0]
+				],
+				"nodes": [{ "hash": "1009a140180541d45df1997890de68c41987d04fe3273d6fbfd3128bfda9abfc", "size": 17836 }]
+			},
+			"n": 33,
+			"splits": [
+				{
+					"mergedFinalHash": "1009a140180541d45df1997890de68c41987d04fe3273d6fbfd3128bfda9abfc",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [
+								[0, 6],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "1dabfedde0a609e0b32dd29697432c092d71c80b32b67a8bf77f79b7dac83e7f", "size": 411 },
+								{ "hash": "e2c0389432e88785265cb0098e851b8383852eaafb1d930463fcb8c3eb40850c", "size": 744 },
+								{ "hash": "85193ca885bdb82175ddabcaaae26b2f880d7497e765ea3e6b7f40344527e78b", "size": 1510 },
+								{ "hash": "1fb2574032f0a157e8cd6d203d5a9120325031e7650505698fd8eb4c1779520d", "size": 470 },
+								{ "hash": "feff7301b82cade94b660b8f8ce65188eb689a6cf33cb57c74364733622e9af3", "size": 507 },
+								{ "hash": "6232edecc5ddff3735e666e9298a51e02c2a39e07929b7d79b6cbe4d7ef22195", "size": 544 },
+								{ "hash": "42f12f79321fd74a37dba135a2f71eff92fac2697380e264acad133462c5ee87", "size": 581 },
+								{ "hash": "3ec91f614691ab39da5b0ac300064c3c0cdd1186a82c17b790db17b5e943db67", "size": 618 },
+								{ "hash": "f5a6eb781dbfb23f51d36d4aa5611089e1ccfe8e14c80eb32142be9a3bbe8e04", "size": 655 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [
+								[6, 0],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "d5cac48a9c1b16950b1c31fa898ab41718515519b8aa031537ed8e39090d888c", "size": 692 },
+								{ "hash": "6010b022b172b087dbdc6fc1462a44fdb27c74c7c5ce36953ad811abd88cac33", "size": 729 },
+								{ "hash": "e4a1ee4ac7f2fb758f3d3279f5654050213a816a4f659de1596ea1c0047ccd2f", "size": 766 },
+								{ "hash": "1b2a66722191511804712b5eab811ad00b8a515a30d66be355591acdd925831d", "size": 803 },
+								{ "hash": "f23dba8222dee07b30ea705103036b9b38653119915851e423d65ad1c744de6e", "size": 840 },
+								{ "hash": "c4aaa513288d1a6b1d1412f8fc17a507ca3f53166cd81828883a547bc5c9f740", "size": 877 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "08bef1184db71338fc973dd13a7185eae87db67e06e4c5eadb5b16d3d8439b2d", "size": 2470 },
+								{ "hash": "96e832ca775ce7531bbf31f388c26962eb7525d69f3ae04897045adb16514d91", "size": 741 }
+							]
+						}
+					],
+					"points": [16]
+				},
+				{
+					"mergedFinalHash": "1009a140180541d45df1997890de68c41987d04fe3273d6fbfd3128bfda9abfc",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[11, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "1fb2574032f0a157e8cd6d203d5a9120325031e7650505698fd8eb4c1779520d", "size": 470 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[11, 0]],
+							"nodes": [
+								{ "hash": "feff7301b82cade94b660b8f8ce65188eb689a6cf33cb57c74364733622e9af3", "size": 507 },
+								{ "hash": "6232edecc5ddff3735e666e9298a51e02c2a39e07929b7d79b6cbe4d7ef22195", "size": 544 },
+								{ "hash": "42f12f79321fd74a37dba135a2f71eff92fac2697380e264acad133462c5ee87", "size": 581 },
+								{ "hash": "3ec91f614691ab39da5b0ac300064c3c0cdd1186a82c17b790db17b5e943db67", "size": 618 },
+								{ "hash": "f5a6eb781dbfb23f51d36d4aa5611089e1ccfe8e14c80eb32142be9a3bbe8e04", "size": 655 },
+								{ "hash": "d5cac48a9c1b16950b1c31fa898ab41718515519b8aa031537ed8e39090d888c", "size": 692 },
+								{ "hash": "6010b022b172b087dbdc6fc1462a44fdb27c74c7c5ce36953ad811abd88cac33", "size": 729 },
+								{ "hash": "e4a1ee4ac7f2fb758f3d3279f5654050213a816a4f659de1596ea1c0047ccd2f", "size": 766 },
+								{ "hash": "1b2a66722191511804712b5eab811ad00b8a515a30d66be355591acdd925831d", "size": 803 },
+								{ "hash": "f23dba8222dee07b30ea705103036b9b38653119915851e423d65ad1c744de6e", "size": 840 },
+								{ "hash": "c4aaa513288d1a6b1d1412f8fc17a507ca3f53166cd81828883a547bc5c9f740", "size": 877 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[11, 0]],
+							"nodes": [
+								{ "hash": "fcc3772bbacfff206f85437ff7c8fa93f1aff55423f9d62a3c9a0eb0b6dae542", "size": 914 },
+								{ "hash": "82735448b05bd38c1ab20e2102c93504d28161e15cb3f2600ab54441aa8b4e66", "size": 951 },
+								{ "hash": "c27141e0ec282c5a4fbabecbd1debe2478cf1dbb1b274d9483232a844771319d", "size": 988 },
+								{ "hash": "68063885d9d364015967d07d0e8afd2986ccfa90f37ced1d5554269cd81ad700", "size": 1025 },
+								{ "hash": "b441d8629792f9aa5f5a083a2842c534861351e1b398161023669652ae7d34be", "size": 1062 },
+								{ "hash": "d8ae81a908799c76962fe6abd872d9442783a5408664f1f143251f34f7668fe1", "size": 1099 },
+								{ "hash": "6c5c4885e48cda17dd9a7ec28bef7f298ec994b58d3f909f0ea929de5ecb8361", "size": 136 },
+								{ "hash": "c53044b284f8b12e68b6df7e8be9f9b54afa9b52b67dfd18883cf0932847a7d0", "size": 173 },
+								{ "hash": "6c94a779a757d142e941c2f99e9fa55b99a87c6405fcd193e2f9a6be8d8d4b5e", "size": 210 },
+								{ "hash": "7edcc2da34f105ff852018c3741341e06d9ad43e98bd52e006a55e451221695c", "size": 247 },
+								{ "hash": "819dc9988b3871d7cee530f60ea0d9f3565ffb732410a7b8b95d8f13c84ddaa6", "size": 284 }
+							]
+						}
+					],
+					"points": [11, 22]
+				},
+				{
+					"mergedFinalHash": "1009a140180541d45df1997890de68c41987d04fe3273d6fbfd3128bfda9abfc",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[9, 6],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "b441d8629792f9aa5f5a083a2842c534861351e1b398161023669652ae7d34be", "size": 1062 },
+								{ "hash": "d8ae81a908799c76962fe6abd872d9442783a5408664f1f143251f34f7668fe1", "size": 1099 },
+								{ "hash": "6c5c4885e48cda17dd9a7ec28bef7f298ec994b58d3f909f0ea929de5ecb8361", "size": 136 },
+								{ "hash": "c53044b284f8b12e68b6df7e8be9f9b54afa9b52b67dfd18883cf0932847a7d0", "size": 173 },
+								{ "hash": "6c94a779a757d142e941c2f99e9fa55b99a87c6405fcd193e2f9a6be8d8d4b5e", "size": 210 },
+								{ "hash": "7edcc2da34f105ff852018c3741341e06d9ad43e98bd52e006a55e451221695c", "size": 247 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "819dc9988b3871d7cee530f60ea0d9f3565ffb732410a7b8b95d8f13c84ddaa6", "size": 284 }]
+						}
+					],
+					"points": [1, 32]
+				},
+				{
+					"mergedFinalHash": "1009a140180541d45df1997890de68c41987d04fe3273d6fbfd3128bfda9abfc",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[7, 5],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "b441d8629792f9aa5f5a083a2842c534861351e1b398161023669652ae7d34be", "size": 1062 },
+								{ "hash": "d8ae81a908799c76962fe6abd872d9442783a5408664f1f143251f34f7668fe1", "size": 1099 },
+								{ "hash": "6c5c4885e48cda17dd9a7ec28bef7f298ec994b58d3f909f0ea929de5ecb8361", "size": 136 },
+								{ "hash": "c53044b284f8b12e68b6df7e8be9f9b54afa9b52b67dfd18883cf0932847a7d0", "size": 173 },
+								{ "hash": "6c94a779a757d142e941c2f99e9fa55b99a87c6405fcd193e2f9a6be8d8d4b5e", "size": 210 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "7edcc2da34f105ff852018c3741341e06d9ad43e98bd52e006a55e451221695c", "size": 247 }]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "819dc9988b3871d7cee530f60ea0d9f3565ffb732410a7b8b95d8f13c84ddaa6", "size": 284 }]
+						}
+					],
+					"points": [1, 2, 3, 31, 32]
+				},
+				{
+					"mergedFinalHash": "1009a140180541d45df1997890de68c41987d04fe3273d6fbfd3128bfda9abfc",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[6, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[7, 0]],
+							"nodes": [
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "1fb2574032f0a157e8cd6d203d5a9120325031e7650505698fd8eb4c1779520d", "size": 470 },
+								{ "hash": "feff7301b82cade94b660b8f8ce65188eb689a6cf33cb57c74364733622e9af3", "size": 507 },
+								{ "hash": "6232edecc5ddff3735e666e9298a51e02c2a39e07929b7d79b6cbe4d7ef22195", "size": 544 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[6, 0]],
+							"nodes": [
+								{ "hash": "42f12f79321fd74a37dba135a2f71eff92fac2697380e264acad133462c5ee87", "size": 581 },
+								{ "hash": "3ec91f614691ab39da5b0ac300064c3c0cdd1186a82c17b790db17b5e943db67", "size": 618 },
+								{ "hash": "f5a6eb781dbfb23f51d36d4aa5611089e1ccfe8e14c80eb32142be9a3bbe8e04", "size": 655 },
+								{ "hash": "d5cac48a9c1b16950b1c31fa898ab41718515519b8aa031537ed8e39090d888c", "size": 692 },
+								{ "hash": "6010b022b172b087dbdc6fc1462a44fdb27c74c7c5ce36953ad811abd88cac33", "size": 729 },
+								{ "hash": "e4a1ee4ac7f2fb758f3d3279f5654050213a816a4f659de1596ea1c0047ccd2f", "size": 766 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[7, 0]],
+							"nodes": [
+								{ "hash": "1b2a66722191511804712b5eab811ad00b8a515a30d66be355591acdd925831d", "size": 803 },
+								{ "hash": "f23dba8222dee07b30ea705103036b9b38653119915851e423d65ad1c744de6e", "size": 840 },
+								{ "hash": "c4aaa513288d1a6b1d1412f8fc17a507ca3f53166cd81828883a547bc5c9f740", "size": 877 },
+								{ "hash": "fcc3772bbacfff206f85437ff7c8fa93f1aff55423f9d62a3c9a0eb0b6dae542", "size": 914 },
+								{ "hash": "82735448b05bd38c1ab20e2102c93504d28161e15cb3f2600ab54441aa8b4e66", "size": 951 },
+								{ "hash": "c27141e0ec282c5a4fbabecbd1debe2478cf1dbb1b274d9483232a844771319d", "size": 988 },
+								{ "hash": "68063885d9d364015967d07d0e8afd2986ccfa90f37ced1d5554269cd81ad700", "size": 1025 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[7, 0]],
+							"nodes": [
+								{ "hash": "b441d8629792f9aa5f5a083a2842c534861351e1b398161023669652ae7d34be", "size": 1062 },
+								{ "hash": "d8ae81a908799c76962fe6abd872d9442783a5408664f1f143251f34f7668fe1", "size": 1099 },
+								{ "hash": "6c5c4885e48cda17dd9a7ec28bef7f298ec994b58d3f909f0ea929de5ecb8361", "size": 136 },
+								{ "hash": "c53044b284f8b12e68b6df7e8be9f9b54afa9b52b67dfd18883cf0932847a7d0", "size": 173 },
+								{ "hash": "6c94a779a757d142e941c2f99e9fa55b99a87c6405fcd193e2f9a6be8d8d4b5e", "size": 210 },
+								{ "hash": "7edcc2da34f105ff852018c3741341e06d9ad43e98bd52e006a55e451221695c", "size": 247 },
+								{ "hash": "819dc9988b3871d7cee530f60ea0d9f3565ffb732410a7b8b95d8f13c84ddaa6", "size": 284 }
+							]
+						}
+					],
+					"points": [6, 13, 19, 26]
+				}
+			],
+			"xorbHash": "1009a140180541d45df1997890de68c41987d04fe3273d6fbfd3128bfda9abfc"
+		},
+		{
+			"fileHash": "ee9d2e84bc1676759d8716968bbfdbd5b27d9844c16807dee499aef6717795cc",
+			"finalHash": "33cfd4b803a6c15577105a41a2900a4f9a92d530a0842c84cf73484952d1926d",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [
+					[0, 0],
+					[0, 0],
+					[0, 0],
+					[1, 0]
+				],
+				"nodes": [{ "hash": "33cfd4b803a6c15577105a41a2900a4f9a92d530a0842c84cf73484952d1926d", "size": 35992 }]
+			},
+			"n": 64,
+			"splits": [
+				{
+					"mergedFinalHash": "33cfd4b803a6c15577105a41a2900a4f9a92d530a0842c84cf73484952d1926d",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [
+								[0, 6],
+								[6, 0]
+							],
+							"nodes": [
+								{ "hash": "1dabfedde0a609e0b32dd29697432c092d71c80b32b67a8bf77f79b7dac83e7f", "size": 411 },
+								{ "hash": "e2c0389432e88785265cb0098e851b8383852eaafb1d930463fcb8c3eb40850c", "size": 744 },
+								{ "hash": "85193ca885bdb82175ddabcaaae26b2f880d7497e765ea3e6b7f40344527e78b", "size": 1510 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "b441d8629792f9aa5f5a083a2842c534861351e1b398161023669652ae7d34be", "size": 1062 },
+								{ "hash": "d8ae81a908799c76962fe6abd872d9442783a5408664f1f143251f34f7668fe1", "size": 1099 },
+								{ "hash": "6c5c4885e48cda17dd9a7ec28bef7f298ec994b58d3f909f0ea929de5ecb8361", "size": 136 },
+								{ "hash": "c53044b284f8b12e68b6df7e8be9f9b54afa9b52b67dfd18883cf0932847a7d0", "size": 173 },
+								{ "hash": "6c94a779a757d142e941c2f99e9fa55b99a87c6405fcd193e2f9a6be8d8d4b5e", "size": 210 },
+								{ "hash": "7edcc2da34f105ff852018c3741341e06d9ad43e98bd52e006a55e451221695c", "size": 247 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [
+								[15, 0],
+								[4, 0]
+							],
+							"nodes": [
+								{ "hash": "819dc9988b3871d7cee530f60ea0d9f3565ffb732410a7b8b95d8f13c84ddaa6", "size": 284 },
+								{ "hash": "0b18a316b8c07f1da356a50f5d2e4e952d2ae7030a5efd1357ecad6265fc1de1", "size": 321 },
+								{ "hash": "fd4ab49f6563bef6217b658a7ac3cc37e7544059a8ba2bb66c5221db769c0110", "size": 358 },
+								{ "hash": "7c135484e0ddfa160e6360fb0b6091ccb7a190927daa32771b2a521d7b25b800", "size": 395 },
+								{ "hash": "79d2fe3562c477712914f0df05c36fb9a552848ad2fa41dfd1dd5c11c9821a63", "size": 432 },
+								{ "hash": "13df3b4f41bde3f5b1c0cf5e580949a6b81e791e1eb9e25bf9ec1002eccbc900", "size": 469 },
+								{ "hash": "4a663cce8067c0dae6f1667301664a3e0d143ea2f08f5e73fd73dd31ab28af94", "size": 506 },
+								{ "hash": "73b049ecae88a4a2c8c7c6648bd8c5d82a877e7490bbb54a578e368ec3e683e6", "size": 543 },
+								{ "hash": "1c4e1f8e8adb94bb3b275ac959d3b35cc558a0522ebafc8d68eac1c089d25230", "size": 580 },
+								{ "hash": "d698d7ab1f20fa56b74e4a883fbb93e542ac4966a6c880fca26e717c908a9dd8", "size": 617 },
+								{ "hash": "514bfb7c2bec7770650b4a58c6a6e8066e7ec9b85f00a93ea4c5d1641be47e3a", "size": 654 },
+								{ "hash": "95d6f5833933763baa6afe3487470f787a74feaf82e8748223c0aebbfa10180a", "size": 691 },
+								{ "hash": "3dd4590e2362b53474c187c1041eb621864ca28078dde8fef772b11425caeb67", "size": 728 },
+								{ "hash": "faa17b234992532bdf6cb19c7ad41e08a9ab08dc3926c0e75ad7b96341c2a789", "size": 765 },
+								{ "hash": "86922026951e9994b2427029fc0d89658c7d556e4b41357c83ce02b2073204b8", "size": 802 },
+								{ "hash": "9e50c43052cb333988ef35afdfd4dcede1ee9466eb02a3e94c3384aeee83bb85", "size": 2628 },
+								{ "hash": "6f2ad36f534f13c285fb9d61db474abc0164b4063626a2d52188f903e2b6ce18", "size": 2961 },
+								{ "hash": "ad31d0ed6a2912b4c911b3f6a41f06cca1e74d571a66156f99a0052a34e6eca5", "size": 3881 },
+								{ "hash": "f399fb05c8576aa5ce2c4ffa6a12e592df16b4a9972b3497ccbdd1fd39169c04", "size": 825 }
+							]
+						}
+					],
+					"points": [32]
+				},
+				{
+					"mergedFinalHash": "33cfd4b803a6c15577105a41a2900a4f9a92d530a0842c84cf73484952d1926d",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [
+								[0, 11],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "1dabfedde0a609e0b32dd29697432c092d71c80b32b67a8bf77f79b7dac83e7f", "size": 411 },
+								{ "hash": "e2c0389432e88785265cb0098e851b8383852eaafb1d930463fcb8c3eb40850c", "size": 744 },
+								{ "hash": "85193ca885bdb82175ddabcaaae26b2f880d7497e765ea3e6b7f40344527e78b", "size": 1510 },
+								{ "hash": "1fb2574032f0a157e8cd6d203d5a9120325031e7650505698fd8eb4c1779520d", "size": 470 },
+								{ "hash": "feff7301b82cade94b660b8f8ce65188eb689a6cf33cb57c74364733622e9af3", "size": 507 },
+								{ "hash": "6232edecc5ddff3735e666e9298a51e02c2a39e07929b7d79b6cbe4d7ef22195", "size": 544 },
+								{ "hash": "42f12f79321fd74a37dba135a2f71eff92fac2697380e264acad133462c5ee87", "size": 581 },
+								{ "hash": "3ec91f614691ab39da5b0ac300064c3c0cdd1186a82c17b790db17b5e943db67", "size": 618 },
+								{ "hash": "f5a6eb781dbfb23f51d36d4aa5611089e1ccfe8e14c80eb32142be9a3bbe8e04", "size": 655 },
+								{ "hash": "d5cac48a9c1b16950b1c31fa898ab41718515519b8aa031537ed8e39090d888c", "size": 692 },
+								{ "hash": "6010b022b172b087dbdc6fc1462a44fdb27c74c7c5ce36953ad811abd88cac33", "size": 729 },
+								{ "hash": "e4a1ee4ac7f2fb758f3d3279f5654050213a816a4f659de1596ea1c0047ccd2f", "size": 766 },
+								{ "hash": "1b2a66722191511804712b5eab811ad00b8a515a30d66be355591acdd925831d", "size": 803 },
+								{ "hash": "f23dba8222dee07b30ea705103036b9b38653119915851e423d65ad1c744de6e", "size": 840 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[21, 0]],
+							"nodes": [
+								{ "hash": "c4aaa513288d1a6b1d1412f8fc17a507ca3f53166cd81828883a547bc5c9f740", "size": 877 },
+								{ "hash": "fcc3772bbacfff206f85437ff7c8fa93f1aff55423f9d62a3c9a0eb0b6dae542", "size": 914 },
+								{ "hash": "82735448b05bd38c1ab20e2102c93504d28161e15cb3f2600ab54441aa8b4e66", "size": 951 },
+								{ "hash": "c27141e0ec282c5a4fbabecbd1debe2478cf1dbb1b274d9483232a844771319d", "size": 988 },
+								{ "hash": "68063885d9d364015967d07d0e8afd2986ccfa90f37ced1d5554269cd81ad700", "size": 1025 },
+								{ "hash": "b441d8629792f9aa5f5a083a2842c534861351e1b398161023669652ae7d34be", "size": 1062 },
+								{ "hash": "d8ae81a908799c76962fe6abd872d9442783a5408664f1f143251f34f7668fe1", "size": 1099 },
+								{ "hash": "6c5c4885e48cda17dd9a7ec28bef7f298ec994b58d3f909f0ea929de5ecb8361", "size": 136 },
+								{ "hash": "c53044b284f8b12e68b6df7e8be9f9b54afa9b52b67dfd18883cf0932847a7d0", "size": 173 },
+								{ "hash": "6c94a779a757d142e941c2f99e9fa55b99a87c6405fcd193e2f9a6be8d8d4b5e", "size": 210 },
+								{ "hash": "7edcc2da34f105ff852018c3741341e06d9ad43e98bd52e006a55e451221695c", "size": 247 },
+								{ "hash": "819dc9988b3871d7cee530f60ea0d9f3565ffb732410a7b8b95d8f13c84ddaa6", "size": 284 },
+								{ "hash": "0b18a316b8c07f1da356a50f5d2e4e952d2ae7030a5efd1357ecad6265fc1de1", "size": 321 },
+								{ "hash": "fd4ab49f6563bef6217b658a7ac3cc37e7544059a8ba2bb66c5221db769c0110", "size": 358 },
+								{ "hash": "7c135484e0ddfa160e6360fb0b6091ccb7a190927daa32771b2a521d7b25b800", "size": 395 },
+								{ "hash": "79d2fe3562c477712914f0df05c36fb9a552848ad2fa41dfd1dd5c11c9821a63", "size": 432 },
+								{ "hash": "13df3b4f41bde3f5b1c0cf5e580949a6b81e791e1eb9e25bf9ec1002eccbc900", "size": 469 },
+								{ "hash": "4a663cce8067c0dae6f1667301664a3e0d143ea2f08f5e73fd73dd31ab28af94", "size": 506 },
+								{ "hash": "73b049ecae88a4a2c8c7c6648bd8c5d82a877e7490bbb54a578e368ec3e683e6", "size": 543 },
+								{ "hash": "1c4e1f8e8adb94bb3b275ac959d3b35cc558a0522ebafc8d68eac1c089d25230", "size": 580 },
+								{ "hash": "d698d7ab1f20fa56b74e4a883fbb93e542ac4966a6c880fca26e717c908a9dd8", "size": 617 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[22, 0]],
+							"nodes": [
+								{ "hash": "514bfb7c2bec7770650b4a58c6a6e8066e7ec9b85f00a93ea4c5d1641be47e3a", "size": 654 },
+								{ "hash": "95d6f5833933763baa6afe3487470f787a74feaf82e8748223c0aebbfa10180a", "size": 691 },
+								{ "hash": "3dd4590e2362b53474c187c1041eb621864ca28078dde8fef772b11425caeb67", "size": 728 },
+								{ "hash": "faa17b234992532bdf6cb19c7ad41e08a9ab08dc3926c0e75ad7b96341c2a789", "size": 765 },
+								{ "hash": "86922026951e9994b2427029fc0d89658c7d556e4b41357c83ce02b2073204b8", "size": 802 },
+								{ "hash": "c10c4e913b240d0e5cd6e4a69328da9ea6004e04d430eea3abd98faa4bc45e29", "size": 839 },
+								{ "hash": "c4c9cde1480e5a6eeaf54684ac73b45adb92ab4899cc771163d8d7de153777a9", "size": 876 },
+								{ "hash": "5aecafedda8a07a8c32c9ce0e33ecf16657a4d1401fca02d621f9113266b67c4", "size": 913 },
+								{ "hash": "57d44034272b4ab45ecfc0bd483fe500238ba3d61f0b68b14b9f4ba68523b376", "size": 950 },
+								{ "hash": "d3b31e882c1acfc88d3bda821dfbe761f2c39333ea4843d89592e24e03063d08", "size": 987 },
+								{ "hash": "0500e4426ae86ae01bc015ee9224136e46aeb92a03fef9591600cbae98fe651c", "size": 1024 },
+								{ "hash": "d77209a7227dc8d3eefd2859773ba9f2cc6a0e485e8aa15bb67f704817d66401", "size": 1061 },
+								{ "hash": "bc327c9d83619dada04b6083ee8c8d3869770034c8bf48383daef6886f2b5b51", "size": 1098 },
+								{ "hash": "823154f14c27903f9358c5a214c58057ca9c3e52e10fbde1d74f48c380a67402", "size": 135 },
+								{ "hash": "7653a72ab18f16a8114d2890cb0afc3551f314e2f3be3dc543c2d25dea33d8b2", "size": 172 },
+								{ "hash": "3fbeff73e4cbb19d24886a02e65a2782367c279a62bcbb091677442725bb3947", "size": 209 },
+								{ "hash": "ad25b8090881aa03235c42109bca67ac44b0441c58be277ae1a3bfd9ac32a0db", "size": 246 },
+								{ "hash": "ca791f07f22273e0e3fa0189e1e348e873ad42cc80fbe390c1daceeecbf63cc9", "size": 283 },
+								{ "hash": "7ed84974ff5e37a14d87626155a77bd4c9af6317c39fc8acda0a7cf4d43b9d72", "size": 320 },
+								{ "hash": "df972c1a9cca1c1b823d4b1fc0e3f5720cd120fc22873fe3190df76a6e953cb7", "size": 357 },
+								{ "hash": "e53bf1989ceb530cb2d24b8b90ad13eb57863d1bc9325d4be21e1824af02dd29", "size": 394 },
+								{ "hash": "2a99d0eff1b98ed2074cfad1f5a69ea8e907827cc90c991a6e3ffa60d040dd91", "size": 431 }
+							]
+						}
+					],
+					"points": [21, 42]
+				},
+				{
+					"mergedFinalHash": "33cfd4b803a6c15577105a41a2900a4f9a92d530a0842c84cf73484952d1926d",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[9, 16],
+								[8, 0]
+							],
+							"nodes": [
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "08bef1184db71338fc973dd13a7185eae87db67e06e4c5eadb5b16d3d8439b2d", "size": 2470 },
+								{ "hash": "c933041e8b459b6175c856285216267f61d4d2750a7404b82c136aa39a69af7b", "size": 1420 },
+								{ "hash": "3b2d4081e4bbbaf5498721ebd28dcd19e066a6666d42071b3bc4d7350c21092d", "size": 1296 },
+								{ "hash": "3111effb06cbbb5c9376d51372e956ee0d6e439c12b8559a5038175750071a06", "size": 1629 },
+								{ "hash": "00b41d92df650c72464cc940376f54708e9e107f34a19068dfb6b83519e1bf0a", "size": 4257 },
+								{ "hash": "c10c4e913b240d0e5cd6e4a69328da9ea6004e04d430eea3abd98faa4bc45e29", "size": 839 },
+								{ "hash": "c4c9cde1480e5a6eeaf54684ac73b45adb92ab4899cc771163d8d7de153777a9", "size": 876 },
+								{ "hash": "5aecafedda8a07a8c32c9ce0e33ecf16657a4d1401fca02d621f9113266b67c4", "size": 913 },
+								{ "hash": "57d44034272b4ab45ecfc0bd483fe500238ba3d61f0b68b14b9f4ba68523b376", "size": 950 },
+								{ "hash": "d3b31e882c1acfc88d3bda821dfbe761f2c39333ea4843d89592e24e03063d08", "size": 987 },
+								{ "hash": "0500e4426ae86ae01bc015ee9224136e46aeb92a03fef9591600cbae98fe651c", "size": 1024 },
+								{ "hash": "d77209a7227dc8d3eefd2859773ba9f2cc6a0e485e8aa15bb67f704817d66401", "size": 1061 },
+								{ "hash": "bc327c9d83619dada04b6083ee8c8d3869770034c8bf48383daef6886f2b5b51", "size": 1098 },
+								{ "hash": "823154f14c27903f9358c5a214c58057ca9c3e52e10fbde1d74f48c380a67402", "size": 135 },
+								{ "hash": "7653a72ab18f16a8114d2890cb0afc3551f314e2f3be3dc543c2d25dea33d8b2", "size": 172 },
+								{ "hash": "3fbeff73e4cbb19d24886a02e65a2782367c279a62bcbb091677442725bb3947", "size": 209 },
+								{ "hash": "ad25b8090881aa03235c42109bca67ac44b0441c58be277ae1a3bfd9ac32a0db", "size": 246 },
+								{ "hash": "ca791f07f22273e0e3fa0189e1e348e873ad42cc80fbe390c1daceeecbf63cc9", "size": 283 },
+								{ "hash": "7ed84974ff5e37a14d87626155a77bd4c9af6317c39fc8acda0a7cf4d43b9d72", "size": 320 },
+								{ "hash": "df972c1a9cca1c1b823d4b1fc0e3f5720cd120fc22873fe3190df76a6e953cb7", "size": 357 },
+								{ "hash": "e53bf1989ceb530cb2d24b8b90ad13eb57863d1bc9325d4be21e1824af02dd29", "size": 394 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "2a99d0eff1b98ed2074cfad1f5a69ea8e907827cc90c991a6e3ffa60d040dd91", "size": 431 }]
+						}
+					],
+					"points": [1, 63]
+				},
+				{
+					"mergedFinalHash": "33cfd4b803a6c15577105a41a2900a4f9a92d530a0842c84cf73484952d1926d",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[7, 15],
+								[8, 0]
+							],
+							"nodes": [
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "08bef1184db71338fc973dd13a7185eae87db67e06e4c5eadb5b16d3d8439b2d", "size": 2470 },
+								{ "hash": "c933041e8b459b6175c856285216267f61d4d2750a7404b82c136aa39a69af7b", "size": 1420 },
+								{ "hash": "3b2d4081e4bbbaf5498721ebd28dcd19e066a6666d42071b3bc4d7350c21092d", "size": 1296 },
+								{ "hash": "3111effb06cbbb5c9376d51372e956ee0d6e439c12b8559a5038175750071a06", "size": 1629 },
+								{ "hash": "00b41d92df650c72464cc940376f54708e9e107f34a19068dfb6b83519e1bf0a", "size": 4257 },
+								{ "hash": "c10c4e913b240d0e5cd6e4a69328da9ea6004e04d430eea3abd98faa4bc45e29", "size": 839 },
+								{ "hash": "c4c9cde1480e5a6eeaf54684ac73b45adb92ab4899cc771163d8d7de153777a9", "size": 876 },
+								{ "hash": "5aecafedda8a07a8c32c9ce0e33ecf16657a4d1401fca02d621f9113266b67c4", "size": 913 },
+								{ "hash": "57d44034272b4ab45ecfc0bd483fe500238ba3d61f0b68b14b9f4ba68523b376", "size": 950 },
+								{ "hash": "d3b31e882c1acfc88d3bda821dfbe761f2c39333ea4843d89592e24e03063d08", "size": 987 },
+								{ "hash": "0500e4426ae86ae01bc015ee9224136e46aeb92a03fef9591600cbae98fe651c", "size": 1024 },
+								{ "hash": "d77209a7227dc8d3eefd2859773ba9f2cc6a0e485e8aa15bb67f704817d66401", "size": 1061 },
+								{ "hash": "bc327c9d83619dada04b6083ee8c8d3869770034c8bf48383daef6886f2b5b51", "size": 1098 },
+								{ "hash": "823154f14c27903f9358c5a214c58057ca9c3e52e10fbde1d74f48c380a67402", "size": 135 },
+								{ "hash": "7653a72ab18f16a8114d2890cb0afc3551f314e2f3be3dc543c2d25dea33d8b2", "size": 172 },
+								{ "hash": "3fbeff73e4cbb19d24886a02e65a2782367c279a62bcbb091677442725bb3947", "size": 209 },
+								{ "hash": "ad25b8090881aa03235c42109bca67ac44b0441c58be277ae1a3bfd9ac32a0db", "size": 246 },
+								{ "hash": "ca791f07f22273e0e3fa0189e1e348e873ad42cc80fbe390c1daceeecbf63cc9", "size": 283 },
+								{ "hash": "7ed84974ff5e37a14d87626155a77bd4c9af6317c39fc8acda0a7cf4d43b9d72", "size": 320 },
+								{ "hash": "df972c1a9cca1c1b823d4b1fc0e3f5720cd120fc22873fe3190df76a6e953cb7", "size": 357 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "e53bf1989ceb530cb2d24b8b90ad13eb57863d1bc9325d4be21e1824af02dd29", "size": 394 }]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "2a99d0eff1b98ed2074cfad1f5a69ea8e907827cc90c991a6e3ffa60d040dd91", "size": 431 }]
+						}
+					],
+					"points": [1, 2, 3, 62, 63]
+				},
+				{
+					"mergedFinalHash": "33cfd4b803a6c15577105a41a2900a4f9a92d530a0842c84cf73484952d1926d",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[12, 0]],
+							"nodes": [
+								{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 },
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "1fb2574032f0a157e8cd6d203d5a9120325031e7650505698fd8eb4c1779520d", "size": 470 },
+								{ "hash": "feff7301b82cade94b660b8f8ce65188eb689a6cf33cb57c74364733622e9af3", "size": 507 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[13, 0]],
+							"nodes": [
+								{ "hash": "6232edecc5ddff3735e666e9298a51e02c2a39e07929b7d79b6cbe4d7ef22195", "size": 544 },
+								{ "hash": "42f12f79321fd74a37dba135a2f71eff92fac2697380e264acad133462c5ee87", "size": 581 },
+								{ "hash": "3ec91f614691ab39da5b0ac300064c3c0cdd1186a82c17b790db17b5e943db67", "size": 618 },
+								{ "hash": "f5a6eb781dbfb23f51d36d4aa5611089e1ccfe8e14c80eb32142be9a3bbe8e04", "size": 655 },
+								{ "hash": "d5cac48a9c1b16950b1c31fa898ab41718515519b8aa031537ed8e39090d888c", "size": 692 },
+								{ "hash": "6010b022b172b087dbdc6fc1462a44fdb27c74c7c5ce36953ad811abd88cac33", "size": 729 },
+								{ "hash": "e4a1ee4ac7f2fb758f3d3279f5654050213a816a4f659de1596ea1c0047ccd2f", "size": 766 },
+								{ "hash": "1b2a66722191511804712b5eab811ad00b8a515a30d66be355591acdd925831d", "size": 803 },
+								{ "hash": "f23dba8222dee07b30ea705103036b9b38653119915851e423d65ad1c744de6e", "size": 840 },
+								{ "hash": "c4aaa513288d1a6b1d1412f8fc17a507ca3f53166cd81828883a547bc5c9f740", "size": 877 },
+								{ "hash": "fcc3772bbacfff206f85437ff7c8fa93f1aff55423f9d62a3c9a0eb0b6dae542", "size": 914 },
+								{ "hash": "82735448b05bd38c1ab20e2102c93504d28161e15cb3f2600ab54441aa8b4e66", "size": 951 },
+								{ "hash": "c27141e0ec282c5a4fbabecbd1debe2478cf1dbb1b274d9483232a844771319d", "size": 988 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[13, 0]],
+							"nodes": [
+								{ "hash": "68063885d9d364015967d07d0e8afd2986ccfa90f37ced1d5554269cd81ad700", "size": 1025 },
+								{ "hash": "b441d8629792f9aa5f5a083a2842c534861351e1b398161023669652ae7d34be", "size": 1062 },
+								{ "hash": "d8ae81a908799c76962fe6abd872d9442783a5408664f1f143251f34f7668fe1", "size": 1099 },
+								{ "hash": "6c5c4885e48cda17dd9a7ec28bef7f298ec994b58d3f909f0ea929de5ecb8361", "size": 136 },
+								{ "hash": "c53044b284f8b12e68b6df7e8be9f9b54afa9b52b67dfd18883cf0932847a7d0", "size": 173 },
+								{ "hash": "6c94a779a757d142e941c2f99e9fa55b99a87c6405fcd193e2f9a6be8d8d4b5e", "size": 210 },
+								{ "hash": "7edcc2da34f105ff852018c3741341e06d9ad43e98bd52e006a55e451221695c", "size": 247 },
+								{ "hash": "819dc9988b3871d7cee530f60ea0d9f3565ffb732410a7b8b95d8f13c84ddaa6", "size": 284 },
+								{ "hash": "0b18a316b8c07f1da356a50f5d2e4e952d2ae7030a5efd1357ecad6265fc1de1", "size": 321 },
+								{ "hash": "fd4ab49f6563bef6217b658a7ac3cc37e7544059a8ba2bb66c5221db769c0110", "size": 358 },
+								{ "hash": "7c135484e0ddfa160e6360fb0b6091ccb7a190927daa32771b2a521d7b25b800", "size": 395 },
+								{ "hash": "79d2fe3562c477712914f0df05c36fb9a552848ad2fa41dfd1dd5c11c9821a63", "size": 432 },
+								{ "hash": "13df3b4f41bde3f5b1c0cf5e580949a6b81e791e1eb9e25bf9ec1002eccbc900", "size": 469 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[13, 0]],
+							"nodes": [
+								{ "hash": "4a663cce8067c0dae6f1667301664a3e0d143ea2f08f5e73fd73dd31ab28af94", "size": 506 },
+								{ "hash": "73b049ecae88a4a2c8c7c6648bd8c5d82a877e7490bbb54a578e368ec3e683e6", "size": 543 },
+								{ "hash": "1c4e1f8e8adb94bb3b275ac959d3b35cc558a0522ebafc8d68eac1c089d25230", "size": 580 },
+								{ "hash": "d698d7ab1f20fa56b74e4a883fbb93e542ac4966a6c880fca26e717c908a9dd8", "size": 617 },
+								{ "hash": "514bfb7c2bec7770650b4a58c6a6e8066e7ec9b85f00a93ea4c5d1641be47e3a", "size": 654 },
+								{ "hash": "95d6f5833933763baa6afe3487470f787a74feaf82e8748223c0aebbfa10180a", "size": 691 },
+								{ "hash": "3dd4590e2362b53474c187c1041eb621864ca28078dde8fef772b11425caeb67", "size": 728 },
+								{ "hash": "faa17b234992532bdf6cb19c7ad41e08a9ab08dc3926c0e75ad7b96341c2a789", "size": 765 },
+								{ "hash": "86922026951e9994b2427029fc0d89658c7d556e4b41357c83ce02b2073204b8", "size": 802 },
+								{ "hash": "c10c4e913b240d0e5cd6e4a69328da9ea6004e04d430eea3abd98faa4bc45e29", "size": 839 },
+								{ "hash": "c4c9cde1480e5a6eeaf54684ac73b45adb92ab4899cc771163d8d7de153777a9", "size": 876 },
+								{ "hash": "5aecafedda8a07a8c32c9ce0e33ecf16657a4d1401fca02d621f9113266b67c4", "size": 913 },
+								{ "hash": "57d44034272b4ab45ecfc0bd483fe500238ba3d61f0b68b14b9f4ba68523b376", "size": 950 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[13, 0]],
+							"nodes": [
+								{ "hash": "d3b31e882c1acfc88d3bda821dfbe761f2c39333ea4843d89592e24e03063d08", "size": 987 },
+								{ "hash": "0500e4426ae86ae01bc015ee9224136e46aeb92a03fef9591600cbae98fe651c", "size": 1024 },
+								{ "hash": "d77209a7227dc8d3eefd2859773ba9f2cc6a0e485e8aa15bb67f704817d66401", "size": 1061 },
+								{ "hash": "bc327c9d83619dada04b6083ee8c8d3869770034c8bf48383daef6886f2b5b51", "size": 1098 },
+								{ "hash": "823154f14c27903f9358c5a214c58057ca9c3e52e10fbde1d74f48c380a67402", "size": 135 },
+								{ "hash": "7653a72ab18f16a8114d2890cb0afc3551f314e2f3be3dc543c2d25dea33d8b2", "size": 172 },
+								{ "hash": "3fbeff73e4cbb19d24886a02e65a2782367c279a62bcbb091677442725bb3947", "size": 209 },
+								{ "hash": "ad25b8090881aa03235c42109bca67ac44b0441c58be277ae1a3bfd9ac32a0db", "size": 246 },
+								{ "hash": "ca791f07f22273e0e3fa0189e1e348e873ad42cc80fbe390c1daceeecbf63cc9", "size": 283 },
+								{ "hash": "7ed84974ff5e37a14d87626155a77bd4c9af6317c39fc8acda0a7cf4d43b9d72", "size": 320 },
+								{ "hash": "df972c1a9cca1c1b823d4b1fc0e3f5720cd120fc22873fe3190df76a6e953cb7", "size": 357 },
+								{ "hash": "e53bf1989ceb530cb2d24b8b90ad13eb57863d1bc9325d4be21e1824af02dd29", "size": 394 },
+								{ "hash": "2a99d0eff1b98ed2074cfad1f5a69ea8e907827cc90c991a6e3ffa60d040dd91", "size": 431 }
+							]
+						}
+					],
+					"points": [12, 25, 38, 51]
+				}
+			],
+			"xorbHash": "33cfd4b803a6c15577105a41a2900a4f9a92d530a0842c84cf73484952d1926d"
+		},
+		{
+			"fileHash": "da93ead4b9916cfad5e4cbffe37fdc92ea76e25a5f83075bc3c3259bcc8ce6a1",
+			"finalHash": "8f390c1cea906d5821dade9cb0f227b46c7cdc8b72924f74bc33aac8340606e8",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [
+					[0, 0],
+					[0, 0],
+					[0, 0],
+					[1, 0]
+				],
+				"nodes": [{ "hash": "8f390c1cea906d5821dade9cb0f227b46c7cdc8b72924f74bc33aac8340606e8", "size": 88475 }]
+			},
+			"n": 150,
+			"splits": [
+				{
+					"mergedFinalHash": "8f390c1cea906d5821dade9cb0f227b46c7cdc8b72924f74bc33aac8340606e8",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [
+								[0, 28],
+								[11, 0]
+							],
+							"nodes": [
+								{ "hash": "1dabfedde0a609e0b32dd29697432c092d71c80b32b67a8bf77f79b7dac83e7f", "size": 411 },
+								{ "hash": "e2c0389432e88785265cb0098e851b8383852eaafb1d930463fcb8c3eb40850c", "size": 744 },
+								{ "hash": "85193ca885bdb82175ddabcaaae26b2f880d7497e765ea3e6b7f40344527e78b", "size": 1510 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "08bef1184db71338fc973dd13a7185eae87db67e06e4c5eadb5b16d3d8439b2d", "size": 2470 },
+								{ "hash": "c933041e8b459b6175c856285216267f61d4d2750a7404b82c136aa39a69af7b", "size": 1420 },
+								{ "hash": "3b2d4081e4bbbaf5498721ebd28dcd19e066a6666d42071b3bc4d7350c21092d", "size": 1296 },
+								{ "hash": "3111effb06cbbb5c9376d51372e956ee0d6e439c12b8559a5038175750071a06", "size": 1629 },
+								{ "hash": "00b41d92df650c72464cc940376f54708e9e107f34a19068dfb6b83519e1bf0a", "size": 4257 },
+								{ "hash": "c10c4e913b240d0e5cd6e4a69328da9ea6004e04d430eea3abd98faa4bc45e29", "size": 839 },
+								{ "hash": "c4c9cde1480e5a6eeaf54684ac73b45adb92ab4899cc771163d8d7de153777a9", "size": 876 },
+								{ "hash": "5aecafedda8a07a8c32c9ce0e33ecf16657a4d1401fca02d621f9113266b67c4", "size": 913 },
+								{ "hash": "57d44034272b4ab45ecfc0bd483fe500238ba3d61f0b68b14b9f4ba68523b376", "size": 950 },
+								{ "hash": "d3b31e882c1acfc88d3bda821dfbe761f2c39333ea4843d89592e24e03063d08", "size": 987 },
+								{ "hash": "0500e4426ae86ae01bc015ee9224136e46aeb92a03fef9591600cbae98fe651c", "size": 1024 },
+								{ "hash": "d77209a7227dc8d3eefd2859773ba9f2cc6a0e485e8aa15bb67f704817d66401", "size": 1061 },
+								{ "hash": "bc327c9d83619dada04b6083ee8c8d3869770034c8bf48383daef6886f2b5b51", "size": 1098 },
+								{ "hash": "823154f14c27903f9358c5a214c58057ca9c3e52e10fbde1d74f48c380a67402", "size": 135 },
+								{ "hash": "7653a72ab18f16a8114d2890cb0afc3551f314e2f3be3dc543c2d25dea33d8b2", "size": 172 },
+								{ "hash": "3fbeff73e4cbb19d24886a02e65a2782367c279a62bcbb091677442725bb3947", "size": 209 },
+								{ "hash": "ad25b8090881aa03235c42109bca67ac44b0441c58be277ae1a3bfd9ac32a0db", "size": 246 },
+								{ "hash": "ca791f07f22273e0e3fa0189e1e348e873ad42cc80fbe390c1daceeecbf63cc9", "size": 283 },
+								{ "hash": "7ed84974ff5e37a14d87626155a77bd4c9af6317c39fc8acda0a7cf4d43b9d72", "size": 320 },
+								{ "hash": "df972c1a9cca1c1b823d4b1fc0e3f5720cd120fc22873fe3190df76a6e953cb7", "size": 357 },
+								{ "hash": "e53bf1989ceb530cb2d24b8b90ad13eb57863d1bc9325d4be21e1824af02dd29", "size": 394 },
+								{ "hash": "2a99d0eff1b98ed2074cfad1f5a69ea8e907827cc90c991a6e3ffa60d040dd91", "size": 431 },
+								{ "hash": "d1e0ac30f1805f754e2e82ce5409eb0c5160935ed14576a989b45f7f4605639e", "size": 468 },
+								{ "hash": "1106edc7cf5d747dad643ccd93e1f292a1a4a32e9d15044bbb6b2f80cef181ab", "size": 505 },
+								{ "hash": "1128e219ba2e0782c8d707a30973e6f9e490b1fbbf2acb24ffd5b845af300ac5", "size": 542 },
+								{ "hash": "2423b0a200a733e84c378253616d263c1a2036f388c255143d32a1c08489cbde", "size": 579 },
+								{ "hash": "fac4dc319a9cba9747339a36698990def5da16fa55ada3405cc5a54d6684f9aa", "size": 616 },
+								{ "hash": "5bbc05d652877ccb11d261dab666fab4656bf8ab7c4d91cf2945043ce8642699", "size": 653 },
+								{ "hash": "df7d17d9efde9aa0583e65b46d861bc8cd4b49f96cb0311428bd084e5764691a", "size": 690 },
+								{ "hash": "b458fd040e1939c099107f918154cbe7fd754a8e67312d2f3c123d1d408b6ffc", "size": 727 },
+								{ "hash": "5dd8f0fcfe0924c29ba6bebd30c5f46b996427c7db21176c277184ac67efb7cf", "size": 764 },
+								{ "hash": "a5a6e08441dbc04bb2ba5d747bf72fc650e158d76fecbf8e5d421152bc2cc113", "size": 801 },
+								{ "hash": "e40df113e6e092eba9877e3c469d7206b4aa2b06c5b1b09343ff06fd88b415e0", "size": 838 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [
+								[14, 0],
+								[10, 0]
+							],
+							"nodes": [
+								{ "hash": "5d2a221e98e6636322d6444ef7ac4d62373d07bde3eaa8a173dc1a43a3c4f011", "size": 875 },
+								{ "hash": "2dc6d1be1cfba1654fd98adb0c3a43b071378301d7a5034071c84b94bef93e06", "size": 912 },
+								{ "hash": "0bc24046cc94371495d8651eb0a300fa7e9a820ad23411446d46a10c592f33ec", "size": 949 },
+								{ "hash": "a323a04c00676b21dda46b60b21e3f8ea5729f86aff6cd3257a62f8f36631354", "size": 986 },
+								{ "hash": "c185615ad7d329759ac8f15cbaa271b0d6fec0bd75ded7a2dddea4c00d34a1bb", "size": 1023 },
+								{ "hash": "33f2d6ee87363b8f6153792957ced912ca47bad89815f505e4d84c5761d1afa9", "size": 1060 },
+								{ "hash": "5e59ed83efd6cd5e452862943164551f96cecdba11513245521e8943090bb3c5", "size": 1097 },
+								{ "hash": "7b8d87484622db6a2bbf2522086fb13c9de1f9e5987de41e37f308b707beac7a", "size": 134 },
+								{ "hash": "49350d31f20215c6bbf7cfbc48fcd6526d13dfaf0671ecd64a8c29c6ca164a2c", "size": 171 },
+								{ "hash": "64c6bed4cf0d3e4e6af1cd57a8a529601e9801193afcd3413f74fcb957c57abc", "size": 208 },
+								{ "hash": "06e09edcc26fd41ee91d07cba8e8c20fcaccd0b040439faeb13a7bbeb90e5b1d", "size": 245 },
+								{ "hash": "5100b2006e28e6a9c9ac72fb0abb2e7ec5689dab516e8ba15abcfcadc47ad232", "size": 282 },
+								{ "hash": "8a98a7c1a374c3f5b3e3c461fae2f6b564c2e9f3d36613f05532efdb2e99438d", "size": 319 },
+								{ "hash": "66769fdc164a8095fc9bf8ff6b171dea2b3eebff13e37eecf4d99df86c79919c", "size": 356 },
+								{ "hash": "fb878499b1d3149dc575f28cba648d2949d9450576e6df03f3451890c4f63dd2", "size": 2913 },
+								{ "hash": "bc8f0b645e48d1efa2f9c9890bb9142e3c8966f50a38bbe24c68b1fee0b5aee4", "size": 1956 },
+								{ "hash": "14279eff9b0d4f32c93c88abc3b94de10075ce9f92e057cc8bd500f0271bd80c", "size": 7866 },
+								{ "hash": "500eb05149a732a2a8654a3423f40c3587095cfd91df8a56c9d44f2c28a5882d", "size": 3863 },
+								{ "hash": "2284b383c73816c4ebe6c9ca12e63f409548d77d6c395958dbf0c8bad05d3930", "size": 3521 },
+								{ "hash": "38432ab70e9ae472f562ba915638e04e7fb8d231252b137144df9210f7859ee8", "size": 6244 },
+								{ "hash": "943392650f95bdedf0189d8e7cbc5591078d3d4697bb75899ffc632052e474a1", "size": 5612 },
+								{ "hash": "9f9dac582fe93ae94ee85907638c234bb6c44f375de3f1000f5c8b6dc58d6981", "size": 1585 },
+								{ "hash": "251c894b522ff253971294a7d2cd866b218b2227598f295b22d7db9105fcc014", "size": 1395 },
+								{ "hash": "9786a872d9ad831b8b5503f7bc434a4b0437b809d34dd6e7fe11524c5b39fb03", "size": 1728 }
+							]
+						}
+					],
+					"points": [75]
+				},
+				{
+					"mergedFinalHash": "8f390c1cea906d5821dade9cb0f227b46c7cdc8b72924f74bc33aac8340606e8",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [
+								[0, 3],
+								[11, 0]
+							],
+							"nodes": [
+								{ "hash": "1dabfedde0a609e0b32dd29697432c092d71c80b32b67a8bf77f79b7dac83e7f", "size": 411 },
+								{ "hash": "e2c0389432e88785265cb0098e851b8383852eaafb1d930463fcb8c3eb40850c", "size": 744 },
+								{ "hash": "85193ca885bdb82175ddabcaaae26b2f880d7497e765ea3e6b7f40344527e78b", "size": 1510 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "08bef1184db71338fc973dd13a7185eae87db67e06e4c5eadb5b16d3d8439b2d", "size": 2470 },
+								{ "hash": "c933041e8b459b6175c856285216267f61d4d2750a7404b82c136aa39a69af7b", "size": 1420 },
+								{ "hash": "3b2d4081e4bbbaf5498721ebd28dcd19e066a6666d42071b3bc4d7350c21092d", "size": 1296 },
+								{ "hash": "3111effb06cbbb5c9376d51372e956ee0d6e439c12b8559a5038175750071a06", "size": 1629 },
+								{ "hash": "00b41d92df650c72464cc940376f54708e9e107f34a19068dfb6b83519e1bf0a", "size": 4257 },
+								{ "hash": "c10c4e913b240d0e5cd6e4a69328da9ea6004e04d430eea3abd98faa4bc45e29", "size": 839 },
+								{ "hash": "c4c9cde1480e5a6eeaf54684ac73b45adb92ab4899cc771163d8d7de153777a9", "size": 876 },
+								{ "hash": "5aecafedda8a07a8c32c9ce0e33ecf16657a4d1401fca02d621f9113266b67c4", "size": 913 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[25, 11],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "57d44034272b4ab45ecfc0bd483fe500238ba3d61f0b68b14b9f4ba68523b376", "size": 950 },
+								{ "hash": "d3b31e882c1acfc88d3bda821dfbe761f2c39333ea4843d89592e24e03063d08", "size": 987 },
+								{ "hash": "0500e4426ae86ae01bc015ee9224136e46aeb92a03fef9591600cbae98fe651c", "size": 1024 },
+								{ "hash": "d77209a7227dc8d3eefd2859773ba9f2cc6a0e485e8aa15bb67f704817d66401", "size": 1061 },
+								{ "hash": "bc327c9d83619dada04b6083ee8c8d3869770034c8bf48383daef6886f2b5b51", "size": 1098 },
+								{ "hash": "823154f14c27903f9358c5a214c58057ca9c3e52e10fbde1d74f48c380a67402", "size": 135 },
+								{ "hash": "7653a72ab18f16a8114d2890cb0afc3551f314e2f3be3dc543c2d25dea33d8b2", "size": 172 },
+								{ "hash": "3fbeff73e4cbb19d24886a02e65a2782367c279a62bcbb091677442725bb3947", "size": 209 },
+								{ "hash": "ad25b8090881aa03235c42109bca67ac44b0441c58be277ae1a3bfd9ac32a0db", "size": 246 },
+								{ "hash": "ca791f07f22273e0e3fa0189e1e348e873ad42cc80fbe390c1daceeecbf63cc9", "size": 283 },
+								{ "hash": "7ed84974ff5e37a14d87626155a77bd4c9af6317c39fc8acda0a7cf4d43b9d72", "size": 320 },
+								{ "hash": "df972c1a9cca1c1b823d4b1fc0e3f5720cd120fc22873fe3190df76a6e953cb7", "size": 357 },
+								{ "hash": "e53bf1989ceb530cb2d24b8b90ad13eb57863d1bc9325d4be21e1824af02dd29", "size": 394 },
+								{ "hash": "2a99d0eff1b98ed2074cfad1f5a69ea8e907827cc90c991a6e3ffa60d040dd91", "size": 431 },
+								{ "hash": "d1e0ac30f1805f754e2e82ce5409eb0c5160935ed14576a989b45f7f4605639e", "size": 468 },
+								{ "hash": "1106edc7cf5d747dad643ccd93e1f292a1a4a32e9d15044bbb6b2f80cef181ab", "size": 505 },
+								{ "hash": "1128e219ba2e0782c8d707a30973e6f9e490b1fbbf2acb24ffd5b845af300ac5", "size": 542 },
+								{ "hash": "2423b0a200a733e84c378253616d263c1a2036f388c255143d32a1c08489cbde", "size": 579 },
+								{ "hash": "fac4dc319a9cba9747339a36698990def5da16fa55ada3405cc5a54d6684f9aa", "size": 616 },
+								{ "hash": "5bbc05d652877ccb11d261dab666fab4656bf8ab7c4d91cf2945043ce8642699", "size": 653 },
+								{ "hash": "df7d17d9efde9aa0583e65b46d861bc8cd4b49f96cb0311428bd084e5764691a", "size": 690 },
+								{ "hash": "b458fd040e1939c099107f918154cbe7fd754a8e67312d2f3c123d1d408b6ffc", "size": 727 },
+								{ "hash": "5dd8f0fcfe0924c29ba6bebd30c5f46b996427c7db21176c277184ac67efb7cf", "size": 764 },
+								{ "hash": "a5a6e08441dbc04bb2ba5d747bf72fc650e158d76fecbf8e5d421152bc2cc113", "size": 801 },
+								{ "hash": "e40df113e6e092eba9877e3c469d7206b4aa2b06c5b1b09343ff06fd88b415e0", "size": 838 },
+								{ "hash": "0b66e1f0130be01f6c0fff41a829dd9b3702b7abade2661f0865316c3f20f249", "size": 2736 },
+								{ "hash": "99e7059c9b120c63fd6c027db9a91c18aa980af0fff670185772b44de1c8bb6a", "size": 4471 },
+								{ "hash": "a2b2a006599d5bbf7d7473e981b4009b95dadc9d138be82a3c0ef6b14368c19f", "size": 1410 },
+								{ "hash": "433cab2e08fabc4d194bded5b83ccee303ed6f8b2144b820f476f0bbc3aaca26", "size": 393 },
+								{ "hash": "422f965d40f948d8998389fecaeffeca5a59ac02085aa6fa4ccf3c1017cf4ded", "size": 430 },
+								{ "hash": "07411612b49d7edf0a8b45add1765eb0cc1b72ec428274be1a120c05fdffae0b", "size": 467 },
+								{ "hash": "9336ed2a8779b0e95ebbb3488cdf502ddbd29081c150bd93ec4c6b36b67336cb", "size": 504 },
+								{ "hash": "cdd8c388712b29fdf3e84daf43e5f2e760b63b6a3f20cf3c1dcabb059ab5966b", "size": 541 },
+								{ "hash": "36d0eda5c1713e21ee6c4626845fb1133abc7506bf80ef996fa4258902b2f774", "size": 578 },
+								{ "hash": "7903c87e60fb278093f21832d62155c870f86bfcdd91be70b4decc7997574d28", "size": 615 },
+								{ "hash": "7f5bf2432754860d997eb802acea8fd0768ca23f4ee542deb5a8d59d6f06ba7e", "size": 652 },
+								{ "hash": "218dc09b3d83e18cf61c53f8d08be65f40219c0368af78feaa261ee20c7000b8", "size": 689 },
+								{ "hash": "7328db9af2d01df73749a16611ec529f58610846c1f7a18395652aeafff68ac2", "size": 726 },
+								{ "hash": "87300ce0d44060edc848ce9fc5352838c4bda571c526367f50e474fc812ceb01", "size": 763 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [
+								[39, 0],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "9b8333115a7b896408cc89b3878f0f921d7dbad32c000e46743dbb1f978a2a83", "size": 800 },
+								{ "hash": "901c05e9d8b840e80a8aca7471f2e2772b90e32bf93556166b52f72f3ffcb39e", "size": 837 },
+								{ "hash": "67ea0dd3457c7d5fb3807c65532b17d8ca5ad95244e5c207bec11230a1c2497a", "size": 874 },
+								{ "hash": "6e0db0da89f453210c1439fed5d640c4e9e102754713411d7b5f18da9543ed5e", "size": 911 },
+								{ "hash": "a286f0cc42113a07fa21bb88c742458791bb72d2317d0ad58330e22668b5fc87", "size": 948 },
+								{ "hash": "ea0bedbf4f7edf6313310d2f470117a653e2cd7aabf37d3fa3ea5e3ab3f0a895", "size": 985 },
+								{ "hash": "a5d40b7e787e723bf4e5c792a1c71c4580d7772a9816cd78dbe6650dab6613a9", "size": 1022 },
+								{ "hash": "319ff0e5a067b412decc7eccda7d1b7c6f85846078edb9a8d1f2263d7cdb7adb", "size": 1059 },
+								{ "hash": "0cadbe91a7339e450e16aa6f0a5c73908ccb117677845fa6cdad54d83d2a2e8f", "size": 1096 },
+								{ "hash": "b534b5e44b49af179ddaa3dd04ef77a2ff41cf2a99ce597511f17712d2964212", "size": 133 },
+								{ "hash": "6d492275f9dc1b3eb14c4fe40e7697fcb8be7bd0e502f36294fd292fc91b6c2f", "size": 170 },
+								{ "hash": "6e2c3fd686f1a39c61e4cc12493e64c9c598fbaa14600741034d6c2b273bbc9e", "size": 207 },
+								{ "hash": "bfbbfd0efc71f898483fe35ef957352ce83da316815a72af275c713017c203b5", "size": 244 },
+								{ "hash": "df9d7f8d2ced5b0b2244b86a1927c198ee3288ca46609e858eabaccb2ca5e802", "size": 281 },
+								{ "hash": "7b29b3872538a0ed752054050ad2e4313b65bda4a48850070bd43a6f40920ca9", "size": 318 },
+								{ "hash": "256819840287ba1d30ed5375d6286f11c26512129ba74cf579d899c2ba2f3e90", "size": 355 },
+								{ "hash": "56455d6fda197306983ebf91057fafa7aeb52a5a7b6c6f0181a80f1f220c6413", "size": 392 },
+								{ "hash": "e7850046aef15361539ebb14a5eec9ff0816b92a7082fe1f9d0aab19b39a1d8f", "size": 429 },
+								{ "hash": "f64427ec5cfb94c6bc0082d31843d1b747e57175c51967f124b44baad56603b7", "size": 466 },
+								{ "hash": "8618bbd2c67b31c04c21e8b7352ff911b7cfe3dbab199f7d133ef3f27784f7c7", "size": 503 },
+								{ "hash": "ac23ed184cad11bea7276976502b43735e1bdb8a5d0df3865856b725485f9ffa", "size": 540 },
+								{ "hash": "f67d4b03fd27e4144644433b6cc363c6b1b1655231c1e664a1744a5bd6c3560a", "size": 577 },
+								{ "hash": "0e16e82216955e904dba6e759ba89f7d904bf076697855d4b2723f0b1e643170", "size": 614 },
+								{ "hash": "2681300f410c9be6abe8cabf3a9288904c1ec8e9cecf7768e176775f1f58786e", "size": 651 },
+								{ "hash": "dfe5d18c6cccc67420b03679d72de5e1c0fdcf124017046b66e01aa5b6237d97", "size": 688 },
+								{ "hash": "3ea4e2da0d2e03c3d1588e18b768e76c71ed0e87b60ac146cfc971146759c066", "size": 725 },
+								{ "hash": "15f969a4d11c40fc62e8898bf33dbd50b972156da8e47e6dcf00e69e76a0fdcf", "size": 762 },
+								{ "hash": "caacbc17a0797f495b88102deb7c82747aaf3645f273dcea45794e5eb8f6e89e", "size": 799 },
+								{ "hash": "71478cfaa143a6eefb5a9f591a40f1c5231643a7ce4e40ec2f0dff9f5f5ac41f", "size": 836 },
+								{ "hash": "1701c077888854984ebcc89c15fb5c36719f73c4519a9f84a60c2c9e8e2a7762", "size": 873 },
+								{ "hash": "6213c946676be514a7299821dfec4b47a6f969255219ebcf9f62a1561b418690", "size": 910 },
+								{ "hash": "9badd8638277c2f5d3b59ef1c5fb5ad555800bcfd72056b0d88fffbd4d51c691", "size": 947 },
+								{ "hash": "6d879f5bb23f939b9d40ef350a34ef323b6ada854ad394d3482ca28f40082f58", "size": 984 },
+								{ "hash": "1fd466fb238af54aa2301ca992081e432ded96f46e7b65288f2cf32a612e6fd2", "size": 1021 },
+								{ "hash": "b4e8561a42a325cbbe628488a11d641184f411bfaa6b7802b3f9fc6c83f6d597", "size": 1058 },
+								{ "hash": "31269674e61de19626854b1b1181f0856eb57f1283c6a301ba6166c2ec313b19", "size": 1095 },
+								{ "hash": "ff0ba635978b684717acd41ed82eed7367193ac6ed7d00f41650b4cafbbced5b", "size": 132 },
+								{ "hash": "e05e547073c027666e8c2004616111f7dea96e6518c65165b04eca07e233eb2d", "size": 169 },
+								{ "hash": "7b29cef35b739e1ef01acc032563ba397fadacdd3132a3167e0b99df5a1800ec", "size": 206 },
+								{ "hash": "9f9dac582fe93ae94ee85907638c234bb6c44f375de3f1000f5c8b6dc58d6981", "size": 1585 },
+								{ "hash": "251c894b522ff253971294a7d2cd866b218b2227598f295b22d7db9105fcc014", "size": 1395 },
+								{ "hash": "9786a872d9ad831b8b5503f7bc434a4b0437b809d34dd6e7fe11524c5b39fb03", "size": 1728 }
+							]
+						}
+					],
+					"points": [50, 100]
+				},
+				{
+					"mergedFinalHash": "8f390c1cea906d5821dade9cb0f227b46c7cdc8b72924f74bc33aac8340606e8",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[9, 5],
+								[24, 0]
+							],
+							"nodes": [
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "08bef1184db71338fc973dd13a7185eae87db67e06e4c5eadb5b16d3d8439b2d", "size": 2470 },
+								{ "hash": "c933041e8b459b6175c856285216267f61d4d2750a7404b82c136aa39a69af7b", "size": 1420 },
+								{ "hash": "3b2d4081e4bbbaf5498721ebd28dcd19e066a6666d42071b3bc4d7350c21092d", "size": 1296 },
+								{ "hash": "3111effb06cbbb5c9376d51372e956ee0d6e439c12b8559a5038175750071a06", "size": 1629 },
+								{ "hash": "00b41d92df650c72464cc940376f54708e9e107f34a19068dfb6b83519e1bf0a", "size": 4257 },
+								{ "hash": "9e50c43052cb333988ef35afdfd4dcede1ee9466eb02a3e94c3384aeee83bb85", "size": 2628 },
+								{ "hash": "6f2ad36f534f13c285fb9d61db474abc0164b4063626a2d52188f903e2b6ce18", "size": 2961 },
+								{ "hash": "ad31d0ed6a2912b4c911b3f6a41f06cca1e74d571a66156f99a0052a34e6eca5", "size": 3881 },
+								{ "hash": "18c7d0f5abe138b967f9ea481e0128bff9cd055ef080d111c7adba07de9dfd8f", "size": 4878 },
+								{ "hash": "d0b27cf88fb13ba6694f300b0f77b0966f80d946b72a2f6b8b945df8385df4ac", "size": 3130 },
+								{ "hash": "0b66e1f0130be01f6c0fff41a829dd9b3702b7abade2661f0865316c3f20f249", "size": 2736 },
+								{ "hash": "99e7059c9b120c63fd6c027db9a91c18aa980af0fff670185772b44de1c8bb6a", "size": 4471 },
+								{ "hash": "a2b2a006599d5bbf7d7473e981b4009b95dadc9d138be82a3c0ef6b14368c19f", "size": 1410 },
+								{ "hash": "fb878499b1d3149dc575f28cba648d2949d9450576e6df03f3451890c4f63dd2", "size": 2913 },
+								{ "hash": "bc8f0b645e48d1efa2f9c9890bb9142e3c8966f50a38bbe24c68b1fee0b5aee4", "size": 1956 },
+								{ "hash": "14279eff9b0d4f32c93c88abc3b94de10075ce9f92e057cc8bd500f0271bd80c", "size": 7866 },
+								{ "hash": "500eb05149a732a2a8654a3423f40c3587095cfd91df8a56c9d44f2c28a5882d", "size": 3863 },
+								{ "hash": "2284b383c73816c4ebe6c9ca12e63f409548d77d6c395958dbf0c8bad05d3930", "size": 3521 },
+								{ "hash": "38432ab70e9ae472f562ba915638e04e7fb8d231252b137144df9210f7859ee8", "size": 6244 },
+								{ "hash": "943392650f95bdedf0189d8e7cbc5591078d3d4697bb75899ffc632052e474a1", "size": 5612 },
+								{ "hash": "9f9dac582fe93ae94ee85907638c234bb6c44f375de3f1000f5c8b6dc58d6981", "size": 1585 },
+								{ "hash": "36f5fe1992ae14618a6524bf3dfd45aa15ec48f10a7e0993ae22e622f7fd12b7", "size": 428 },
+								{ "hash": "8e4ff34b7f687ecbfa750650f16fd1cebdbc3658e479f23e4687dea47f62bbb2", "size": 465 },
+								{ "hash": "59c7d3af01e87f42a17e61a35741b1b7cfcf5b8f35c657c2564c44f4d6e0f270", "size": 502 },
+								{ "hash": "f91ae962900867e7df744a2fc84d619a6dd80c767dddbddb2ce0310fd7720bf0", "size": 539 },
+								{ "hash": "524c1248b1ef80bfcea68e56552d98c9a05304678edaa266619ddde5fccf5808", "size": 576 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "1e1823fa83af89449e14a2b44674d07b3aa9bad7e03da4e2bb305006077f85e1", "size": 613 }]
+						}
+					],
+					"points": [1, 149]
+				},
+				{
+					"mergedFinalHash": "8f390c1cea906d5821dade9cb0f227b46c7cdc8b72924f74bc33aac8340606e8",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[7, 4],
+								[24, 0]
+							],
+							"nodes": [
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "08bef1184db71338fc973dd13a7185eae87db67e06e4c5eadb5b16d3d8439b2d", "size": 2470 },
+								{ "hash": "c933041e8b459b6175c856285216267f61d4d2750a7404b82c136aa39a69af7b", "size": 1420 },
+								{ "hash": "3b2d4081e4bbbaf5498721ebd28dcd19e066a6666d42071b3bc4d7350c21092d", "size": 1296 },
+								{ "hash": "3111effb06cbbb5c9376d51372e956ee0d6e439c12b8559a5038175750071a06", "size": 1629 },
+								{ "hash": "00b41d92df650c72464cc940376f54708e9e107f34a19068dfb6b83519e1bf0a", "size": 4257 },
+								{ "hash": "9e50c43052cb333988ef35afdfd4dcede1ee9466eb02a3e94c3384aeee83bb85", "size": 2628 },
+								{ "hash": "6f2ad36f534f13c285fb9d61db474abc0164b4063626a2d52188f903e2b6ce18", "size": 2961 },
+								{ "hash": "ad31d0ed6a2912b4c911b3f6a41f06cca1e74d571a66156f99a0052a34e6eca5", "size": 3881 },
+								{ "hash": "18c7d0f5abe138b967f9ea481e0128bff9cd055ef080d111c7adba07de9dfd8f", "size": 4878 },
+								{ "hash": "d0b27cf88fb13ba6694f300b0f77b0966f80d946b72a2f6b8b945df8385df4ac", "size": 3130 },
+								{ "hash": "0b66e1f0130be01f6c0fff41a829dd9b3702b7abade2661f0865316c3f20f249", "size": 2736 },
+								{ "hash": "99e7059c9b120c63fd6c027db9a91c18aa980af0fff670185772b44de1c8bb6a", "size": 4471 },
+								{ "hash": "a2b2a006599d5bbf7d7473e981b4009b95dadc9d138be82a3c0ef6b14368c19f", "size": 1410 },
+								{ "hash": "fb878499b1d3149dc575f28cba648d2949d9450576e6df03f3451890c4f63dd2", "size": 2913 },
+								{ "hash": "bc8f0b645e48d1efa2f9c9890bb9142e3c8966f50a38bbe24c68b1fee0b5aee4", "size": 1956 },
+								{ "hash": "14279eff9b0d4f32c93c88abc3b94de10075ce9f92e057cc8bd500f0271bd80c", "size": 7866 },
+								{ "hash": "500eb05149a732a2a8654a3423f40c3587095cfd91df8a56c9d44f2c28a5882d", "size": 3863 },
+								{ "hash": "2284b383c73816c4ebe6c9ca12e63f409548d77d6c395958dbf0c8bad05d3930", "size": 3521 },
+								{ "hash": "38432ab70e9ae472f562ba915638e04e7fb8d231252b137144df9210f7859ee8", "size": 6244 },
+								{ "hash": "943392650f95bdedf0189d8e7cbc5591078d3d4697bb75899ffc632052e474a1", "size": 5612 },
+								{ "hash": "9f9dac582fe93ae94ee85907638c234bb6c44f375de3f1000f5c8b6dc58d6981", "size": 1585 },
+								{ "hash": "36f5fe1992ae14618a6524bf3dfd45aa15ec48f10a7e0993ae22e622f7fd12b7", "size": 428 },
+								{ "hash": "8e4ff34b7f687ecbfa750650f16fd1cebdbc3658e479f23e4687dea47f62bbb2", "size": 465 },
+								{ "hash": "59c7d3af01e87f42a17e61a35741b1b7cfcf5b8f35c657c2564c44f4d6e0f270", "size": 502 },
+								{ "hash": "f91ae962900867e7df744a2fc84d619a6dd80c767dddbddb2ce0310fd7720bf0", "size": 539 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "524c1248b1ef80bfcea68e56552d98c9a05304678edaa266619ddde5fccf5808", "size": 576 }]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "1e1823fa83af89449e14a2b44674d07b3aa9bad7e03da4e2bb305006077f85e1", "size": 613 }]
+						}
+					],
+					"points": [1, 2, 3, 148, 149]
+				},
+				{
+					"mergedFinalHash": "8f390c1cea906d5821dade9cb0f227b46c7cdc8b72924f74bc33aac8340606e8",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [
+								[0, 4],
+								[6, 0]
+							],
+							"nodes": [
+								{ "hash": "1dabfedde0a609e0b32dd29697432c092d71c80b32b67a8bf77f79b7dac83e7f", "size": 411 },
+								{ "hash": "e2c0389432e88785265cb0098e851b8383852eaafb1d930463fcb8c3eb40850c", "size": 744 },
+								{ "hash": "85193ca885bdb82175ddabcaaae26b2f880d7497e765ea3e6b7f40344527e78b", "size": 1510 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "b441d8629792f9aa5f5a083a2842c534861351e1b398161023669652ae7d34be", "size": 1062 },
+								{ "hash": "d8ae81a908799c76962fe6abd872d9442783a5408664f1f143251f34f7668fe1", "size": 1099 },
+								{ "hash": "6c5c4885e48cda17dd9a7ec28bef7f298ec994b58d3f909f0ea929de5ecb8361", "size": 136 },
+								{ "hash": "c53044b284f8b12e68b6df7e8be9f9b54afa9b52b67dfd18883cf0932847a7d0", "size": 173 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[30, 0]],
+							"nodes": [
+								{ "hash": "6c94a779a757d142e941c2f99e9fa55b99a87c6405fcd193e2f9a6be8d8d4b5e", "size": 210 },
+								{ "hash": "7edcc2da34f105ff852018c3741341e06d9ad43e98bd52e006a55e451221695c", "size": 247 },
+								{ "hash": "819dc9988b3871d7cee530f60ea0d9f3565ffb732410a7b8b95d8f13c84ddaa6", "size": 284 },
+								{ "hash": "0b18a316b8c07f1da356a50f5d2e4e952d2ae7030a5efd1357ecad6265fc1de1", "size": 321 },
+								{ "hash": "fd4ab49f6563bef6217b658a7ac3cc37e7544059a8ba2bb66c5221db769c0110", "size": 358 },
+								{ "hash": "7c135484e0ddfa160e6360fb0b6091ccb7a190927daa32771b2a521d7b25b800", "size": 395 },
+								{ "hash": "79d2fe3562c477712914f0df05c36fb9a552848ad2fa41dfd1dd5c11c9821a63", "size": 432 },
+								{ "hash": "13df3b4f41bde3f5b1c0cf5e580949a6b81e791e1eb9e25bf9ec1002eccbc900", "size": 469 },
+								{ "hash": "4a663cce8067c0dae6f1667301664a3e0d143ea2f08f5e73fd73dd31ab28af94", "size": 506 },
+								{ "hash": "73b049ecae88a4a2c8c7c6648bd8c5d82a877e7490bbb54a578e368ec3e683e6", "size": 543 },
+								{ "hash": "1c4e1f8e8adb94bb3b275ac959d3b35cc558a0522ebafc8d68eac1c089d25230", "size": 580 },
+								{ "hash": "d698d7ab1f20fa56b74e4a883fbb93e542ac4966a6c880fca26e717c908a9dd8", "size": 617 },
+								{ "hash": "514bfb7c2bec7770650b4a58c6a6e8066e7ec9b85f00a93ea4c5d1641be47e3a", "size": 654 },
+								{ "hash": "95d6f5833933763baa6afe3487470f787a74feaf82e8748223c0aebbfa10180a", "size": 691 },
+								{ "hash": "3dd4590e2362b53474c187c1041eb621864ca28078dde8fef772b11425caeb67", "size": 728 },
+								{ "hash": "faa17b234992532bdf6cb19c7ad41e08a9ab08dc3926c0e75ad7b96341c2a789", "size": 765 },
+								{ "hash": "86922026951e9994b2427029fc0d89658c7d556e4b41357c83ce02b2073204b8", "size": 802 },
+								{ "hash": "c10c4e913b240d0e5cd6e4a69328da9ea6004e04d430eea3abd98faa4bc45e29", "size": 839 },
+								{ "hash": "c4c9cde1480e5a6eeaf54684ac73b45adb92ab4899cc771163d8d7de153777a9", "size": 876 },
+								{ "hash": "5aecafedda8a07a8c32c9ce0e33ecf16657a4d1401fca02d621f9113266b67c4", "size": 913 },
+								{ "hash": "57d44034272b4ab45ecfc0bd483fe500238ba3d61f0b68b14b9f4ba68523b376", "size": 950 },
+								{ "hash": "d3b31e882c1acfc88d3bda821dfbe761f2c39333ea4843d89592e24e03063d08", "size": 987 },
+								{ "hash": "0500e4426ae86ae01bc015ee9224136e46aeb92a03fef9591600cbae98fe651c", "size": 1024 },
+								{ "hash": "d77209a7227dc8d3eefd2859773ba9f2cc6a0e485e8aa15bb67f704817d66401", "size": 1061 },
+								{ "hash": "bc327c9d83619dada04b6083ee8c8d3869770034c8bf48383daef6886f2b5b51", "size": 1098 },
+								{ "hash": "823154f14c27903f9358c5a214c58057ca9c3e52e10fbde1d74f48c380a67402", "size": 135 },
+								{ "hash": "7653a72ab18f16a8114d2890cb0afc3551f314e2f3be3dc543c2d25dea33d8b2", "size": 172 },
+								{ "hash": "3fbeff73e4cbb19d24886a02e65a2782367c279a62bcbb091677442725bb3947", "size": 209 },
+								{ "hash": "ad25b8090881aa03235c42109bca67ac44b0441c58be277ae1a3bfd9ac32a0db", "size": 246 },
+								{ "hash": "ca791f07f22273e0e3fa0189e1e348e873ad42cc80fbe390c1daceeecbf63cc9", "size": 283 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[30, 0]],
+							"nodes": [
+								{ "hash": "7ed84974ff5e37a14d87626155a77bd4c9af6317c39fc8acda0a7cf4d43b9d72", "size": 320 },
+								{ "hash": "df972c1a9cca1c1b823d4b1fc0e3f5720cd120fc22873fe3190df76a6e953cb7", "size": 357 },
+								{ "hash": "e53bf1989ceb530cb2d24b8b90ad13eb57863d1bc9325d4be21e1824af02dd29", "size": 394 },
+								{ "hash": "2a99d0eff1b98ed2074cfad1f5a69ea8e907827cc90c991a6e3ffa60d040dd91", "size": 431 },
+								{ "hash": "d1e0ac30f1805f754e2e82ce5409eb0c5160935ed14576a989b45f7f4605639e", "size": 468 },
+								{ "hash": "1106edc7cf5d747dad643ccd93e1f292a1a4a32e9d15044bbb6b2f80cef181ab", "size": 505 },
+								{ "hash": "1128e219ba2e0782c8d707a30973e6f9e490b1fbbf2acb24ffd5b845af300ac5", "size": 542 },
+								{ "hash": "2423b0a200a733e84c378253616d263c1a2036f388c255143d32a1c08489cbde", "size": 579 },
+								{ "hash": "fac4dc319a9cba9747339a36698990def5da16fa55ada3405cc5a54d6684f9aa", "size": 616 },
+								{ "hash": "5bbc05d652877ccb11d261dab666fab4656bf8ab7c4d91cf2945043ce8642699", "size": 653 },
+								{ "hash": "df7d17d9efde9aa0583e65b46d861bc8cd4b49f96cb0311428bd084e5764691a", "size": 690 },
+								{ "hash": "b458fd040e1939c099107f918154cbe7fd754a8e67312d2f3c123d1d408b6ffc", "size": 727 },
+								{ "hash": "5dd8f0fcfe0924c29ba6bebd30c5f46b996427c7db21176c277184ac67efb7cf", "size": 764 },
+								{ "hash": "a5a6e08441dbc04bb2ba5d747bf72fc650e158d76fecbf8e5d421152bc2cc113", "size": 801 },
+								{ "hash": "e40df113e6e092eba9877e3c469d7206b4aa2b06c5b1b09343ff06fd88b415e0", "size": 838 },
+								{ "hash": "5d2a221e98e6636322d6444ef7ac4d62373d07bde3eaa8a173dc1a43a3c4f011", "size": 875 },
+								{ "hash": "2dc6d1be1cfba1654fd98adb0c3a43b071378301d7a5034071c84b94bef93e06", "size": 912 },
+								{ "hash": "0bc24046cc94371495d8651eb0a300fa7e9a820ad23411446d46a10c592f33ec", "size": 949 },
+								{ "hash": "a323a04c00676b21dda46b60b21e3f8ea5729f86aff6cd3257a62f8f36631354", "size": 986 },
+								{ "hash": "c185615ad7d329759ac8f15cbaa271b0d6fec0bd75ded7a2dddea4c00d34a1bb", "size": 1023 },
+								{ "hash": "33f2d6ee87363b8f6153792957ced912ca47bad89815f505e4d84c5761d1afa9", "size": 1060 },
+								{ "hash": "5e59ed83efd6cd5e452862943164551f96cecdba11513245521e8943090bb3c5", "size": 1097 },
+								{ "hash": "7b8d87484622db6a2bbf2522086fb13c9de1f9e5987de41e37f308b707beac7a", "size": 134 },
+								{ "hash": "49350d31f20215c6bbf7cfbc48fcd6526d13dfaf0671ecd64a8c29c6ca164a2c", "size": 171 },
+								{ "hash": "64c6bed4cf0d3e4e6af1cd57a8a529601e9801193afcd3413f74fcb957c57abc", "size": 208 },
+								{ "hash": "06e09edcc26fd41ee91d07cba8e8c20fcaccd0b040439faeb13a7bbeb90e5b1d", "size": 245 },
+								{ "hash": "5100b2006e28e6a9c9ac72fb0abb2e7ec5689dab516e8ba15abcfcadc47ad232", "size": 282 },
+								{ "hash": "8a98a7c1a374c3f5b3e3c461fae2f6b564c2e9f3d36613f05532efdb2e99438d", "size": 319 },
+								{ "hash": "66769fdc164a8095fc9bf8ff6b171dea2b3eebff13e37eecf4d99df86c79919c", "size": 356 },
+								{ "hash": "433cab2e08fabc4d194bded5b83ccee303ed6f8b2144b820f476f0bbc3aaca26", "size": 393 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[30, 0]],
+							"nodes": [
+								{ "hash": "422f965d40f948d8998389fecaeffeca5a59ac02085aa6fa4ccf3c1017cf4ded", "size": 430 },
+								{ "hash": "07411612b49d7edf0a8b45add1765eb0cc1b72ec428274be1a120c05fdffae0b", "size": 467 },
+								{ "hash": "9336ed2a8779b0e95ebbb3488cdf502ddbd29081c150bd93ec4c6b36b67336cb", "size": 504 },
+								{ "hash": "cdd8c388712b29fdf3e84daf43e5f2e760b63b6a3f20cf3c1dcabb059ab5966b", "size": 541 },
+								{ "hash": "36d0eda5c1713e21ee6c4626845fb1133abc7506bf80ef996fa4258902b2f774", "size": 578 },
+								{ "hash": "7903c87e60fb278093f21832d62155c870f86bfcdd91be70b4decc7997574d28", "size": 615 },
+								{ "hash": "7f5bf2432754860d997eb802acea8fd0768ca23f4ee542deb5a8d59d6f06ba7e", "size": 652 },
+								{ "hash": "218dc09b3d83e18cf61c53f8d08be65f40219c0368af78feaa261ee20c7000b8", "size": 689 },
+								{ "hash": "7328db9af2d01df73749a16611ec529f58610846c1f7a18395652aeafff68ac2", "size": 726 },
+								{ "hash": "87300ce0d44060edc848ce9fc5352838c4bda571c526367f50e474fc812ceb01", "size": 763 },
+								{ "hash": "9b8333115a7b896408cc89b3878f0f921d7dbad32c000e46743dbb1f978a2a83", "size": 800 },
+								{ "hash": "901c05e9d8b840e80a8aca7471f2e2772b90e32bf93556166b52f72f3ffcb39e", "size": 837 },
+								{ "hash": "67ea0dd3457c7d5fb3807c65532b17d8ca5ad95244e5c207bec11230a1c2497a", "size": 874 },
+								{ "hash": "6e0db0da89f453210c1439fed5d640c4e9e102754713411d7b5f18da9543ed5e", "size": 911 },
+								{ "hash": "a286f0cc42113a07fa21bb88c742458791bb72d2317d0ad58330e22668b5fc87", "size": 948 },
+								{ "hash": "ea0bedbf4f7edf6313310d2f470117a653e2cd7aabf37d3fa3ea5e3ab3f0a895", "size": 985 },
+								{ "hash": "a5d40b7e787e723bf4e5c792a1c71c4580d7772a9816cd78dbe6650dab6613a9", "size": 1022 },
+								{ "hash": "319ff0e5a067b412decc7eccda7d1b7c6f85846078edb9a8d1f2263d7cdb7adb", "size": 1059 },
+								{ "hash": "0cadbe91a7339e450e16aa6f0a5c73908ccb117677845fa6cdad54d83d2a2e8f", "size": 1096 },
+								{ "hash": "b534b5e44b49af179ddaa3dd04ef77a2ff41cf2a99ce597511f17712d2964212", "size": 133 },
+								{ "hash": "6d492275f9dc1b3eb14c4fe40e7697fcb8be7bd0e502f36294fd292fc91b6c2f", "size": 170 },
+								{ "hash": "6e2c3fd686f1a39c61e4cc12493e64c9c598fbaa14600741034d6c2b273bbc9e", "size": 207 },
+								{ "hash": "bfbbfd0efc71f898483fe35ef957352ce83da316815a72af275c713017c203b5", "size": 244 },
+								{ "hash": "df9d7f8d2ced5b0b2244b86a1927c198ee3288ca46609e858eabaccb2ca5e802", "size": 281 },
+								{ "hash": "7b29b3872538a0ed752054050ad2e4313b65bda4a48850070bd43a6f40920ca9", "size": 318 },
+								{ "hash": "256819840287ba1d30ed5375d6286f11c26512129ba74cf579d899c2ba2f3e90", "size": 355 },
+								{ "hash": "56455d6fda197306983ebf91057fafa7aeb52a5a7b6c6f0181a80f1f220c6413", "size": 392 },
+								{ "hash": "e7850046aef15361539ebb14a5eec9ff0816b92a7082fe1f9d0aab19b39a1d8f", "size": 429 },
+								{ "hash": "f64427ec5cfb94c6bc0082d31843d1b747e57175c51967f124b44baad56603b7", "size": 466 },
+								{ "hash": "8618bbd2c67b31c04c21e8b7352ff911b7cfe3dbab199f7d133ef3f27784f7c7", "size": 503 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [
+								[19, 0],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "ac23ed184cad11bea7276976502b43735e1bdb8a5d0df3865856b725485f9ffa", "size": 540 },
+								{ "hash": "f67d4b03fd27e4144644433b6cc363c6b1b1655231c1e664a1744a5bd6c3560a", "size": 577 },
+								{ "hash": "0e16e82216955e904dba6e759ba89f7d904bf076697855d4b2723f0b1e643170", "size": 614 },
+								{ "hash": "2681300f410c9be6abe8cabf3a9288904c1ec8e9cecf7768e176775f1f58786e", "size": 651 },
+								{ "hash": "dfe5d18c6cccc67420b03679d72de5e1c0fdcf124017046b66e01aa5b6237d97", "size": 688 },
+								{ "hash": "3ea4e2da0d2e03c3d1588e18b768e76c71ed0e87b60ac146cfc971146759c066", "size": 725 },
+								{ "hash": "15f969a4d11c40fc62e8898bf33dbd50b972156da8e47e6dcf00e69e76a0fdcf", "size": 762 },
+								{ "hash": "caacbc17a0797f495b88102deb7c82747aaf3645f273dcea45794e5eb8f6e89e", "size": 799 },
+								{ "hash": "71478cfaa143a6eefb5a9f591a40f1c5231643a7ce4e40ec2f0dff9f5f5ac41f", "size": 836 },
+								{ "hash": "1701c077888854984ebcc89c15fb5c36719f73c4519a9f84a60c2c9e8e2a7762", "size": 873 },
+								{ "hash": "6213c946676be514a7299821dfec4b47a6f969255219ebcf9f62a1561b418690", "size": 910 },
+								{ "hash": "9badd8638277c2f5d3b59ef1c5fb5ad555800bcfd72056b0d88fffbd4d51c691", "size": 947 },
+								{ "hash": "6d879f5bb23f939b9d40ef350a34ef323b6ada854ad394d3482ca28f40082f58", "size": 984 },
+								{ "hash": "1fd466fb238af54aa2301ca992081e432ded96f46e7b65288f2cf32a612e6fd2", "size": 1021 },
+								{ "hash": "b4e8561a42a325cbbe628488a11d641184f411bfaa6b7802b3f9fc6c83f6d597", "size": 1058 },
+								{ "hash": "31269674e61de19626854b1b1181f0856eb57f1283c6a301ba6166c2ec313b19", "size": 1095 },
+								{ "hash": "ff0ba635978b684717acd41ed82eed7367193ac6ed7d00f41650b4cafbbced5b", "size": 132 },
+								{ "hash": "e05e547073c027666e8c2004616111f7dea96e6518c65165b04eca07e233eb2d", "size": 169 },
+								{ "hash": "7b29cef35b739e1ef01acc032563ba397fadacdd3132a3167e0b99df5a1800ec", "size": 206 },
+								{ "hash": "9f9dac582fe93ae94ee85907638c234bb6c44f375de3f1000f5c8b6dc58d6981", "size": 1585 },
+								{ "hash": "251c894b522ff253971294a7d2cd866b218b2227598f295b22d7db9105fcc014", "size": 1395 },
+								{ "hash": "9786a872d9ad831b8b5503f7bc434a4b0437b809d34dd6e7fe11524c5b39fb03", "size": 1728 }
+							]
+						}
+					],
+					"points": [30, 60, 90, 120]
+				}
+			],
+			"xorbHash": "8f390c1cea906d5821dade9cb0f227b46c7cdc8b72924f74bc33aac8340606e8"
+		},
+		{
+			"fileHash": "f0d8c7045a0da2cb94dfc75f7e8cf12e999448dc1dc299e1115b7bc29868e09f",
+			"finalHash": "0814346d175e34223cb59748c6d8f3f5eb247e0a816eecbd66d2416bba6a9af1",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [
+					[0, 0],
+					[0, 0],
+					[0, 0],
+					[0, 0],
+					[1, 0]
+				],
+				"nodes": [{ "hash": "0814346d175e34223cb59748c6d8f3f5eb247e0a816eecbd66d2416bba6a9af1", "size": 200586 }]
+			},
+			"n": 333,
+			"splits": [
+				{
+					"mergedFinalHash": "0814346d175e34223cb59748c6d8f3f5eb247e0a816eecbd66d2416bba6a9af1",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [
+								[0, 14],
+								[0, 13],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "ff89c785771396ae73543ab8d148f6c5e81f75e9a7fbd4b2021cbf3bd9742ebf", "size": 14625 },
+								{ "hash": "6cdd8dd37b630d9f7a74a00558480746f2a1889ab1232ef4eb8fefc72361d213", "size": 16661 },
+								{ "hash": "3caa0cbec59bb30d6b23a2de535d03467f84d4989cb465623d226d615b45eff1", "size": 11889 },
+								{ "hash": "0b66e1f0130be01f6c0fff41a829dd9b3702b7abade2661f0865316c3f20f249", "size": 2736 },
+								{ "hash": "99e7059c9b120c63fd6c027db9a91c18aa980af0fff670185772b44de1c8bb6a", "size": 4471 },
+								{ "hash": "a2b2a006599d5bbf7d7473e981b4009b95dadc9d138be82a3c0ef6b14368c19f", "size": 1410 },
+								{ "hash": "fb878499b1d3149dc575f28cba648d2949d9450576e6df03f3451890c4f63dd2", "size": 2913 },
+								{ "hash": "bc8f0b645e48d1efa2f9c9890bb9142e3c8966f50a38bbe24c68b1fee0b5aee4", "size": 1956 },
+								{ "hash": "14279eff9b0d4f32c93c88abc3b94de10075ce9f92e057cc8bd500f0271bd80c", "size": 7866 },
+								{ "hash": "500eb05149a732a2a8654a3423f40c3587095cfd91df8a56c9d44f2c28a5882d", "size": 3863 },
+								{ "hash": "2284b383c73816c4ebe6c9ca12e63f409548d77d6c395958dbf0c8bad05d3930", "size": 3521 },
+								{ "hash": "38432ab70e9ae472f562ba915638e04e7fb8d231252b137144df9210f7859ee8", "size": 6244 },
+								{ "hash": "943392650f95bdedf0189d8e7cbc5591078d3d4697bb75899ffc632052e474a1", "size": 5612 },
+								{ "hash": "9f9dac582fe93ae94ee85907638c234bb6c44f375de3f1000f5c8b6dc58d6981", "size": 1585 },
+								{ "hash": "251c894b522ff253971294a7d2cd866b218b2227598f295b22d7db9105fcc014", "size": 1395 },
+								{ "hash": "2c3b7e7d8772d50fd47e64be6ed61d4481d76f9d6fd3bb71da65eca11e429850", "size": 3065 },
+								{ "hash": "30f82e9cdd4207723e7955ac21e93a8a720bd73d1777b606041190ae098443a2", "size": 724 },
+								{ "hash": "18e62912794248ea462904c872fbac8560ecf4c48fafb28e64aadcfd7b03c627", "size": 761 },
+								{ "hash": "b5f54946e7265573f7ab60b1498b9940605666815167d60336d6b771ace2f32a", "size": 798 },
+								{ "hash": "ca039b0c6d3166b72d0c63381822bc2cea9579dcd38438837c7d0b6b9d46a7e6", "size": 835 },
+								{ "hash": "882aab189e36ea42c123f30647b2b60ed6233eb48ba5ca17566001167c4139d1", "size": 872 },
+								{ "hash": "37470f8a4dd8f711456ee4dc90534372acc6ede0d546a34f5e1dc497e40eae6a", "size": 909 },
+								{ "hash": "40a4424a527b870cf3e8fb878d9e11b69e735a59362fb25841192473531120a0", "size": 946 },
+								{ "hash": "39460375682825b5f3bb64535f339035f4d4786455111c109516d962fb7029a5", "size": 983 },
+								{ "hash": "88cf8d9ad65306d0e4a1c74ec28b9c3b291edb6d77bded0422c4670a021c122f", "size": 1020 },
+								{ "hash": "5a4ad0de46026e17207e686deada54122eb8b5062ab6d4e10f78ab1c46f6f375", "size": 1057 },
+								{ "hash": "ba1af34a4103553a247894508c4d8c9e108c2acc476c1a91fbfb200587260625", "size": 1094 },
+								{ "hash": "0f6da6783b87804e10c92f17b0e8ebfe28b350efebc793f5e57fceb63c71f58d", "size": 131 },
+								{ "hash": "09eb2043fcbf6eb316251d1978e349396e8708b7e74f2aedac56ee5875a07e35", "size": 168 },
+								{ "hash": "189e9b14691c5510c94f72a910db638517bde6b5dcc60a530e562bda04e1aa46", "size": 205 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [
+								[49, 0],
+								[8, 0],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "a4c05fa65d9599a6510c81ca39ebe2734635ad04d009c0e5f4ce3a3a64ffba34", "size": 242 },
+								{ "hash": "c69869624ff13001ac7d4ef1dde3b6d08c29c2cea50f444f2a200dcbdf07c614", "size": 279 },
+								{ "hash": "34c4e4aa37de61b94c4cc984161e2ff4b958e94a65bc2c8429cc1f601bb52f9f", "size": 316 },
+								{ "hash": "e777cf6f2c5bcd8d6a78c572a610741e9e7cf40208fce64c3934ee17d839c7e1", "size": 353 },
+								{ "hash": "78cd8f0886d4a0caf9c9f35a6fb0dcf3215a5654cb1d4546f36a0b02a5108508", "size": 390 },
+								{ "hash": "682dbc73b9708e1e6d20844896d574a41f7358319be2bdaec95119c673cb79b1", "size": 427 },
+								{ "hash": "e55ed25d8e390e4768a246497b62aefb5ad95bacee94aace4ff0894879cad424", "size": 464 },
+								{ "hash": "b37a4b2308a1a2a29b50c5565e3467e910e7d0a2e8b9e8f22a3ff7ab7c651ed3", "size": 501 },
+								{ "hash": "c98013a2eb2d888023f416369d2f1576a13cf8f3de238d534a7835819057b82e", "size": 538 },
+								{ "hash": "a90fef8daff4b1a990a3155c5a5bd00e859b0e172070fcbba868445b428b3db3", "size": 575 },
+								{ "hash": "61336692d03506f629b429d1fe9514cff1452b0799f4adbf0fec63600662d26d", "size": 612 },
+								{ "hash": "398964e725019eb83139d82fe69d716368da154c35814cf14d0870e893714089", "size": 649 },
+								{ "hash": "b23f8d1d5d1b9db88b64708181c04074d9b09bc0041f8644d1ebf8e76a23c933", "size": 686 },
+								{ "hash": "cf24dce154f4657de902cf6f7948f4c1eca7a9aab25c7f22299f5093a3912c19", "size": 723 },
+								{ "hash": "04b243e90357f63d349db9a254b6aefc2ce9c347c0c82256ad28d4a163ea970b", "size": 760 },
+								{ "hash": "78114858daf291e626617bc6cd48351058595c4746ff2c13783e66d7a2a614c3", "size": 797 },
+								{ "hash": "b7ad1ac41342b70ea40189a71db97f498f401cbdb1352bfcf64117f4c2d2937d", "size": 834 },
+								{ "hash": "a1124928017204cd17e5091e43a04478ba9eeda01d198254d88144f08ce6b6de", "size": 871 },
+								{ "hash": "0cdf1dbf75b863dcba2443b133f2166922bfa4885d8db9083b4066bdb21a49c0", "size": 908 },
+								{ "hash": "34952133f293940c0f6163eb41329f10f40c242a671b22bc75c7dd66b8338e42", "size": 945 },
+								{ "hash": "02f6f8097ede5a2092daa3a8ad4edc81914b314269eaf9ceb23f7bd3b9f7820d", "size": 982 },
+								{ "hash": "fc3fd9e8f4834c4664d5845e53fa696197870126810fd6ed9496a0a537c3c456", "size": 1019 },
+								{ "hash": "d7937c7587ab6b9e865d3f104b23295cea384848e084fa68b9eb833829f9e346", "size": 1056 },
+								{ "hash": "0700325214a7ed9165dc9575e54b9ab1cc79092b36878b702110be795a613bb3", "size": 1093 },
+								{ "hash": "c66133bbde49c487c41460d415c79989b6dacfab4570ef821debd8ecdefe532b", "size": 130 },
+								{ "hash": "b28344f7b1cf866c807c0048cf430f94b0a9714b725fe4c0ae0cde6156d6b5ef", "size": 167 },
+								{ "hash": "4885021a6922dcfe2ffd681b6bd711dd70a4800a083288ac8f0f1d689165c479", "size": 204 },
+								{ "hash": "47e9e1e188736824e1aab3f997925a03ef61b64ec87e66b5ee3b9a5c0cd3f6c1", "size": 241 },
+								{ "hash": "ac23981da6997dae50d4d713aeaae841d1ba3a07a2d339519839baa93d524541", "size": 278 },
+								{ "hash": "fc373d6ab5821271edbce9a3773168eb2b590d74852682876b6bde485bb29863", "size": 315 },
+								{ "hash": "5f9ec918b69f4d18c34d683489eb288294bf09e8187d3b397c9862926714202b", "size": 352 },
+								{ "hash": "11fb14513424a74904db80c7884edbbed2110c9f5c6ba7d0c128ef38729af7e4", "size": 389 },
+								{ "hash": "0f90056276c2a27dddf57aeb1faedb7e6654924068733e9f39a3d37438e132a8", "size": 426 },
+								{ "hash": "d79244ef25b241c40c3ee6be9ab7a8a6bebc200b10805a68cdaf706931b1395c", "size": 463 },
+								{ "hash": "68164855595bb03b927c2fa1d434a555a7a17c409ca708ccd6a1ba0c07bbe398", "size": 500 },
+								{ "hash": "09a424e0a934b0fe1c86633ebc9a053c09d8aba57f99da921c0bfe85621a2504", "size": 537 },
+								{ "hash": "f8fad26480d23d7a53f03be8127ce626ff86e15c9b7ae14f89e1b25dfd439249", "size": 574 },
+								{ "hash": "7bfddcb1becf53726fdfb3a8dc93bb19e97a7201331a7fb72a13ed860d84b4c5", "size": 611 },
+								{ "hash": "6e405a160c6a46bbf94ae3d15b38fe5683c5bb46183e47a930b967dbb0ba0d6e", "size": 648 },
+								{ "hash": "ebf82574bdb4d59db6dbd2fe684b07d8642133baacb8470836c3426ed052de8d", "size": 685 },
+								{ "hash": "2cab984c86adf1d6aab9d362a009a7c6f05a29ebc9e2e3de12d65b67d5aad123", "size": 722 },
+								{ "hash": "74c00a24053d93bc9db0799b6d7c6ceeb766b595007eef0f3ee934e887a696f4", "size": 759 },
+								{ "hash": "f27b18cda11252f6513acd5f033d7ed3c8661e76bf3a3cec18fea6e9ad653604", "size": 796 },
+								{ "hash": "8bca1819a07c306579880820ab3efa7c32eecdf08ac7b9178b899de39b63e44c", "size": 833 },
+								{ "hash": "dd7e45ea4ae574d68787d708907d50db9e28a25126eed065bcd47274fcab083e", "size": 870 },
+								{ "hash": "950a17ee6390f1082012a9a3b201a171f09a9229b9d45a6473aa402cf4f2a627", "size": 907 },
+								{ "hash": "5856bf8595fafb23430e83c0066f795e86dec0471fcae38f669342542eab427f", "size": 944 },
+								{ "hash": "5d1ce5cf905a8865f21c4682ef2d45b1ae6c889bb266c68e9d69351f245e5d1b", "size": 981 },
+								{ "hash": "687ab598cc249028b9f142f55f59dfa4274886785264a2aeab8ba87728e34798", "size": 1018 },
+								{ "hash": "46aae3d2af32a5b9b1e9932c24c232f7caadc66ba4efb65aab2271ab20a91930", "size": 2276 },
+								{ "hash": "25066bb821886d6a3d40fecd934acb7bc1a84573b7c023998cba37ba1c14e81b", "size": 1200 },
+								{ "hash": "0d09a96778b7b50bac6265843fe90b3d067de9ff4012e271388a7f907855403a", "size": 4491 },
+								{ "hash": "ba2026269f778cc9918b6f5957de3a3852fa2e52b8efb48e35961050e5e082cd", "size": 2163 },
+								{ "hash": "a2aaf1c9717fa3fdeadbce9ffa11170413c86093ad392d14c1b1477b7f851972", "size": 3402 },
+								{ "hash": "b4c56e0dff5046de9cd1a6128a7a5028b8cb86f6d6997210d0ba2442bbef5fd3", "size": 2940 },
+								{ "hash": "58bab1af50abe9b3079315a2d4b2ec2b05c72d970589f966e97f0bf199ae6d59", "size": 2273 },
+								{ "hash": "1d31127b3bd2d69ea51ac96a6a61b4668c15d11447bc559d9d67524b31d568f0", "size": 606 },
+								{ "hash": "e2003cd8075c016301dea7d7823766fd1f00cb69420557e890a65c52d6abc741", "size": 11571 },
+								{ "hash": "6955769d5a15dc60df8395ae7e836f9098ecefe6755d796173c0b16dcbc3be86", "size": 35855 },
+								{ "hash": "7994f515a15e21a1493bb5db0f8027534a863874b8b305e8689e2a023917484f", "size": 3124 }
+							]
+						}
+					],
+					"points": [166]
+				},
+				{
+					"mergedFinalHash": "0814346d175e34223cb59748c6d8f3f5eb247e0a816eecbd66d2416bba6a9af1",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [
+								[0, 22],
+								[0, 6],
+								[2, 0]
+							],
+							"nodes": [
+								{ "hash": "ff89c785771396ae73543ab8d148f6c5e81f75e9a7fbd4b2021cbf3bd9742ebf", "size": 14625 },
+								{ "hash": "6cdd8dd37b630d9f7a74a00558480746f2a1889ab1232ef4eb8fefc72361d213", "size": 16661 },
+								{ "hash": "ad31d0ed6a2912b4c911b3f6a41f06cca1e74d571a66156f99a0052a34e6eca5", "size": 3881 },
+								{ "hash": "18c7d0f5abe138b967f9ea481e0128bff9cd055ef080d111c7adba07de9dfd8f", "size": 4878 },
+								{ "hash": "d0b27cf88fb13ba6694f300b0f77b0966f80d946b72a2f6b8b945df8385df4ac", "size": 3130 },
+								{ "hash": "0b66e1f0130be01f6c0fff41a829dd9b3702b7abade2661f0865316c3f20f249", "size": 2736 },
+								{ "hash": "99e7059c9b120c63fd6c027db9a91c18aa980af0fff670185772b44de1c8bb6a", "size": 4471 },
+								{ "hash": "a2b2a006599d5bbf7d7473e981b4009b95dadc9d138be82a3c0ef6b14368c19f", "size": 1410 },
+								{ "hash": "433cab2e08fabc4d194bded5b83ccee303ed6f8b2144b820f476f0bbc3aaca26", "size": 393 },
+								{ "hash": "422f965d40f948d8998389fecaeffeca5a59ac02085aa6fa4ccf3c1017cf4ded", "size": 430 },
+								{ "hash": "07411612b49d7edf0a8b45add1765eb0cc1b72ec428274be1a120c05fdffae0b", "size": 467 },
+								{ "hash": "9336ed2a8779b0e95ebbb3488cdf502ddbd29081c150bd93ec4c6b36b67336cb", "size": 504 },
+								{ "hash": "cdd8c388712b29fdf3e84daf43e5f2e760b63b6a3f20cf3c1dcabb059ab5966b", "size": 541 },
+								{ "hash": "36d0eda5c1713e21ee6c4626845fb1133abc7506bf80ef996fa4258902b2f774", "size": 578 },
+								{ "hash": "7903c87e60fb278093f21832d62155c870f86bfcdd91be70b4decc7997574d28", "size": 615 },
+								{ "hash": "7f5bf2432754860d997eb802acea8fd0768ca23f4ee542deb5a8d59d6f06ba7e", "size": 652 },
+								{ "hash": "218dc09b3d83e18cf61c53f8d08be65f40219c0368af78feaa261ee20c7000b8", "size": 689 },
+								{ "hash": "7328db9af2d01df73749a16611ec529f58610846c1f7a18395652aeafff68ac2", "size": 726 },
+								{ "hash": "87300ce0d44060edc848ce9fc5352838c4bda571c526367f50e474fc812ceb01", "size": 763 },
+								{ "hash": "9b8333115a7b896408cc89b3878f0f921d7dbad32c000e46743dbb1f978a2a83", "size": 800 },
+								{ "hash": "901c05e9d8b840e80a8aca7471f2e2772b90e32bf93556166b52f72f3ffcb39e", "size": 837 },
+								{ "hash": "67ea0dd3457c7d5fb3807c65532b17d8ca5ad95244e5c207bec11230a1c2497a", "size": 874 },
+								{ "hash": "6e0db0da89f453210c1439fed5d640c4e9e102754713411d7b5f18da9543ed5e", "size": 911 },
+								{ "hash": "a286f0cc42113a07fa21bb88c742458791bb72d2317d0ad58330e22668b5fc87", "size": 948 },
+								{ "hash": "ea0bedbf4f7edf6313310d2f470117a653e2cd7aabf37d3fa3ea5e3ab3f0a895", "size": 985 },
+								{ "hash": "a5d40b7e787e723bf4e5c792a1c71c4580d7772a9816cd78dbe6650dab6613a9", "size": 1022 },
+								{ "hash": "319ff0e5a067b412decc7eccda7d1b7c6f85846078edb9a8d1f2263d7cdb7adb", "size": 1059 },
+								{ "hash": "0cadbe91a7339e450e16aa6f0a5c73908ccb117677845fa6cdad54d83d2a2e8f", "size": 1096 },
+								{ "hash": "b534b5e44b49af179ddaa3dd04ef77a2ff41cf2a99ce597511f17712d2964212", "size": 133 },
+								{ "hash": "6d492275f9dc1b3eb14c4fe40e7697fcb8be7bd0e502f36294fd292fc91b6c2f", "size": 170 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[28, 7],
+								[13, 0]
+							],
+							"nodes": [
+								{ "hash": "6e2c3fd686f1a39c61e4cc12493e64c9c598fbaa14600741034d6c2b273bbc9e", "size": 207 },
+								{ "hash": "bfbbfd0efc71f898483fe35ef957352ce83da316815a72af275c713017c203b5", "size": 244 },
+								{ "hash": "df9d7f8d2ced5b0b2244b86a1927c198ee3288ca46609e858eabaccb2ca5e802", "size": 281 },
+								{ "hash": "7b29b3872538a0ed752054050ad2e4313b65bda4a48850070bd43a6f40920ca9", "size": 318 },
+								{ "hash": "256819840287ba1d30ed5375d6286f11c26512129ba74cf579d899c2ba2f3e90", "size": 355 },
+								{ "hash": "56455d6fda197306983ebf91057fafa7aeb52a5a7b6c6f0181a80f1f220c6413", "size": 392 },
+								{ "hash": "e7850046aef15361539ebb14a5eec9ff0816b92a7082fe1f9d0aab19b39a1d8f", "size": 429 },
+								{ "hash": "f64427ec5cfb94c6bc0082d31843d1b747e57175c51967f124b44baad56603b7", "size": 466 },
+								{ "hash": "8618bbd2c67b31c04c21e8b7352ff911b7cfe3dbab199f7d133ef3f27784f7c7", "size": 503 },
+								{ "hash": "ac23ed184cad11bea7276976502b43735e1bdb8a5d0df3865856b725485f9ffa", "size": 540 },
+								{ "hash": "f67d4b03fd27e4144644433b6cc363c6b1b1655231c1e664a1744a5bd6c3560a", "size": 577 },
+								{ "hash": "0e16e82216955e904dba6e759ba89f7d904bf076697855d4b2723f0b1e643170", "size": 614 },
+								{ "hash": "2681300f410c9be6abe8cabf3a9288904c1ec8e9cecf7768e176775f1f58786e", "size": 651 },
+								{ "hash": "dfe5d18c6cccc67420b03679d72de5e1c0fdcf124017046b66e01aa5b6237d97", "size": 688 },
+								{ "hash": "3ea4e2da0d2e03c3d1588e18b768e76c71ed0e87b60ac146cfc971146759c066", "size": 725 },
+								{ "hash": "15f969a4d11c40fc62e8898bf33dbd50b972156da8e47e6dcf00e69e76a0fdcf", "size": 762 },
+								{ "hash": "caacbc17a0797f495b88102deb7c82747aaf3645f273dcea45794e5eb8f6e89e", "size": 799 },
+								{ "hash": "71478cfaa143a6eefb5a9f591a40f1c5231643a7ce4e40ec2f0dff9f5f5ac41f", "size": 836 },
+								{ "hash": "1701c077888854984ebcc89c15fb5c36719f73c4519a9f84a60c2c9e8e2a7762", "size": 873 },
+								{ "hash": "6213c946676be514a7299821dfec4b47a6f969255219ebcf9f62a1561b418690", "size": 910 },
+								{ "hash": "9badd8638277c2f5d3b59ef1c5fb5ad555800bcfd72056b0d88fffbd4d51c691", "size": 947 },
+								{ "hash": "6d879f5bb23f939b9d40ef350a34ef323b6ada854ad394d3482ca28f40082f58", "size": 984 },
+								{ "hash": "1fd466fb238af54aa2301ca992081e432ded96f46e7b65288f2cf32a612e6fd2", "size": 1021 },
+								{ "hash": "b4e8561a42a325cbbe628488a11d641184f411bfaa6b7802b3f9fc6c83f6d597", "size": 1058 },
+								{ "hash": "31269674e61de19626854b1b1181f0856eb57f1283c6a301ba6166c2ec313b19", "size": 1095 },
+								{ "hash": "ff0ba635978b684717acd41ed82eed7367193ac6ed7d00f41650b4cafbbced5b", "size": 132 },
+								{ "hash": "e05e547073c027666e8c2004616111f7dea96e6518c65165b04eca07e233eb2d", "size": 169 },
+								{ "hash": "7b29cef35b739e1ef01acc032563ba397fadacdd3132a3167e0b99df5a1800ec", "size": 206 },
+								{ "hash": "9f9dac582fe93ae94ee85907638c234bb6c44f375de3f1000f5c8b6dc58d6981", "size": 1585 },
+								{ "hash": "251c894b522ff253971294a7d2cd866b218b2227598f295b22d7db9105fcc014", "size": 1395 },
+								{ "hash": "2c3b7e7d8772d50fd47e64be6ed61d4481d76f9d6fd3bb71da65eca11e429850", "size": 3065 },
+								{ "hash": "8a5c6b317d72dfe5e3317b038455860b8c31c8855a273a9e36de62968aaa9c76", "size": 5845 },
+								{ "hash": "e410680127d780c01bf17954d7a77c008ca40474b0990c88226737aeccce863c", "size": 4900 },
+								{ "hash": "f754a24368e1bc5f05c4f5cf0ec6f2be974183c6424100752d5e6de3ae7d8cbe", "size": 1338 },
+								{ "hash": "7437091571d0b80a06d6a1006df788c71784d6bd6e803934b3097e46e5a64d82", "size": 5175 },
+								{ "hash": "135f89933dda276c238fa697d7d76dc8a82af9fac560a83baa39fb1c6fa6b4d7", "size": 4170 },
+								{ "hash": "e3719ee129ff1f0cf61dffcb2767a95818c4c783bc9071eeb6c7c8d066eec251", "size": 5837 },
+								{ "hash": "25a207531c2e1d87e620b0db6aae8123b6794bab2e88156a1507d793df1cdc7e", "size": 1334 },
+								{ "hash": "5fe3d485e1382c646b898d6da3a0b1d36a3d657e832db8ee1b7672f3dcd13caf", "size": 1389 },
+								{ "hash": "43c63ac559a6506c920557ed795ff3df0dd6e58c1ad69e165a5eef545c3cfa82", "size": 4536 },
+								{ "hash": "510533c1cc0e4a8e9707a868c5876ffe807e161c6e53f556e42c3859825755fd", "size": 6349 },
+								{ "hash": "d5b90fdb9f3bded9015fb386b07040c368dd3b910d4718045b97b005e3dc4065", "size": 1055 },
+								{ "hash": "a156f3c355360e34492cdd6120eeab7e661ac47c421fd5476b777f47a150fd81", "size": 1092 },
+								{ "hash": "a2619d3ee8c5d447880c11ea9c3f4bcb42653b32621561107a1742b092b277e4", "size": 129 },
+								{ "hash": "67d0dbb1c91abbb56b14401fa21a6e1c270548cdd5b9ea907c76acb159c90118", "size": 166 },
+								{ "hash": "7f0f0d9f9a455849d0b3bb2aa6d376423cb114f7ba5d74f9ae9091bea27faced", "size": 203 },
+								{ "hash": "f3fa49b8b275a169eafdc6903f607ee223714887db0ed3f403b25c33ba3f6471", "size": 240 },
+								{ "hash": "3bbca0632c133b6b493cf862474dedea02403b834f2e1246cb7b0f5f9d6da4ae", "size": 277 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [
+								[17, 0],
+								[18, 0]
+							],
+							"nodes": [
+								{ "hash": "54e99aea53202518b699ca9b9f73c00665e4ef3e10eef4c07fdeaf42d19f1f4c", "size": 314 },
+								{ "hash": "0661273e1fa89e0c3e3e45cd2f6f119305b193a4484199e9b1e5476d3eb944c3", "size": 351 },
+								{ "hash": "636b2bf7b66ce602ab8cc867d4baf4acdfe486d3a08f03ee5319b103a4053735", "size": 388 },
+								{ "hash": "6a4d149e33f57cad54f244632df330d6320cb01ea9efd23c4fa5cab3a4895c11", "size": 425 },
+								{ "hash": "db9c93ec4e4285608b056020c8038215dc1bc627b56ce5ecc48c9744ca1d3066", "size": 462 },
+								{ "hash": "21d7d587dd2dfb8d23a16fa58253516a50429ad2a6a90294a1424cbcd5ad7be5", "size": 499 },
+								{ "hash": "aacb7a1e30c228de6499fb812ebbd9de19d69b94ac64a9309e4d1b9713a882c7", "size": 536 },
+								{ "hash": "b324e19abfa3830178bec20286d415a3b2cc773de114076e90c0c9ae8cd2e7ff", "size": 573 },
+								{ "hash": "897da108d30e34e34d20f8c12f93b7441223386ea838578e3a19a7dd866523f9", "size": 610 },
+								{ "hash": "772d5687b2081236f736c781c0f300f72c9a6ba2324f0138d0a9c212a81d00f1", "size": 647 },
+								{ "hash": "2b7cf8a8274303b0ca14575142c47f426a95beddca39800c3c178ec9146c94f7", "size": 684 },
+								{ "hash": "41fcba84ba1aa52f7e88526cf93e2cba69471bc49145e0e6155842303a2a5116", "size": 721 },
+								{ "hash": "5ab883f65acfea2a240b7bed63b55433395235b5c5e5dfa345c1a2b305488e68", "size": 758 },
+								{ "hash": "71da559a285908c17fe3c406a8be583b787e161d621825f7eb70723bad1914ba", "size": 795 },
+								{ "hash": "0a21523e1dd6cfae90f80367501a43b4f9d0f38f7faa9ed99ee808e32dc14449", "size": 832 },
+								{ "hash": "368d47f8edce34758599712e5483987af8b566d38cffa01491e24858862300b6", "size": 869 },
+								{ "hash": "87490996863526a962320a68e7625945c47af4df294b8714f81cf6d1d2701108", "size": 906 },
+								{ "hash": "b4c56e0dff5046de9cd1a6128a7a5028b8cb86f6d6997210d0ba2442bbef5fd3", "size": 2940 },
+								{ "hash": "58bab1af50abe9b3079315a2d4b2ec2b05c72d970589f966e97f0bf199ae6d59", "size": 2273 },
+								{ "hash": "1d31127b3bd2d69ea51ac96a6a61b4668c15d11447bc559d9d67524b31d568f0", "size": 606 },
+								{ "hash": "e606de75c7075b2859ec6131eea03c5bef1caabf65db10dc7b0aa383ba0cb693", "size": 939 },
+								{ "hash": "2320f9e01fe34a2bfd4ce22a4fce5195d62e7b5a649e608ac8c39b30323e66ad", "size": 2305 },
+								{ "hash": "30aab064f085a32d2529c79fc2ca87a59a576e621ffdb3a80e254059544fdd7b", "size": 2510 },
+								{ "hash": "300ba251be1964cfb9318a85843bc5ecf49cedb2743ce2fa7480d479b1215040", "size": 5817 },
+								{ "hash": "3af13dd54e731d9bac7aecc286bc6a6788f0b79aa12156293279dc11c4a5daf8", "size": 4138 },
+								{ "hash": "35926c069d17d4a0e85d17b1b2b1a1d16c6d18eacb365bf6d5fe54945eb58b73", "size": 1666 },
+								{ "hash": "70b7ebd746f770a0fcd5e3e477f2be10f4e0d7e111e2d1dc44033639f4dc6ac1", "size": 4806 },
+								{ "hash": "356bfe3d68631ff2cc4d963098ae6c848ea72c0a25a607a07cb13efbd28b122b", "size": 7803 },
+								{ "hash": "b0f2ba289de0ef17be6cdb2809b6a1c2dfb2dbff12631ad94fc10b545a4270aa", "size": 2630 },
+								{ "hash": "4454c631f6e7437063deabe1793cd56e427a926f1f30128bafc2d371f4997b8b", "size": 1170 },
+								{ "hash": "100d33fcfa9f406fd74eafe830ff47e79d31aeb3c029badd2d5710eff0719e3d", "size": 4797 },
+								{ "hash": "7ecbbaee8e02ab7f98b9b31eb4c49000298b6cf72feeac65229f048959215e29", "size": 3094 },
+								{ "hash": "11cf27d385d3148067ac7ac989eda62045fb307e7893b8c0b70d51e1417e529c", "size": 5751 },
+								{ "hash": "e72cdd97e79bdba0f582ae5f725d551309fe27d41b99c743555c84c01162226c", "size": 2393 },
+								{ "hash": "e6ca7ea3045c1af27a6dde0d66cbbf172056f28a9e265b5817b0c601d07dc781", "size": 731 }
+							]
+						}
+					],
+					"points": [111, 222]
+				},
+				{
+					"mergedFinalHash": "0814346d175e34223cb59748c6d8f3f5eb247e0a816eecbd66d2416bba6a9af1",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[9, 8],
+								[10, 13],
+								[7, 0]
+							],
+							"nodes": [
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "08bef1184db71338fc973dd13a7185eae87db67e06e4c5eadb5b16d3d8439b2d", "size": 2470 },
+								{ "hash": "c933041e8b459b6175c856285216267f61d4d2750a7404b82c136aa39a69af7b", "size": 1420 },
+								{ "hash": "3b2d4081e4bbbaf5498721ebd28dcd19e066a6666d42071b3bc4d7350c21092d", "size": 1296 },
+								{ "hash": "3111effb06cbbb5c9376d51372e956ee0d6e439c12b8559a5038175750071a06", "size": 1629 },
+								{ "hash": "00b41d92df650c72464cc940376f54708e9e107f34a19068dfb6b83519e1bf0a", "size": 4257 },
+								{ "hash": "9e50c43052cb333988ef35afdfd4dcede1ee9466eb02a3e94c3384aeee83bb85", "size": 2628 },
+								{ "hash": "6f2ad36f534f13c285fb9d61db474abc0164b4063626a2d52188f903e2b6ce18", "size": 2961 },
+								{ "hash": "3caa0cbec59bb30d6b23a2de535d03467f84d4989cb465623d226d615b45eff1", "size": 11889 },
+								{ "hash": "565c474b4607c3495816653f49174f2fc2747cd7cc4a2f86046fddfc30970e0d", "size": 13486 },
+								{ "hash": "c6fc4623a64caaa501a59b9b4d81ef2ff39a876283fb981374f0dbd8517e71f5", "size": 15250 },
+								{ "hash": "20c8e792c4dad2e3bf4303b572bf6ddef18ed39853741dfccdcdd84e49497fa2", "size": 14836 },
+								{ "hash": "e44cc74ac29a422d633b2c2382ba83a74b6d44b3702e17722ab19a6ee477952c", "size": 13810 },
+								{ "hash": "6c14a2fe05cbec83c48407c0aaa45102382deec0dab937b4eef4d4b069d9b0a6", "size": 32404 },
+								{ "hash": "24ad7969493056da710fdc175dfd846d65a1f705de26c2f8c0ed22139fe3537f", "size": 17075 },
+								{ "hash": "e606de75c7075b2859ec6131eea03c5bef1caabf65db10dc7b0aa383ba0cb693", "size": 939 },
+								{ "hash": "2320f9e01fe34a2bfd4ce22a4fce5195d62e7b5a649e608ac8c39b30323e66ad", "size": 2305 },
+								{ "hash": "30aab064f085a32d2529c79fc2ca87a59a576e621ffdb3a80e254059544fdd7b", "size": 2510 },
+								{ "hash": "300ba251be1964cfb9318a85843bc5ecf49cedb2743ce2fa7480d479b1215040", "size": 5817 },
+								{ "hash": "3af13dd54e731d9bac7aecc286bc6a6788f0b79aa12156293279dc11c4a5daf8", "size": 4138 },
+								{ "hash": "35926c069d17d4a0e85d17b1b2b1a1d16c6d18eacb365bf6d5fe54945eb58b73", "size": 1666 },
+								{ "hash": "70b7ebd746f770a0fcd5e3e477f2be10f4e0d7e111e2d1dc44033639f4dc6ac1", "size": 4806 },
+								{ "hash": "356bfe3d68631ff2cc4d963098ae6c848ea72c0a25a607a07cb13efbd28b122b", "size": 7803 },
+								{ "hash": "b0f2ba289de0ef17be6cdb2809b6a1c2dfb2dbff12631ad94fc10b545a4270aa", "size": 2630 },
+								{ "hash": "4454c631f6e7437063deabe1793cd56e427a926f1f30128bafc2d371f4997b8b", "size": 1170 },
+								{ "hash": "100d33fcfa9f406fd74eafe830ff47e79d31aeb3c029badd2d5710eff0719e3d", "size": 4797 },
+								{ "hash": "7ecbbaee8e02ab7f98b9b31eb4c49000298b6cf72feeac65229f048959215e29", "size": 3094 },
+								{ "hash": "11cf27d385d3148067ac7ac989eda62045fb307e7893b8c0b70d51e1417e529c", "size": 5751 },
+								{ "hash": "c681ce00affef583a8ba686a79dfd2a3032a165edd5a47903633f6f8b9eac262", "size": 1088 },
+								{ "hash": "c003e6361216a3556bcb75a817c6b31275ab1af34214c2f9d6f97e460d4d4b1d", "size": 125 },
+								{ "hash": "82d491714a55fa33acbf92ac0921b6c052e1f3d5540796eba5844f5214a4f099", "size": 162 },
+								{ "hash": "491ff5c8ba8d894abfb48284f15be0c66858373c440a0ef3bdbf79d39856b43e", "size": 199 },
+								{ "hash": "75e232c494bf0cb4b64d1876c3ff7b1bb99fe0dd16af5e736efea34bc9109145", "size": 236 },
+								{ "hash": "0f5c4b5d03a32ac75f723bdb827c4508dd78f83bbd4327ea50effbf3999a49ab", "size": 273 },
+								{ "hash": "e617bb473c8eb2bfed14512c0fe7e96162acbecd29b803fc85eff3534cbc64b0", "size": 310 },
+								{ "hash": "6ef7db551a567ddb7b1c10841033b6882a2c9fe5172c2e9e0bf2b61f18fe8a1d", "size": 347 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "311d29a716e4cbf9062e49496490b3b1a51864c4c0ec25365176b7b468c63d6f", "size": 384 }]
+						}
+					],
+					"points": [1, 332]
+				},
+				{
+					"mergedFinalHash": "0814346d175e34223cb59748c6d8f3f5eb247e0a816eecbd66d2416bba6a9af1",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[7, 7],
+								[10, 13],
+								[7, 0]
+							],
+							"nodes": [
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "08bef1184db71338fc973dd13a7185eae87db67e06e4c5eadb5b16d3d8439b2d", "size": 2470 },
+								{ "hash": "c933041e8b459b6175c856285216267f61d4d2750a7404b82c136aa39a69af7b", "size": 1420 },
+								{ "hash": "3b2d4081e4bbbaf5498721ebd28dcd19e066a6666d42071b3bc4d7350c21092d", "size": 1296 },
+								{ "hash": "3111effb06cbbb5c9376d51372e956ee0d6e439c12b8559a5038175750071a06", "size": 1629 },
+								{ "hash": "00b41d92df650c72464cc940376f54708e9e107f34a19068dfb6b83519e1bf0a", "size": 4257 },
+								{ "hash": "9e50c43052cb333988ef35afdfd4dcede1ee9466eb02a3e94c3384aeee83bb85", "size": 2628 },
+								{ "hash": "6f2ad36f534f13c285fb9d61db474abc0164b4063626a2d52188f903e2b6ce18", "size": 2961 },
+								{ "hash": "3caa0cbec59bb30d6b23a2de535d03467f84d4989cb465623d226d615b45eff1", "size": 11889 },
+								{ "hash": "565c474b4607c3495816653f49174f2fc2747cd7cc4a2f86046fddfc30970e0d", "size": 13486 },
+								{ "hash": "c6fc4623a64caaa501a59b9b4d81ef2ff39a876283fb981374f0dbd8517e71f5", "size": 15250 },
+								{ "hash": "20c8e792c4dad2e3bf4303b572bf6ddef18ed39853741dfccdcdd84e49497fa2", "size": 14836 },
+								{ "hash": "e44cc74ac29a422d633b2c2382ba83a74b6d44b3702e17722ab19a6ee477952c", "size": 13810 },
+								{ "hash": "6c14a2fe05cbec83c48407c0aaa45102382deec0dab937b4eef4d4b069d9b0a6", "size": 32404 },
+								{ "hash": "24ad7969493056da710fdc175dfd846d65a1f705de26c2f8c0ed22139fe3537f", "size": 17075 },
+								{ "hash": "e606de75c7075b2859ec6131eea03c5bef1caabf65db10dc7b0aa383ba0cb693", "size": 939 },
+								{ "hash": "2320f9e01fe34a2bfd4ce22a4fce5195d62e7b5a649e608ac8c39b30323e66ad", "size": 2305 },
+								{ "hash": "30aab064f085a32d2529c79fc2ca87a59a576e621ffdb3a80e254059544fdd7b", "size": 2510 },
+								{ "hash": "300ba251be1964cfb9318a85843bc5ecf49cedb2743ce2fa7480d479b1215040", "size": 5817 },
+								{ "hash": "3af13dd54e731d9bac7aecc286bc6a6788f0b79aa12156293279dc11c4a5daf8", "size": 4138 },
+								{ "hash": "35926c069d17d4a0e85d17b1b2b1a1d16c6d18eacb365bf6d5fe54945eb58b73", "size": 1666 },
+								{ "hash": "70b7ebd746f770a0fcd5e3e477f2be10f4e0d7e111e2d1dc44033639f4dc6ac1", "size": 4806 },
+								{ "hash": "356bfe3d68631ff2cc4d963098ae6c848ea72c0a25a607a07cb13efbd28b122b", "size": 7803 },
+								{ "hash": "b0f2ba289de0ef17be6cdb2809b6a1c2dfb2dbff12631ad94fc10b545a4270aa", "size": 2630 },
+								{ "hash": "4454c631f6e7437063deabe1793cd56e427a926f1f30128bafc2d371f4997b8b", "size": 1170 },
+								{ "hash": "100d33fcfa9f406fd74eafe830ff47e79d31aeb3c029badd2d5710eff0719e3d", "size": 4797 },
+								{ "hash": "7ecbbaee8e02ab7f98b9b31eb4c49000298b6cf72feeac65229f048959215e29", "size": 3094 },
+								{ "hash": "11cf27d385d3148067ac7ac989eda62045fb307e7893b8c0b70d51e1417e529c", "size": 5751 },
+								{ "hash": "c681ce00affef583a8ba686a79dfd2a3032a165edd5a47903633f6f8b9eac262", "size": 1088 },
+								{ "hash": "c003e6361216a3556bcb75a817c6b31275ab1af34214c2f9d6f97e460d4d4b1d", "size": 125 },
+								{ "hash": "82d491714a55fa33acbf92ac0921b6c052e1f3d5540796eba5844f5214a4f099", "size": 162 },
+								{ "hash": "491ff5c8ba8d894abfb48284f15be0c66858373c440a0ef3bdbf79d39856b43e", "size": 199 },
+								{ "hash": "75e232c494bf0cb4b64d1876c3ff7b1bb99fe0dd16af5e736efea34bc9109145", "size": 236 },
+								{ "hash": "0f5c4b5d03a32ac75f723bdb827c4508dd78f83bbd4327ea50effbf3999a49ab", "size": 273 },
+								{ "hash": "e617bb473c8eb2bfed14512c0fe7e96162acbecd29b803fc85eff3534cbc64b0", "size": 310 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "6ef7db551a567ddb7b1c10841033b6882a2c9fe5172c2e9e0bf2b61f18fe8a1d", "size": 347 }]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "311d29a716e4cbf9062e49496490b3b1a51864c4c0ec25365176b7b468c63d6f", "size": 384 }]
+						}
+					],
+					"points": [1, 2, 3, 331, 332]
+				},
+				{
+					"mergedFinalHash": "0814346d175e34223cb59748c6d8f3f5eb247e0a816eecbd66d2416bba6a9af1",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [
+								[0, 19],
+								[11, 0]
+							],
+							"nodes": [
+								{ "hash": "1dabfedde0a609e0b32dd29697432c092d71c80b32b67a8bf77f79b7dac83e7f", "size": 411 },
+								{ "hash": "e2c0389432e88785265cb0098e851b8383852eaafb1d930463fcb8c3eb40850c", "size": 744 },
+								{ "hash": "85193ca885bdb82175ddabcaaae26b2f880d7497e765ea3e6b7f40344527e78b", "size": 1510 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "08bef1184db71338fc973dd13a7185eae87db67e06e4c5eadb5b16d3d8439b2d", "size": 2470 },
+								{ "hash": "c933041e8b459b6175c856285216267f61d4d2750a7404b82c136aa39a69af7b", "size": 1420 },
+								{ "hash": "3b2d4081e4bbbaf5498721ebd28dcd19e066a6666d42071b3bc4d7350c21092d", "size": 1296 },
+								{ "hash": "3111effb06cbbb5c9376d51372e956ee0d6e439c12b8559a5038175750071a06", "size": 1629 },
+								{ "hash": "00b41d92df650c72464cc940376f54708e9e107f34a19068dfb6b83519e1bf0a", "size": 4257 },
+								{ "hash": "c10c4e913b240d0e5cd6e4a69328da9ea6004e04d430eea3abd98faa4bc45e29", "size": 839 },
+								{ "hash": "c4c9cde1480e5a6eeaf54684ac73b45adb92ab4899cc771163d8d7de153777a9", "size": 876 },
+								{ "hash": "5aecafedda8a07a8c32c9ce0e33ecf16657a4d1401fca02d621f9113266b67c4", "size": 913 },
+								{ "hash": "57d44034272b4ab45ecfc0bd483fe500238ba3d61f0b68b14b9f4ba68523b376", "size": 950 },
+								{ "hash": "d3b31e882c1acfc88d3bda821dfbe761f2c39333ea4843d89592e24e03063d08", "size": 987 },
+								{ "hash": "0500e4426ae86ae01bc015ee9224136e46aeb92a03fef9591600cbae98fe651c", "size": 1024 },
+								{ "hash": "d77209a7227dc8d3eefd2859773ba9f2cc6a0e485e8aa15bb67f704817d66401", "size": 1061 },
+								{ "hash": "bc327c9d83619dada04b6083ee8c8d3869770034c8bf48383daef6886f2b5b51", "size": 1098 },
+								{ "hash": "823154f14c27903f9358c5a214c58057ca9c3e52e10fbde1d74f48c380a67402", "size": 135 },
+								{ "hash": "7653a72ab18f16a8114d2890cb0afc3551f314e2f3be3dc543c2d25dea33d8b2", "size": 172 },
+								{ "hash": "3fbeff73e4cbb19d24886a02e65a2782367c279a62bcbb091677442725bb3947", "size": 209 },
+								{ "hash": "ad25b8090881aa03235c42109bca67ac44b0441c58be277ae1a3bfd9ac32a0db", "size": 246 },
+								{ "hash": "ca791f07f22273e0e3fa0189e1e348e873ad42cc80fbe390c1daceeecbf63cc9", "size": 283 },
+								{ "hash": "7ed84974ff5e37a14d87626155a77bd4c9af6317c39fc8acda0a7cf4d43b9d72", "size": 320 },
+								{ "hash": "df972c1a9cca1c1b823d4b1fc0e3f5720cd120fc22873fe3190df76a6e953cb7", "size": 357 },
+								{ "hash": "e53bf1989ceb530cb2d24b8b90ad13eb57863d1bc9325d4be21e1824af02dd29", "size": 394 },
+								{ "hash": "2a99d0eff1b98ed2074cfad1f5a69ea8e907827cc90c991a6e3ffa60d040dd91", "size": 431 },
+								{ "hash": "d1e0ac30f1805f754e2e82ce5409eb0c5160935ed14576a989b45f7f4605639e", "size": 468 },
+								{ "hash": "1106edc7cf5d747dad643ccd93e1f292a1a4a32e9d15044bbb6b2f80cef181ab", "size": 505 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[9, 44],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "1128e219ba2e0782c8d707a30973e6f9e490b1fbbf2acb24ffd5b845af300ac5", "size": 542 },
+								{ "hash": "2423b0a200a733e84c378253616d263c1a2036f388c255143d32a1c08489cbde", "size": 579 },
+								{ "hash": "fac4dc319a9cba9747339a36698990def5da16fa55ada3405cc5a54d6684f9aa", "size": 616 },
+								{ "hash": "5bbc05d652877ccb11d261dab666fab4656bf8ab7c4d91cf2945043ce8642699", "size": 653 },
+								{ "hash": "df7d17d9efde9aa0583e65b46d861bc8cd4b49f96cb0311428bd084e5764691a", "size": 690 },
+								{ "hash": "b458fd040e1939c099107f918154cbe7fd754a8e67312d2f3c123d1d408b6ffc", "size": 727 },
+								{ "hash": "5dd8f0fcfe0924c29ba6bebd30c5f46b996427c7db21176c277184ac67efb7cf", "size": 764 },
+								{ "hash": "a5a6e08441dbc04bb2ba5d747bf72fc650e158d76fecbf8e5d421152bc2cc113", "size": 801 },
+								{ "hash": "e40df113e6e092eba9877e3c469d7206b4aa2b06c5b1b09343ff06fd88b415e0", "size": 838 },
+								{ "hash": "0b66e1f0130be01f6c0fff41a829dd9b3702b7abade2661f0865316c3f20f249", "size": 2736 },
+								{ "hash": "99e7059c9b120c63fd6c027db9a91c18aa980af0fff670185772b44de1c8bb6a", "size": 4471 },
+								{ "hash": "a2b2a006599d5bbf7d7473e981b4009b95dadc9d138be82a3c0ef6b14368c19f", "size": 1410 },
+								{ "hash": "433cab2e08fabc4d194bded5b83ccee303ed6f8b2144b820f476f0bbc3aaca26", "size": 393 },
+								{ "hash": "422f965d40f948d8998389fecaeffeca5a59ac02085aa6fa4ccf3c1017cf4ded", "size": 430 },
+								{ "hash": "07411612b49d7edf0a8b45add1765eb0cc1b72ec428274be1a120c05fdffae0b", "size": 467 },
+								{ "hash": "9336ed2a8779b0e95ebbb3488cdf502ddbd29081c150bd93ec4c6b36b67336cb", "size": 504 },
+								{ "hash": "cdd8c388712b29fdf3e84daf43e5f2e760b63b6a3f20cf3c1dcabb059ab5966b", "size": 541 },
+								{ "hash": "36d0eda5c1713e21ee6c4626845fb1133abc7506bf80ef996fa4258902b2f774", "size": 578 },
+								{ "hash": "7903c87e60fb278093f21832d62155c870f86bfcdd91be70b4decc7997574d28", "size": 615 },
+								{ "hash": "7f5bf2432754860d997eb802acea8fd0768ca23f4ee542deb5a8d59d6f06ba7e", "size": 652 },
+								{ "hash": "218dc09b3d83e18cf61c53f8d08be65f40219c0368af78feaa261ee20c7000b8", "size": 689 },
+								{ "hash": "7328db9af2d01df73749a16611ec529f58610846c1f7a18395652aeafff68ac2", "size": 726 },
+								{ "hash": "87300ce0d44060edc848ce9fc5352838c4bda571c526367f50e474fc812ceb01", "size": 763 },
+								{ "hash": "9b8333115a7b896408cc89b3878f0f921d7dbad32c000e46743dbb1f978a2a83", "size": 800 },
+								{ "hash": "901c05e9d8b840e80a8aca7471f2e2772b90e32bf93556166b52f72f3ffcb39e", "size": 837 },
+								{ "hash": "67ea0dd3457c7d5fb3807c65532b17d8ca5ad95244e5c207bec11230a1c2497a", "size": 874 },
+								{ "hash": "6e0db0da89f453210c1439fed5d640c4e9e102754713411d7b5f18da9543ed5e", "size": 911 },
+								{ "hash": "a286f0cc42113a07fa21bb88c742458791bb72d2317d0ad58330e22668b5fc87", "size": 948 },
+								{ "hash": "ea0bedbf4f7edf6313310d2f470117a653e2cd7aabf37d3fa3ea5e3ab3f0a895", "size": 985 },
+								{ "hash": "a5d40b7e787e723bf4e5c792a1c71c4580d7772a9816cd78dbe6650dab6613a9", "size": 1022 },
+								{ "hash": "319ff0e5a067b412decc7eccda7d1b7c6f85846078edb9a8d1f2263d7cdb7adb", "size": 1059 },
+								{ "hash": "0cadbe91a7339e450e16aa6f0a5c73908ccb117677845fa6cdad54d83d2a2e8f", "size": 1096 },
+								{ "hash": "b534b5e44b49af179ddaa3dd04ef77a2ff41cf2a99ce597511f17712d2964212", "size": 133 },
+								{ "hash": "6d492275f9dc1b3eb14c4fe40e7697fcb8be7bd0e502f36294fd292fc91b6c2f", "size": 170 },
+								{ "hash": "6e2c3fd686f1a39c61e4cc12493e64c9c598fbaa14600741034d6c2b273bbc9e", "size": 207 },
+								{ "hash": "bfbbfd0efc71f898483fe35ef957352ce83da316815a72af275c713017c203b5", "size": 244 },
+								{ "hash": "df9d7f8d2ced5b0b2244b86a1927c198ee3288ca46609e858eabaccb2ca5e802", "size": 281 },
+								{ "hash": "7b29b3872538a0ed752054050ad2e4313b65bda4a48850070bd43a6f40920ca9", "size": 318 },
+								{ "hash": "256819840287ba1d30ed5375d6286f11c26512129ba74cf579d899c2ba2f3e90", "size": 355 },
+								{ "hash": "56455d6fda197306983ebf91057fafa7aeb52a5a7b6c6f0181a80f1f220c6413", "size": 392 },
+								{ "hash": "e7850046aef15361539ebb14a5eec9ff0816b92a7082fe1f9d0aab19b39a1d8f", "size": 429 },
+								{ "hash": "f64427ec5cfb94c6bc0082d31843d1b747e57175c51967f124b44baad56603b7", "size": 466 },
+								{ "hash": "8618bbd2c67b31c04c21e8b7352ff911b7cfe3dbab199f7d133ef3f27784f7c7", "size": 503 },
+								{ "hash": "ac23ed184cad11bea7276976502b43735e1bdb8a5d0df3865856b725485f9ffa", "size": 540 },
+								{ "hash": "f67d4b03fd27e4144644433b6cc363c6b1b1655231c1e664a1744a5bd6c3560a", "size": 577 },
+								{ "hash": "0e16e82216955e904dba6e759ba89f7d904bf076697855d4b2723f0b1e643170", "size": 614 },
+								{ "hash": "2681300f410c9be6abe8cabf3a9288904c1ec8e9cecf7768e176775f1f58786e", "size": 651 },
+								{ "hash": "dfe5d18c6cccc67420b03679d72de5e1c0fdcf124017046b66e01aa5b6237d97", "size": 688 },
+								{ "hash": "3ea4e2da0d2e03c3d1588e18b768e76c71ed0e87b60ac146cfc971146759c066", "size": 725 },
+								{ "hash": "15f969a4d11c40fc62e8898bf33dbd50b972156da8e47e6dcf00e69e76a0fdcf", "size": 762 },
+								{ "hash": "caacbc17a0797f495b88102deb7c82747aaf3645f273dcea45794e5eb8f6e89e", "size": 799 },
+								{ "hash": "71478cfaa143a6eefb5a9f591a40f1c5231643a7ce4e40ec2f0dff9f5f5ac41f", "size": 836 },
+								{ "hash": "1701c077888854984ebcc89c15fb5c36719f73c4519a9f84a60c2c9e8e2a7762", "size": 873 },
+								{ "hash": "6213c946676be514a7299821dfec4b47a6f969255219ebcf9f62a1561b418690", "size": 910 },
+								{ "hash": "9badd8638277c2f5d3b59ef1c5fb5ad555800bcfd72056b0d88fffbd4d51c691", "size": 947 },
+								{ "hash": "6d879f5bb23f939b9d40ef350a34ef323b6ada854ad394d3482ca28f40082f58", "size": 984 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[11, 47],
+								[2, 0]
+							],
+							"nodes": [
+								{ "hash": "1fd466fb238af54aa2301ca992081e432ded96f46e7b65288f2cf32a612e6fd2", "size": 1021 },
+								{ "hash": "b4e8561a42a325cbbe628488a11d641184f411bfaa6b7802b3f9fc6c83f6d597", "size": 1058 },
+								{ "hash": "31269674e61de19626854b1b1181f0856eb57f1283c6a301ba6166c2ec313b19", "size": 1095 },
+								{ "hash": "ff0ba635978b684717acd41ed82eed7367193ac6ed7d00f41650b4cafbbced5b", "size": 132 },
+								{ "hash": "e05e547073c027666e8c2004616111f7dea96e6518c65165b04eca07e233eb2d", "size": 169 },
+								{ "hash": "7b29cef35b739e1ef01acc032563ba397fadacdd3132a3167e0b99df5a1800ec", "size": 206 },
+								{ "hash": "f9f6ee031ef2f3016d34c68beb6b6725b934807cbba1d8cf8f1d7ce8d14ab5c2", "size": 243 },
+								{ "hash": "644dd7a35780c1af185228740f61a6192611fc2e6f75836ade72616a3f3f29bd", "size": 280 },
+								{ "hash": "e7b60e39f3dac9ff1128a22ef9078ab3b13fc0e060e24e14433327130271cb83", "size": 317 },
+								{ "hash": "1f15578e06e22cf599b43f392b4adfa2df4fc896c6f39286112c0d5e32fd4af6", "size": 354 },
+								{ "hash": "bea8a9e8ee033bc78d4acdd81f003992f902756ac64e6552bce9e415b5528aac", "size": 391 },
+								{ "hash": "251c894b522ff253971294a7d2cd866b218b2227598f295b22d7db9105fcc014", "size": 1395 },
+								{ "hash": "2c3b7e7d8772d50fd47e64be6ed61d4481d76f9d6fd3bb71da65eca11e429850", "size": 3065 },
+								{ "hash": "30f82e9cdd4207723e7955ac21e93a8a720bd73d1777b606041190ae098443a2", "size": 724 },
+								{ "hash": "18e62912794248ea462904c872fbac8560ecf4c48fafb28e64aadcfd7b03c627", "size": 761 },
+								{ "hash": "b5f54946e7265573f7ab60b1498b9940605666815167d60336d6b771ace2f32a", "size": 798 },
+								{ "hash": "ca039b0c6d3166b72d0c63381822bc2cea9579dcd38438837c7d0b6b9d46a7e6", "size": 835 },
+								{ "hash": "882aab189e36ea42c123f30647b2b60ed6233eb48ba5ca17566001167c4139d1", "size": 872 },
+								{ "hash": "37470f8a4dd8f711456ee4dc90534372acc6ede0d546a34f5e1dc497e40eae6a", "size": 909 },
+								{ "hash": "40a4424a527b870cf3e8fb878d9e11b69e735a59362fb25841192473531120a0", "size": 946 },
+								{ "hash": "39460375682825b5f3bb64535f339035f4d4786455111c109516d962fb7029a5", "size": 983 },
+								{ "hash": "88cf8d9ad65306d0e4a1c74ec28b9c3b291edb6d77bded0422c4670a021c122f", "size": 1020 },
+								{ "hash": "5a4ad0de46026e17207e686deada54122eb8b5062ab6d4e10f78ab1c46f6f375", "size": 1057 },
+								{ "hash": "ba1af34a4103553a247894508c4d8c9e108c2acc476c1a91fbfb200587260625", "size": 1094 },
+								{ "hash": "0f6da6783b87804e10c92f17b0e8ebfe28b350efebc793f5e57fceb63c71f58d", "size": 131 },
+								{ "hash": "09eb2043fcbf6eb316251d1978e349396e8708b7e74f2aedac56ee5875a07e35", "size": 168 },
+								{ "hash": "189e9b14691c5510c94f72a910db638517bde6b5dcc60a530e562bda04e1aa46", "size": 205 },
+								{ "hash": "a4c05fa65d9599a6510c81ca39ebe2734635ad04d009c0e5f4ce3a3a64ffba34", "size": 242 },
+								{ "hash": "c69869624ff13001ac7d4ef1dde3b6d08c29c2cea50f444f2a200dcbdf07c614", "size": 279 },
+								{ "hash": "34c4e4aa37de61b94c4cc984161e2ff4b958e94a65bc2c8429cc1f601bb52f9f", "size": 316 },
+								{ "hash": "e777cf6f2c5bcd8d6a78c572a610741e9e7cf40208fce64c3934ee17d839c7e1", "size": 353 },
+								{ "hash": "78cd8f0886d4a0caf9c9f35a6fb0dcf3215a5654cb1d4546f36a0b02a5108508", "size": 390 },
+								{ "hash": "682dbc73b9708e1e6d20844896d574a41f7358319be2bdaec95119c673cb79b1", "size": 427 },
+								{ "hash": "e55ed25d8e390e4768a246497b62aefb5ad95bacee94aace4ff0894879cad424", "size": 464 },
+								{ "hash": "b37a4b2308a1a2a29b50c5565e3467e910e7d0a2e8b9e8f22a3ff7ab7c651ed3", "size": 501 },
+								{ "hash": "c98013a2eb2d888023f416369d2f1576a13cf8f3de238d534a7835819057b82e", "size": 538 },
+								{ "hash": "a90fef8daff4b1a990a3155c5a5bd00e859b0e172070fcbba868445b428b3db3", "size": 575 },
+								{ "hash": "61336692d03506f629b429d1fe9514cff1452b0799f4adbf0fec63600662d26d", "size": 612 },
+								{ "hash": "398964e725019eb83139d82fe69d716368da154c35814cf14d0870e893714089", "size": 649 },
+								{ "hash": "b23f8d1d5d1b9db88b64708181c04074d9b09bc0041f8644d1ebf8e76a23c933", "size": 686 },
+								{ "hash": "cf24dce154f4657de902cf6f7948f4c1eca7a9aab25c7f22299f5093a3912c19", "size": 723 },
+								{ "hash": "04b243e90357f63d349db9a254b6aefc2ce9c347c0c82256ad28d4a163ea970b", "size": 760 },
+								{ "hash": "78114858daf291e626617bc6cd48351058595c4746ff2c13783e66d7a2a614c3", "size": 797 },
+								{ "hash": "b7ad1ac41342b70ea40189a71db97f498f401cbdb1352bfcf64117f4c2d2937d", "size": 834 },
+								{ "hash": "a1124928017204cd17e5091e43a04478ba9eeda01d198254d88144f08ce6b6de", "size": 871 },
+								{ "hash": "0cdf1dbf75b863dcba2443b133f2166922bfa4885d8db9083b4066bdb21a49c0", "size": 908 },
+								{ "hash": "34952133f293940c0f6163eb41329f10f40c242a671b22bc75c7dd66b8338e42", "size": 945 },
+								{ "hash": "02f6f8097ede5a2092daa3a8ad4edc81914b314269eaf9ceb23f7bd3b9f7820d", "size": 982 },
+								{ "hash": "fc3fd9e8f4834c4664d5845e53fa696197870126810fd6ed9496a0a537c3c456", "size": 1019 },
+								{ "hash": "d7937c7587ab6b9e865d3f104b23295cea384848e084fa68b9eb833829f9e346", "size": 1056 },
+								{ "hash": "0700325214a7ed9165dc9575e54b9ab1cc79092b36878b702110be795a613bb3", "size": 1093 },
+								{ "hash": "c66133bbde49c487c41460d415c79989b6dacfab4570ef821debd8ecdefe532b", "size": 130 },
+								{ "hash": "b28344f7b1cf866c807c0048cf430f94b0a9714b725fe4c0ae0cde6156d6b5ef", "size": 167 },
+								{ "hash": "4885021a6922dcfe2ffd681b6bd711dd70a4800a083288ac8f0f1d689165c479", "size": 204 },
+								{ "hash": "47e9e1e188736824e1aab3f997925a03ef61b64ec87e66b5ee3b9a5c0cd3f6c1", "size": 241 },
+								{ "hash": "ac23981da6997dae50d4d713aeaae841d1ba3a07a2d339519839baa93d524541", "size": 278 },
+								{ "hash": "fc373d6ab5821271edbce9a3773168eb2b590d74852682876b6bde485bb29863", "size": 315 },
+								{ "hash": "5f9ec918b69f4d18c34d683489eb288294bf09e8187d3b397c9862926714202b", "size": 352 },
+								{ "hash": "11fb14513424a74904db80c7884edbbed2110c9f5c6ba7d0c128ef38729af7e4", "size": 389 },
+								{ "hash": "0f90056276c2a27dddf57aeb1faedb7e6654924068733e9f39a3d37438e132a8", "size": 426 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[16, 21],
+								[7, 0]
+							],
+							"nodes": [
+								{ "hash": "d79244ef25b241c40c3ee6be9ab7a8a6bebc200b10805a68cdaf706931b1395c", "size": 463 },
+								{ "hash": "68164855595bb03b927c2fa1d434a555a7a17c409ca708ccd6a1ba0c07bbe398", "size": 500 },
+								{ "hash": "09a424e0a934b0fe1c86633ebc9a053c09d8aba57f99da921c0bfe85621a2504", "size": 537 },
+								{ "hash": "f8fad26480d23d7a53f03be8127ce626ff86e15c9b7ae14f89e1b25dfd439249", "size": 574 },
+								{ "hash": "7bfddcb1becf53726fdfb3a8dc93bb19e97a7201331a7fb72a13ed860d84b4c5", "size": 611 },
+								{ "hash": "6e405a160c6a46bbf94ae3d15b38fe5683c5bb46183e47a930b967dbb0ba0d6e", "size": 648 },
+								{ "hash": "ebf82574bdb4d59db6dbd2fe684b07d8642133baacb8470836c3426ed052de8d", "size": 685 },
+								{ "hash": "2cab984c86adf1d6aab9d362a009a7c6f05a29ebc9e2e3de12d65b67d5aad123", "size": 722 },
+								{ "hash": "74c00a24053d93bc9db0799b6d7c6ceeb766b595007eef0f3ee934e887a696f4", "size": 759 },
+								{ "hash": "f27b18cda11252f6513acd5f033d7ed3c8661e76bf3a3cec18fea6e9ad653604", "size": 796 },
+								{ "hash": "8bca1819a07c306579880820ab3efa7c32eecdf08ac7b9178b899de39b63e44c", "size": 833 },
+								{ "hash": "dd7e45ea4ae574d68787d708907d50db9e28a25126eed065bcd47274fcab083e", "size": 870 },
+								{ "hash": "950a17ee6390f1082012a9a3b201a171f09a9229b9d45a6473aa402cf4f2a627", "size": 907 },
+								{ "hash": "5856bf8595fafb23430e83c0066f795e86dec0471fcae38f669342542eab427f", "size": 944 },
+								{ "hash": "5d1ce5cf905a8865f21c4682ef2d45b1ae6c889bb266c68e9d69351f245e5d1b", "size": 981 },
+								{ "hash": "687ab598cc249028b9f142f55f59dfa4274886785264a2aeab8ba87728e34798", "size": 1018 },
+								{ "hash": "46aae3d2af32a5b9b1e9932c24c232f7caadc66ba4efb65aab2271ab20a91930", "size": 2276 },
+								{ "hash": "25066bb821886d6a3d40fecd934acb7bc1a84573b7c023998cba37ba1c14e81b", "size": 1200 },
+								{ "hash": "0d09a96778b7b50bac6265843fe90b3d067de9ff4012e271388a7f907855403a", "size": 4491 },
+								{ "hash": "ba2026269f778cc9918b6f5957de3a3852fa2e52b8efb48e35961050e5e082cd", "size": 2163 },
+								{ "hash": "a2aaf1c9717fa3fdeadbce9ffa11170413c86093ad392d14c1b1477b7f851972", "size": 3402 },
+								{ "hash": "b4c56e0dff5046de9cd1a6128a7a5028b8cb86f6d6997210d0ba2442bbef5fd3", "size": 2940 },
+								{ "hash": "58bab1af50abe9b3079315a2d4b2ec2b05c72d970589f966e97f0bf199ae6d59", "size": 2273 },
+								{ "hash": "ad222e28ea5c3f1b0143dc96c67b95ae7879d0ef0edb100370f8ab605e93535d", "size": 165 },
+								{ "hash": "cbb3edf6d62e8841ed51cb9a45ca3c026bbe02dc153b51a43d7e4253211e809f", "size": 202 },
+								{ "hash": "6e045ae34a69849ddf3e00d6b1f2daf8d75b39c77c3ece88e69aa184292e2f00", "size": 239 },
+								{ "hash": "e085ad9a6fddacc3c27f277465fcb24d362dbabff19b6ec37b31432584648f46", "size": 276 },
+								{ "hash": "243da9612befe8da77bfd9d9c4a6cee77654bf32a3cdc1f9b74b012c55246f00", "size": 313 },
+								{ "hash": "ffa915d8bd41018315c4cfe82bbc6fb1725e1c2f4ae065e7c528f4622df0b7ac", "size": 350 },
+								{ "hash": "1c043ac3781399d7434897b7ea4a84cef62e9b3b251a68a1de0a3215ecbd2112", "size": 387 },
+								{ "hash": "4eba6c37cd5c612e26757e798ac3bdc2e12a7012a7feedbc54dd36bcdd28b425", "size": 424 },
+								{ "hash": "03c87931a2226bbca63846db121ff685dff437e699c2ac02c0f72cbd8d46e6dd", "size": 461 },
+								{ "hash": "1608663433fa3eba10b0ac975ce9b0298ce500863d3fa58636ced854e48d8a4b", "size": 498 },
+								{ "hash": "677035d2a93c63b1fba475c38c0e62523554eee5401ff66f8e74049a495c939c", "size": 535 },
+								{ "hash": "19e7c8996b4c3d74e70453cee029293921636972f9b5715db465bfc2e0888478", "size": 572 },
+								{ "hash": "066b4094e1aaca173bdfe4b1c286c21bae0a80031431ff8e982701dd0837c976", "size": 609 },
+								{ "hash": "7a03f4eceeaf1148aadb5601861996dd11d9a8cfce981768a2212510c39ee9b5", "size": 646 },
+								{ "hash": "c94c2a942db010af0d8efc7c806330b9e9b07d0b4c53dc2a52d7784c6e682e94", "size": 683 },
+								{ "hash": "70d2e27bd24da87493686d013a3551ffbb8b6af0b4f09b791d5114aa32004a32", "size": 720 },
+								{ "hash": "77330d90e3ce693129a11ce3cca44ecf1776ce919250ccdf8c61de4f3b6ec3e8", "size": 757 },
+								{ "hash": "e8223b03af2253a8a15c48debef65acd4eecfef744e4a0189ca905d899dade46", "size": 794 },
+								{ "hash": "751c1a1159ebf350b95ecf6a216666fda39b26f88243854c8162a7424b775cf6", "size": 831 },
+								{ "hash": "f27f6cea5933aab4d1b540b4374d876add851a1457ade99d9688f41fcdc9f5ab", "size": 868 },
+								{ "hash": "b57adff50acab412db7c62664a17d1e330fbea721299fba531a3cf300e966d91", "size": 905 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [
+								[58, 0],
+								[2, 0]
+							],
+							"nodes": [
+								{ "hash": "0249567eeb95b933037b425f6cb387213cf9ad635f839687b1a1214c03ab287c", "size": 942 },
+								{ "hash": "8728fad0069521a0e2ba1c3160a6445880619dad09384ebfe801cedc4fcd7b43", "size": 979 },
+								{ "hash": "1b42383f224ff644d0301e63666f39ccbeb7ff2602ed0531c7569152a2fc0b9c", "size": 1016 },
+								{ "hash": "75feb1a73f72dfb89ad301c92cea14f6e2df06d5b2909b67e94caa9e79f04329", "size": 1053 },
+								{ "hash": "51204d512f2d4b4dc0d004099fa259daa84f186ef65b15ec9dc68b245255689c", "size": 1090 },
+								{ "hash": "ffec46af5064f143931fa2cdda802c60449dbe9ed283191d293f9b008251c99a", "size": 127 },
+								{ "hash": "08a778f52493cbbc6a500307bbf46720301679e7445bda7bce2a114447ed36fd", "size": 164 },
+								{ "hash": "c408f2e920b0fe6c9e60cd49775e50fa8f158e5428079fe511f77af687fdeb37", "size": 201 },
+								{ "hash": "d247da48378517ae7405fe56109f8810363a40f2f830487428c0e2174cd5893f", "size": 238 },
+								{ "hash": "e4b7373eab7fcb7c8792ad06b6a4a551d480478751bfb1fa4e118a9c7ffdcac6", "size": 275 },
+								{ "hash": "f38732a7a35b5957aeacbf7c04af59356245cfa59557308e1b1700ed91591c9f", "size": 312 },
+								{ "hash": "c42be149caf63f76cca8a52e26dd6f6564321658931a2757b2fa255ee390fd50", "size": 349 },
+								{ "hash": "63c9824df54c21ada92ebb57d97e74555747fcba2964df066e12786b5ca4869f", "size": 386 },
+								{ "hash": "d4858bc4c979a1f6c91f03b195ae33f8f1fd8527519a63dc4d360b93eb20b1c0", "size": 423 },
+								{ "hash": "df768c5cf8b3e1591b0dceaf5a94d0e7b188ac5f7b815d81310eb55b8461b0cd", "size": 460 },
+								{ "hash": "0b5b692f7376036965a26ad6789fdb4c2ce29fffec74e0030412472ee3fd455f", "size": 497 },
+								{ "hash": "efe4d57687e97d95032d7a68e4b02f063487f9029ff3a98e54522859819413c9", "size": 534 },
+								{ "hash": "0e56cdbf7125d692ecc88100dcedcb95047d002e0629abbeee30ba327a5f16e7", "size": 571 },
+								{ "hash": "b998fe0e0906301daec5811f2eab13aa8536d11ac91e1410e6523ba5132e220e", "size": 608 },
+								{ "hash": "0ba7f159af6cacec0928c9d5c50da25cf9cfd84048130225d1c1b823cd1f7913", "size": 645 },
+								{ "hash": "0154709af0117a8be4a24b0ae643eccc897ff1c40d9a868b761b5fcde992c844", "size": 682 },
+								{ "hash": "0494004efbf062177693fcb223de7c16c9a2ad5f16c772b3623e9e9553fed913", "size": 719 },
+								{ "hash": "5d42ee25bfe8ad6069f746dac376bc6f1e177f24fcdc71412f3f2e0f25a26036", "size": 756 },
+								{ "hash": "349099b556161b4c5a24ac8098ca6df343a7d3515820c54f3747fb0af1ac97d3", "size": 793 },
+								{ "hash": "d0248e3f9df0123807b1b159421eb05d010f18d2db4bf234179b875c44dcaa3b", "size": 830 },
+								{ "hash": "4e7259167f6456b2f379a0e05652e060dcb34e9568f209b531a0fd1a30e74d86", "size": 867 },
+								{ "hash": "8b1378db9f73e4c9238000829e06d638f452c6cd2cb429cdabb770a9960cbda2", "size": 904 },
+								{ "hash": "e2883b1b91d781fd7b87b2be6eca4cab51d15c71ed0b5092a2305fe1bb6e79b3", "size": 941 },
+								{ "hash": "b11b1e99ca6f8130f9f0d4552327e792170561e25d90203af2577323549239ee", "size": 978 },
+								{ "hash": "a9524ab7be3522e6c3dec5d22f0003683d29138af9938ecf08387b27bba567fe", "size": 1015 },
+								{ "hash": "127c1f26720214a4b35b12eb14738656012ce80b1e919f16b16de06ffe7f3218", "size": 1052 },
+								{ "hash": "c8f277eac2d175d0250f663143967ca95890bf009d01883d7fa17c81b9d1673f", "size": 1089 },
+								{ "hash": "c217f84d0a4986df12a4e99f772aa7dd857c8015a27911592cfe75c5f32ccd95", "size": 126 },
+								{ "hash": "9e275a5ddb7da966ffad6fd7a41f856cb16e68420638720e99acfcca08ab422f", "size": 163 },
+								{ "hash": "2b77a9101be5664d629f27a1896b41b5bfff0428fddaa9454a2ef888c112ea54", "size": 200 },
+								{ "hash": "cc3dfa85fbe8bf047f10e9c6180393be3e031a811fbcf390e0141734d069e580", "size": 237 },
+								{ "hash": "78b37353e9aeffa51cbd9965a312334b4b8fcef294ac614a7c57f9111f2fec64", "size": 274 },
+								{ "hash": "157d0648e73508db99ec18037934e5af7d3f4f230f295972a2ffda30344012e9", "size": 311 },
+								{ "hash": "69813a95b93dddc4681ea506cc9750e1865927055064a40707c7c061ae8875bc", "size": 348 },
+								{ "hash": "fd52d381d7c7dbaec9f8a812589879763ce2f79ff853ae82cbe632252e4142b5", "size": 385 },
+								{ "hash": "4d8a42f09e2e281371576f7e22be3dfdfc39f495ef6ad5514535b7383a39ce90", "size": 422 },
+								{ "hash": "8a18a009f11d6b7c9d20ae7958646c8d39ee24a6de6c8d78ab9f1e49858a6b87", "size": 459 },
+								{ "hash": "18024a580159bdb7a930e0b011544476bbbe8f60376a80a2275b40dd72d821e9", "size": 496 },
+								{ "hash": "38ba91dfde28ef605b924d1ed4a01115e8e64f02341d2f97bc1f3fb1717d07ea", "size": 533 },
+								{ "hash": "4e56e9d7e620a572190e47bf10c63bfe4158beed7b88962052281843fbca84b1", "size": 570 },
+								{ "hash": "740d563a3271b29ead447088fd5da440539d3890c884eea991b03f10e4de6883", "size": 607 },
+								{ "hash": "b4c52628a0ec914b79bd4426e371a21583e4009a464ec0854032f22aebc75932", "size": 644 },
+								{ "hash": "377f45859a0cfb46872e2491a0a5e2e32b20c2aecbb94af0834358edf8326b31", "size": 681 },
+								{ "hash": "8a848ec3df83643469474663a60cf7e2a1207058d10dba4eefd7850872ddd97f", "size": 718 },
+								{ "hash": "d8ecda404dec509a2813c42192b9ea373746935d086d729016c6a1935c56e8cf", "size": 755 },
+								{ "hash": "cbace56d20afe34924f5d320cb58b34767b56b4c7189ed3bb5fe6071eec45fd6", "size": 792 },
+								{ "hash": "bd5b3604154d35e64e93c03e6476cf2b7bef57eae8b6307e5f4da170b4ba5898", "size": 829 },
+								{ "hash": "68ed6f57c46a95830db988cbe12bc5f856c81a2d6c3dcd416b6c9ff9dac91897", "size": 866 },
+								{ "hash": "f18d31a3521b1cfb65b005fe6db8c551db48d88654d04393ee7be96f66578664", "size": 903 },
+								{ "hash": "506e86dd5d2c5ff9d9f6d86d05f1881c2d310a3d9516336337150398d535b295", "size": 940 },
+								{ "hash": "20c78e21f36c140612faeb839bfe62c6244e7dc143b178340a15c0897e4da515", "size": 977 },
+								{ "hash": "c8f1a8c751ac8fb2235d6b481f16c5560ffb7ca936410c607b21b3e281f63c3e", "size": 1014 },
+								{ "hash": "e7eea5b8adb17b446b6ba7e0bddeaa5bc4cd955a093c10dc075aa02e7d6a0978", "size": 1051 },
+								{ "hash": "e72cdd97e79bdba0f582ae5f725d551309fe27d41b99c743555c84c01162226c", "size": 2393 },
+								{ "hash": "e6ca7ea3045c1af27a6dde0d66cbbf172056f28a9e265b5817b0c601d07dc781", "size": 731 }
+							]
+						}
+					],
+					"points": [66, 133, 199, 266]
+				}
+			],
+			"xorbHash": "0814346d175e34223cb59748c6d8f3f5eb247e0a816eecbd66d2416bba6a9af1"
+		},
+		{
+			"fileHash": "66c28944dabf2c8768a19a36f44e4e79645f902a84ed848731cc415cc08c6be6",
+			"finalHash": "249bd2a13be8360d929ca67e88b751fd39fac4c5021cf03f8b0aecbacd800651",
+			"full": {
+				"at_end": true,
+				"at_start": true,
+				"levels": [
+					[0, 0],
+					[0, 0],
+					[0, 0],
+					[0, 0],
+					[0, 0],
+					[1, 0]
+				],
+				"nodes": [{ "hash": "249bd2a13be8360d929ca67e88b751fd39fac4c5021cf03f8b0aecbacd800651", "size": 599500 }]
+			},
+			"n": 1000,
+			"splits": [
+				{
+					"mergedFinalHash": "249bd2a13be8360d929ca67e88b751fd39fac4c5021cf03f8b0aecbacd800651",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [
+								[0, 13],
+								[0, 44],
+								[9, 0]
+							],
+							"nodes": [
+								{ "hash": "ff89c785771396ae73543ab8d148f6c5e81f75e9a7fbd4b2021cbf3bd9742ebf", "size": 14625 },
+								{ "hash": "6cdd8dd37b630d9f7a74a00558480746f2a1889ab1232ef4eb8fefc72361d213", "size": 16661 },
+								{ "hash": "3caa0cbec59bb30d6b23a2de535d03467f84d4989cb465623d226d615b45eff1", "size": 11889 },
+								{ "hash": "565c474b4607c3495816653f49174f2fc2747cd7cc4a2f86046fddfc30970e0d", "size": 13486 },
+								{ "hash": "c6fc4623a64caaa501a59b9b4d81ef2ff39a876283fb981374f0dbd8517e71f5", "size": 15250 },
+								{ "hash": "20c8e792c4dad2e3bf4303b572bf6ddef18ed39853741dfccdcdd84e49497fa2", "size": 14836 },
+								{ "hash": "e44cc74ac29a422d633b2c2382ba83a74b6d44b3702e17722ab19a6ee477952c", "size": 13810 },
+								{ "hash": "6c14a2fe05cbec83c48407c0aaa45102382deec0dab937b4eef4d4b069d9b0a6", "size": 32404 },
+								{ "hash": "24ad7969493056da710fdc175dfd846d65a1f705de26c2f8c0ed22139fe3537f", "size": 17075 },
+								{ "hash": "e606de75c7075b2859ec6131eea03c5bef1caabf65db10dc7b0aa383ba0cb693", "size": 939 },
+								{ "hash": "2320f9e01fe34a2bfd4ce22a4fce5195d62e7b5a649e608ac8c39b30323e66ad", "size": 2305 },
+								{ "hash": "30aab064f085a32d2529c79fc2ca87a59a576e621ffdb3a80e254059544fdd7b", "size": 2510 },
+								{ "hash": "300ba251be1964cfb9318a85843bc5ecf49cedb2743ce2fa7480d479b1215040", "size": 5817 },
+								{ "hash": "3af13dd54e731d9bac7aecc286bc6a6788f0b79aa12156293279dc11c4a5daf8", "size": 4138 },
+								{ "hash": "35926c069d17d4a0e85d17b1b2b1a1d16c6d18eacb365bf6d5fe54945eb58b73", "size": 1666 },
+								{ "hash": "70b7ebd746f770a0fcd5e3e477f2be10f4e0d7e111e2d1dc44033639f4dc6ac1", "size": 4806 },
+								{ "hash": "356bfe3d68631ff2cc4d963098ae6c848ea72c0a25a607a07cb13efbd28b122b", "size": 7803 },
+								{ "hash": "b0f2ba289de0ef17be6cdb2809b6a1c2dfb2dbff12631ad94fc10b545a4270aa", "size": 2630 },
+								{ "hash": "4454c631f6e7437063deabe1793cd56e427a926f1f30128bafc2d371f4997b8b", "size": 1170 },
+								{ "hash": "100d33fcfa9f406fd74eafe830ff47e79d31aeb3c029badd2d5710eff0719e3d", "size": 4797 },
+								{ "hash": "7ecbbaee8e02ab7f98b9b31eb4c49000298b6cf72feeac65229f048959215e29", "size": 3094 },
+								{ "hash": "11cf27d385d3148067ac7ac989eda62045fb307e7893b8c0b70d51e1417e529c", "size": 5751 },
+								{ "hash": "e72cdd97e79bdba0f582ae5f725d551309fe27d41b99c743555c84c01162226c", "size": 2393 },
+								{ "hash": "f6e250c93b05602ae40570a6b1701fc691206fc77fff91de31072b802b784dd6", "size": 1610 },
+								{ "hash": "d582a8df2240f0dc3a7e17ceaeb62a37719d6d5c31acbc57106c32634b2e442a", "size": 2202 },
+								{ "hash": "2512a59af3577a6b0c4f1d2434d7d760a1767c146aecc2447fd501a3a1384ea7", "size": 7119 },
+								{ "hash": "6b16ab4a188ea1ee1bcf9969202a8f242afdd7030aaf98237163f3b004b166ad", "size": 4411 },
+								{ "hash": "e6046d3bc0b96ca35ba8753f0ffbddcf2a5c814d50b10de12fd8fc63ff37456f", "size": 3114 },
+								{ "hash": "0a7c359585e9a79c0e3059f6f37f15a3d138b7f3b4bafe45444667c49a21144c", "size": 2346 },
+								{ "hash": "648c1076be2516fb0a3f9bc86d4176d759ee723ddb47762f8ef412e2df13d917", "size": 2148 },
+								{ "hash": "037a8181167f66ac4c7368589ad3703c72d8e57483acea1cd8510e346187f04c", "size": 3382 },
+								{ "hash": "ec990516bc78e493a43418b2426c30926c6466f6cb5eec836ef3094ad6f6cc5c", "size": 2925 },
+								{ "hash": "7886019e9f25e536efa91ae3fc7e9edaa66251bec13b5486f746d919051237be", "size": 2418 },
+								{ "hash": "407ef3ce35e189e46c69c5ea66d51d0049e1f59e69817d0e955f45c48d98c84c", "size": 3105 },
+								{ "hash": "bd38a67be6919b32e3e2d5f43ffbe6607c5ea6eea314ba4c8d1d84856d4c3c5e", "size": 3020 },
+								{ "hash": "5e14a246fe2d9865a5cc8f23d0b57952911c0b3122384a73fd146152f2d99dc1", "size": 5782 },
+								{ "hash": "581ba2b6d284e4ebe6a5d4d0d01ba6985189ec5bf6bab6de3f7d504b62a7378e", "size": 5098 },
+								{ "hash": "9592de26442ad7186943bb09d4e80ea35cb3ad2ff685cb58d3957d2c0d0c0e82", "size": 4095 },
+								{ "hash": "1fce5d00a8b43b2d7facb49a133e3d231c3be0736854474936cd879d0044178d", "size": 3570 },
+								{ "hash": "e3f2bd777387bf36855a44c2e5fdb625f132c7e5caa1a83c6af09d63660702a1", "size": 4495 },
+								{ "hash": "8d4597fba52f51c1b47cd08cb3f2ed64f6fe1a9534102d34f5a703528327b47f", "size": 3615 },
+								{ "hash": "3cb94d8a35733b346ce094207024925369ddb5ffffeabf41706cbf7ee5bbbd6c", "size": 1530 },
+								{ "hash": "a2a6d95a9e87670cee9fa0dd916fcca25794972ad67b75f76a70e17737a0fb0b", "size": 1890 },
+								{ "hash": "729f5d0effb3f8c9925e0725bf96409c4328dc45c6eb25a444d1afc34cd74b1c", "size": 3195 },
+								{ "hash": "69f716b742040352ca5b108cff48f6757acaa0d68e1a15f488bdd73da9eba333", "size": 3222 },
+								{ "hash": "d39a9731a27d9530cff288f525dfe272584e4c46829e823ee3ea335241cf6eb3", "size": 3814 },
+								{ "hash": "87a356e3441976df3786f9bfc491816a43d802fc28582df71a856f2178f1eba3", "size": 2831 },
+								{ "hash": "ce932248d4d9ac1dd3387dc97b62187afad7e76ea3b67e97ba9d1fd87e52b5c5", "size": 915 },
+								{ "hash": "8eef1fe2a0b1287a02ee456a4c6cddb3dbb1333fc557b2354319fa522816ea54", "size": 1248 },
+								{ "hash": "da3acb8c8684ea4aaeefd4c233a302b85194661df524567bea45942aad0c93aa", "size": 1581 },
+								{ "hash": "0efd261490d46a71bc5efe127ea0774c4e0b547654ae153f611c04dee4d79f53", "size": 2626 },
+								{ "hash": "70ba7ca9dc5454014f3d86862d19921479352beb767d9953891b91e8e70dbfd5", "size": 3218 },
+								{ "hash": "b8a3f63e5a31b2d8756317a3aa265cd70d6126b5035fc849ba15185544511dce", "size": 5937 },
+								{ "hash": "7228a483b9b40deb8f0bf12de5e73c9138ab26b38e6ce5b2269754f11a0ae6c1", "size": 119 },
+								{ "hash": "d8f22e432ce90725e9fda4b9d5c84c6fe48272c4c9a058704abf4eec5379621b", "size": 156 },
+								{ "hash": "96b438236766519e5bd2b32ff0269fbe2b707ea6be565791be5c6ab4f42a94c9", "size": 193 },
+								{ "hash": "0e1017c1c95c8cdedb88aa37f30d3feae60811285dbcc0406b229bc267884a9d", "size": 230 },
+								{ "hash": "37e0a9e8ae5b0780b8afc9ac88e1b039f06df06d1b04cba3938350a173958edf", "size": 267 },
+								{ "hash": "2ad482423775aa1fb8aae130fd5b251f1785e4349ec3de85678ab9cc40a8068c", "size": 304 },
+								{ "hash": "7ffe70544e05ee2b6411c80f5635d085f930fc5efa43db4ef51508d7e2db787c", "size": 341 },
+								{ "hash": "db08b4648562904f18d8f9ea7db863bbb12a2f3e1b69db84bc4eda3576b59d47", "size": 378 },
+								{ "hash": "f0772e985b8a57f87ba9184e36ed182eef58c003ff5d9903e51d1e9a13ca01f0", "size": 415 },
+								{ "hash": "404a2d21b917495bac0546cbdc04bc35c5941a00a80af8d5496338dcbed9c170", "size": 452 },
+								{ "hash": "5ced66404db785492292781354539a701460a8f70596aa9c1f93bed22d2fef20", "size": 489 },
+								{ "hash": "9139a278602d60f71bc4f9f0cd8e76d59eb426fdd03852b1fe2cdd423ec2f8cd", "size": 526 },
+								{ "hash": "3b8863ac64e518fb0af1406d4e20ae9b629fd3f36c39d879268e144b5af56223", "size": 563 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [
+								[48, 0],
+								[28, 0],
+								[9, 0]
+							],
+							"nodes": [
+								{ "hash": "869dfb18df8cc4b5f419cff900b9b45e4484ea0dd5b00046e563e5b3890be410", "size": 600 },
+								{ "hash": "a0737c89bc95c750ddcc9c4cf371500a454319ba2e45497ab74fea1b3cb5ae35", "size": 637 },
+								{ "hash": "5436a121503a6e77145404c8f86bcc347b20e83aa471ea6943d52c79b1453bc2", "size": 674 },
+								{ "hash": "cfebdd9bc0d1421c114acff2683c60fee9d8797f24430dd1846feb024a88dd1b", "size": 711 },
+								{ "hash": "4dda4bc7248bdefae754e81249d9b5f70e053f092c5a6981a9006c6c6c2018d3", "size": 748 },
+								{ "hash": "2afcc2ad33ae613d7dbb8f43dfa706d156c3d41217d50b1be5836caf486a970f", "size": 785 },
+								{ "hash": "8587fbfc0d4ec916bed8e842c3b5c9112d7894a8c137ced0df45e7176e7b7d96", "size": 822 },
+								{ "hash": "5b5f295e48e0de2e5da97357df2ce4491cfd1673a59cedcf02508ed88e1b6821", "size": 859 },
+								{ "hash": "5faa0f3383a739fdb486180d70e098b080455c99767971627d78f353db30023a", "size": 896 },
+								{ "hash": "af381e9618ff25645af187e253b8741a1f89cd3e8d571db63756567513d7e33d", "size": 933 },
+								{ "hash": "f52a797943224568dfec65b35bd674e536fe8c8c853fa51753405645b7ac8ad6", "size": 970 },
+								{ "hash": "4501525f4866c0a00da318f1121b7ac99b193877ad55a4f846650f4a085fe580", "size": 1007 },
+								{ "hash": "a978b9e26eaa2999bb768e68e5b9884b28680d0bde29d7efdfcc5b17e632062a", "size": 1044 },
+								{ "hash": "67fe35ae385503b2d435440ad11b66c6992de712603f9b9ea6f723e55863a51e", "size": 1081 },
+								{ "hash": "19ca8ab1faf29ebe79e5366c979fc609c69ff20686da57c72d93f3c73e72e313", "size": 118 },
+								{ "hash": "5ff38d9a222829d32c676e51915900dc061f3b993011675a191dd6617f6ad871", "size": 155 },
+								{ "hash": "493230971678e3789c3512f71bdb8030102e2a09ee88eab9edc97bf3b7496a73", "size": 192 },
+								{ "hash": "bc8352277f34465d95b01c34ffe33ad4acc0a3cd948d06a3b86aaae80b5f2aa4", "size": 229 },
+								{ "hash": "7d5041dc9b1408c68327d6ad8e3a096ed9e8ef1fd5831e7ad0db691b505c1556", "size": 266 },
+								{ "hash": "80900532fb6e063249eacc858205d7281060a83f7a368f9ffe69a348ebda1185", "size": 303 },
+								{ "hash": "966eac49f6684562d90869590a1743a4e1fb456191065cec1d7e34607578e309", "size": 340 },
+								{ "hash": "99c232c7d3396e4e324e6017baf91d850581113fc4b3ecab92c4e307e23f9aae", "size": 377 },
+								{ "hash": "1f3ba9c7b200fac9c5a8aa06c426538fcc46b511912c34bc0a20c013cf40d316", "size": 414 },
+								{ "hash": "d033a2bde27edc760081b671bbdf548149593fefe892cd1abff192e4c108f5ad", "size": 451 },
+								{ "hash": "53552b5d7291665c92e400d37fa53b903f10233d51461f9b13784cfcce4322d3", "size": 488 },
+								{ "hash": "a8ba0264f3e52daef4f117281f4a21add43626ec010d13b9ddf6b95bf8f75dce", "size": 525 },
+								{ "hash": "11592f75143147bdae8cf53f0252b95719d842b3c26383e402aade39353049d7", "size": 562 },
+								{ "hash": "e7179ec3d27b21866e41baa257746f8320990d3e0e2d744961bfabacadd09ce1", "size": 599 },
+								{ "hash": "e2ab00e233e321b4c23b8cfa32444cdc4d0d909949701ef0416547817960e922", "size": 636 },
+								{ "hash": "f8d18473bead5e0baeb1bdf1fcf2fde46d5f77c5588c9cfd8818db9ca10fbb03", "size": 673 },
+								{ "hash": "8d77f226adf1d0e94dfb95dfeb44879657f062cc39629fbe4308b994c02a3c35", "size": 710 },
+								{ "hash": "805e6f115cf8705d4bee4147f5b6b00dffc4caa4f5bbd4ddb64a0559d2b102eb", "size": 747 },
+								{ "hash": "b6a13e06179c8dcd8c2a436010f54fb9fda8d99ff62d3d89277764f25fba86d5", "size": 784 },
+								{ "hash": "e776c875b8defa4c2442af82d10cb81d750023d292ca70a91c8de756577f3abb", "size": 821 },
+								{ "hash": "4980456ffecdc92c438351a0a9a8b1ddfe84db984edf98bfa83cceb17a260859", "size": 858 },
+								{ "hash": "7a46251fbaba62b81f921652316c21a4245227ab56381422e66415f8702a9fdf", "size": 895 },
+								{ "hash": "bcd710b83e754228cbce3c36a399858c546adac8a261ddd386be32f2ccc54e51", "size": 932 },
+								{ "hash": "2929e1535a278ef8b5efbdcce1aa867066126772a29d06b57806aeec76c488cd", "size": 969 },
+								{ "hash": "50467001736c94bed55a860907fee2c05f4853b93d09a3079d0d533c7aeb5c5c", "size": 1006 },
+								{ "hash": "558f3366df1be5a5fd440fa76b15c05f16d827b874c755a492bd982849dbd137", "size": 1043 },
+								{ "hash": "bcaeedb0cc5dc96dfd25690cbdac9a136c40ed01785ee1ff00febfb82eff3c2b", "size": 1080 },
+								{ "hash": "1b17c4869b3909c1c2289613f22a77bc7401a1b35d70a4088e98826fc8be21de", "size": 117 },
+								{ "hash": "31fb6ba955a31a962a496149195a13bbc659ed11e80813657862aeed8ef7474c", "size": 154 },
+								{ "hash": "3138e24b79cb1e934e341519f298789c69ae7534ee821acc02b060eb96f7be58", "size": 191 },
+								{ "hash": "41cb8a5b3ddfc8e410f9dfc6ea9e4a4dbc324c0ddb9041caaaac8ee575c37a46", "size": 228 },
+								{ "hash": "87272d676196d8303516eb81161433de486c3187e5845f4ee039bd9463779e3d", "size": 265 },
+								{ "hash": "07125e41c3ade1690e7cd59e2081903429e7873f313bb3e4960a3a7a416525d1", "size": 302 },
+								{ "hash": "6c79e6b5f186b2bf40bd2b7515d9fdb3e4e9d78715c2de1d9082aaa6a4eaae18", "size": 339 },
+								{ "hash": "2d76de888c7d51e921c415976a1bec45dbd8f0af16d5e3ccf9ef7c990b5221fd", "size": 2250 },
+								{ "hash": "4a45a0b892ebf55bfbafffa872ad037dd04680449d6b908c7b40c04a58d147f0", "size": 2466 },
+								{ "hash": "8a1c92f7861354d38caa66a2e8bbe350c760a0db47269fedef1041987e5b6773", "size": 2238 },
+								{ "hash": "f8b9575a9637502c8a00c66601e7ed241e0488e6173cce1e8f0803af7a4ca18e", "size": 7712 },
+								{ "hash": "ccbd16c0c7aa91e218d40394608911bd0bd6b14ee84a05d2cdfe5c4a3ad56fc4", "size": 2709 },
+								{ "hash": "b76270bbf21f528d7d55fad5bcd79b067eb37724e9af1a291d9260060d6c8ad5", "size": 2800 },
+								{ "hash": "7d19b78dafc740c4e957fc91d304f3b84b4b4e29111a97b5569f550ec35a4884", "size": 2906 },
+								{ "hash": "331254549deede71f71f2d7ec69d3dc83f62ee3b7c2f5d8a4b6adf0ce219c771", "size": 2568 },
+								{ "hash": "e58321d48592d62c952451c3aad7bc7902e708329c97eaa486cfe8a991c4c74f", "size": 2901 },
+								{ "hash": "49b7045f7c740d6672d75b8f46f89fa08858ee258aed01b548992d781d2b7db1", "size": 2575 },
+								{ "hash": "9cf5360341e2338680a4a792b5e2bf1c8c35f9fcad819111b7956e4ebf3675b1", "size": 1911 },
+								{ "hash": "29603f01a3b9acd78f70bac25b1e4e190f98a35b1ac63ea51ca3472eaf1151bd", "size": 1455 },
+								{ "hash": "1cf3ee9ee5a7677bef5edb84d6a3307b8099d0b5f80f4c102c0791708201db0c", "size": 3165 },
+								{ "hash": "1d0d6ce97f411e9b2d0e85c05dc8ce0c14417f0a3454f2e51324788fa52c3230", "size": 8028 },
+								{ "hash": "d4194f5835bb4fb5a8630eb480f04a2deec7a76db92d2fc24c4627ee4b2a174b", "size": 2017 },
+								{ "hash": "764af58f858bf223163a3e23f2f730274c2cf11555add56c1a65b9e9206ee580", "size": 1008 },
+								{ "hash": "54d2c720e8676ecbed6e1d1bd6edc760c390df216d6e41e315e95f9ddcbb6cb7", "size": 2420 },
+								{ "hash": "f973ce594aa803ddcb5fe0a331799ca5a303507a1591a0b06b56265b93369297", "size": 1896 },
+								{ "hash": "d8e8f7ba52d029a4bd96af5ee171455be59b6fe075687537dc06e2a1822a8fad", "size": 7686 },
+								{ "hash": "b2c68fcda0c25cf52e50f9f0e1d16cf91fbbbcac497b57c83bd6c2757cec0198", "size": 2565 },
+								{ "hash": "1a5db86238f67e884b0c800b14a5f55dd1945a63946051c31a66498fae123a18", "size": 3348 },
+								{ "hash": "772515f1241e2ed424a097e7c365e32ad62855a77b74ec1d46af523ac52c4abb", "size": 3897 },
+								{ "hash": "067f510095ae2260b8a1ec7dc71e93743b68fc2f62d18c8d1cd1fbfeef2d9557", "size": 2448 },
+								{ "hash": "603549b2e02a1588a17b0957a71c8dea2982929188f0badbfa3a07bce368ae77", "size": 4820 },
+								{ "hash": "698ce57b1bc0e168c8aee8e47f81d82f3d7d6602f721cda15a935054b3bf9d19", "size": 1522 },
+								{ "hash": "c8c3b03fcf9e02e1eccdc0b78ba8eaead86843096ecd94f1ec2a0c87f027de66", "size": 780 },
+								{ "hash": "735d715ff7abc2e5074dd15f52f451dc337b1370f26fbbbda7c521773ecc540f", "size": 4338 },
+								{ "hash": "b4f7bc9d37817aa3da10956688676985bd3fc9f110d957099b52d226a75772f8", "size": 7335 },
+								{ "hash": "0c62739d46b73588e1896190475d8dba7ba91b80f8f843cabd057037741a276c", "size": 21860 },
+								{ "hash": "08bb6b33d0b85ccc9c129c57dc71778d47cfa3be8ae0d3ffaf85757467e27ca6", "size": 31867 },
+								{ "hash": "27a3cafd85f10942f5db6245e23d1800e377ece47ae3ea25123f12395f169019", "size": 12088 },
+								{ "hash": "facead7e03c6a1326c7aa3e7b67f312b76662c6b47cd117d4150f97bdcd6d067", "size": 17375 },
+								{ "hash": "0ee55d109c8636a8377ca5d2a9458c6c46a62969400a92616802082048ca1c65", "size": 22237 },
+								{ "hash": "8d97f4b833e462dfc8170d9efd8f2c4a27d1faaa5fc0b5fbb596a90b7363af3e", "size": 24800 },
+								{ "hash": "ad38f7210a7e064efe5b518b49f39bf401e3a7ab0e133becbbe0435e49b4d7c4", "size": 17620 },
+								{ "hash": "55a9ad0ebb7a28dc41cc389f12e2dbe9028a1a5c221e13b5b4f8402ffafd3bd5", "size": 25573 },
+								{ "hash": "875ade5a8bcd12ad5d9eda0327c807e11c8218e1307d05db1c09a6a5f4355c2f", "size": 4030 }
+							]
+						}
+					],
+					"points": [500]
+				},
+				{
+					"mergedFinalHash": "249bd2a13be8360d929ca67e88b751fd39fac4c5021cf03f8b0aecbacd800651",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [
+								[0, 9],
+								[0, 13],
+								[9, 0]
+							],
+							"nodes": [
+								{ "hash": "ff89c785771396ae73543ab8d148f6c5e81f75e9a7fbd4b2021cbf3bd9742ebf", "size": 14625 },
+								{ "hash": "6cdd8dd37b630d9f7a74a00558480746f2a1889ab1232ef4eb8fefc72361d213", "size": 16661 },
+								{ "hash": "3caa0cbec59bb30d6b23a2de535d03467f84d4989cb465623d226d615b45eff1", "size": 11889 },
+								{ "hash": "565c474b4607c3495816653f49174f2fc2747cd7cc4a2f86046fddfc30970e0d", "size": 13486 },
+								{ "hash": "c6fc4623a64caaa501a59b9b4d81ef2ff39a876283fb981374f0dbd8517e71f5", "size": 15250 },
+								{ "hash": "20c8e792c4dad2e3bf4303b572bf6ddef18ed39853741dfccdcdd84e49497fa2", "size": 14836 },
+								{ "hash": "e44cc74ac29a422d633b2c2382ba83a74b6d44b3702e17722ab19a6ee477952c", "size": 13810 },
+								{ "hash": "6c14a2fe05cbec83c48407c0aaa45102382deec0dab937b4eef4d4b069d9b0a6", "size": 32404 },
+								{ "hash": "24ad7969493056da710fdc175dfd846d65a1f705de26c2f8c0ed22139fe3537f", "size": 17075 },
+								{ "hash": "e606de75c7075b2859ec6131eea03c5bef1caabf65db10dc7b0aa383ba0cb693", "size": 939 },
+								{ "hash": "2320f9e01fe34a2bfd4ce22a4fce5195d62e7b5a649e608ac8c39b30323e66ad", "size": 2305 },
+								{ "hash": "30aab064f085a32d2529c79fc2ca87a59a576e621ffdb3a80e254059544fdd7b", "size": 2510 },
+								{ "hash": "300ba251be1964cfb9318a85843bc5ecf49cedb2743ce2fa7480d479b1215040", "size": 5817 },
+								{ "hash": "3af13dd54e731d9bac7aecc286bc6a6788f0b79aa12156293279dc11c4a5daf8", "size": 4138 },
+								{ "hash": "35926c069d17d4a0e85d17b1b2b1a1d16c6d18eacb365bf6d5fe54945eb58b73", "size": 1666 },
+								{ "hash": "70b7ebd746f770a0fcd5e3e477f2be10f4e0d7e111e2d1dc44033639f4dc6ac1", "size": 4806 },
+								{ "hash": "356bfe3d68631ff2cc4d963098ae6c848ea72c0a25a607a07cb13efbd28b122b", "size": 7803 },
+								{ "hash": "b0f2ba289de0ef17be6cdb2809b6a1c2dfb2dbff12631ad94fc10b545a4270aa", "size": 2630 },
+								{ "hash": "4454c631f6e7437063deabe1793cd56e427a926f1f30128bafc2d371f4997b8b", "size": 1170 },
+								{ "hash": "100d33fcfa9f406fd74eafe830ff47e79d31aeb3c029badd2d5710eff0719e3d", "size": 4797 },
+								{ "hash": "7ecbbaee8e02ab7f98b9b31eb4c49000298b6cf72feeac65229f048959215e29", "size": 3094 },
+								{ "hash": "11cf27d385d3148067ac7ac989eda62045fb307e7893b8c0b70d51e1417e529c", "size": 5751 },
+								{ "hash": "c681ce00affef583a8ba686a79dfd2a3032a165edd5a47903633f6f8b9eac262", "size": 1088 },
+								{ "hash": "c003e6361216a3556bcb75a817c6b31275ab1af34214c2f9d6f97e460d4d4b1d", "size": 125 },
+								{ "hash": "82d491714a55fa33acbf92ac0921b6c052e1f3d5540796eba5844f5214a4f099", "size": 162 },
+								{ "hash": "491ff5c8ba8d894abfb48284f15be0c66858373c440a0ef3bdbf79d39856b43e", "size": 199 },
+								{ "hash": "75e232c494bf0cb4b64d1876c3ff7b1bb99fe0dd16af5e736efea34bc9109145", "size": 236 },
+								{ "hash": "0f5c4b5d03a32ac75f723bdb827c4508dd78f83bbd4327ea50effbf3999a49ab", "size": 273 },
+								{ "hash": "e617bb473c8eb2bfed14512c0fe7e96162acbecd29b803fc85eff3534cbc64b0", "size": 310 },
+								{ "hash": "6ef7db551a567ddb7b1c10841033b6882a2c9fe5172c2e9e0bf2b61f18fe8a1d", "size": 347 },
+								{ "hash": "311d29a716e4cbf9062e49496490b3b1a51864c4c0ec25365176b7b468c63d6f", "size": 384 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[41, 68],
+								[42, 0]
+							],
+							"nodes": [
+								{ "hash": "e62cf2ee46fc26319d33018481b43d605217d8698a373e2117ac81aa8f56459a", "size": 421 },
+								{ "hash": "7c57a2e24aec38715acf236df7275556ce48d24472cc9f37ef37bae1629c56c4", "size": 458 },
+								{ "hash": "e6383bda38441f146134061e73eb6e02eea1dbaa9c87cf3587a6614b577c6542", "size": 495 },
+								{ "hash": "f7c3e86774b8f350f9132520b4f20aee851b8c61040b226ee1660ca3c6c80b31", "size": 532 },
+								{ "hash": "37194704636392911e388a8ea36f6982de8856873a679c1dce26539a4a82fae2", "size": 569 },
+								{ "hash": "16e8b06f14cd9270f054110a8e3f57ba2b67995747e67631a656de96d0dbe34c", "size": 606 },
+								{ "hash": "cc29cdc294be4f39394dd99f2b24ebc01c79cd7d01fb33bc9413b61ddbdfc6ef", "size": 643 },
+								{ "hash": "524fa4649fc6797d0f9ccf9a8cf7fc065afe3dcef568aed72c277821b37e0c4a", "size": 680 },
+								{ "hash": "95d2942133b70c7aa698a511bd13f4aca9db66a4c86b1716de1709a2b9bc5366", "size": 717 },
+								{ "hash": "55c5d9a4e14a83b035407e309d62cb0575d8d350695522186a56882c5856f28d", "size": 754 },
+								{ "hash": "5ced1f751cf065652b5d85a8cb0fec4ed2abc12ad8dc7d54cfc0b1fca6eed55a", "size": 791 },
+								{ "hash": "6734af5cb5ec9c16204096e4ab87360886e14d3f056451824a206abf4c79c346", "size": 828 },
+								{ "hash": "92a4c9be526969b125f0f89ee01999ce172a5b5dd6988348d84c2c331bcbab72", "size": 865 },
+								{ "hash": "8d9d19b297c854ad1b8a6c6b82396f65556280588fd6837fa601d2afcc304781", "size": 902 },
+								{ "hash": "1e953230b388745d1ae6a26a81d60bd78ba002bea48325b74fedb1e68defa6a9", "size": 939 },
+								{ "hash": "6190f0e750a7fd6091f7a713a63cb52fd0f11fce91d81bce67353074ff505e67", "size": 976 },
+								{ "hash": "2278075338693346eb05122dffe4bf1755ca484633d5879798bdc8f635681ec2", "size": 1013 },
+								{ "hash": "52e17a3a16c0f61909868295f8b8b5fa475f328636549f5b9266b1bdac2b7976", "size": 1050 },
+								{ "hash": "6b98cdf4eb121104c3e4aeb9eb6f407aaee406e13ca50f4cc04a5f396a654b4b", "size": 1087 },
+								{ "hash": "a7cdc82877de96eab60e9152fb835f6c03b6cc674fe020e5171c4aed506fa483", "size": 124 },
+								{ "hash": "477984cd0d8b86ad66d7fe339265409189871dfd20efbd5c04c9a4dc8fecd08c", "size": 161 },
+								{ "hash": "f47461a79df37fc6455a37b5f3fbccf0c5452daa91c2b4a1cc9f3c26d9969209", "size": 198 },
+								{ "hash": "41682d128cb40aae8e0c36f28b7ea70e6cbdd56a596373dec25e704ead177523", "size": 235 },
+								{ "hash": "c2dc037a5da963c38c3311a615057869d288722187c7a7c238a72b92d31ee336", "size": 272 },
+								{ "hash": "ed042fddb0fd420f9dbb56e83241c0c31afeee96620a43760308bf38d84a597e", "size": 309 },
+								{ "hash": "7b6464d7d6d944b2affccc4fad1185f2c72e11d6b4061af4907af6c31ccf6dfd", "size": 346 },
+								{ "hash": "5052e5bf3f3b33570287450329ad6f2d346f64c3094668d769429acebdc8d559", "size": 383 },
+								{ "hash": "50238a831d9315127c35f182650e6df9f7605decf0aab2e994cd78930cebf41e", "size": 420 },
+								{ "hash": "31c3192b3de878f3891119fac6b15e18d5d154bd5d3a691eeb3bd1680b58246e", "size": 457 },
+								{ "hash": "43adf30cb11daad9f79469683a1266efc5f8e155458e31a47d3d1b0ffe20a36b", "size": 494 },
+								{ "hash": "d768b87420271f9f52798617afb5f20b6a16f1a57f1d914b9e2812a3ee92f085", "size": 531 },
+								{ "hash": "cf9bb57bba263bc1da5f98fc0b75cd891f01778b94449e8f7479d36fd3e3dd09", "size": 568 },
+								{ "hash": "15819ada424f0a7ae4f4ba750897c24648fa45a7f41d44c6bce4dc0293a52457", "size": 605 },
+								{ "hash": "f0fed5398862d8f7a709ac4561af6d0e28b66002213da5e6053f8d829b8ba8e0", "size": 642 },
+								{ "hash": "38d65df7e53123322e32a17d498e7acd0ca4a90b3aba8a599c3b2dc27eb92985", "size": 679 },
+								{ "hash": "a60d7d364a5d5291ecfc44a43ea67331ed207f7e2565480f4d53e51799157c98", "size": 716 },
+								{ "hash": "1484267979de1840c66a15a25f7b649939d474847227646d8c34575c52db3ad4", "size": 753 },
+								{ "hash": "a81dc3108269a9162ddfca8a6d405de0d798fdf040ae1b1d1c090f1a863efa80", "size": 790 },
+								{ "hash": "cfbbf1bb70e4d90f178693c50ef5a298807241ea9a1888289d91bfcd9793a21d", "size": 827 },
+								{ "hash": "c6dc3634f6df961ab3dc6b66aaf33942596de2330daac30abbceb6a9ae8438f2", "size": 864 },
+								{ "hash": "c28947c00e0636d093a08c7743dc279d758ca9c526b5645613445f6e616f6610", "size": 901 },
+								{ "hash": "ec990516bc78e493a43418b2426c30926c6466f6cb5eec836ef3094ad6f6cc5c", "size": 2925 },
+								{ "hash": "7886019e9f25e536efa91ae3fc7e9edaa66251bec13b5486f746d919051237be", "size": 2418 },
+								{ "hash": "407ef3ce35e189e46c69c5ea66d51d0049e1f59e69817d0e955f45c48d98c84c", "size": 3105 },
+								{ "hash": "bd38a67be6919b32e3e2d5f43ffbe6607c5ea6eea314ba4c8d1d84856d4c3c5e", "size": 3020 },
+								{ "hash": "5e14a246fe2d9865a5cc8f23d0b57952911c0b3122384a73fd146152f2d99dc1", "size": 5782 },
+								{ "hash": "581ba2b6d284e4ebe6a5d4d0d01ba6985189ec5bf6bab6de3f7d504b62a7378e", "size": 5098 },
+								{ "hash": "9592de26442ad7186943bb09d4e80ea35cb3ad2ff685cb58d3957d2c0d0c0e82", "size": 4095 },
+								{ "hash": "1fce5d00a8b43b2d7facb49a133e3d231c3be0736854474936cd879d0044178d", "size": 3570 },
+								{ "hash": "e3f2bd777387bf36855a44c2e5fdb625f132c7e5caa1a83c6af09d63660702a1", "size": 4495 },
+								{ "hash": "8d4597fba52f51c1b47cd08cb3f2ed64f6fe1a9534102d34f5a703528327b47f", "size": 3615 },
+								{ "hash": "3cb94d8a35733b346ce094207024925369ddb5ffffeabf41706cbf7ee5bbbd6c", "size": 1530 },
+								{ "hash": "a2a6d95a9e87670cee9fa0dd916fcca25794972ad67b75f76a70e17737a0fb0b", "size": 1890 },
+								{ "hash": "729f5d0effb3f8c9925e0725bf96409c4328dc45c6eb25a444d1afc34cd74b1c", "size": 3195 },
+								{ "hash": "69f716b742040352ca5b108cff48f6757acaa0d68e1a15f488bdd73da9eba333", "size": 3222 },
+								{ "hash": "d39a9731a27d9530cff288f525dfe272584e4c46829e823ee3ea335241cf6eb3", "size": 3814 },
+								{ "hash": "87a356e3441976df3786f9bfc491816a43d802fc28582df71a856f2178f1eba3", "size": 2831 },
+								{ "hash": "ce932248d4d9ac1dd3387dc97b62187afad7e76ea3b67e97ba9d1fd87e52b5c5", "size": 915 },
+								{ "hash": "8eef1fe2a0b1287a02ee456a4c6cddb3dbb1333fc557b2354319fa522816ea54", "size": 1248 },
+								{ "hash": "da3acb8c8684ea4aaeefd4c233a302b85194661df524567bea45942aad0c93aa", "size": 1581 },
+								{ "hash": "0efd261490d46a71bc5efe127ea0774c4e0b547654ae153f611c04dee4d79f53", "size": 2626 },
+								{ "hash": "70ba7ca9dc5454014f3d86862d19921479352beb767d9953891b91e8e70dbfd5", "size": 3218 },
+								{ "hash": "b8a3f63e5a31b2d8756317a3aa265cd70d6126b5035fc849ba15185544511dce", "size": 5937 },
+								{ "hash": "f55958b64e12473c09e75e896aed728a06277c46006bafe9cb5b969d2958d5d7", "size": 1269 },
+								{ "hash": "9cc102418da7da2c20f751d60fb89e3a42d5e4d3c1aa96c674a1de0077c67488", "size": 1134 },
+								{ "hash": "50b000d8bd33a622cb78042efca342441e7cdc04ca3cbe2b99642c2d661d7ef4", "size": 2630 },
+								{ "hash": "b727ca93975b2ff3f821dfbb91ddec7c9d069ff8488c6e15402a54209cc032dc", "size": 7065 },
+								{ "hash": "6584669d7e27f31d8bff4d7e31307657398959a2b304266146acd4cb2391c223", "size": 4796 },
+								{ "hash": "aec67a9a0501aae74ef419da49492162f471450d0f39564439f51bf8d1c7690c", "size": 3726 },
+								{ "hash": "6dc144f70764ec81e8f4eab81b5124c91a654769ebf65abe727dd367b9797fab", "size": 6723 },
+								{ "hash": "830f4bdc325baefa9f755312103568cf6e1a14e19cd569bd7a262a0363be5b2c", "size": 2907 },
+								{ "hash": "0420327c2d190b29e04ae0f6b9ca5113fdbe153c18dd0c4d2631c2d76914d487", "size": 2394 },
+								{ "hash": "0e4e4eb188fdb6c7a9516192ec44b6b04041420dd8effc9993b23301193149a4", "size": 1325 },
+								{ "hash": "2d76de888c7d51e921c415976a1bec45dbd8f0af16d5e3ccf9ef7c990b5221fd", "size": 2250 },
+								{ "hash": "4a45a0b892ebf55bfbafffa872ad037dd04680449d6b908c7b40c04a58d147f0", "size": 2466 },
+								{ "hash": "8a1c92f7861354d38caa66a2e8bbe350c760a0db47269fedef1041987e5b6773", "size": 2238 },
+								{ "hash": "f8b9575a9637502c8a00c66601e7ed241e0488e6173cce1e8f0803af7a4ca18e", "size": 7712 },
+								{ "hash": "ccbd16c0c7aa91e218d40394608911bd0bd6b14ee84a05d2cdfe5c4a3ad56fc4", "size": 2709 },
+								{ "hash": "b76270bbf21f528d7d55fad5bcd79b067eb37724e9af1a291d9260060d6c8ad5", "size": 2800 },
+								{ "hash": "7d19b78dafc740c4e957fc91d304f3b84b4b4e29111a97b5569f550ec35a4884", "size": 2906 },
+								{ "hash": "331254549deede71f71f2d7ec69d3dc83f62ee3b7c2f5d8a4b6adf0ce219c771", "size": 2568 },
+								{ "hash": "e58321d48592d62c952451c3aad7bc7902e708329c97eaa486cfe8a991c4c74f", "size": 2901 },
+								{ "hash": "49b7045f7c740d6672d75b8f46f89fa08858ee258aed01b548992d781d2b7db1", "size": 2575 },
+								{ "hash": "2606e6f5128b48765e8c3dfe962cd0bff1da6b61e3ea6b403c56455e99edcf3e", "size": 226 },
+								{ "hash": "51a4454e63042993ac0663a2be423edbf19344869c8ed2856a695519134778e5", "size": 263 },
+								{ "hash": "5e7971ee71ffa1bada150184c57946d8fe392341fbae68d6924d9505c3daa172", "size": 300 },
+								{ "hash": "2933016a4ee7bc0d1b890f14275fa2bf9b011beb9d6eaceb8df446422aa4db09", "size": 337 },
+								{ "hash": "3478fdc0070f03d74ccf980092778bfb40788142eecebf6d8a2a0098cf6c3dcf", "size": 374 },
+								{ "hash": "79558cafb3c2b0ecbb79a8bbee539f09e7e47994a6d39e6e0958d99e10b63850", "size": 411 },
+								{ "hash": "91459d9e8d4356ba018acf995416f6d3f6bbae7f658f50d3b949db2f5b6dc4f9", "size": 448 },
+								{ "hash": "57005a89a1dac930fe4c5ebddc120972c050c770c59621bf381d0ef00191e524", "size": 485 },
+								{ "hash": "3590ef98a9427b54b4115f3b40a731ae721c39bb962589d6a8ad431943d9e174", "size": 522 },
+								{ "hash": "1da243b57b8f86068676b88c2532f93317934e6424d641e16b410589a18576e5", "size": 559 },
+								{ "hash": "afac452771c2739d28d371409c25a4b56930d3c37f189272abdfbe4ac2cf4253", "size": 596 },
+								{ "hash": "3702702ebde78a1a6ad32399b53e1c91656563c8cc77588e54a4bd887d5fc3e2", "size": 633 },
+								{ "hash": "09ea07172570205ddea487135d4aa39ae52108765c3f12120a20ed1ec9bbf67a", "size": 670 },
+								{ "hash": "6fc2e6090b7e1963697ccac8dab333ef832f130ffa2dfcc2061c6452a40a1ba4", "size": 707 },
+								{ "hash": "d4d0d09212165764275b3d12096dfa1d100b57ca97ac32a399e64310709a7808", "size": 744 },
+								{ "hash": "6ec5fe6997440e1e8c4f73ebf038cfd0cf870d92600374ff95fd735bf207164f", "size": 781 },
+								{ "hash": "6d6876f2b4a9f0e63c36bb18966bee8a2e72c716571e1798eb3ae0ad20688827", "size": 818 },
+								{ "hash": "166b9097c5db1388e5c0ea715c4c5738b49b86da2aaf6584bfea12468b31038a", "size": 855 },
+								{ "hash": "bdceca14b8078b60dab2b2b93dbc7e20ffc60deff3e9b63ce9d4b97ef7672625", "size": 892 },
+								{ "hash": "30d191aad58f4f3468a3bbbc830a75fcdd6bc1b4ee54771b296805a2a4cab0e6", "size": 929 },
+								{ "hash": "4ac39b7b39aa1b926c93c0caf88f8f42adfa36c1bec343847e96cdb700c9a94e", "size": 966 },
+								{ "hash": "4c4a5ab7b68d9030b133dc94c2094cc3cc1087849f15c66313e0a61a737e009a", "size": 1003 },
+								{ "hash": "209f32a02de7c9a12be5370a83b114b05dad5f1f1e5e7247168d5c0a840bd47d", "size": 1040 },
+								{ "hash": "4f131d77ee3354d63d26ca3269bf5bd5bf05b6c9e649a6a1b300d6985b55c3a5", "size": 1077 },
+								{ "hash": "82e9f5b074f1bb2ce8bedbb1bc7a32a1895dfab625bb8d2eaf23bfb21c788e65", "size": 114 },
+								{ "hash": "6c672c548af9088294f55db951243ba4f478d0d8462b0edb5fba8c1e4d91ea7f", "size": 151 },
+								{ "hash": "a79ac213e833e6044100e90912c3721d26fed46988fb6d999fd30f683f2aa3ae", "size": 188 },
+								{ "hash": "4b31aa9a751bd2cc33ddc557fd09be61b166cb8b8ba260e41523a173fc1d9d09", "size": 225 },
+								{ "hash": "6f0cfb977c08e9e475b1ba9bd2931479c18baa097fc5e73a108785558c3ed43c", "size": 262 },
+								{ "hash": "2623e8e076eb0229ff974664e7809136a1ba0665c7a81374adb95f7b89ce0c59", "size": 299 },
+								{ "hash": "e72afa16e26a121fc5d2f582d7bc45dfbdffdd3287bce8647eba4cc32cfbf3b3", "size": 336 },
+								{ "hash": "bfdcb6200a9875a860ee358548796fe3e53ad2d9e87c6a17d804e0a9ce1355dc", "size": 373 },
+								{ "hash": "6ed4b6f528962f41310186b4fbcb2d0481682705547cb8ae8b3f47f77fa65cb0", "size": 410 },
+								{ "hash": "4962734b2fde200eeb5044f11aa0b357bc3b19564f5c0e8631fed838b757985d", "size": 447 },
+								{ "hash": "98fffad82c46cafc33e988922cf0e83ac6855b97beb535fba01cb3b5ff646565", "size": 484 },
+								{ "hash": "5ec599f69b4d3c4a4c54722f22027951211d482325313f1532d211eaca178b7a", "size": 521 },
+								{ "hash": "a3b464645b16c4ba374306a7b80ebe56e7fa344a2416c075b726670f0aa264f0", "size": 558 },
+								{ "hash": "a7ca10ea4c6357b3c2e87eae2e7a42688a21463d7ef3331c7026caa990aba4e1", "size": 595 },
+								{ "hash": "3a58ea91074fe000b4024a05c65c6a39f774d32cf15f6c6adc13593835d2afe4", "size": 632 },
+								{ "hash": "d110a0d65bd62c4f6132b77038994e005722a7a8627261e293d4693aa0d37588", "size": 669 },
+								{ "hash": "59421eeb06b366c0b3f6cef411d636819359a357f9480d691dbbd9ff8e0ef5ab", "size": 706 },
+								{ "hash": "1199c03efba74c44b342221e997c0e063c78c0450772bb441c4402fc54eeb33c", "size": 743 },
+								{ "hash": "a2a1bd0329d512a0286942cbd2331305ccbfc2e72a75ddaefbf3bd0af77db4a3", "size": 780 },
+								{ "hash": "514b6e4e7e5eef6a6d0fa0da3fe5f9f5a73cf2e1f45779cf16b151c81f5d1f21", "size": 817 },
+								{ "hash": "0c2327fa12d5394ad531cf233fb159f755f38faee768c9cc31fe61f781060b93", "size": 854 },
+								{ "hash": "bdd5179d22707c7834377013bfc264b7acadfa98c2ec59b93a57300a70225483", "size": 891 },
+								{ "hash": "1b80d022a38b14804ee24e367d2eb7f6c1f00f719de90b64e8bebcefb09a9c3a", "size": 928 },
+								{ "hash": "cfa9eadde4f6ae8f3b9b17261d95604b0f44fc607463c6dc2eab73f4c6723326", "size": 965 },
+								{ "hash": "e286f1ea8e0b16a5ad35ee2303cb4f069a7e9222e9279e62ff56c96ba64050fa", "size": 1002 },
+								{ "hash": "5d659c025a7b08e8f1f6c2f116a849b70b6002c4faa702fb59a9777ab0efab5f", "size": 1039 },
+								{ "hash": "80bc927a58d36233c08eb9d94f65f90b79e1b4152e4afde817dd6b7af4ecc5ae", "size": 1076 },
+								{ "hash": "5f19dab49afe74fedc299e1a501d4dcb3f4a7f9f69017d67c27ca2adce24df03", "size": 113 },
+								{ "hash": "f047ab2519037157c8b32895a97cbc00451e753a0468e822e0cc4ae9017df26a", "size": 150 },
+								{ "hash": "db2bdad910c57a2ab2faeb1e6804889bcc2ec9b3de8a7b2d277ab952c11d748c", "size": 187 },
+								{ "hash": "739941afc5dd9d627c9c5b97f89885502c2074d4e9ac3b1d0747ce0855fab97f", "size": 224 },
+								{ "hash": "e37bad782e26bfa55f010882b92248305512652de1e75285ea52aeeaec0278e0", "size": 261 },
+								{ "hash": "d07a84746b44205c024c218383f002bc4413cf17ffd0614cf2612f481e264207", "size": 298 },
+								{ "hash": "16ab4112679c8276ca390943e32f7e7c06a3ec81820828dfb4718cdbb08794d5", "size": 335 },
+								{ "hash": "7b071b3f4db521395ed1d8f53f25d80a1d956037e7f8e4a3e43b598a9410a8f5", "size": 372 },
+								{ "hash": "36c73f84d717f4d62997129e19808857eb308a868a01ea1a960375ee18f90ebd", "size": 409 },
+								{ "hash": "d126a7770714704ffc3c32380697e0e12a3a07921a4bf65f79068f3ab0da735f", "size": 446 },
+								{ "hash": "e5ce688ec4b4178765b094f313e19933ebba528b89f0b3c972c3b571349a4c91", "size": 483 },
+								{ "hash": "2eca45c888aa7b8468e20e23bc5ce2a8a0ac4bbf759763fdb683f547540450f1", "size": 520 },
+								{ "hash": "efa759f63a4fd6bb14d844e58b89b34c2bbf4e35c262faceeea8547b7b427492", "size": 557 },
+								{ "hash": "b499c284289f897c7c86ecb7dc5a1ddbfb6e7cfdde73c4372f8b651c17375cd2", "size": 594 },
+								{ "hash": "7be0e2103e561b7c84919b5e22426fe1f2c0757dc6fdd50aae5e0395b7b76276", "size": 631 },
+								{ "hash": "893c3883d50ad81c8cc817c0ee5e0cf094048a2780b40b7c757301b3df3dbe55", "size": 668 },
+								{ "hash": "5238ce7777c1cff52fb5a1e4a07443c9b968991460e704324c0c98818b7a05c3", "size": 705 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [
+								[4, 0],
+								[44, 0],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "a1ca718a13242a38a212d0c9c036a47b25c54e6491a5b6a0b67abccf6aec49a4", "size": 742 },
+								{ "hash": "32418d2c7a22ffc6fea2abf4bf82e85b26b0aeb81e34aa72c988be69b8a8c9b1", "size": 779 },
+								{ "hash": "0608e381f3756b9eca50338f5583cb013115238399118ea5312dcfc4a81fe341", "size": 816 },
+								{ "hash": "0ea993f8cd1765305e809c935b4d4d48afdbc4338e19d87e8dcec228274c28b4", "size": 853 },
+								{ "hash": "603549b2e02a1588a17b0957a71c8dea2982929188f0badbfa3a07bce368ae77", "size": 4820 },
+								{ "hash": "698ce57b1bc0e168c8aee8e47f81d82f3d7d6602f721cda15a935054b3bf9d19", "size": 1522 },
+								{ "hash": "c8c3b03fcf9e02e1eccdc0b78ba8eaead86843096ecd94f1ec2a0c87f027de66", "size": 780 },
+								{ "hash": "735d715ff7abc2e5074dd15f52f451dc337b1370f26fbbbda7c521773ecc540f", "size": 4338 },
+								{ "hash": "b4f7bc9d37817aa3da10956688676985bd3fc9f110d957099b52d226a75772f8", "size": 7335 },
+								{ "hash": "48bbf9c8e0fb9e218a4ae7814a8209f8db5aafbd9cb1205c3a59747c45f0e723", "size": 3111 },
+								{ "hash": "76fda3a53709154a710ec71a28b8dbf343c5aa92aed62b9d7af5379bcf01abb2", "size": 1554 },
+								{ "hash": "00d36875ebb3d9150391502a4639e291751807041dd30933333b143df3ba21b2", "size": 4662 },
+								{ "hash": "d03e57c09a7e376735a8da0157ecc76506ac96b058e4a9896f43c8799be49ada", "size": 7659 },
+								{ "hash": "476d98142f0314546b21a1b0b98fc915c14b1a538495f4a6eb8e18cd5aacccf6", "size": 2366 },
+								{ "hash": "80c319c07cf127b1f385b531a9bfe4bac1b1fa1d3e4d2df2e32bca0aa5f4840a", "size": 663 },
+								{ "hash": "51324ef2a7ee3c82298a474e237dc8aaf279bdd5c28b5185ea197461b88f630c", "size": 1845 },
+								{ "hash": "92366b26310630d809ab380ea7292a8eee56b6443a7ca8bc80f664634b143a3c", "size": 3435 },
+								{ "hash": "a0720c2b0e3e7d03956333981734f0bc7c3ed14243ac6437bed42c3328e1b24a", "size": 3030 },
+								{ "hash": "3a37eaffa534c1125ffbdebb94a2ec0d0849adcf61ce1f4ea6430ff1d8b5222d", "size": 5655 },
+								{ "hash": "685c4dab99006ed9bcfde70c1439223ba563d3884e55d493edcfd6beed67fbd5", "size": 1730 },
+								{ "hash": "d8c9c7f665ea76f6c09793a8abef8605fbcd3b73aa993f5d54bca595ddb9b9ef", "size": 3092 },
+								{ "hash": "8d3503a00e2c7f758cc2166720125b34bc165221b318dba3a45a78fb2f0344ed", "size": 3135 },
+								{ "hash": "c5a00c360844d2f795965a2db2c452061172728b059750f4a1a9cb1e15737069", "size": 5943 },
+								{ "hash": "b56f95b4da10a03eba817b1ae20e3314f50ca73d66aaedb31c0ccd42e4e03fab", "size": 3355 },
+								{ "hash": "f75a79c619fb402e46ba1c1506d10bf2d74d0ccd36b8194e17c777424d3099a1", "size": 2492 },
+								{ "hash": "964ea5714989102df71899f609b7898765513eb89fd22b4458074f9c3fed3548", "size": 2760 },
+								{ "hash": "62202ffea68e3b4630e1de20bb38c0ed27ecba72ebd59bdeedf1f632c859c3a7", "size": 6340 },
+								{ "hash": "6e0d4fe42045de650ae1f401fa5ea4d3371b58ba7c9d5a375f63b5eb9fb32480", "size": 2988 },
+								{ "hash": "6439f59690051aadf58f65fcccb92c31af7315fa40ee5e2213040d763c5af89f", "size": 2962 },
+								{ "hash": "52b9eb417846c9411889e34c3119a87550e8323186000faca2c1b9b6b8981850", "size": 3598 },
+								{ "hash": "df9ee35931b0567f0653187387772734f36e229eddf776072050d66fec016d62", "size": 2097 },
+								{ "hash": "9f9b8e0428817b6dd02517e16791227be666bf89dcdf3c9bfbf1c8819b4e5e93", "size": 2430 },
+								{ "hash": "1746d4f26b9a637b7cb268d99cc4f43e528d83ba94c4631f6dcaa438ec9d61e7", "size": 2763 },
+								{ "hash": "7ff21b6c2add2ad39a54d91d37d95e6d04b2669b91be83ef8e004bd38a1815a8", "size": 3525 },
+								{ "hash": "8410e692e3c2d97804a8cc8c16c9a0d4dee4086f41719191e3fea8af9e1d13ed", "size": 1857 },
+								{ "hash": "b8057b8ea466d2b47324de056bd87909069bbffae69f5cdae9da83f6b1490e9d", "size": 1428 },
+								{ "hash": "5088c5b9608ac098c858d7dd1dc3f5258eb7394138dd892b8ef0a90ef2ae1b6a", "size": 4627 },
+								{ "hash": "b545e9aed3a2b6dd92858193d1c3d5f97ee727f1d6dbdb4b5ae761caec955cb7", "size": 2538 },
+								{ "hash": "d19df790553cb5c1f398fdb2472de93d9a39578c45fceef15efc8f6985f05d75", "size": 5075 },
+								{ "hash": "b0727ae5b368287b0c96249937d8352aa0a738f6adc058ed59e5039aedddf4aa", "size": 1771 },
+								{ "hash": "0e2b0c6b75a9312c1b3123342df57f450f5bf37369c063551e3f08a620bae44e", "size": 1314 },
+								{ "hash": "22f68e8faf2860d44c638608f2a794e0f87ec8a04e49fdb4eacf33aa1e91f70c", "size": 3627 },
+								{ "hash": "c880ffab99bbb8141a57dd72211f88aa00b33969a9bb7366298067c12ab54c04", "size": 7938 },
+								{ "hash": "26e049584f30f61ec60c71f73163ecb5fcc05a6bee68094ff218caf77f460c89", "size": 1490 },
+								{ "hash": "de455d4fc626fd878a01f7a860a5fe0152ac4b0540bdc405408bf34a90b5b87d", "size": 756 },
+								{ "hash": "82ac69113c44e12a13b7c68a1359d9ced87dbec177cf04a243bd9525f3a6d70d", "size": 4266 },
+								{ "hash": "9c7a075a589542e59cb1a0415fe4a86b7253ed020e235efc314e403715144d4b", "size": 4509 },
+								{ "hash": "79ebc2f62b2a7eff62eab6d00fd8e3b012f311898b96b7e09bf38647c5d6530c", "size": 5841 },
+								{ "hash": "ad38f7210a7e064efe5b518b49f39bf401e3a7ab0e133becbbe0435e49b4d7c4", "size": 17620 },
+								{ "hash": "55a9ad0ebb7a28dc41cc389f12e2dbe9028a1a5c221e13b5b4f8402ffafd3bd5", "size": 25573 },
+								{ "hash": "875ade5a8bcd12ad5d9eda0327c807e11c8218e1307d05db1c09a6a5f4355c2f", "size": 4030 }
+							]
+						}
+					],
+					"points": [333, 666]
+				},
+				{
+					"mergedFinalHash": "249bd2a13be8360d929ca67e88b751fd39fac4c5021cf03f8b0aecbacd800651",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[9, 7],
+								[10, 13],
+								[28, 0]
+							],
+							"nodes": [
+								{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 },
+								{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 },
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "08bef1184db71338fc973dd13a7185eae87db67e06e4c5eadb5b16d3d8439b2d", "size": 2470 },
+								{ "hash": "c933041e8b459b6175c856285216267f61d4d2750a7404b82c136aa39a69af7b", "size": 1420 },
+								{ "hash": "3b2d4081e4bbbaf5498721ebd28dcd19e066a6666d42071b3bc4d7350c21092d", "size": 1296 },
+								{ "hash": "3111effb06cbbb5c9376d51372e956ee0d6e439c12b8559a5038175750071a06", "size": 1629 },
+								{ "hash": "00b41d92df650c72464cc940376f54708e9e107f34a19068dfb6b83519e1bf0a", "size": 4257 },
+								{ "hash": "9e50c43052cb333988ef35afdfd4dcede1ee9466eb02a3e94c3384aeee83bb85", "size": 2628 },
+								{ "hash": "6f2ad36f534f13c285fb9d61db474abc0164b4063626a2d52188f903e2b6ce18", "size": 2961 },
+								{ "hash": "3caa0cbec59bb30d6b23a2de535d03467f84d4989cb465623d226d615b45eff1", "size": 11889 },
+								{ "hash": "565c474b4607c3495816653f49174f2fc2747cd7cc4a2f86046fddfc30970e0d", "size": 13486 },
+								{ "hash": "c6fc4623a64caaa501a59b9b4d81ef2ff39a876283fb981374f0dbd8517e71f5", "size": 15250 },
+								{ "hash": "20c8e792c4dad2e3bf4303b572bf6ddef18ed39853741dfccdcdd84e49497fa2", "size": 14836 },
+								{ "hash": "e44cc74ac29a422d633b2c2382ba83a74b6d44b3702e17722ab19a6ee477952c", "size": 13810 },
+								{ "hash": "6c14a2fe05cbec83c48407c0aaa45102382deec0dab937b4eef4d4b069d9b0a6", "size": 32404 },
+								{ "hash": "24ad7969493056da710fdc175dfd846d65a1f705de26c2f8c0ed22139fe3537f", "size": 17075 },
+								{ "hash": "e2003cd8075c016301dea7d7823766fd1f00cb69420557e890a65c52d6abc741", "size": 11571 },
+								{ "hash": "6955769d5a15dc60df8395ae7e836f9098ecefe6755d796173c0b16dcbc3be86", "size": 35855 },
+								{ "hash": "5eb935a048cf5e5a664a64176771af8448f630f0bd2b8e9fe358bfaafdcf71b4", "size": 23195 },
+								{ "hash": "945742788a156f729e57aded9ecaba201ddb9ed68070eddae0fc702d3180c908", "size": 8455 },
+								{ "hash": "ff2782cc8d91f4c76c46ac331f6c14b5b6ff34afb5e57f0367d67cb0abd26a5b", "size": 35198 },
+								{ "hash": "8396119b5bc6d8f5c6e6621b402879cb3b2eed36b4e0c513256e92b3beee27b2", "size": 6615 },
+								{ "hash": "3dae54eeb089dcb899e3ceff2e1577675a341aff43e26a05e8c11254c6c70058", "size": 12030 },
+								{ "hash": "5468d7aa29ad6563375644f6ee759af149d244101eae724dad04b8d945492963", "size": 15765 },
+								{ "hash": "1fb88d4bcfb630d902aa6e8c7cf9b20aa5039df6b3de2829fd034b9319589daa", "size": 18217 },
+								{ "hash": "5758a57ebc687d327882bb9cc3712adc360880d519a22505425145f70d1dcf01", "size": 13349 },
+								{ "hash": "0483a662ab159ec4a665e32fdea59bf05c3fb744e6dc8e8563dbc1eba4b575cd", "size": 17375 },
+								{ "hash": "f762db322b2007f82458a84d861e3244985ed2ae8373eca0dcf986d123ca1be9", "size": 20281 },
+								{ "hash": "85cb000652bbeca3f9d29f67f4fa7f3f7312578fbdf92ec74e07ce030a735f97", "size": 11053 },
+								{ "hash": "f86d72d708d1c81344b0fed0042ad2abd5a7c659740c53876872c49aa006eb78", "size": 14567 },
+								{ "hash": "2d310f7794b0da9545618e84a6391fccf785da77796e0985bf0d719ca34ef5c3", "size": 28488 },
+								{ "hash": "0c62739d46b73588e1896190475d8dba7ba91b80f8f843cabd057037741a276c", "size": 21860 },
+								{ "hash": "08bb6b33d0b85ccc9c129c57dc71778d47cfa3be8ae0d3ffaf85757467e27ca6", "size": 31867 },
+								{ "hash": "27a3cafd85f10942f5db6245e23d1800e377ece47ae3ea25123f12395f169019", "size": 12088 },
+								{ "hash": "facead7e03c6a1326c7aa3e7b67f312b76662c6b47cd117d4150f97bdcd6d067", "size": 17375 },
+								{ "hash": "0ee55d109c8636a8377ca5d2a9458c6c46a62969400a92616802082048ca1c65", "size": 22237 },
+								{ "hash": "8d97f4b833e462dfc8170d9efd8f2c4a27d1faaa5fc0b5fbb596a90b7363af3e", "size": 24800 },
+								{ "hash": "c7d3f13535ba99ffbdd8ed7b75558be379482f7ace4bd3120b787f82139af9bf", "size": 1498 },
+								{ "hash": "25a400bde7fd1627c65b2d99d7f7524e2f20109f6c5acd389b02253959025e2b", "size": 1670 },
+								{ "hash": "19c43e3836db48404ddf77ccf30f1b4ea782bf1553073a6e26b9077d49a52f5a", "size": 5922 },
+								{ "hash": "5fc289aeee68c5c4fc97247292550502c247d2777e1d966688833230fd6b8b5b", "size": 6678 },
+								{ "hash": "3746569f8ab62071ee7d10602a5e9dd25f8ec3c799bd44ba756e5ff9b0342379", "size": 880 },
+								{ "hash": "0bfc04b7f3a44a2aaa44adf79942383065e43fc71d7d4b550f31fd38698ee718", "size": 972 },
+								{ "hash": "c8233635779d6b20439f11f1755b4409ce43896bf71347832a5da25036f2f2f6", "size": 2360 },
+								{ "hash": "f8433ff96c3c440fa65d49f0b87f80906cebafa630df82f8e82ebc239b770d2d", "size": 4858 },
+								{ "hash": "4852bd0110eaa09231a5373c271431a66edbb8b03b3c43db9e518eb7753e8cb3", "size": 4580 },
+								{ "hash": "963f44e8ab940928bcd366117e87be5a84be755076a1399819d41ec77c2fcbf5", "size": 3575 },
+								{ "hash": "f01f038fc8c2cd2c26117601bf77dbd375a10ada1869aa39b03e7efb5efea2ee", "size": 2170 },
+								{ "hash": "c46ae48e2d365c06ef94eae6b65b27128372fc8715a4dc355e277f8b68fd7a77", "size": 1746 },
+								{ "hash": "711cce35bb0b516e88190b59576425f2b25bedb884f8440883f597089dd7866a", "size": 2846 },
+								{ "hash": "b380f2e566880e6c2f50344fb40f7aa814efea8adc888955e4386f7858996066", "size": 804 },
+								{ "hash": "c5957da4181f4e0fd609df13dc81138bf7ea02c376d3ddcfbc85211c70d6541d", "size": 841 },
+								{ "hash": "f5bdd196debdd306f80fec75868eb7ff0fb0a1a91149d87ec48489f192b4a5cb", "size": 878 },
+								{ "hash": "0e4013e8def0206835f9ff47e739f68082c1c807857155438cfb704293df41d8", "size": 915 },
+								{ "hash": "b702140987ed4a974a11b3ac065327f723d7c22d6f4afe04b3b3fc6230365af0", "size": 952 },
+								{ "hash": "6a53d06c52e33c76e10c61d0397fb138b676d2970ffb51c8ba4ef5e560fec469", "size": 989 },
+								{ "hash": "68569707ec58e088857528eb2a8bbf02c22bd01553231019f6e2df4c74df570e", "size": 1026 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "a079a4127f027928bfd62ee2712563653d72e268d4fdf49a8e35e56c395b2b51", "size": 1063 }]
+						}
+					],
+					"points": [1, 999]
+				},
+				{
+					"mergedFinalHash": "249bd2a13be8360d929ca67e88b751fd39fac4c5021cf03f8b0aecbacd800651",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "10bb77c0c77ad7311e5235905cd4edc1f36641f3a2c9b9d4e5cd8b2c9694067a", "size": 100 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "0e9c93ddd9ef73c224d3f331e3e39abeceeecd4d766dcf824b4e7ce1af5ada94", "size": 137 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "83129654996aa8d1a8031003544bb8faaead035ebacc8b1c9b9341451236433c", "size": 174 }]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[7, 6],
+								[10, 13],
+								[28, 0]
+							],
+							"nodes": [
+								{ "hash": "af9a68ad05126c9961f8f7f999e44c1033a3b157b9469ffb0ec9b7ec4ccf4fc9", "size": 211 },
+								{ "hash": "4825b1a4e1c85f31fb2531bb6ac72bab5b1069df0ca6bd8a2abcf5edc001e99f", "size": 248 },
+								{ "hash": "a757182a18d3b6d8083e8c77bb88ba74c4e391815b1b2fcd37c055a6221517d0", "size": 285 },
+								{ "hash": "a9f0ac9ee974f50d1b8553a51d7d24308bc1aafae62513302f337be322c73240", "size": 322 },
+								{ "hash": "a1165105f4d4d8a79dc602ab32d0d79fafaaf1a7d12a3533a492ad05755a54a6", "size": 359 },
+								{ "hash": "52b8f53aa4b0957ca388bd251adb87dd020e709513ca90eb6523a41c5c8a747b", "size": 396 },
+								{ "hash": "ee5e6845ef85677c35871c9361d6b355cb1317610463702623dbe3a01177ba3c", "size": 433 },
+								{ "hash": "a9a42a28ce459ac0361d135a74753d659734d4dad79093a2a9e9fb9ebf2ac61b", "size": 3375 },
+								{ "hash": "56add117b2fca18395c388c89e14be1caf3686f5a2469e387096ad51d20077b5", "size": 4707 },
+								{ "hash": "cd5c361d9fcb30c55938b52c67eb9b1f793bd0f57bfe0ec93190c03adde64104", "size": 3878 },
+								{ "hash": "08bef1184db71338fc973dd13a7185eae87db67e06e4c5eadb5b16d3d8439b2d", "size": 2470 },
+								{ "hash": "c933041e8b459b6175c856285216267f61d4d2750a7404b82c136aa39a69af7b", "size": 1420 },
+								{ "hash": "3b2d4081e4bbbaf5498721ebd28dcd19e066a6666d42071b3bc4d7350c21092d", "size": 1296 },
+								{ "hash": "3111effb06cbbb5c9376d51372e956ee0d6e439c12b8559a5038175750071a06", "size": 1629 },
+								{ "hash": "00b41d92df650c72464cc940376f54708e9e107f34a19068dfb6b83519e1bf0a", "size": 4257 },
+								{ "hash": "9e50c43052cb333988ef35afdfd4dcede1ee9466eb02a3e94c3384aeee83bb85", "size": 2628 },
+								{ "hash": "6f2ad36f534f13c285fb9d61db474abc0164b4063626a2d52188f903e2b6ce18", "size": 2961 },
+								{ "hash": "3caa0cbec59bb30d6b23a2de535d03467f84d4989cb465623d226d615b45eff1", "size": 11889 },
+								{ "hash": "565c474b4607c3495816653f49174f2fc2747cd7cc4a2f86046fddfc30970e0d", "size": 13486 },
+								{ "hash": "c6fc4623a64caaa501a59b9b4d81ef2ff39a876283fb981374f0dbd8517e71f5", "size": 15250 },
+								{ "hash": "20c8e792c4dad2e3bf4303b572bf6ddef18ed39853741dfccdcdd84e49497fa2", "size": 14836 },
+								{ "hash": "e44cc74ac29a422d633b2c2382ba83a74b6d44b3702e17722ab19a6ee477952c", "size": 13810 },
+								{ "hash": "6c14a2fe05cbec83c48407c0aaa45102382deec0dab937b4eef4d4b069d9b0a6", "size": 32404 },
+								{ "hash": "24ad7969493056da710fdc175dfd846d65a1f705de26c2f8c0ed22139fe3537f", "size": 17075 },
+								{ "hash": "e2003cd8075c016301dea7d7823766fd1f00cb69420557e890a65c52d6abc741", "size": 11571 },
+								{ "hash": "6955769d5a15dc60df8395ae7e836f9098ecefe6755d796173c0b16dcbc3be86", "size": 35855 },
+								{ "hash": "5eb935a048cf5e5a664a64176771af8448f630f0bd2b8e9fe358bfaafdcf71b4", "size": 23195 },
+								{ "hash": "945742788a156f729e57aded9ecaba201ddb9ed68070eddae0fc702d3180c908", "size": 8455 },
+								{ "hash": "ff2782cc8d91f4c76c46ac331f6c14b5b6ff34afb5e57f0367d67cb0abd26a5b", "size": 35198 },
+								{ "hash": "8396119b5bc6d8f5c6e6621b402879cb3b2eed36b4e0c513256e92b3beee27b2", "size": 6615 },
+								{ "hash": "3dae54eeb089dcb899e3ceff2e1577675a341aff43e26a05e8c11254c6c70058", "size": 12030 },
+								{ "hash": "5468d7aa29ad6563375644f6ee759af149d244101eae724dad04b8d945492963", "size": 15765 },
+								{ "hash": "1fb88d4bcfb630d902aa6e8c7cf9b20aa5039df6b3de2829fd034b9319589daa", "size": 18217 },
+								{ "hash": "5758a57ebc687d327882bb9cc3712adc360880d519a22505425145f70d1dcf01", "size": 13349 },
+								{ "hash": "0483a662ab159ec4a665e32fdea59bf05c3fb744e6dc8e8563dbc1eba4b575cd", "size": 17375 },
+								{ "hash": "f762db322b2007f82458a84d861e3244985ed2ae8373eca0dcf986d123ca1be9", "size": 20281 },
+								{ "hash": "85cb000652bbeca3f9d29f67f4fa7f3f7312578fbdf92ec74e07ce030a735f97", "size": 11053 },
+								{ "hash": "f86d72d708d1c81344b0fed0042ad2abd5a7c659740c53876872c49aa006eb78", "size": 14567 },
+								{ "hash": "2d310f7794b0da9545618e84a6391fccf785da77796e0985bf0d719ca34ef5c3", "size": 28488 },
+								{ "hash": "0c62739d46b73588e1896190475d8dba7ba91b80f8f843cabd057037741a276c", "size": 21860 },
+								{ "hash": "08bb6b33d0b85ccc9c129c57dc71778d47cfa3be8ae0d3ffaf85757467e27ca6", "size": 31867 },
+								{ "hash": "27a3cafd85f10942f5db6245e23d1800e377ece47ae3ea25123f12395f169019", "size": 12088 },
+								{ "hash": "facead7e03c6a1326c7aa3e7b67f312b76662c6b47cd117d4150f97bdcd6d067", "size": 17375 },
+								{ "hash": "0ee55d109c8636a8377ca5d2a9458c6c46a62969400a92616802082048ca1c65", "size": 22237 },
+								{ "hash": "8d97f4b833e462dfc8170d9efd8f2c4a27d1faaa5fc0b5fbb596a90b7363af3e", "size": 24800 },
+								{ "hash": "c7d3f13535ba99ffbdd8ed7b75558be379482f7ace4bd3120b787f82139af9bf", "size": 1498 },
+								{ "hash": "25a400bde7fd1627c65b2d99d7f7524e2f20109f6c5acd389b02253959025e2b", "size": 1670 },
+								{ "hash": "19c43e3836db48404ddf77ccf30f1b4ea782bf1553073a6e26b9077d49a52f5a", "size": 5922 },
+								{ "hash": "5fc289aeee68c5c4fc97247292550502c247d2777e1d966688833230fd6b8b5b", "size": 6678 },
+								{ "hash": "3746569f8ab62071ee7d10602a5e9dd25f8ec3c799bd44ba756e5ff9b0342379", "size": 880 },
+								{ "hash": "0bfc04b7f3a44a2aaa44adf79942383065e43fc71d7d4b550f31fd38698ee718", "size": 972 },
+								{ "hash": "c8233635779d6b20439f11f1755b4409ce43896bf71347832a5da25036f2f2f6", "size": 2360 },
+								{ "hash": "f8433ff96c3c440fa65d49f0b87f80906cebafa630df82f8e82ebc239b770d2d", "size": 4858 },
+								{ "hash": "4852bd0110eaa09231a5373c271431a66edbb8b03b3c43db9e518eb7753e8cb3", "size": 4580 },
+								{ "hash": "963f44e8ab940928bcd366117e87be5a84be755076a1399819d41ec77c2fcbf5", "size": 3575 },
+								{ "hash": "f01f038fc8c2cd2c26117601bf77dbd375a10ada1869aa39b03e7efb5efea2ee", "size": 2170 },
+								{ "hash": "c46ae48e2d365c06ef94eae6b65b27128372fc8715a4dc355e277f8b68fd7a77", "size": 1746 },
+								{ "hash": "711cce35bb0b516e88190b59576425f2b25bedb884f8440883f597089dd7866a", "size": 2846 },
+								{ "hash": "b380f2e566880e6c2f50344fb40f7aa814efea8adc888955e4386f7858996066", "size": 804 },
+								{ "hash": "c5957da4181f4e0fd609df13dc81138bf7ea02c376d3ddcfbc85211c70d6541d", "size": 841 },
+								{ "hash": "f5bdd196debdd306f80fec75868eb7ff0fb0a1a91149d87ec48489f192b4a5cb", "size": 878 },
+								{ "hash": "0e4013e8def0206835f9ff47e739f68082c1c807857155438cfb704293df41d8", "size": 915 },
+								{ "hash": "b702140987ed4a974a11b3ac065327f723d7c22d6f4afe04b3b3fc6230365af0", "size": 952 },
+								{ "hash": "6a53d06c52e33c76e10c61d0397fb138b676d2970ffb51c8ba4ef5e560fec469", "size": 989 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "68569707ec58e088857528eb2a8bbf02c22bd01553231019f6e2df4c74df570e", "size": 1026 }]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [[1, 0]],
+							"nodes": [{ "hash": "a079a4127f027928bfd62ee2712563653d72e268d4fdf49a8e35e56c395b2b51", "size": 1063 }]
+						}
+					],
+					"points": [1, 2, 3, 998, 999]
+				},
+				{
+					"mergedFinalHash": "249bd2a13be8360d929ca67e88b751fd39fac4c5021cf03f8b0aecbacd800651",
+					"parts": [
+						{
+							"at_end": false,
+							"at_start": true,
+							"levels": [
+								[0, 48],
+								[0, 13],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "ff89c785771396ae73543ab8d148f6c5e81f75e9a7fbd4b2021cbf3bd9742ebf", "size": 14625 },
+								{ "hash": "6cdd8dd37b630d9f7a74a00558480746f2a1889ab1232ef4eb8fefc72361d213", "size": 16661 },
+								{ "hash": "3caa0cbec59bb30d6b23a2de535d03467f84d4989cb465623d226d615b45eff1", "size": 11889 },
+								{ "hash": "0b66e1f0130be01f6c0fff41a829dd9b3702b7abade2661f0865316c3f20f249", "size": 2736 },
+								{ "hash": "99e7059c9b120c63fd6c027db9a91c18aa980af0fff670185772b44de1c8bb6a", "size": 4471 },
+								{ "hash": "a2b2a006599d5bbf7d7473e981b4009b95dadc9d138be82a3c0ef6b14368c19f", "size": 1410 },
+								{ "hash": "fb878499b1d3149dc575f28cba648d2949d9450576e6df03f3451890c4f63dd2", "size": 2913 },
+								{ "hash": "bc8f0b645e48d1efa2f9c9890bb9142e3c8966f50a38bbe24c68b1fee0b5aee4", "size": 1956 },
+								{ "hash": "14279eff9b0d4f32c93c88abc3b94de10075ce9f92e057cc8bd500f0271bd80c", "size": 7866 },
+								{ "hash": "500eb05149a732a2a8654a3423f40c3587095cfd91df8a56c9d44f2c28a5882d", "size": 3863 },
+								{ "hash": "2284b383c73816c4ebe6c9ca12e63f409548d77d6c395958dbf0c8bad05d3930", "size": 3521 },
+								{ "hash": "38432ab70e9ae472f562ba915638e04e7fb8d231252b137144df9210f7859ee8", "size": 6244 },
+								{ "hash": "943392650f95bdedf0189d8e7cbc5591078d3d4697bb75899ffc632052e474a1", "size": 5612 },
+								{ "hash": "9f9dac582fe93ae94ee85907638c234bb6c44f375de3f1000f5c8b6dc58d6981", "size": 1585 },
+								{ "hash": "251c894b522ff253971294a7d2cd866b218b2227598f295b22d7db9105fcc014", "size": 1395 },
+								{ "hash": "2c3b7e7d8772d50fd47e64be6ed61d4481d76f9d6fd3bb71da65eca11e429850", "size": 3065 },
+								{ "hash": "30f82e9cdd4207723e7955ac21e93a8a720bd73d1777b606041190ae098443a2", "size": 724 },
+								{ "hash": "18e62912794248ea462904c872fbac8560ecf4c48fafb28e64aadcfd7b03c627", "size": 761 },
+								{ "hash": "b5f54946e7265573f7ab60b1498b9940605666815167d60336d6b771ace2f32a", "size": 798 },
+								{ "hash": "ca039b0c6d3166b72d0c63381822bc2cea9579dcd38438837c7d0b6b9d46a7e6", "size": 835 },
+								{ "hash": "882aab189e36ea42c123f30647b2b60ed6233eb48ba5ca17566001167c4139d1", "size": 872 },
+								{ "hash": "37470f8a4dd8f711456ee4dc90534372acc6ede0d546a34f5e1dc497e40eae6a", "size": 909 },
+								{ "hash": "40a4424a527b870cf3e8fb878d9e11b69e735a59362fb25841192473531120a0", "size": 946 },
+								{ "hash": "39460375682825b5f3bb64535f339035f4d4786455111c109516d962fb7029a5", "size": 983 },
+								{ "hash": "88cf8d9ad65306d0e4a1c74ec28b9c3b291edb6d77bded0422c4670a021c122f", "size": 1020 },
+								{ "hash": "5a4ad0de46026e17207e686deada54122eb8b5062ab6d4e10f78ab1c46f6f375", "size": 1057 },
+								{ "hash": "ba1af34a4103553a247894508c4d8c9e108c2acc476c1a91fbfb200587260625", "size": 1094 },
+								{ "hash": "0f6da6783b87804e10c92f17b0e8ebfe28b350efebc793f5e57fceb63c71f58d", "size": 131 },
+								{ "hash": "09eb2043fcbf6eb316251d1978e349396e8708b7e74f2aedac56ee5875a07e35", "size": 168 },
+								{ "hash": "189e9b14691c5510c94f72a910db638517bde6b5dcc60a530e562bda04e1aa46", "size": 205 },
+								{ "hash": "a4c05fa65d9599a6510c81ca39ebe2734635ad04d009c0e5f4ce3a3a64ffba34", "size": 242 },
+								{ "hash": "c69869624ff13001ac7d4ef1dde3b6d08c29c2cea50f444f2a200dcbdf07c614", "size": 279 },
+								{ "hash": "34c4e4aa37de61b94c4cc984161e2ff4b958e94a65bc2c8429cc1f601bb52f9f", "size": 316 },
+								{ "hash": "e777cf6f2c5bcd8d6a78c572a610741e9e7cf40208fce64c3934ee17d839c7e1", "size": 353 },
+								{ "hash": "78cd8f0886d4a0caf9c9f35a6fb0dcf3215a5654cb1d4546f36a0b02a5108508", "size": 390 },
+								{ "hash": "682dbc73b9708e1e6d20844896d574a41f7358319be2bdaec95119c673cb79b1", "size": 427 },
+								{ "hash": "e55ed25d8e390e4768a246497b62aefb5ad95bacee94aace4ff0894879cad424", "size": 464 },
+								{ "hash": "b37a4b2308a1a2a29b50c5565e3467e910e7d0a2e8b9e8f22a3ff7ab7c651ed3", "size": 501 },
+								{ "hash": "c98013a2eb2d888023f416369d2f1576a13cf8f3de238d534a7835819057b82e", "size": 538 },
+								{ "hash": "a90fef8daff4b1a990a3155c5a5bd00e859b0e172070fcbba868445b428b3db3", "size": 575 },
+								{ "hash": "61336692d03506f629b429d1fe9514cff1452b0799f4adbf0fec63600662d26d", "size": 612 },
+								{ "hash": "398964e725019eb83139d82fe69d716368da154c35814cf14d0870e893714089", "size": 649 },
+								{ "hash": "b23f8d1d5d1b9db88b64708181c04074d9b09bc0041f8644d1ebf8e76a23c933", "size": 686 },
+								{ "hash": "cf24dce154f4657de902cf6f7948f4c1eca7a9aab25c7f22299f5093a3912c19", "size": 723 },
+								{ "hash": "04b243e90357f63d349db9a254b6aefc2ce9c347c0c82256ad28d4a163ea970b", "size": 760 },
+								{ "hash": "78114858daf291e626617bc6cd48351058595c4746ff2c13783e66d7a2a614c3", "size": 797 },
+								{ "hash": "b7ad1ac41342b70ea40189a71db97f498f401cbdb1352bfcf64117f4c2d2937d", "size": 834 },
+								{ "hash": "a1124928017204cd17e5091e43a04478ba9eeda01d198254d88144f08ce6b6de", "size": 871 },
+								{ "hash": "0cdf1dbf75b863dcba2443b133f2166922bfa4885d8db9083b4066bdb21a49c0", "size": 908 },
+								{ "hash": "34952133f293940c0f6163eb41329f10f40c242a671b22bc75c7dd66b8338e42", "size": 945 },
+								{ "hash": "02f6f8097ede5a2092daa3a8ad4edc81914b314269eaf9ceb23f7bd3b9f7820d", "size": 982 },
+								{ "hash": "fc3fd9e8f4834c4664d5845e53fa696197870126810fd6ed9496a0a537c3c456", "size": 1019 },
+								{ "hash": "d7937c7587ab6b9e865d3f104b23295cea384848e084fa68b9eb833829f9e346", "size": 1056 },
+								{ "hash": "0700325214a7ed9165dc9575e54b9ab1cc79092b36878b702110be795a613bb3", "size": 1093 },
+								{ "hash": "c66133bbde49c487c41460d415c79989b6dacfab4570ef821debd8ecdefe532b", "size": 130 },
+								{ "hash": "b28344f7b1cf866c807c0048cf430f94b0a9714b725fe4c0ae0cde6156d6b5ef", "size": 167 },
+								{ "hash": "4885021a6922dcfe2ffd681b6bd711dd70a4800a083288ac8f0f1d689165c479", "size": 204 },
+								{ "hash": "47e9e1e188736824e1aab3f997925a03ef61b64ec87e66b5ee3b9a5c0cd3f6c1", "size": 241 },
+								{ "hash": "ac23981da6997dae50d4d713aeaae841d1ba3a07a2d339519839baa93d524541", "size": 278 },
+								{ "hash": "fc373d6ab5821271edbce9a3773168eb2b590d74852682876b6bde485bb29863", "size": 315 },
+								{ "hash": "5f9ec918b69f4d18c34d683489eb288294bf09e8187d3b397c9862926714202b", "size": 352 },
+								{ "hash": "11fb14513424a74904db80c7884edbbed2110c9f5c6ba7d0c128ef38729af7e4", "size": 389 },
+								{ "hash": "0f90056276c2a27dddf57aeb1faedb7e6654924068733e9f39a3d37438e132a8", "size": 426 },
+								{ "hash": "d79244ef25b241c40c3ee6be9ab7a8a6bebc200b10805a68cdaf706931b1395c", "size": 463 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[15, 26],
+								[30, 0]
+							],
+							"nodes": [
+								{ "hash": "68164855595bb03b927c2fa1d434a555a7a17c409ca708ccd6a1ba0c07bbe398", "size": 500 },
+								{ "hash": "09a424e0a934b0fe1c86633ebc9a053c09d8aba57f99da921c0bfe85621a2504", "size": 537 },
+								{ "hash": "f8fad26480d23d7a53f03be8127ce626ff86e15c9b7ae14f89e1b25dfd439249", "size": 574 },
+								{ "hash": "7bfddcb1becf53726fdfb3a8dc93bb19e97a7201331a7fb72a13ed860d84b4c5", "size": 611 },
+								{ "hash": "6e405a160c6a46bbf94ae3d15b38fe5683c5bb46183e47a930b967dbb0ba0d6e", "size": 648 },
+								{ "hash": "ebf82574bdb4d59db6dbd2fe684b07d8642133baacb8470836c3426ed052de8d", "size": 685 },
+								{ "hash": "2cab984c86adf1d6aab9d362a009a7c6f05a29ebc9e2e3de12d65b67d5aad123", "size": 722 },
+								{ "hash": "74c00a24053d93bc9db0799b6d7c6ceeb766b595007eef0f3ee934e887a696f4", "size": 759 },
+								{ "hash": "f27b18cda11252f6513acd5f033d7ed3c8661e76bf3a3cec18fea6e9ad653604", "size": 796 },
+								{ "hash": "8bca1819a07c306579880820ab3efa7c32eecdf08ac7b9178b899de39b63e44c", "size": 833 },
+								{ "hash": "dd7e45ea4ae574d68787d708907d50db9e28a25126eed065bcd47274fcab083e", "size": 870 },
+								{ "hash": "950a17ee6390f1082012a9a3b201a171f09a9229b9d45a6473aa402cf4f2a627", "size": 907 },
+								{ "hash": "5856bf8595fafb23430e83c0066f795e86dec0471fcae38f669342542eab427f", "size": 944 },
+								{ "hash": "5d1ce5cf905a8865f21c4682ef2d45b1ae6c889bb266c68e9d69351f245e5d1b", "size": 981 },
+								{ "hash": "687ab598cc249028b9f142f55f59dfa4274886785264a2aeab8ba87728e34798", "size": 1018 },
+								{ "hash": "46aae3d2af32a5b9b1e9932c24c232f7caadc66ba4efb65aab2271ab20a91930", "size": 2276 },
+								{ "hash": "25066bb821886d6a3d40fecd934acb7bc1a84573b7c023998cba37ba1c14e81b", "size": 1200 },
+								{ "hash": "0d09a96778b7b50bac6265843fe90b3d067de9ff4012e271388a7f907855403a", "size": 4491 },
+								{ "hash": "ba2026269f778cc9918b6f5957de3a3852fa2e52b8efb48e35961050e5e082cd", "size": 2163 },
+								{ "hash": "a2aaf1c9717fa3fdeadbce9ffa11170413c86093ad392d14c1b1477b7f851972", "size": 3402 },
+								{ "hash": "b4c56e0dff5046de9cd1a6128a7a5028b8cb86f6d6997210d0ba2442bbef5fd3", "size": 2940 },
+								{ "hash": "58bab1af50abe9b3079315a2d4b2ec2b05c72d970589f966e97f0bf199ae6d59", "size": 2273 },
+								{ "hash": "1d31127b3bd2d69ea51ac96a6a61b4668c15d11447bc559d9d67524b31d568f0", "size": 606 },
+								{ "hash": "e606de75c7075b2859ec6131eea03c5bef1caabf65db10dc7b0aa383ba0cb693", "size": 939 },
+								{ "hash": "2320f9e01fe34a2bfd4ce22a4fce5195d62e7b5a649e608ac8c39b30323e66ad", "size": 2305 },
+								{ "hash": "30aab064f085a32d2529c79fc2ca87a59a576e621ffdb3a80e254059544fdd7b", "size": 2510 },
+								{ "hash": "300ba251be1964cfb9318a85843bc5ecf49cedb2743ce2fa7480d479b1215040", "size": 5817 },
+								{ "hash": "3af13dd54e731d9bac7aecc286bc6a6788f0b79aa12156293279dc11c4a5daf8", "size": 4138 },
+								{ "hash": "35926c069d17d4a0e85d17b1b2b1a1d16c6d18eacb365bf6d5fe54945eb58b73", "size": 1666 },
+								{ "hash": "70b7ebd746f770a0fcd5e3e477f2be10f4e0d7e111e2d1dc44033639f4dc6ac1", "size": 4806 },
+								{ "hash": "356bfe3d68631ff2cc4d963098ae6c848ea72c0a25a607a07cb13efbd28b122b", "size": 7803 },
+								{ "hash": "b0f2ba289de0ef17be6cdb2809b6a1c2dfb2dbff12631ad94fc10b545a4270aa", "size": 2630 },
+								{ "hash": "4454c631f6e7437063deabe1793cd56e427a926f1f30128bafc2d371f4997b8b", "size": 1170 },
+								{ "hash": "100d33fcfa9f406fd74eafe830ff47e79d31aeb3c029badd2d5710eff0719e3d", "size": 4797 },
+								{ "hash": "7ecbbaee8e02ab7f98b9b31eb4c49000298b6cf72feeac65229f048959215e29", "size": 3094 },
+								{ "hash": "11cf27d385d3148067ac7ac989eda62045fb307e7893b8c0b70d51e1417e529c", "size": 5751 },
+								{ "hash": "e72cdd97e79bdba0f582ae5f725d551309fe27d41b99c743555c84c01162226c", "size": 2393 },
+								{ "hash": "f6e250c93b05602ae40570a6b1701fc691206fc77fff91de31072b802b784dd6", "size": 1610 },
+								{ "hash": "d582a8df2240f0dc3a7e17ceaeb62a37719d6d5c31acbc57106c32634b2e442a", "size": 2202 },
+								{ "hash": "2512a59af3577a6b0c4f1d2434d7d760a1767c146aecc2447fd501a3a1384ea7", "size": 7119 },
+								{ "hash": "6b16ab4a188ea1ee1bcf9969202a8f242afdd7030aaf98237163f3b004b166ad", "size": 4411 },
+								{ "hash": "e6046d3bc0b96ca35ba8753f0ffbddcf2a5c814d50b10de12fd8fc63ff37456f", "size": 3114 },
+								{ "hash": "0a7c359585e9a79c0e3059f6f37f15a3d138b7f3b4bafe45444667c49a21144c", "size": 2346 },
+								{ "hash": "648c1076be2516fb0a3f9bc86d4176d759ee723ddb47762f8ef412e2df13d917", "size": 2148 },
+								{ "hash": "037a8181167f66ac4c7368589ad3703c72d8e57483acea1cd8510e346187f04c", "size": 3382 },
+								{ "hash": "d6552c9d9a0a999b30aaab99fcb3e3cb1571e0c30b6249408231d493356fcc49", "size": 938 },
+								{ "hash": "1b192f7eb1293f9dc7352da4bc04b3968951629fa744ad2d633f801417f8be4a", "size": 975 },
+								{ "hash": "8bd9705ed6269fe379ed1ec732acbb07d68803cb518cd6307a66a5f376e1cf50", "size": 1012 },
+								{ "hash": "df9f659bf79bc449fd0f2b1e0afe2f4159b762df6f542d584543e262c3f16ef4", "size": 1049 },
+								{ "hash": "473ba02d3829a20ec12c7c33fc6712ec2d5b05730e7c7915fead6c320d351e5d", "size": 1086 },
+								{ "hash": "c2179ffe780f729591a58e5b1d5f5ed577d400121b0442ca54003fee63c8cd79", "size": 123 },
+								{ "hash": "b01a4f13d1fb364f2edf3c71d4c764bf09a2149facedbdeae971e313c3e393c8", "size": 160 },
+								{ "hash": "29dda9d05a91582ecad0773a7eed830c4dacfeaac74cbf56e6cead73ab417aa3", "size": 197 },
+								{ "hash": "3d5318f45bb2e4b6f35f97c14e7b516e47772f71fda5f47edf40124fcbff37fa", "size": 234 },
+								{ "hash": "8a1447919a91a487ce123b1699bdfabb64211de24d474175c71e1467331e9901", "size": 271 },
+								{ "hash": "2be4b9d32d0e4c77cbbd2c717a18a0f72d0ea2d126a6892c0d847eb89a2785df", "size": 308 },
+								{ "hash": "4e69da89d14a80c820789cef8537b42bb65eca29884737f2933a17c6e7a156b2", "size": 345 },
+								{ "hash": "9300eca11aa806e49bb882d691e39d42830e77f2b4562d8bddf7fbf17b186c32", "size": 382 },
+								{ "hash": "e917666ccbf72c2a9564a1e12657b5c341fc21a375bd7ce06fb8232e784a7091", "size": 419 },
+								{ "hash": "3343b114cbcfb17b358194f38e04be329154f8804ccbf7d22510d3e5da929562", "size": 456 },
+								{ "hash": "355caecec1de19c1a435a59bdf9cd9f62d964fad161a15b1ed1f6179fb0c3a93", "size": 493 },
+								{ "hash": "7cbe2fd798c696dec430678eebf87bb76a7024ff44b7f9886cbe9368e183bab6", "size": 530 },
+								{ "hash": "d3abdc4b4bbbe26e73b2013373b200dfb462f419b68bb67cce57e912432fd543", "size": 567 },
+								{ "hash": "38d7d3983833ff436a97a54d1aa83b1c06520dfd2e5662fd9788278ab8ca3c25", "size": 604 },
+								{ "hash": "4225a3b230cf1ae492e666e03a7d0196a2ff9fafc4a26508165188d3976a717a", "size": 641 },
+								{ "hash": "0282cbe3becab22049f023e8bf5db3fed7a772d28a4916b7a9f3132f94e7a0bc", "size": 678 },
+								{ "hash": "d28dc0369fcecf5a7288c15f2fc2617ed5b929dd3cfc1524b2ff8200a97a1b09", "size": 715 },
+								{ "hash": "c1f4c9aa49dc96e2d4acdf58f96ca6018af087182db6658a8680b86aa4bbb5e4", "size": 752 },
+								{ "hash": "9b00a507841af79f355549b013f7a1bce61d02f953f97cc7f37f56cdc692e3e3", "size": 789 },
+								{ "hash": "988c78f3d1852407f81aae09ea72db8affc609b57f900d9dd0bf1dd18b3d7cf6", "size": 826 },
+								{ "hash": "0f1a006398e189cf9e9425beeb11e56279b0e2b1df6c6ce46a527935fd3525a2", "size": 863 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[25, 13],
+								[31, 0]
+							],
+							"nodes": [
+								{ "hash": "6f8a60dae14affba937f4ec15c796726d5186545f7922ab7057d61310a9bc669", "size": 900 },
+								{ "hash": "c475047e257d9c8b2ad758aaef793fbb2abf39195b947ba6b4e67fc06a3cd428", "size": 937 },
+								{ "hash": "4c32f058bcc10be0398ffff7f5a631720b4ed6f67b10bf40678bd7231bd467b1", "size": 974 },
+								{ "hash": "d7e515f5d73cab4d49981ca27784f9a8c107c47bd17e90fbc41d9c18206befaa", "size": 1011 },
+								{ "hash": "9fbfd3323fd30264b49b52da7bc900c1cf58d3c32b9b446c42e6c59919201db2", "size": 1048 },
+								{ "hash": "399fe3d77be51a03b4eaa39b8c724a243933def8c2233889c801bd20702cb171", "size": 1085 },
+								{ "hash": "2c23a39ebe1820e6afac23061905fdc296ede482ec70039c913ba3ce59e6d033", "size": 122 },
+								{ "hash": "ae6cc90be10348a1421acbf06e9776bb106f57d3a19f5d830d1ec085717bee59", "size": 159 },
+								{ "hash": "bb940ca4675f6da736acc13030cd5dcfd0b4ac58dfd6b67e3ae052f40055e543", "size": 196 },
+								{ "hash": "52de77656b5f1acf2d506546ce8c250e06eba727ea1a4e6049f0f7a3b5252e6a", "size": 233 },
+								{ "hash": "2080f14f5c700a29cb33b1733071b4bfced5341ec6f0a72dbe3068e6a1226799", "size": 270 },
+								{ "hash": "4f6df3b70276d46fd62c26f0ce1e4cf55228d8d75df4bafcda5ce10e8d2550a9", "size": 307 },
+								{ "hash": "66935da22b1498659b2344e0c1418974161a537e35cf47362a9f0e1672374b2d", "size": 344 },
+								{ "hash": "122ebbe07c2565f3b1b78885b71d66cc36562720e0fe0d1e966b139406510692", "size": 381 },
+								{ "hash": "e16ac1ebf0a1cbed3dcde553347af19d034b303feadb96da72c857c8d847b246", "size": 418 },
+								{ "hash": "c82d205d856bebbaa9ba3af45b1c7467cdc58d2a954adbe64ab30d36512a744d", "size": 455 },
+								{ "hash": "0166e2d0ea9d9f42eb393907f5f727531f83bc369c7c732ca7a766f64f83c035", "size": 492 },
+								{ "hash": "548bc28d16ec7ab271addc1ad0cc14462a9c7923e6b58973fd9a2dea49c1584f", "size": 529 },
+								{ "hash": "7f383c8c2a2556de6ed80126f68ed42b840dc484b70435ba159b3cd3a3b1d841", "size": 566 },
+								{ "hash": "a9921bebc3888ca12175ff5c45d9f02fa8f531354e96d4147a6c4feac07a6604", "size": 603 },
+								{ "hash": "a3f7baf2b14b1f9f0ac7097c134b0fcf03abd1b0d59bc9bd1c1002aed52c93ab", "size": 640 },
+								{ "hash": "99ee16b35c77fb599148266add4464aec65762a501dca7640d2772d1bc7c717e", "size": 677 },
+								{ "hash": "ffffb17d5e207f0bcc5febdbfe04f4c33cbe53d6115f3ad9b6c957716796f847", "size": 714 },
+								{ "hash": "cf05af89610a23458c27d230af0563d4b0a19f1ecec7880e11984becbff59502", "size": 751 },
+								{ "hash": "250226ad0dc2e7033e4b54c2c0c66f9e07818659631a25ba63df79d94ea4306c", "size": 788 },
+								{ "hash": "e3f2bd777387bf36855a44c2e5fdb625f132c7e5caa1a83c6af09d63660702a1", "size": 4495 },
+								{ "hash": "8d4597fba52f51c1b47cd08cb3f2ed64f6fe1a9534102d34f5a703528327b47f", "size": 3615 },
+								{ "hash": "3cb94d8a35733b346ce094207024925369ddb5ffffeabf41706cbf7ee5bbbd6c", "size": 1530 },
+								{ "hash": "a2a6d95a9e87670cee9fa0dd916fcca25794972ad67b75f76a70e17737a0fb0b", "size": 1890 },
+								{ "hash": "729f5d0effb3f8c9925e0725bf96409c4328dc45c6eb25a444d1afc34cd74b1c", "size": 3195 },
+								{ "hash": "69f716b742040352ca5b108cff48f6757acaa0d68e1a15f488bdd73da9eba333", "size": 3222 },
+								{ "hash": "d39a9731a27d9530cff288f525dfe272584e4c46829e823ee3ea335241cf6eb3", "size": 3814 },
+								{ "hash": "87a356e3441976df3786f9bfc491816a43d802fc28582df71a856f2178f1eba3", "size": 2831 },
+								{ "hash": "ce932248d4d9ac1dd3387dc97b62187afad7e76ea3b67e97ba9d1fd87e52b5c5", "size": 915 },
+								{ "hash": "8eef1fe2a0b1287a02ee456a4c6cddb3dbb1333fc557b2354319fa522816ea54", "size": 1248 },
+								{ "hash": "da3acb8c8684ea4aaeefd4c233a302b85194661df524567bea45942aad0c93aa", "size": 1581 },
+								{ "hash": "0efd261490d46a71bc5efe127ea0774c4e0b547654ae153f611c04dee4d79f53", "size": 2626 },
+								{ "hash": "70ba7ca9dc5454014f3d86862d19921479352beb767d9953891b91e8e70dbfd5", "size": 3218 },
+								{ "hash": "b8a3f63e5a31b2d8756317a3aa265cd70d6126b5035fc849ba15185544511dce", "size": 5937 },
+								{ "hash": "f55958b64e12473c09e75e896aed728a06277c46006bafe9cb5b969d2958d5d7", "size": 1269 },
+								{ "hash": "9cc102418da7da2c20f751d60fb89e3a42d5e4d3c1aa96c674a1de0077c67488", "size": 1134 },
+								{ "hash": "50b000d8bd33a622cb78042efca342441e7cdc04ca3cbe2b99642c2d661d7ef4", "size": 2630 },
+								{ "hash": "b727ca93975b2ff3f821dfbb91ddec7c9d069ff8488c6e15402a54209cc032dc", "size": 7065 },
+								{ "hash": "6584669d7e27f31d8bff4d7e31307657398959a2b304266146acd4cb2391c223", "size": 4796 },
+								{ "hash": "aec67a9a0501aae74ef419da49492162f471450d0f39564439f51bf8d1c7690c", "size": 3726 },
+								{ "hash": "6dc144f70764ec81e8f4eab81b5124c91a654769ebf65abe727dd367b9797fab", "size": 6723 },
+								{ "hash": "830f4bdc325baefa9f755312103568cf6e1a14e19cd569bd7a262a0363be5b2c", "size": 2907 },
+								{ "hash": "0420327c2d190b29e04ae0f6b9ca5113fdbe153c18dd0c4d2631c2d76914d487", "size": 2394 },
+								{ "hash": "0e4e4eb188fdb6c7a9516192ec44b6b04041420dd8effc9993b23301193149a4", "size": 1325 },
+								{ "hash": "2d76de888c7d51e921c415976a1bec45dbd8f0af16d5e3ccf9ef7c990b5221fd", "size": 2250 },
+								{ "hash": "4a45a0b892ebf55bfbafffa872ad037dd04680449d6b908c7b40c04a58d147f0", "size": 2466 },
+								{ "hash": "8a1c92f7861354d38caa66a2e8bbe350c760a0db47269fedef1041987e5b6773", "size": 2238 },
+								{ "hash": "f8b9575a9637502c8a00c66601e7ed241e0488e6173cce1e8f0803af7a4ca18e", "size": 7712 },
+								{ "hash": "ccbd16c0c7aa91e218d40394608911bd0bd6b14ee84a05d2cdfe5c4a3ad56fc4", "size": 2709 },
+								{ "hash": "b76270bbf21f528d7d55fad5bcd79b067eb37724e9af1a291d9260060d6c8ad5", "size": 2800 },
+								{ "hash": "7d19b78dafc740c4e957fc91d304f3b84b4b4e29111a97b5569f550ec35a4884", "size": 2906 },
+								{ "hash": "9b11c59b4d6e885abf5a263bd4472a35499b07d63793dfc0e657cd4968ec08b2", "size": 819 },
+								{ "hash": "a14c564f5411288255b67d592b0d8ddc5a3bab1179aa9ab4ca5d3a702226888b", "size": 856 },
+								{ "hash": "e75793de0b386134a9657006b46fc60ac0f388ed6dcb6d3510f641a8390fc8a8", "size": 893 },
+								{ "hash": "f9c72a904161aea86f7837a45ef464d4b15795f700b167d49d98b57155738698", "size": 930 },
+								{ "hash": "0b370c33772f21e4d29674b4d81ca482a50984dae3db2d2dd099ae17cb0938fe", "size": 967 },
+								{ "hash": "f66a1b5bec61c1697ed6a8fe016132a055e04f1574717fb91a6551bc7ebd2058", "size": 1004 },
+								{ "hash": "679de6fb8b0a41daffc6b03e471b9d222b3a771d513053514df3627ca06e37cb", "size": 1041 },
+								{ "hash": "cf0d950056c9bf76d045921dd8df5694bc8183dc18ee182e0176b97fe56bc77f", "size": 1078 },
+								{ "hash": "8b2361d3636285b92639250710f0204e292f28756b1ae24cf2728afbd67d59ff", "size": 115 },
+								{ "hash": "e9648a49b8dfff842d18e84881cb7b97d66210cf1f9ed5551c71c4a9c53210a2", "size": 152 },
+								{ "hash": "c15a475055645a2a5497dfefdf98566951105f4480e5516428b9c7ac0f7f20b4", "size": 189 },
+								{ "hash": "2606e6f5128b48765e8c3dfe962cd0bff1da6b61e3ea6b403c56455e99edcf3e", "size": 226 },
+								{ "hash": "51a4454e63042993ac0663a2be423edbf19344869c8ed2856a695519134778e5", "size": 263 }
+							]
+						},
+						{
+							"at_end": false,
+							"at_start": false,
+							"levels": [
+								[70, 19],
+								[19, 0]
+							],
+							"nodes": [
+								{ "hash": "5e7971ee71ffa1bada150184c57946d8fe392341fbae68d6924d9505c3daa172", "size": 300 },
+								{ "hash": "2933016a4ee7bc0d1b890f14275fa2bf9b011beb9d6eaceb8df446422aa4db09", "size": 337 },
+								{ "hash": "3478fdc0070f03d74ccf980092778bfb40788142eecebf6d8a2a0098cf6c3dcf", "size": 374 },
+								{ "hash": "79558cafb3c2b0ecbb79a8bbee539f09e7e47994a6d39e6e0958d99e10b63850", "size": 411 },
+								{ "hash": "91459d9e8d4356ba018acf995416f6d3f6bbae7f658f50d3b949db2f5b6dc4f9", "size": 448 },
+								{ "hash": "57005a89a1dac930fe4c5ebddc120972c050c770c59621bf381d0ef00191e524", "size": 485 },
+								{ "hash": "3590ef98a9427b54b4115f3b40a731ae721c39bb962589d6a8ad431943d9e174", "size": 522 },
+								{ "hash": "1da243b57b8f86068676b88c2532f93317934e6424d641e16b410589a18576e5", "size": 559 },
+								{ "hash": "afac452771c2739d28d371409c25a4b56930d3c37f189272abdfbe4ac2cf4253", "size": 596 },
+								{ "hash": "3702702ebde78a1a6ad32399b53e1c91656563c8cc77588e54a4bd887d5fc3e2", "size": 633 },
+								{ "hash": "09ea07172570205ddea487135d4aa39ae52108765c3f12120a20ed1ec9bbf67a", "size": 670 },
+								{ "hash": "6fc2e6090b7e1963697ccac8dab333ef832f130ffa2dfcc2061c6452a40a1ba4", "size": 707 },
+								{ "hash": "d4d0d09212165764275b3d12096dfa1d100b57ca97ac32a399e64310709a7808", "size": 744 },
+								{ "hash": "6ec5fe6997440e1e8c4f73ebf038cfd0cf870d92600374ff95fd735bf207164f", "size": 781 },
+								{ "hash": "6d6876f2b4a9f0e63c36bb18966bee8a2e72c716571e1798eb3ae0ad20688827", "size": 818 },
+								{ "hash": "166b9097c5db1388e5c0ea715c4c5738b49b86da2aaf6584bfea12468b31038a", "size": 855 },
+								{ "hash": "bdceca14b8078b60dab2b2b93dbc7e20ffc60deff3e9b63ce9d4b97ef7672625", "size": 892 },
+								{ "hash": "30d191aad58f4f3468a3bbbc830a75fcdd6bc1b4ee54771b296805a2a4cab0e6", "size": 929 },
+								{ "hash": "4ac39b7b39aa1b926c93c0caf88f8f42adfa36c1bec343847e96cdb700c9a94e", "size": 966 },
+								{ "hash": "4c4a5ab7b68d9030b133dc94c2094cc3cc1087849f15c66313e0a61a737e009a", "size": 1003 },
+								{ "hash": "209f32a02de7c9a12be5370a83b114b05dad5f1f1e5e7247168d5c0a840bd47d", "size": 1040 },
+								{ "hash": "4f131d77ee3354d63d26ca3269bf5bd5bf05b6c9e649a6a1b300d6985b55c3a5", "size": 1077 },
+								{ "hash": "82e9f5b074f1bb2ce8bedbb1bc7a32a1895dfab625bb8d2eaf23bfb21c788e65", "size": 114 },
+								{ "hash": "6c672c548af9088294f55db951243ba4f478d0d8462b0edb5fba8c1e4d91ea7f", "size": 151 },
+								{ "hash": "a79ac213e833e6044100e90912c3721d26fed46988fb6d999fd30f683f2aa3ae", "size": 188 },
+								{ "hash": "4b31aa9a751bd2cc33ddc557fd09be61b166cb8b8ba260e41523a173fc1d9d09", "size": 225 },
+								{ "hash": "6f0cfb977c08e9e475b1ba9bd2931479c18baa097fc5e73a108785558c3ed43c", "size": 262 },
+								{ "hash": "2623e8e076eb0229ff974664e7809136a1ba0665c7a81374adb95f7b89ce0c59", "size": 299 },
+								{ "hash": "e72afa16e26a121fc5d2f582d7bc45dfbdffdd3287bce8647eba4cc32cfbf3b3", "size": 336 },
+								{ "hash": "bfdcb6200a9875a860ee358548796fe3e53ad2d9e87c6a17d804e0a9ce1355dc", "size": 373 },
+								{ "hash": "6ed4b6f528962f41310186b4fbcb2d0481682705547cb8ae8b3f47f77fa65cb0", "size": 410 },
+								{ "hash": "4962734b2fde200eeb5044f11aa0b357bc3b19564f5c0e8631fed838b757985d", "size": 447 },
+								{ "hash": "98fffad82c46cafc33e988922cf0e83ac6855b97beb535fba01cb3b5ff646565", "size": 484 },
+								{ "hash": "5ec599f69b4d3c4a4c54722f22027951211d482325313f1532d211eaca178b7a", "size": 521 },
+								{ "hash": "a3b464645b16c4ba374306a7b80ebe56e7fa344a2416c075b726670f0aa264f0", "size": 558 },
+								{ "hash": "a7ca10ea4c6357b3c2e87eae2e7a42688a21463d7ef3331c7026caa990aba4e1", "size": 595 },
+								{ "hash": "3a58ea91074fe000b4024a05c65c6a39f774d32cf15f6c6adc13593835d2afe4", "size": 632 },
+								{ "hash": "d110a0d65bd62c4f6132b77038994e005722a7a8627261e293d4693aa0d37588", "size": 669 },
+								{ "hash": "59421eeb06b366c0b3f6cef411d636819359a357f9480d691dbbd9ff8e0ef5ab", "size": 706 },
+								{ "hash": "1199c03efba74c44b342221e997c0e063c78c0450772bb441c4402fc54eeb33c", "size": 743 },
+								{ "hash": "a2a1bd0329d512a0286942cbd2331305ccbfc2e72a75ddaefbf3bd0af77db4a3", "size": 780 },
+								{ "hash": "514b6e4e7e5eef6a6d0fa0da3fe5f9f5a73cf2e1f45779cf16b151c81f5d1f21", "size": 817 },
+								{ "hash": "0c2327fa12d5394ad531cf233fb159f755f38faee768c9cc31fe61f781060b93", "size": 854 },
+								{ "hash": "bdd5179d22707c7834377013bfc264b7acadfa98c2ec59b93a57300a70225483", "size": 891 },
+								{ "hash": "1b80d022a38b14804ee24e367d2eb7f6c1f00f719de90b64e8bebcefb09a9c3a", "size": 928 },
+								{ "hash": "cfa9eadde4f6ae8f3b9b17261d95604b0f44fc607463c6dc2eab73f4c6723326", "size": 965 },
+								{ "hash": "e286f1ea8e0b16a5ad35ee2303cb4f069a7e9222e9279e62ff56c96ba64050fa", "size": 1002 },
+								{ "hash": "5d659c025a7b08e8f1f6c2f116a849b70b6002c4faa702fb59a9777ab0efab5f", "size": 1039 },
+								{ "hash": "80bc927a58d36233c08eb9d94f65f90b79e1b4152e4afde817dd6b7af4ecc5ae", "size": 1076 },
+								{ "hash": "5f19dab49afe74fedc299e1a501d4dcb3f4a7f9f69017d67c27ca2adce24df03", "size": 113 },
+								{ "hash": "f047ab2519037157c8b32895a97cbc00451e753a0468e822e0cc4ae9017df26a", "size": 150 },
+								{ "hash": "db2bdad910c57a2ab2faeb1e6804889bcc2ec9b3de8a7b2d277ab952c11d748c", "size": 187 },
+								{ "hash": "739941afc5dd9d627c9c5b97f89885502c2074d4e9ac3b1d0747ce0855fab97f", "size": 224 },
+								{ "hash": "e37bad782e26bfa55f010882b92248305512652de1e75285ea52aeeaec0278e0", "size": 261 },
+								{ "hash": "d07a84746b44205c024c218383f002bc4413cf17ffd0614cf2612f481e264207", "size": 298 },
+								{ "hash": "16ab4112679c8276ca390943e32f7e7c06a3ec81820828dfb4718cdbb08794d5", "size": 335 },
+								{ "hash": "7b071b3f4db521395ed1d8f53f25d80a1d956037e7f8e4a3e43b598a9410a8f5", "size": 372 },
+								{ "hash": "36c73f84d717f4d62997129e19808857eb308a868a01ea1a960375ee18f90ebd", "size": 409 },
+								{ "hash": "d126a7770714704ffc3c32380697e0e12a3a07921a4bf65f79068f3ab0da735f", "size": 446 },
+								{ "hash": "e5ce688ec4b4178765b094f313e19933ebba528b89f0b3c972c3b571349a4c91", "size": 483 },
+								{ "hash": "2eca45c888aa7b8468e20e23bc5ce2a8a0ac4bbf759763fdb683f547540450f1", "size": 520 },
+								{ "hash": "efa759f63a4fd6bb14d844e58b89b34c2bbf4e35c262faceeea8547b7b427492", "size": 557 },
+								{ "hash": "b499c284289f897c7c86ecb7dc5a1ddbfb6e7cfdde73c4372f8b651c17375cd2", "size": 594 },
+								{ "hash": "7be0e2103e561b7c84919b5e22426fe1f2c0757dc6fdd50aae5e0395b7b76276", "size": 631 },
+								{ "hash": "893c3883d50ad81c8cc817c0ee5e0cf094048a2780b40b7c757301b3df3dbe55", "size": 668 },
+								{ "hash": "5238ce7777c1cff52fb5a1e4a07443c9b968991460e704324c0c98818b7a05c3", "size": 705 },
+								{ "hash": "a1ca718a13242a38a212d0c9c036a47b25c54e6491a5b6a0b67abccf6aec49a4", "size": 742 },
+								{ "hash": "32418d2c7a22ffc6fea2abf4bf82e85b26b0aeb81e34aa72c988be69b8a8c9b1", "size": 779 },
+								{ "hash": "0608e381f3756b9eca50338f5583cb013115238399118ea5312dcfc4a81fe341", "size": 816 },
+								{ "hash": "0ea993f8cd1765305e809c935b4d4d48afdbc4338e19d87e8dcec228274c28b4", "size": 853 },
+								{ "hash": "603549b2e02a1588a17b0957a71c8dea2982929188f0badbfa3a07bce368ae77", "size": 4820 },
+								{ "hash": "698ce57b1bc0e168c8aee8e47f81d82f3d7d6602f721cda15a935054b3bf9d19", "size": 1522 },
+								{ "hash": "c8c3b03fcf9e02e1eccdc0b78ba8eaead86843096ecd94f1ec2a0c87f027de66", "size": 780 },
+								{ "hash": "735d715ff7abc2e5074dd15f52f451dc337b1370f26fbbbda7c521773ecc540f", "size": 4338 },
+								{ "hash": "b4f7bc9d37817aa3da10956688676985bd3fc9f110d957099b52d226a75772f8", "size": 7335 },
+								{ "hash": "48bbf9c8e0fb9e218a4ae7814a8209f8db5aafbd9cb1205c3a59747c45f0e723", "size": 3111 },
+								{ "hash": "76fda3a53709154a710ec71a28b8dbf343c5aa92aed62b9d7af5379bcf01abb2", "size": 1554 },
+								{ "hash": "00d36875ebb3d9150391502a4639e291751807041dd30933333b143df3ba21b2", "size": 4662 },
+								{ "hash": "d03e57c09a7e376735a8da0157ecc76506ac96b058e4a9896f43c8799be49ada", "size": 7659 },
+								{ "hash": "476d98142f0314546b21a1b0b98fc915c14b1a538495f4a6eb8e18cd5aacccf6", "size": 2366 },
+								{ "hash": "80c319c07cf127b1f385b531a9bfe4bac1b1fa1d3e4d2df2e32bca0aa5f4840a", "size": 663 },
+								{ "hash": "51324ef2a7ee3c82298a474e237dc8aaf279bdd5c28b5185ea197461b88f630c", "size": 1845 },
+								{ "hash": "92366b26310630d809ab380ea7292a8eee56b6443a7ca8bc80f664634b143a3c", "size": 3435 },
+								{ "hash": "a0720c2b0e3e7d03956333981734f0bc7c3ed14243ac6437bed42c3328e1b24a", "size": 3030 },
+								{ "hash": "3a37eaffa534c1125ffbdebb94a2ec0d0849adcf61ce1f4ea6430ff1d8b5222d", "size": 5655 },
+								{ "hash": "685c4dab99006ed9bcfde70c1439223ba563d3884e55d493edcfd6beed67fbd5", "size": 1730 },
+								{ "hash": "d8c9c7f665ea76f6c09793a8abef8605fbcd3b73aa993f5d54bca595ddb9b9ef", "size": 3092 },
+								{ "hash": "8d3503a00e2c7f758cc2166720125b34bc165221b318dba3a45a78fb2f0344ed", "size": 3135 },
+								{ "hash": "c5a00c360844d2f795965a2db2c452061172728b059750f4a1a9cb1e15737069", "size": 5943 },
+								{ "hash": "34db7faaa4aae0b57ed739b0b6e4646bd003a507a81078391bf59582277d63ce", "size": 997 },
+								{ "hash": "cc26c973aa023cffd98799788ec627ee70fac3b5b611120c84023b77a50508f5", "size": 1034 },
+								{ "hash": "d545dc52200e939a3d5f5cff67e4cc963fa524e695896183ea07ae1bd7ae2a25", "size": 1071 },
+								{ "hash": "2cc0c444853b91fa07aa0af13534942b96608fed8fd573648dbbb16b41742fd3", "size": 108 },
+								{ "hash": "75a3f9c6704d58aba5eef4812dc68b679542f7657085a8ab5878cb9ca665b740", "size": 145 },
+								{ "hash": "140bb8a9fa95a00d088c5f41326afa5fffcf9242b336ed42e98e07afc75e0f66", "size": 182 },
+								{ "hash": "ed9a408e6068bc2aa07d7ae2bb7661535fb474849690befa8d3dc37c07ca018a", "size": 219 },
+								{ "hash": "d75496a53ad635f8443e28ebc088782e4c263f8e7110a062d3aec31fe6437053", "size": 256 },
+								{ "hash": "f4cd94036e5c3e4f651fab643c3dd229e560055df7eeae0b5eec9077d4cf5da6", "size": 293 },
+								{ "hash": "c4463b14c4b00ee8dbc21031a4bdbb3b86d5cf4d5aea1e68059e4e944fd562fe", "size": 330 },
+								{ "hash": "168f06ba3ccd619413e351a66e9fb45371329e16e9fa005ae17b523845006667", "size": 367 },
+								{ "hash": "3b379d82074ef34ea87551bb749a3ce6eba4f9e8830d1b8a9ea386e0e7144abd", "size": 404 },
+								{ "hash": "2b55f7965ec295511c4560a6d8283fb7e07c01af667fdc64114658ac2e5a31e4", "size": 441 },
+								{ "hash": "4deb84b4d16c66c2f391e9aa96e241c340f189dbb0049bc4bf3d8d4984d61f14", "size": 478 },
+								{ "hash": "da05b77f5fe91aa29ff0c1c6f1724ed5399caaf96da042e276eefc7c5a8fb2fd", "size": 515 },
+								{ "hash": "a7cb585e6d5c67b26ab05320fd6a0d66e1c7c7b0375678ad224e491a374834a9", "size": 552 },
+								{ "hash": "dd1cd40d9c84b35b92e45889e87535830c168f5452abfa62b3ea71e2bbfe2866", "size": 589 },
+								{ "hash": "e2539dcf21a840206612efb71ad7bce2836a7157e8a51840f1dcc7943be51a04", "size": 626 },
+								{ "hash": "41ae6dfe7f7780338251e7ccf5ee9b3ac91de890c953eca1bc61541ec9633b81", "size": 663 }
+							]
+						},
+						{
+							"at_end": true,
+							"at_start": false,
+							"levels": [
+								[26, 0],
+								[18, 0],
+								[3, 0]
+							],
+							"nodes": [
+								{ "hash": "44ed090c300cc097250fa620a34313c02d99eea2565163ac4a8b702a096b10c3", "size": 700 },
+								{ "hash": "03b6c34e3964bdeb5ed99c8865cc6b84a6fbcbbcc49f1175463a04f6232a5c05", "size": 737 },
+								{ "hash": "d4aeeee3832d24826055bb53a9fda170891d608fdcbd0900859179d72d95eab3", "size": 774 },
+								{ "hash": "2246838023aedee63764aecbbb457483d8ce7248cc96342a68e0dd0a6dfdb2e2", "size": 811 },
+								{ "hash": "b5b1fa35128b4e89c5875389c807e5d1c1a09c8c99d18215eb4844b73f59997e", "size": 848 },
+								{ "hash": "abee6538ecb241f9b390e579de71e816cab38440d4681646b62eb7d77a561859", "size": 885 },
+								{ "hash": "b9b967b99e6555e69e6dc294628115726d3779412de880b4ee36a233b6267008", "size": 922 },
+								{ "hash": "001f6ea1bec6c30ef7f344c642c8ec9085520478134ba6c684c9882144c243d3", "size": 959 },
+								{ "hash": "dfc5800da5e461d88166f84161097f2770270245e06d25e9d9144f4c5bc601b6", "size": 996 },
+								{ "hash": "5efa69adacd20dc485fe2c57f9f6b4fac2030c80a73c59e3985d623230affc94", "size": 1033 },
+								{ "hash": "05bd9b72fac3f84697d5e8e6e825db4adbf3a9b8df4e8b3270384752dd1597a8", "size": 1070 },
+								{ "hash": "d4db7ac1a915799edae5ffbce859aa76e67d47d66cb34a64c13631a5e106987e", "size": 107 },
+								{ "hash": "d72e4a71a7b56114105eced40b7ac70d931d680378ac3e6f60ea7ef89d0e6ff6", "size": 144 },
+								{ "hash": "fe5f2554e56214d17fbb3b2466bc2d17b8065c32d7f154a5942396f9b50dadf5", "size": 181 },
+								{ "hash": "a40f4f42ff54739e17aecba60c87f3cae2637f0478260f0442bef89c6e62395a", "size": 218 },
+								{ "hash": "0786ab6299a316a009782e53032ac2dfd3dc49e13ef2d96c36348b53c38eebce", "size": 255 },
+								{ "hash": "64c680d13039012a9a5f93ddb684e11ac3bfdd5adac14fafa86cccfed9f0ad31", "size": 292 },
+								{ "hash": "970d27efafd4bfc51d6817c1d0f56ef98d338d76dda72a94d51fd04c0a28942a", "size": 329 },
+								{ "hash": "22f378e138b8252babf5e3698b051ecb3dfc8de5e84ac0e927c7fc42372dc8ac", "size": 366 },
+								{ "hash": "cb15f41639e0c0e053c6bf6b88871b31637173eed82e7d54349fe32abc2565f3", "size": 403 },
+								{ "hash": "c3b1a7afbf8d7b486cf77209279bad3597796d54932483c196ccf4a8a32ad936", "size": 440 },
+								{ "hash": "e1ddeb05ee0cb9e820f97a44cc9eedb65001be37ea4de1cce951b413940c7f6d", "size": 477 },
+								{ "hash": "efcc302e1c741d2aff5d8608658c1a75b6a5cf54bd419b9a5b2a9fa50971f77a", "size": 514 },
+								{ "hash": "c90f4a780a66c3917f67c97116db8831875a98f853040ad8e3e21f47ec6eccf9", "size": 551 },
+								{ "hash": "b8cc5c74908cddc60d4270387a9fa3e57712ae21f399c7790860019b3ef1c8fb", "size": 588 },
+								{ "hash": "838394e481d738a2977f4a99bc859ee533df25d30bdcb3991e63c34ea6a92910", "size": 625 },
+								{ "hash": "df9ee35931b0567f0653187387772734f36e229eddf776072050d66fec016d62", "size": 2097 },
+								{ "hash": "9f9b8e0428817b6dd02517e16791227be666bf89dcdf3c9bfbf1c8819b4e5e93", "size": 2430 },
+								{ "hash": "1746d4f26b9a637b7cb268d99cc4f43e528d83ba94c4631f6dcaa438ec9d61e7", "size": 2763 },
+								{ "hash": "7ff21b6c2add2ad39a54d91d37d95e6d04b2669b91be83ef8e004bd38a1815a8", "size": 3525 },
+								{ "hash": "8410e692e3c2d97804a8cc8c16c9a0d4dee4086f41719191e3fea8af9e1d13ed", "size": 1857 },
+								{ "hash": "b8057b8ea466d2b47324de056bd87909069bbffae69f5cdae9da83f6b1490e9d", "size": 1428 },
+								{ "hash": "5088c5b9608ac098c858d7dd1dc3f5258eb7394138dd892b8ef0a90ef2ae1b6a", "size": 4627 },
+								{ "hash": "b545e9aed3a2b6dd92858193d1c3d5f97ee727f1d6dbdb4b5ae761caec955cb7", "size": 2538 },
+								{ "hash": "d19df790553cb5c1f398fdb2472de93d9a39578c45fceef15efc8f6985f05d75", "size": 5075 },
+								{ "hash": "b0727ae5b368287b0c96249937d8352aa0a738f6adc058ed59e5039aedddf4aa", "size": 1771 },
+								{ "hash": "0e2b0c6b75a9312c1b3123342df57f450f5bf37369c063551e3f08a620bae44e", "size": 1314 },
+								{ "hash": "22f68e8faf2860d44c638608f2a794e0f87ec8a04e49fdb4eacf33aa1e91f70c", "size": 3627 },
+								{ "hash": "c880ffab99bbb8141a57dd72211f88aa00b33969a9bb7366298067c12ab54c04", "size": 7938 },
+								{ "hash": "26e049584f30f61ec60c71f73163ecb5fcc05a6bee68094ff218caf77f460c89", "size": 1490 },
+								{ "hash": "de455d4fc626fd878a01f7a860a5fe0152ac4b0540bdc405408bf34a90b5b87d", "size": 756 },
+								{ "hash": "82ac69113c44e12a13b7c68a1359d9ced87dbec177cf04a243bd9525f3a6d70d", "size": 4266 },
+								{ "hash": "9c7a075a589542e59cb1a0415fe4a86b7253ed020e235efc314e403715144d4b", "size": 4509 },
+								{ "hash": "79ebc2f62b2a7eff62eab6d00fd8e3b012f311898b96b7e09bf38647c5d6530c", "size": 5841 },
+								{ "hash": "ad38f7210a7e064efe5b518b49f39bf401e3a7ab0e133becbbe0435e49b4d7c4", "size": 17620 },
+								{ "hash": "55a9ad0ebb7a28dc41cc389f12e2dbe9028a1a5c221e13b5b4f8402ffafd3bd5", "size": 25573 },
+								{ "hash": "875ade5a8bcd12ad5d9eda0327c807e11c8218e1307d05db1c09a6a5f4355c2f", "size": 4030 }
+							]
+						}
+					],
+					"points": [200, 400, 600, 800]
+				}
+			],
+			"xorbHash": "249bd2a13be8360d929ca67e88b751fd39fac4c5021cf03f8b0aecbacd800651"
+		}
+	],
+	"description": "Reference vectors for MerkleHashSubtree, generated from xet-core. chunk(i) = (compute_data_hash(le_bytes(i)), 100 + (i*37) % 1000)"
+}


### PR DESCRIPTION
Two changes:

- A commit file with an `edit` operation that's passed a `XetBlob` will not download the xet blob if not needed (eg for buckets) - allow editing bucket files in place (& later with git LFS v2, dataset/... files)
- Add `rangeEditCache: new Map()` optional param for repeated edits (eg appends) to a file, to have even less API round trips

cc @assafvayner

cc @mishig25 @lhoestq - we should really be able to edit 1TB files with 0 download for buckets (for models we still need to compute sha256 of whole file)

## How it works

- `commit`'s `edit` operations already wrap the edits in a `SplicedBlob`. When its `originalBlob` is a `XetBlob` (as returned by `downloadFile`, which now carries the file's xet `hash`), `createXorbs` takes a **range-edit path** instead of streaming the whole blob:
  1. `GET /v2/reconstructions/{hash}` → the original file's term layout;
  2. `GET /v2/file-chunk-hashes/{hash}` with `X-Range-Dirty` (dirty ranges snapped to term boundaries) → chunk-aligned re-chunk **windows**, opaque `MerkleHashSubtree` summaries of the untouched gaps, and verification range-hashes for the untouched terms;
  3. only the window bytes are downloaded & re-chunked; the new file hash comes from merging the gap subtrees with subtrees built from the window chunks; the shard reuses the untouched terms verbatim.
- `MerkleHashSubtree` is a TS port of xet-core's O(log n) partial-merkle state (`xet_core_structures/src/merklehash/merkle_hash_subtree.rs`), tested byte-for-byte against fixtures generated from the Rust code (serde-compatible JSON, identical hashes, merging Rust-produced parts in TS).
- `rangeEditCache`: after any upload through the cache, the file's terms + an open subtree (everything but the last term) + the last term's chunks are kept in memory; a later append (or edit of the last term) synthesizes the `file-chunk-hashes` response locally → **zero CAS metadata calls per append**.
- Fallbacks: any non-`XetBlob` original, non-xet files, 404s from the CAS metadata endpoints → previous behavior (full local re-chunk + dedup).

### Note: mid-segment window ends (xet-core bug found along the way)

The server extends windows past the requested (term-aligned) end until the chunker provably re-syncs (2 stable-sized clean chunks) — so window ends usually land **mid-term**. A partially-covered term can neither be reused (no verification hash is provided for it) nor partially referenced. This PR handles it by extending the *effective* window to the next term boundary (the extra chunks re-produce the original chunks exactly, since the chunker resets at chunk boundaries) and splitting the window's chunk list at the server's window end for the hash merge. xet-core's own `upload_ranges` silently drops the tail of the partially-swallowed segment in this situation (its tests miss it because their weak test PRNG only produces max-size/unstable chunks, so windows always extend to EOF) — fix being PR'd to xet-core separately.

### Validation

Besides unit tests (including a TS mirror of the server's `ChunkWindowBuilder` state machine, and Rust-generated subtree fixtures), `scripts/test-range-edit.ts` runs against the production Hub: mid-file edit, second-round edit of a composed file, append, growing header edit, and 3 cached appends with 0 `file-chunk-hashes` calls — every composed shard accepted by xetcas, which verifies the file hash and verification hashes server-side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the xet upload/commit path for file edits and composed file hashes; incorrect range composition could produce rejected or corrupt shards, though fallbacks and server-side verification limit exposure.
> 
> **Overview**
> Adds **efficient in-place edits** for xet-backed Hub files: when `commit` uses an `edit` operation whose `originalContent` is the `XetBlob` from `downloadFile` (now including the file’s xet `hash`), uploads take a **range-edit path** that calls CAS reconstruction + `file-chunk-hashes` APIs and only downloads/re-chunks **dirty windows**, reusing untouched terms and gap merkle data instead of streaming the whole file.
> 
> Introduces **`rangeEditCache`** on `commit` / `uploadShards`: a shared `Map()` keeps partial merkle state after uploads so **repeated appends** (or last-term edits) can skip CAS metadata round-trips entirely. README and `CommitEditFile` docs are updated; wiring flows through `createXorbs` → `rangeEdit.ts` and cache population in `uploadShards`.
> 
> **`@huggingface/xetchunk-wasm`** gains a **`MerkleHashSubtree`** port (serde-compatible with CAS `hashRanges`) plus tests against Rust fixtures. Coverage includes `rangeEdit.spec.ts`, subtree tests, and a live Hub script (`test-range-edit.ts`) for mid-file edits, appends, header patches, and cached appends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e57e587e855633f2a6adfa0ab165a79e7890282. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->