### PR TITLE
[hub] Fix parameter counts for packed MLX models

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -11,7 +11,7 @@ import {
 	parseTotalParameters,
 	SafetensorParseError,
 } from "./parse-safetensors-metadata";
-import type { Dtype, TensorInfo, SafetensorsFileHeader } from "./parse-safetensors-metadata";
+import type { Dtype, MlxQuantizationConfig, TensorInfo, SafetensorsFileHeader } from "./parse-safetensors-metadata";
 import { sum } from "../utils/sum";
 
 describe("parseSafetensorsMetadata", () => {
@@ -195,32 +195,38 @@ describe("parseSafetensorsMetadata", () => {
 		 * and a fetch that serves it (including the `Range: bytes=0-0` probe `WebBlob.create`
 		 * uses to learn the file size).
 		 */
-		const fetchForFile = (header: Record<string, unknown>, dataBytes = 0): typeof fetch => {
+		const fetchForFile = (
+			header: Record<string, unknown>,
+			dataBytes = 0,
+			config?: Record<string, unknown>,
+		): typeof fetch => {
 			const headerBytes = new TextEncoder().encode(JSON.stringify(header));
 			const file = new Uint8Array(8 + headerBytes.length + dataBytes);
 			new DataView(file.buffer).setBigUint64(0, BigInt(headerBytes.length), true);
 			file.set(headerBytes, 8);
+			const configFile = config ? new TextEncoder().encode(JSON.stringify(config)) : undefined;
 			return (async (input: RequestInfo | URL, init?: RequestInit) => {
 				const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-				if (!url.endsWith(".safetensors")) {
-					// config.json, the sharded index, existence probes... — `downloadFile` treats a
-					// 404 as "not found" only when the Hub's X-Error-Code says so.
+				const resource = url.endsWith(".safetensors") ? file : url.endsWith("config.json") ? configFile : undefined;
+				if (!resource) {
+					// The sharded index, existence probes... — `downloadFile` treats a 404 as "not
+					// found" only when the Hub's X-Error-Code says so.
 					return new Response(null, { status: 404, headers: { "X-Error-Code": "EntryNotFound" } });
 				}
 				const range = new Headers(init?.headers).get("range");
 				if (range?.startsWith("bytes=")) {
 					const [start, endRaw] = range.slice("bytes=".length).split("-");
 					const startByte = Number(start);
-					const endByte = endRaw === "" ? file.length - 1 : Number(endRaw);
-					return new Response(file.slice(startByte, endByte + 1), {
+					const endByte = endRaw === "" ? resource.length - 1 : Math.min(Number(endRaw), resource.length - 1);
+					return new Response(resource.slice(startByte, endByte + 1), {
 						status: 206,
 						headers: {
-							"content-range": `bytes ${startByte}-${endByte}/${file.length}`,
+							"content-range": `bytes ${startByte}-${endByte}/${resource.length}`,
 							etag: '"hermetic-test-file"',
 						},
 					});
 				}
-				return new Response(file, { status: 200, headers: { etag: '"hermetic-test-file"' } });
+				return new Response(resource, { status: 200, headers: { etag: '"hermetic-test-file"' } });
 			}) as typeof fetch;
 		};
 
@@ -309,6 +315,113 @@ describe("parseSafetensorsMetadata", () => {
 			assert(!parse.sharded);
 			assert.deepStrictEqual(parse.parameterCount, { F32: 200 });
 			assert.strictEqual(parse.parameterTotal, 200);
+		});
+
+		it("honors total_parameters for packed MLX weights without weakening the metadata cap", async () => {
+			const quantization = { group_size: 64, bits: 8, mode: "affine" };
+			const fetch = fetchForFile(
+				{
+					__metadata__: { format: "mlx", total_parameters: "210" },
+					"quantized.weight": { dtype: "U32", shape: [10, 5], data_offsets: [0, 200] },
+					"quantized.scales": { dtype: "BF16", shape: [10, 2], data_offsets: [200, 240] },
+					"quantized.biases": { dtype: "BF16", shape: [10, 2], data_offsets: [240, 280] },
+					"norm.weight": { dtype: "BF16", shape: [10], data_offsets: [280, 300] },
+				},
+				300,
+				{ quantization, quantization_config: quantization },
+			);
+
+			const parse = await parseSafetensorsMetadata({
+				repo: "some-user/packed-mlx-model",
+				computeParametersCount: true,
+				fetch,
+			});
+
+			assert(!parse.sharded);
+			// 50 packed U32 containers hold 200 8-bit weights. Plural scales/biases are
+			// quantization state; the BF16 norm remains a real parameter.
+			assert.deepStrictEqual(parse.parameterCount, { U32: 200, BF16: 10 });
+			assert.strictEqual(parse.parameterTotal, 210);
+		});
+
+		it("caps inflated total_parameters at the MLX-aware logical count", async () => {
+			const quantization = { group_size: 64, bits: 8, mode: "affine" };
+			const fetch = fetchForFile(
+				{
+					__metadata__: { format: "mlx", total_parameters: "999000000000" },
+					"quantized.weight": { dtype: "U32", shape: [10, 5], data_offsets: [0, 200] },
+					"quantized.scales": { dtype: "BF16", shape: [10, 2], data_offsets: [200, 240] },
+					"quantized.biases": { dtype: "BF16", shape: [10, 2], data_offsets: [240, 280] },
+					"norm.weight": { dtype: "BF16", shape: [10], data_offsets: [280, 300] },
+				},
+				300,
+				{ quantization, quantization_config: quantization },
+			);
+
+			const parse = await parseSafetensorsMetadata({
+				repo: "some-user/inflated-packed-mlx-model",
+				computeParametersCount: true,
+				fetch,
+			});
+
+			assert(!parse.sharded);
+			assert.deepStrictEqual(parse.parameterCount, { U32: 200, BF16: 10 });
+			assert.strictEqual(parse.parameterTotal, 210);
+		});
+
+		it("does not relabel another top-level quantizer as MLX", async () => {
+			const fetch = fetchForFile(
+				{
+					__metadata__: { format: "pt" },
+					"quantized.qweight": { dtype: "I32", shape: [10], data_offsets: [0, 40] },
+					"quantized.scales": { dtype: "F16", shape: [2], data_offsets: [40, 44] },
+				},
+				44,
+				{
+					quantization: { quant_method: "gptq", bits: 2, group_size: 64, mode: "affine" },
+					quantization_config: { quant_method: "gptq", bits: 4 },
+				},
+			);
+
+			const parse = await parseSafetensorsMetadata({
+				repo: "some-user/gptq-model",
+				computeParametersCount: true,
+				fetch,
+			});
+
+			assert(!parse.sharded);
+			assert.deepStrictEqual(parse.parameterCount, { I32: 80 });
+		});
+
+		it("accepts valid per-module MLX overrides when the top-level tuple is only a placeholder", async () => {
+			const quantization = {
+				group_size: 16,
+				bits: 4,
+				mode: "affine",
+				nvfp4_layer: { group_size: 16, bits: 4, mode: "nvfp4" },
+				affine_layer: { group_size: 64, bits: 8, mode: "affine" },
+			};
+			const fetch = fetchForFile(
+				{
+					__metadata__: { format: "mlx" },
+					"nvfp4_layer.weight": { dtype: "U32", shape: [12], data_offsets: [0, 48] },
+					"nvfp4_layer.scales": { dtype: "U8", shape: [3], data_offsets: [48, 51] },
+					"affine_layer.weight": { dtype: "U32", shape: [24], data_offsets: [51, 147] },
+					"affine_layer.scales": { dtype: "BF16", shape: [3], data_offsets: [147, 153] },
+					"affine_layer.biases": { dtype: "BF16", shape: [3], data_offsets: [153, 159] },
+				},
+				159,
+				{ quantization, quantization_config: quantization },
+			);
+
+			const parse = await parseSafetensorsMetadata({
+				repo: "some-user/mixed-mlx-model",
+				computeParametersCount: true,
+				fetch,
+			});
+
+			assert(!parse.sharded);
+			assert.deepStrictEqual(parse.parameterCount, { U32: 192 });
 		});
 
 		it("skips the offsets check (rather than guessing) when the file size is unknown", () => {
@@ -403,6 +516,145 @@ describe("parseSafetensorsMetadata", () => {
 			);
 
 			assert.deepStrictEqual(parameterCount, { F32: 12 });
+		});
+	});
+
+	describe("MLX packed weights", () => {
+		const tensor = (dtype: Dtype, shape: number[]): TensorInfo => ({ dtype, shape, data_offsets: [0, 0] });
+
+		for (const [bits, storedElements] of [
+			[4, 12],
+			[6, 18],
+			[8, 24],
+		] as const) {
+			it(`reports the same logical count for ${bits}-bit U32 weights`, () => {
+				const parameterCount = computeNumOfParamsByDtypeSingleFile(
+					{
+						"quantized.weight": tensor("U32", [storedElements]),
+						"quantized.scales": tensor("BF16", [3]),
+						"quantized.biases": tensor("BF16", [3]),
+						"quantized.bias": tensor("BF16", [2]),
+						"dense.weight": tensor("BF16", [5]),
+					},
+					{ quant_method: "mlx", mode: "affine", bits, group_size: 64 },
+				);
+
+				// Singular `.bias` is learned; only MLX's plural `.biases` is quantization state.
+				assert.deepStrictEqual(parameterCount, { U32: 96, BF16: 7 });
+			});
+		}
+
+		it("uses per-module bit widths and leaves explicitly unquantized modules alone", () => {
+			const quantConfig = {
+				quant_method: "mlx",
+				mode: "affine",
+				bits: 8,
+				group_size: 64,
+				four_bit: { bits: 4 },
+				dense: false,
+			};
+			const parameterCount = computeNumOfParamsByDtypeSingleFile(
+				{
+					"four_bit.weight": tensor("U32", [12]),
+					"four_bit.scales": tensor("BF16", [1]),
+					"four_bit.biases": tensor("BF16", [1]),
+					"dense.weight": tensor("U32", [12]),
+				},
+				quantConfig,
+			);
+
+			assert.deepStrictEqual(parameterCount, { U32: 108 });
+		});
+
+		it("applies MLX defaults independently inside partial per-module overrides", () => {
+			const quantConfig: MlxQuantizationConfig = {
+				quant_method: "mlx",
+				mode: "affine",
+				bits: 8,
+				group_size: 64,
+				partial_affine: { group_size: 32 },
+				partial_mxfp4: { mode: "mxfp4" },
+			};
+			const parameterCount = computeNumOfParamsByDtypeSingleFile(
+				{
+					"partial_affine.weight": tensor("U32", [12]),
+					"partial_affine.scales": tensor("BF16", [1]),
+					"partial_affine.biases": tensor("BF16", [1]),
+					"partial_mxfp4.weight": tensor("U32", [12]),
+					"partial_mxfp4.scales": tensor("U8", [1]),
+				},
+				quantConfig,
+			);
+
+			assert.deepStrictEqual(parameterCount, { U32: 192 });
+		});
+
+		it("does not trust explicit overrides without their serialized quantization state", () => {
+			const quantConfig: MlxQuantizationConfig = {
+				quant_method: "mlx",
+				mode: "affine",
+				bits: 4,
+				group_size: 64,
+				quantized: { bits: 4 },
+			};
+			const parameterCount = computeNumOfParamsByDtypeSingleFile(
+				{ "quantized.weight": tensor("U32", [12]) },
+				quantConfig,
+			);
+
+			assert.deepStrictEqual(parameterCount, { U32: 12 });
+		});
+
+		it("keeps orphan plural tensors that do not belong to a packed module", () => {
+			const parameterCount = computeNumOfParamsByDtypeSingleFile(
+				{
+					"quantized.weight": tensor("U32", [12]),
+					"quantized.scales": tensor("BF16", [3]),
+					"quantized.biases": tensor("BF16", [3]),
+					"learned.scales": tensor("BF16", [4]),
+					"learned.biases": tensor("BF16", [5]),
+				},
+				{ quant_method: "mlx", mode: "affine", bits: 4, group_size: 64 },
+			);
+
+			assert.deepStrictEqual(parameterCount, { U32: 96, BF16: 9 });
+		});
+
+		it("only treats plural biases as affine quantization state", () => {
+			const parameterCount = computeNumOfParamsByDtypeSingleFile(
+				{
+					"quantized.weight": tensor("U32", [12]),
+					"quantized.scales": tensor("U8", [3]),
+					"quantized.biases": tensor("BF16", [4]),
+				},
+				{ quant_method: "mlx", mode: "mxfp4", bits: 4, group_size: 32 },
+			);
+
+			assert.deepStrictEqual(parameterCount, { U32: 96, BF16: 4 });
+		});
+
+		it("does not inflate weights for unsupported bit widths", () => {
+			const parameterCount = computeNumOfParamsByDtypeSingleFile(
+				{
+					"quantized.weight": tensor("U32", [12]),
+					"quantized.scales": tensor("BF16", [3]),
+				},
+				{ quant_method: "mlx", mode: "affine", bits: 1, group_size: 64 },
+			);
+
+			assert.deepStrictEqual(parameterCount, { U32: 12, BF16: 3 });
+		});
+
+		it("ignores malformed non-string modes", () => {
+			const parameterCount = computeNumOfParamsByDtypeSingleFile(
+				{
+					"quantized.weight": tensor("U32", [12]),
+					"quantized.scales": tensor("BF16", [3]),
+				},
+				{ quant_method: "mlx", mode: 1 as unknown as string, bits: 4, group_size: 64 },
+			);
+
+			assert.deepStrictEqual(parameterCount, { U32: 12, BF16: 3 });
 		});
 	});
 

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -51,6 +51,10 @@ const MAX_SHARD_COUNT = 10_000; // well above any real sharded model; blocks cra
 const MAX_TENSOR_DIM = 2 ** 32;
 const GPTQ_QWEIGHT_SUFFIX = "qweight";
 const GPTQ_AWQ_AUXILIARY_SUFFIXES = ["qzeros", "g_idx", "scales"];
+const MLX_QUANTIZATION_METHOD = "mlx";
+const MLX_QUANTIZATION_MODES: ReadonlySet<string> = new Set(["affine", "mxfp4", "nvfp4", "mxfp8"]);
+const MLX_AFFINE_BITS: ReadonlySet<number> = new Set([2, 3, 4, 5, 6, 8]);
+const MLX_AFFINE_GROUP_SIZES: ReadonlySet<number> = new Set([32, 64, 128]);
 
 /**
  * Block/group scales and zero-points stored alongside quantized weights. They are quantization
@@ -598,7 +602,8 @@ export async function parseSafetensorsMetadata(
 
 	// Fetch model config for quantization information
 	const modelConfig = params.computeParametersCount ? await fetchModelConfig(params) : null;
-	const quantConfig = modelConfig?.quantization_config ?? modelConfig?.text_config?.quantization_config;
+	const quantConfig =
+		getModelQuantizationConfig(modelConfig) ?? getModelQuantizationConfig(modelConfig?.text_config ?? null);
 	const expertDtype = modelConfig?.expert_dtype ?? modelConfig?.text_config?.expert_dtype;
 
 	// Resolve which file to parse, in order:
@@ -681,6 +686,9 @@ export async function parseSafetensorsMetadata(
 
 export interface QuantizationConfig {
 	quant_method?: string;
+	/** MLX quantization mode (e.g. `affine`); MLX configs do not declare `quant_method`. */
+	mode?: string;
+	group_size?: number;
 	modules_to_not_convert?: string[];
 	bits?: number;
 	load_in_4bit?: boolean;
@@ -695,15 +703,201 @@ export interface QuantizationConfig {
 	ignore?: string[];
 }
 
+export interface MlxQuantizationConfig extends QuantizationConfig {
+	[key: string]: unknown;
+}
+
+function getQuantizationMethod(quantConfig: QuantizationConfig | undefined): string | undefined {
+	return typeof quantConfig?.quant_method === "string" ? quantConfig.quant_method.toLowerCase() : undefined;
+}
+
 export interface ModelConfig {
-	quantization_config?: QuantizationConfig;
-	text_config?: { quantization_config?: QuantizationConfig } & Pick<ModelConfig, "expert_dtype">;
+	/** Current MLX format, optionally with per-module overrides keyed by module name. */
+	quantization?: MlxQuantizationConfig;
+	quantization_config?: QuantizationConfig | MlxQuantizationConfig;
+	text_config?: Pick<ModelConfig, "expert_dtype" | "quantization" | "quantization_config">;
 	/**
 	 * Some MoEs store their experts at a narrower precision than the rest of the model and declare
 	 * it here, *outside* `quantization_config` (e.g. DeepSeek-V4 is `quant_method: "fp8"` for
 	 * attention but `expert_dtype: "fp4"` for the experts, which dominate the parameter count).
 	 */
 	expert_dtype?: string;
+}
+
+interface MlxQuantizationParameters {
+	bits: number;
+	groupSize: number;
+	mode: string;
+}
+
+const MLX_MODE_DEFAULTS: Readonly<Record<string, { bits: number; groupSize: number }>> = {
+	affine: { bits: 4, groupSize: 64 },
+	mxfp4: { bits: 4, groupSize: 32 },
+	nvfp4: { bits: 4, groupSize: 16 },
+	mxfp8: { bits: 8, groupSize: 32 },
+};
+
+/** Validates a complete set of MLX parameters. Config is untrusted and defines the safety cap. */
+function parseMlxQuantizationParameters(
+	bits: unknown,
+	groupSize: unknown,
+	mode: unknown,
+): MlxQuantizationParameters | undefined {
+	if (mode !== undefined && typeof mode !== "string") {
+		return undefined;
+	}
+	const normalizedMode = (mode ?? "affine").toLowerCase();
+	if (!MLX_QUANTIZATION_MODES.has(normalizedMode)) {
+		return undefined;
+	}
+	const defaults = MLX_MODE_DEFAULTS[normalizedMode];
+	const resolvedBits = bits ?? defaults.bits;
+	const resolvedGroupSize = groupSize ?? defaults.groupSize;
+	if (
+		typeof resolvedBits !== "number" ||
+		!Number.isInteger(resolvedBits) ||
+		typeof resolvedGroupSize !== "number" ||
+		!Number.isInteger(resolvedGroupSize)
+	) {
+		return undefined;
+	}
+
+	const valid =
+		(normalizedMode === "affine" &&
+			MLX_AFFINE_BITS.has(resolvedBits) &&
+			MLX_AFFINE_GROUP_SIZES.has(resolvedGroupSize)) ||
+		(normalizedMode === "mxfp4" && resolvedBits === 4 && resolvedGroupSize === 32) ||
+		(normalizedMode === "nvfp4" && resolvedBits === 4 && resolvedGroupSize === 16) ||
+		(normalizedMode === "mxfp8" && resolvedBits === 8 && resolvedGroupSize === 32);
+	return valid ? { bits: resolvedBits, groupSize: resolvedGroupSize, mode: normalizedMode } : undefined;
+}
+
+function hasMlxParameterFields(value: Record<string, unknown>): boolean {
+	return "bits" in value || "group_size" in value || "mode" in value;
+}
+
+function hasValidMlxConfiguration(quantConfig: QuantizationConfig & Record<string, unknown>): boolean {
+	if (
+		hasMlxParameterFields(quantConfig) &&
+		parseMlxQuantizationParameters(quantConfig.bits, quantConfig.group_size, quantConfig.mode)
+	) {
+		return true;
+	}
+	return Object.values(quantConfig).some(
+		(value) =>
+			typeof value === "object" &&
+			value !== null &&
+			hasMlxParameterFields(value as Record<string, unknown>) &&
+			Boolean(
+				parseMlxQuantizationParameters(
+					(value as { bits?: unknown }).bits,
+					(value as { group_size?: unknown }).group_size,
+					(value as { mode?: unknown }).mode,
+				),
+			),
+	);
+}
+
+/**
+ * Normalizes MLX's `quantization` convention into the existing quantization dispatch.
+ *
+ * Current mlx-lm writes both `quantization` and `quantization_config`, but older repositories may
+ * only have the latter. Unlike Transformers quantizers, MLX does not write `quant_method`; its
+ * recognized `mode` plus a supported bit width is the identifying information.
+ */
+function getModelQuantizationConfig(modelConfig: ModelConfig | null): QuantizationConfig | undefined {
+	const mlxConfig = modelConfig?.quantization;
+	const mlxMethod = getQuantizationMethod(mlxConfig);
+	if (
+		mlxConfig &&
+		(mlxConfig.quant_method === undefined || mlxMethod === MLX_QUANTIZATION_METHOD) &&
+		hasValidMlxConfiguration(mlxConfig)
+	) {
+		return {
+			...mlxConfig,
+			quant_method: MLX_QUANTIZATION_METHOD,
+			mode: mlxConfig.mode ?? "affine",
+		};
+	}
+
+	const quantConfig = modelConfig?.quantization_config;
+	const quantMethod = getQuantizationMethod(quantConfig);
+	if (quantConfig && (quantConfig.quant_method === undefined || quantMethod === MLX_QUANTIZATION_METHOD)) {
+		const mode = quantConfig.mode ?? "affine";
+		if (hasValidMlxConfiguration(quantConfig as QuantizationConfig & Record<string, unknown>)) {
+			return { ...quantConfig, mode, quant_method: MLX_QUANTIZATION_METHOD };
+		}
+	}
+	return quantConfig;
+}
+
+/** Resolves MLX's optional per-module quantization override for one tensor. */
+function getMlxQuantizationParameters(
+	tensorName: string,
+	quantConfig: QuantizationConfig,
+): MlxQuantizationParameters | undefined {
+	const moduleName = getTensorModuleName(tensorName);
+	const moduleConfig = (quantConfig as QuantizationConfig & Record<string, unknown>)[moduleName];
+	if (moduleConfig === false) {
+		return undefined;
+	}
+
+	const override =
+		typeof moduleConfig === "object" && moduleConfig !== null
+			? (moduleConfig as { bits?: unknown; group_size?: unknown; mode?: unknown })
+			: undefined;
+	return override
+		? parseMlxQuantizationParameters(override.bits, override.group_size, override.mode)
+		: parseMlxQuantizationParameters(quantConfig.bits, quantConfig.group_size, quantConfig.mode);
+}
+
+function getTensorModuleName(tensorName: string): string {
+	const suffixIndex = tensorName.lastIndexOf(".");
+	return suffixIndex === -1 ? tensorName : tensorName.slice(0, suffixIndex);
+}
+
+/**
+ * Identifies actual MLX-packed modules across all shards. A global MLX config only applies where
+ * the serialized weights contain the sibling `.scales` tensor mlx-lm itself uses as its signal;
+ * affine modules also require their serialized zero points (`.biases`). Requiring a U32 `.weight`
+ * avoids dropping an unrelated learned tensor merely because its name ends in `.scales` or `.biases`.
+ */
+function getMlxQuantizedModules(
+	headers: SafetensorsFileHeader[],
+	quantConfig?: QuantizationConfig,
+): ReadonlySet<string> | undefined {
+	if (!quantConfig || getQuantizationMethod(quantConfig) !== MLX_QUANTIZATION_METHOD) {
+		return undefined;
+	}
+
+	const modulesWithScales = new Set<string>();
+	const modulesWithBiases = new Set<string>();
+	const modulesWithU32Weights = new Set<string>();
+	for (const header of headers) {
+		for (const [tensorName, info] of typedEntries(omit(header, "__metadata__"))) {
+			const suffix = getTensorSuffix(tensorName);
+			if (suffix === "scales") {
+				modulesWithScales.add(getTensorModuleName(tensorName));
+			} else if (suffix === "biases") {
+				modulesWithBiases.add(getTensorModuleName(tensorName));
+			} else if (suffix === "weight" && info.dtype === "U32") {
+				modulesWithU32Weights.add(getTensorModuleName(tensorName));
+			}
+		}
+	}
+
+	const quantizedModules = new Set<string>();
+	for (const moduleName of modulesWithU32Weights) {
+		const params = getMlxQuantizationParameters(`${moduleName}.weight`, quantConfig);
+		if (
+			params &&
+			modulesWithScales.has(moduleName) &&
+			(params.mode !== "affine" || modulesWithBiases.has(moduleName))
+		) {
+			quantizedModules.add(moduleName);
+		}
+	}
+	return quantizedModules;
 }
 
 /**
@@ -748,9 +942,19 @@ export function globMatch(pattern: string, str: string): boolean {
  * so bare names like `"lm_head"` must match `"model.lm_head.weight"`. When the
  * pattern contains a `*` we fall back to proper glob matching for flexibility.
  */
-export function isQuantizedTensor(tensorName: string, quantConfig?: QuantizationConfig): boolean {
+export function isQuantizedTensor(
+	tensorName: string,
+	quantConfig?: QuantizationConfig,
+	mlxQuantizedModules?: ReadonlySet<string>,
+): boolean {
 	if (!quantConfig) {
 		return false;
+	}
+	if (getQuantizationMethod(quantConfig) === MLX_QUANTIZATION_METHOD) {
+		return (
+			getMlxQuantizationParameters(tensorName, quantConfig) !== undefined &&
+			(mlxQuantizedModules === undefined || mlxQuantizedModules.has(getTensorModuleName(tensorName)))
+		);
 	}
 	// compressed-tensors spells the same concept `ignore`, with `re:`-prefixed targets
 	if (quantConfig.ignore?.length) {
@@ -813,14 +1017,24 @@ export function getQuantizationMultiplier(
 	dtype: Dtype,
 	quantConfig?: QuantizationConfig,
 	expertDtype?: string,
+	mlxQuantizedModules?: ReadonlySet<string>,
 ): number {
-	if (!quantConfig || !isQuantizedTensor(tensorName, quantConfig)) {
+	if (!quantConfig || !isQuantizedTensor(tensorName, quantConfig, mlxQuantizedModules)) {
 		return 1;
 	}
 
-	const quantMethod = quantConfig.quant_method?.toLowerCase();
+	const quantMethod = getQuantizationMethod(quantConfig);
 
 	switch (quantMethod) {
+		case MLX_QUANTIZATION_METHOD: {
+			// MLX packs quantized weights into U32 containers. `scales` and `biases` are handled
+			// separately by shouldSkipTensor; singular `.bias` remains a real model parameter.
+			if (dtype !== "U32" || getTensorSuffix(tensorName) !== "weight") {
+				return 1;
+			}
+			return packingFactor(dtype, getMlxQuantizationParameters(tensorName, quantConfig)?.bits);
+		}
+
 		case "mxfp4":
 			if (dtype === "U8" && tensorName.includes("_blocks")) {
 				return 2;
@@ -910,11 +1124,25 @@ export function computeNumOfParamsByDtypeSingleFile(
 	quantConfig?: QuantizationConfig,
 	expertDtype?: string,
 ): Partial<Record<Dtype, number>> {
+	return computeNumOfParamsByDtypeForHeader(
+		header,
+		quantConfig,
+		expertDtype,
+		getMlxQuantizedModules([header], quantConfig),
+	);
+}
+
+function computeNumOfParamsByDtypeForHeader(
+	header: SafetensorsFileHeader,
+	quantConfig?: QuantizationConfig,
+	expertDtype?: string,
+	mlxQuantizedModules?: ReadonlySet<string>,
+): Partial<Record<Dtype, number>> {
 	const counter: Partial<Record<Dtype, number>> = {};
 	const tensors = omit(header, "__metadata__");
 
 	for (const [tensorName, v] of typedEntries(tensors)) {
-		if (shouldSkipTensor(tensorName, v.dtype, quantConfig)) {
+		if (shouldSkipTensor(tensorName, v.dtype, quantConfig, mlxQuantizedModules)) {
 			continue;
 		}
 		if (v.shape.length === 0) {
@@ -925,7 +1153,9 @@ export function computeNumOfParamsByDtypeSingleFile(
 		if (!Number.isFinite(elements)) {
 			continue;
 		}
-		const multiplier = quantConfig ? getQuantizationMultiplier(tensorName, v.dtype, quantConfig, expertDtype) : 1;
+		const multiplier = quantConfig
+			? getQuantizationMultiplier(tensorName, v.dtype, quantConfig, expertDtype, mlxQuantizedModules)
+			: 1;
 		if (multiplier === 0) {
 			continue;
 		}
@@ -942,8 +1172,12 @@ function computeNumOfParamsByDtypeSharded(
 	expertDtype?: string,
 ): Partial<Record<Dtype, number>> {
 	const counter: Partial<Record<Dtype, number>> = {};
-	for (const header of Object.values(shardedMap)) {
-		for (const [k, v] of typedEntries(computeNumOfParamsByDtypeSingleFile(header, quantConfig, expertDtype))) {
+	const headers = Object.values(shardedMap);
+	const mlxQuantizedModules = getMlxQuantizedModules(headers, quantConfig);
+	for (const header of headers) {
+		for (const [k, v] of typedEntries(
+			computeNumOfParamsByDtypeForHeader(header, quantConfig, expertDtype, mlxQuantizedModules),
+		)) {
 			counter[k] = (counter[k] ?? 0) + (v ?? 0);
 		}
 	}
@@ -955,7 +1189,12 @@ function getTensorSuffix(tensorName: string): string {
 	return lastDotIndex === -1 ? tensorName : tensorName.slice(lastDotIndex + 1);
 }
 
-function shouldSkipTensor(tensorName: string, dtype: Dtype, quantConfig?: QuantizationConfig): boolean {
+function shouldSkipTensor(
+	tensorName: string,
+	dtype: Dtype,
+	quantConfig?: QuantizationConfig,
+	mlxQuantizedModules?: ReadonlySet<string>,
+): boolean {
 	// Exponent-only dtypes only ever hold MX block scales, so they're never parameters — true even
 	// with no quantization_config at all, since a model can ship scales without declaring a config.
 	if (SCALE_ONLY_DTYPES.has(dtype)) {
@@ -968,7 +1207,13 @@ function shouldSkipTensor(tensorName: string, dtype: Dtype, quantConfig?: Quanti
 	if (QUANTIZATION_AUXILIARY_SUFFIXES.includes(getTensorSuffix(tensorName))) {
 		return true;
 	}
-	const quantMethod = quantConfig.quant_method?.toLowerCase();
+	const quantMethod = getQuantizationMethod(quantConfig);
+
+	if (quantMethod === MLX_QUANTIZATION_METHOD && isQuantizedTensor(tensorName, quantConfig, mlxQuantizedModules)) {
+		const suffix = getTensorSuffix(tensorName);
+		const mode = getMlxQuantizationParameters(tensorName, quantConfig)?.mode;
+		return suffix === "scales" || (suffix === "biases" && mode === "affine");
+	}
 
 	// gpt-oss-style mxfp4 keeps the UE8M0 block exponents in `..._scales` next to `..._blocks`.
 	// Gated on the U8 container the scales actually use, so a learnable `*_scales` parameter in some


### PR DESCRIPTION
## Summary

Fixes huggingface/hub-docs#2704.

Packed MLX weights are stored in `U32` containers, so counting stored elements under-reports logical parameters and rejects valid `total_parameters` metadata.

Affected examples:

- [`avlp12/Motif-3-Alis-MLX-8bit`](https://hf.co/avlp12/Motif-3-Alis-MLX-8bit): 88.6B reported instead of 314.8B
- [`North-Micro-Vision-Instruct` 4-bit](https://hf.co/mlx-community/North-Micro-Vision-Instruct-4bit), [6-bit](https://hf.co/mlx-community/North-Micro-Vision-Instruct-6bit), and [8-bit](https://hf.co/mlx-community/North-Micro-Vision-Instruct-8bit): the same 2.485B model reports different totals by bit width

This change recognizes validated MLX configs, expands packed weights by `32 / bits`, supports per-module and sharded settings, and excludes confirmed scales and zero-point biases. The existing cap on untrusted metadata remains in place.

MLX needs its own adapter in the common quantization flow because the storage layouts differ: the existing MXFP4 branch expects `U8` `*_blocks`/`*_scales`; MLX MXFP4 uses `U32` `.weight`/`.scales`; compressed-tensors uses `format`/`config_groups`; and GPTQ/AWQ uses `.qweight`/`.qzeros`.

## Verification

- Affected models resolve to 314.6B, 314.8B, and a consistent 2.485B across the North variants
- 71 parser tests, type checking, linting, and formatting pass