### PR TITLE
Point Unsloth docsUrl at the docs root

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -749,7 +749,7 @@ export const LOCAL_APPS = {
 	},
 	unsloth: {
 		prettyLabel: "Unsloth Desktop",
-		docsUrl: "https://unsloth.ai/",
+		docsUrl: "https://unsloth.ai/docs",
 		mainTask: "text-generation",
 		displayOnModelPage: isUnslothModel,
 		deeplink: (model, filepath) => {


### PR DESCRIPTION
Follow-up to #2413. The bare homepage is what the Hub opens when the `unsloth://` handler is not installed, and it is also the docs link shown in local-app settings. `https://unsloth.ai/docs` lands on the Unsloth docs (which feature Unsloth Desktop and its download button) and matches the docs-root convention used by the other entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation URL change in local app metadata with no runtime or security impact.
> 
> **Overview**
> Updates the **Unsloth Desktop** entry in `LOCAL_APPS` so `docsUrl` is `https://unsloth.ai/docs` instead of the bare homepage.
> 
> That link is what the Hub shows for Unsloth documentation (including when the `unsloth://` deeplink handler is not installed) and in local-app settings, aligning Unsloth with other apps that use a docs-root URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 705532cfd18912961a2c9d8df275d5d177d44f8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->