### PR TITLE
Replace KerasFormers with ZeroModels entry for download counting

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -756,11 +756,11 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.keras_hub,
 		filter: true,
 	},
-	kerasformers: {
-		prettyLabel: "KerasFormers",
-		repoName: "KerasFormers",
-		repoUrl: "https://github.com/IMvision12/KerasFormers",
-		docsUrl: "https://imvision12.github.io/KerasFormers/",
+	zeromodels: {
+		prettyLabel: "ZeroModels",
+		repoName: "ZeroModels",
+		repoUrl: "https://github.com/IMvision12/ZeroModels",
+		docsUrl: "https://imvision12.github.io/ZeroModels/",
 		countDownloads: `path:"model.weights.h5" OR path:"model.weights.json"`,
 		filter: false,
 	},


### PR DESCRIPTION
Renaming our library identifier from kerasformers to zeromodels. The original name collided with Keras's own branding "kerasformers" read as an official Keras/Keras-Hub sub-project, which it isn't, causing confusion about ownership and affiliation.

https://huggingface.co/zeromodels

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only registry rename in the tasks package; no runtime logic changes beyond how this library is labeled and counted on the Hub.
> 
> **Overview**
> Renames the Hub **library_name** registry entry from **`kerasformers`** to **`zeromodels`** in `MODEL_LIBRARIES_UI_ELEMENTS`, updating labels and links to the **ZeroModels** GitHub repo and docs while keeping the same download-count query (`model.weights.h5` / `model.weights.json`) and **`filter: false`**.
> 
> Models should use **`library_name: zeromodels`** on the Hub so UI and download stats align with the new identifier and avoid confusion with official Keras branding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c71a9b695ff4bd3cc70aa93ac84793b0474e30e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->