### PR TITLE
Rename Unsloth Studio to Unsloth Desktop and use deeplink

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -301,7 +301,7 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 	});
 
 	it("unsloth tagged model", async () => {
-		const { displayOnModelPage, snippet: snippetFunc } = LOCAL_APPS.unsloth;
+		const { displayOnModelPage, deeplink } = LOCAL_APPS.unsloth;
 		const model: ModelData = {
 			id: "some-user/my-unsloth-finetune",
 			tags: ["unsloth", "conversational"],
@@ -309,25 +309,11 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		};
 
 		expect(displayOnModelPage(model)).toBe(true);
-		const snippet = snippetFunc(model);
-		expect(snippet[0].setup).toBe("curl -fsSL https://unsloth.ai/install.sh | sh");
-		expect(snippet[0].content).toBe(
-			"# Run unsloth studio\nunsloth studio -H 0.0.0.0 -p 8888\n# Then open http://localhost:8888 in your browser\n# Search for some-user/my-unsloth-finetune to start chatting",
-		);
-		expect(snippet[1].setup).toBe("irm https://unsloth.ai/install.ps1 | iex");
-		expect(snippet[1].content).toBe(snippet[0].content);
-		expect(snippet[2].setup).toBe("# No setup required");
-		expect(snippet[2].content).toBe(
-			"# Open https://huggingface.co/spaces/unsloth/studio in your browser\n# Search for some-user/my-unsloth-finetune to start chatting",
-		);
-		expect(snippet[3].setup).toBe("pip install unsloth");
-		expect(snippet[3].content).toBe(
-			'from unsloth import FastModel\nmodel, tokenizer = FastModel.from_pretrained(\n    model_name="some-user/my-unsloth-finetune",\n    max_seq_length=2048,\n)',
-		);
+		expect(deeplink(model, undefined).href).toBe("https://unsloth.ai/open_from_hf?model=some-user/my-unsloth-finetune");
 	});
 
 	it("unsloth namespace gguf model", async () => {
-		const { displayOnModelPage, snippet: snippetFunc } = LOCAL_APPS.unsloth;
+		const { displayOnModelPage, deeplink } = LOCAL_APPS.unsloth;
 		const model: ModelData = {
 			id: "unsloth/Llama-3.2-3B-Instruct-GGUF",
 			tags: ["conversational"],
@@ -336,18 +322,12 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		};
 
 		expect(displayOnModelPage(model)).toBe(true);
-		const snippet = snippetFunc(model);
-		expect(snippet[0].setup).toBe("curl -fsSL https://unsloth.ai/install.sh | sh");
-		expect(snippet[0].content).toBe(
-			"# Run unsloth studio\nunsloth studio -H 0.0.0.0 -p 8888\n# Then open http://localhost:8888 in your browser\n# Search for unsloth/Llama-3.2-3B-Instruct-GGUF to start chatting",
+		expect(deeplink(model, undefined).href).toBe(
+			"https://unsloth.ai/open_from_hf?model=unsloth/Llama-3.2-3B-Instruct-GGUF",
 		);
-		expect(snippet[1].setup).toBe("irm https://unsloth.ai/install.ps1 | iex");
-		expect(snippet[1].content).toBe(snippet[0].content);
-		expect(snippet[2].setup).toBe("# No setup required");
-		expect(snippet[2].content).toBe(
-			"# Open https://huggingface.co/spaces/unsloth/studio in your browser\n# Search for unsloth/Llama-3.2-3B-Instruct-GGUF to start chatting",
+		expect(deeplink(model, "Llama-3.2-3B-Instruct-UD-Q4_K_XL.gguf").href).toBe(
+			"https://unsloth.ai/open_from_hf?model=unsloth/Llama-3.2-3B-Instruct-GGUF&file=Llama-3.2-3B-Instruct-UD-Q4_K_XL.gguf",
 		);
-		expect(snippet).toHaveLength(3); // GGUF models only get 3 snippets
 	});
 
 	it("non unsloth namespace gguf model", async () => {

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -225,56 +225,6 @@ const snippetOllama = (model: ModelData, filepath?: string): string => {
 	return `ollama run hf.co/${model.id}${getQuantTag(filepath)}`;
 };
 
-const snippetUnsloth = (model: ModelData): LocalAppSnippet[] => {
-	const isGguf = isLlamaCppGgufModel(model);
-
-	const studio_content = [
-		"# Run unsloth studio",
-		"unsloth studio -H 0.0.0.0 -p 8888",
-		"# Then open http://localhost:8888 in your browser",
-		"# Search for " + model.id + " to start chatting",
-	].join("\n");
-
-	const studio_instructions: LocalAppSnippet = {
-		title: "Install Unsloth Studio (macOS, Linux, WSL)",
-		setup: "curl -fsSL https://unsloth.ai/install.sh | sh",
-		content: studio_content,
-	};
-
-	const studio_instructions_windows: LocalAppSnippet = {
-		title: "Install Unsloth Studio (Windows)",
-		setup: "irm https://unsloth.ai/install.ps1 | iex",
-		content: studio_content,
-	};
-
-	const hf_spaces_instructions: LocalAppSnippet = {
-		title: "Using HuggingFace Spaces for Unsloth",
-		setup: "# No setup required",
-		content:
-			"# Open https://huggingface.co/spaces/unsloth/studio in your browser\n# Search for " +
-			model.id +
-			" to start chatting",
-	};
-
-	const fastmodel_instructions: LocalAppSnippet = {
-		title: "Load model with FastModel",
-		setup: "pip install unsloth",
-		content: [
-			"from unsloth import FastModel",
-			"model, tokenizer = FastModel.from_pretrained(",
-			'    model_name="' + model.id + '",',
-			"    max_seq_length=2048,",
-			")",
-		].join("\n"),
-	};
-
-	if (isGguf) {
-		return [studio_instructions, studio_instructions_windows, hf_spaces_instructions];
-	} else {
-		return [studio_instructions, studio_instructions_windows, hf_spaces_instructions, fastmodel_instructions];
-	}
-};
-
 const snippetLocalAI = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
 	const command = (binary: string) =>
 		["# Load and run the model:", `${binary} huggingface://${model.id}/${filepath ?? "{{GGUF_FILE}}"}`].join("\n");
@@ -798,11 +748,12 @@ export const LOCAL_APPS = {
 		snippet: snippetOllama,
 	},
 	unsloth: {
-		prettyLabel: "Unsloth Studio",
+		prettyLabel: "Unsloth Desktop",
 		docsUrl: "https://unsloth.ai/docs/new/studio",
 		mainTask: "text-generation",
 		displayOnModelPage: isUnslothModel,
-		snippet: snippetUnsloth,
+		deeplink: (model, filepath) =>
+			new URL(`https://unsloth.ai/open_from_hf?model=${model.id}${filepath ? `&file=${filepath}` : ""}`),
 	},
 	"docker-model-runner": {
 		prettyLabel: "Docker Model Runner",


### PR DESCRIPTION
Unsloth Studio is now Unsloth Desktop, so this updates the label on the model page. It also switches the button from copy-paste terminal instructions to a deeplink, so clicking it just opens the app on that model:

```
https://unsloth.ai/open_from_hf?model=<model_id>
https://unsloth.ai/open_from_hf?model=<model_id>&file=<file.gguf>
```

We're pointing at an unsloth.ai page rather than the unsloth:// scheme directly so people without the app land on the website instead of hitting a dead link the page hands off to the app if it's there.

One side effect: since a local app is either a deeplink or a snippet, this removes the old install commands, the Spaces block, and the FastModel snippet.

Could you also swap the Unsloth icon for our new logo?

https://cdn-uploads.huggingface.co/production/uploads/65fd82a0493ef28bc303a7eb/qu2c9mSt1TWhL1kChTDN8.png

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Model-page UX and copy only in `packages/tasks`; no auth or data-path changes, with behavior covered by updated unit tests.
> 
> **Overview**
> Rebrands the model-page local app from **Unsloth Studio** to **Unsloth Desktop** and replaces copy-paste terminal snippets with an **HTTPS deeplink** (`https://unsloth.ai/open_from_hf?model=…`, optional `&file=` for GGUF), matching other deeplink-based apps like LM Studio.
> 
> **Removes** `snippetUnsloth` and its install/Spaces/FastModel instructions, since a local app is either a deeplink or snippets. **Tests** now assert `deeplink` URLs instead of snippet content; visibility rules (`isUnslothModel`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c2a5f149cf36a9053b051c067c032cd86647e72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->