### PR TITLE
perf(blake3-jit,xetchunk): 8-way interleaved SIMD + shared wasm memory — E2E chunking +15-17%, ~2/3 of native Rust --release (same-core)

### DIFF
--- a/packages/blake3-jit/src/index.ts
+++ b/packages/blake3-jit/src/index.ts
@@ -52,7 +52,7 @@ import { Hasher } from "./hasher.js";
  * ```
  */
 export function createKeyed(key: Uint8Array): Hasher {
-  return Hasher.newKeyed(key);
+	return Hasher.newKeyed(key);
 }
 
 /**
@@ -69,7 +69,7 @@ export function createKeyed(key: Uint8Array): Hasher {
  * ```
  */
 export function createDeriveKey(context: string): Hasher {
-  return Hasher.newDeriveKey(context);
+	return Hasher.newDeriveKey(context);
 }
 
 /**
@@ -86,7 +86,7 @@ export function createDeriveKey(context: string): Hasher {
  * ```
  */
 export function createHasher(): Hasher {
-  return new Hasher();
+	return new Hasher();
 }
 
 // Import for default export
@@ -95,17 +95,17 @@ import { hash, hashInto, warmupSimd } from "./hash.js";
 // Pre-warm SIMD in browser environments (non-blocking)
 // This avoids initialization latency on first large hash
 if (typeof globalThis !== "undefined" && typeof globalThis.document !== "undefined") {
-  queueMicrotask(() => {
-    warmupSimd();
-  });
+	queueMicrotask(() => {
+		warmupSimd();
+	});
 }
 
 // Default export for convenience
 export default {
-  hash,
-  hashInto,
-  Hasher,
-  createHasher,
-  createKeyed,
-  createDeriveKey,
+	hash,
+	hashInto,
+	Hasher,
+	createHasher,
+	createKeyed,
+	createDeriveKey,
 };

--- a/packages/blake3-jit/src/index.ts
+++ b/packages/blake3-jit/src/index.ts
@@ -27,6 +27,11 @@
 export { Hasher, XofReader } from "./hasher.js";
 export { hash, hashInto, warmupSimd } from "./hash.js";
 
+// Shared-memory one-shot engine (advanced; used by @huggingface/xetchunk-wasm
+// to hash regions of a shared WebAssembly.Memory in place)
+export { getOneShotContext, ensureOneShotCapacity, runOneShotRegion, ONESHOT_RESERVED_END } from "./wasm-oneshot.js";
+export { KEYED_HASH } from "./constants.js";
+
 // Convenience imports
 import { Hasher } from "./hasher.js";
 

--- a/packages/blake3-jit/src/wasm-oneshot.ts
+++ b/packages/blake3-jit/src/wasm-oneshot.ts
@@ -1195,7 +1195,7 @@ export function runOneShotRegion(
 	// zero-pad the final block in place (wasm always reads full 64-byte
 	// blocks), saving the clobbered bytes for restore below
 	const padStart = ptr + len;
-	const padEnd = ptr + (((len + 63) & ~63) || 64);
+	const padEnd = ptr + ((len + 63) & ~63 || 64);
 	const padLen = padEnd - padStart;
 	if (padLen > 0) {
 		padSave.set(view8.subarray(padStart, padEnd));

--- a/packages/blake3-jit/src/wasm-oneshot.ts
+++ b/packages/blake3-jit/src/wasm-oneshot.ts
@@ -60,7 +60,9 @@ function lebU(n: number): number[] {
 	do {
 		let b = v & 0x7f;
 		v >>>= 7;
-		if (v !== 0) {b |= 0x80;}
+		if (v !== 0) {
+			b |= 0x80;
+		}
 		out.push(b);
 	} while (v !== 0);
 	return out;
@@ -223,7 +225,18 @@ function emitVecRounds(c: Code, groups: VecGroup[], interleave: VecInterleave = 
 			// s[a] = s[a] + s[b] + m
 			for (let gi = 0; gi < gs.length; gi++) {
 				for (let i = 0; i < 4; i++) {
-					c.push(LOCAL_GET, sa[gi][i], LOCAL_GET, sb[gi][i], ...V_ADD, LOCAL_GET, msg[gi][i], ...V_ADD, LOCAL_SET, sa[gi][i]);
+					c.push(
+						LOCAL_GET,
+						sa[gi][i],
+						LOCAL_GET,
+						sb[gi][i],
+						...V_ADD,
+						LOCAL_GET,
+						msg[gi][i],
+						...V_ADD,
+						LOCAL_SET,
+						sa[gi][i],
+					);
 				}
 			}
 			// s[d] = rotr16/8(s[d] ^ s[a])
@@ -584,40 +597,42 @@ function buildLeafGroup(): Code {
 }
 
 /**
- * Function 5: leafGroup8(inPtr, counterLo, cvOutPtr)
- * Compress 8 consecutive FULL chunks (8192 bytes) as TWO independent 4-lane
+ * Function 5: leafGroupN(inPtr, counterLo, cvOutPtr)
+ * Compress nGroups*4 consecutive FULL chunks as nGroups independent 4-lane
  * SIMD groups whose instruction streams are interleaved, hiding the serial
- * add→xor→rotate dependency chains of a single group. Writes 8 lane-major
- * CVs (256 bytes) to cvOutPtr.
+ * add→xor→rotate dependency chains of a single group. Writes nGroups*4
+ * lane-major CVs (nGroups*128 bytes) to cvOutPtr.
  */
-function buildLeafGroup8(interleave: VecInterleave): Code {
+function buildLeafGroupN(nGroups: number, interleave: VecInterleave): Code {
 	const c: Code = [];
-	// locals: 3 x i32 (pos=3, addr=4, flagsBase=5), 78 x v128 ($6..$83)
-	c.push(0x02, 0x03, 0x7f, 0x4e, 0x7b);
-	const MA = 6; // 6..21
-	const MB = 22; // 22..37
-	const SA = 38; // 38..53
-	const SB = 54; // 54..69
-	const T = 70; // 70..77
-	const CTRA = 78;
-	const CTRB = 79;
+	// locals: 3 x i32 (pos=3, addr=4, flagsBase=5), then per group 16 message
+	// + 16 state v128 locals, 8 shared temps, and one counter vector per group.
+	const numV128 = nGroups * 32 + 8 + nGroups;
+	c.push(0x02, 0x03, 0x7f, numV128, 0x7b);
+	const M = (g: number) => 6 + g * 32; // 16 message words
+	const S = (g: number) => 6 + g * 32 + 16; // 16 state words
+	const T = 6 + nGroups * 32; // 8 shared temps
+	const CTR = (g: number) => T + 8 + g;
 
 	// flagsBase = mem[FLAGS]
 	emitI32Const(c, FLAGS_OFF);
 	emitI32Load(c, 0);
 	c.push(LOCAL_SET, 5);
-	// ctrA = splat(counterLo) + [0,1,2,3]; ctrB = splat(counterLo) + [4,5,6,7]
-	c.push(LOCAL_GET, 1, ...V_SPLAT);
-	emitV128Const(c, [0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]);
-	c.push(...V_ADD, LOCAL_SET, CTRA);
-	c.push(LOCAL_GET, 1, ...V_SPLAT);
-	emitV128Const(c, [4, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0]);
-	c.push(...V_ADD, LOCAL_SET, CTRB);
-	// sA0..7 = sB0..7 = splat(key[i]) - the CVs carry across all 16 blocks
+	// ctr[g] = splat(counterLo) + [g*4, g*4+1, g*4+2, g*4+3]
+	for (let g = 0; g < nGroups; g++) {
+		c.push(LOCAL_GET, 1, ...V_SPLAT);
+		emitV128Const(c, [g * 4, 0, 0, 0, g * 4 + 1, 0, 0, 0, g * 4 + 2, 0, 0, 0, g * 4 + 3, 0, 0, 0]);
+		c.push(...V_ADD, LOCAL_SET, CTR(g));
+	}
+	// s0..s7 = splat(key[i]) in every group - the CVs carry across all 16 blocks
 	for (let i = 0; i < 8; i++) {
 		emitI32Const(c, KEY_OFF);
 		emitI32Load(c, i * 4);
-		c.push(...V_SPLAT, LOCAL_TEE, SA + i, LOCAL_SET, SB + i);
+		c.push(...V_SPLAT);
+		for (let g = 0; g < nGroups - 1; g++) {
+			c.push(LOCAL_TEE, S(g) + i);
+		}
+		c.push(LOCAL_SET, S(nGroups - 1) + i);
 	}
 	// pos = 0
 	emitI32Const(c, 0);
@@ -628,42 +643,55 @@ function buildLeafGroup8(interleave: VecInterleave): Code {
 		// addr = inPtr + (pos << 6)
 		c.push(LOCAL_GET, 0, LOCAL_GET, 3, I32_CONST, 6, I32_SHL, I32_ADD, LOCAL_SET, 4);
 		// load + transpose 16 message words per group (lane stride = 1024);
-		// group B lanes live 4096 bytes further in.
+		// group g's lanes live g*4096 bytes further in.
 		for (let wg = 0; wg < 4; wg++) {
-			emitTransposedLoad(c, 4, 1024, wg, MA, T);
-			emitTransposedLoad(c, 4, 1024, wg, MB, T, 4096);
+			for (let g = 0; g < nGroups; g++) {
+				emitTransposedLoad(c, 4, 1024, wg, M(g), T, g * 4096);
+			}
 		}
 		// s8..s11 = IV[0..3]
 		for (let i = 0; i < 4; i++) {
 			emitV128Const(c, splatBytes(IV[i]));
-			c.push(LOCAL_TEE, SA + 8 + i, LOCAL_SET, SB + 8 + i);
+			for (let g = 0; g < nGroups - 1; g++) {
+				c.push(LOCAL_TEE, S(g) + 8 + i);
+			}
+			c.push(LOCAL_SET, S(nGroups - 1) + 8 + i);
 		}
 		// s12 = ctr, s13 = 0, s14 = 64
-		c.push(LOCAL_GET, CTRA, LOCAL_SET, SA + 12);
-		c.push(LOCAL_GET, CTRB, LOCAL_SET, SB + 12);
+		for (let g = 0; g < nGroups; g++) {
+			c.push(LOCAL_GET, CTR(g), LOCAL_SET, S(g) + 12);
+		}
 		emitV128Const(c, new Array(16).fill(0));
-		c.push(LOCAL_TEE, SA + 13, LOCAL_SET, SB + 13);
+		for (let g = 0; g < nGroups - 1; g++) {
+			c.push(LOCAL_TEE, S(g) + 13);
+		}
+		c.push(LOCAL_SET, S(nGroups - 1) + 13);
 		emitV128Const(c, splatBytes(64));
-		c.push(LOCAL_TEE, SA + 14, LOCAL_SET, SB + 14);
+		for (let g = 0; g < nGroups - 1; g++) {
+			c.push(LOCAL_TEE, S(g) + 14);
+		}
+		c.push(LOCAL_SET, S(nGroups - 1) + 14);
 		// s15 = splat(flagsBase | (pos==0 ? CHUNK_START : 0) | (pos==15 ? CHUNK_END : 0))
 		c.push(LOCAL_GET, 5);
 		c.push(LOCAL_GET, 3, I32_EQZ);
 		c.push(LOCAL_GET, 3, I32_CONST, 15, I32_EQ, I32_CONST, 1, I32_SHL);
-		c.push(I32_OR, I32_OR, ...V_SPLAT, LOCAL_TEE, SA + 15, LOCAL_SET, SB + 15);
+		c.push(I32_OR, I32_OR, ...V_SPLAT);
+		for (let g = 0; g < nGroups - 1; g++) {
+			c.push(LOCAL_TEE, S(g) + 15);
+		}
+		c.push(LOCAL_SET, S(nGroups - 1) + 15);
 
 		emitVecRounds(
 			c,
-			[
-				{ s: SA, m: MA },
-				{ s: SB, m: MB },
-			],
+			Array.from({ length: nGroups }, (_, g) => ({ s: S(g), m: M(g) })),
 			interleave,
 		);
 
 		// cv[i] = s[i] ^ s[i+8]
 		for (let i = 0; i < 8; i++) {
-			c.push(LOCAL_GET, SA + i, LOCAL_GET, SA + 8 + i, ...V_XOR, LOCAL_SET, SA + i);
-			c.push(LOCAL_GET, SB + i, LOCAL_GET, SB + 8 + i, ...V_XOR, LOCAL_SET, SB + i);
+			for (let g = 0; g < nGroups; g++) {
+				c.push(LOCAL_GET, S(g) + i, LOCAL_GET, S(g) + 8 + i, ...V_XOR, LOCAL_SET, S(g) + i);
+			}
 		}
 		// pos++; loop while pos < 16
 		c.push(LOCAL_GET, 3, I32_CONST, 1, I32_ADD, LOCAL_TEE, 3);
@@ -671,8 +699,9 @@ function buildLeafGroup8(interleave: VecInterleave): Code {
 	}
 	c.push(END, END);
 
-	emitUntransposeStore(c, SA, T, 2);
-	emitUntransposeStore(c, SB, T, 2, 128);
+	for (let g = 0; g < nGroups; g++) {
+		emitUntransposeStore(c, S(g), T, 2, g * 128);
+	}
 	c.push(END);
 	return c;
 }
@@ -733,7 +762,7 @@ function buildParentGroup(): Code {
  * Full BLAKE3 of mem[INPUT .. INPUT+inputLen) with key/flags from memory.
  * Writes the 32-byte root hash to mem[OUT].
  */
-function buildHashOneShot(): Code {
+function buildHashOneShot(leafWide: number): Code {
 	const c: Code = [];
 	// locals: 7 x i32 - nf=1, rem=2, nc=3, i=4, cvCount=5, pairs=6, odd=7
 	c.push(0x01, 0x07, 0x7f);
@@ -755,33 +784,37 @@ function buildHashOneShot(): Code {
 	c.push(CALL, 0x01, RETURN);
 	c.push(END);
 
-	// === leaves, 8-wide (two interleaved 4-lane groups) ===
+	// === leaves, leafWide-wide (interleaved 4-lane groups) ===
 	// i = 0
 	emitI32Const(c, 0);
 	c.push(LOCAL_SET, 4);
 	c.push(BLOCK, VOID, LOOP, VOID);
 	{
-		c.push(LOCAL_GET, 4, I32_CONST, 8, I32_ADD, LOCAL_GET, 1, I32_GT_U, BR_IF, 0x01);
+		c.push(LOCAL_GET, 4, I32_CONST, leafWide, I32_ADD, LOCAL_GET, 1, I32_GT_U, BR_IF, 0x01);
 		emitI32Const(c, INPUT_OFF);
 		c.push(LOCAL_GET, 4, I32_CONST, 10, I32_SHL, I32_ADD);
 		c.push(LOCAL_GET, 4);
 		emitI32Const(c, CV_ARR_OFF);
 		c.push(LOCAL_GET, 4, I32_CONST, 5, I32_SHL, I32_ADD);
 		c.push(CALL, 0x05);
-		c.push(LOCAL_GET, 4, I32_CONST, 8, I32_ADD, LOCAL_SET, 4);
+		c.push(LOCAL_GET, 4, I32_CONST, leafWide, I32_ADD, LOCAL_SET, 4);
 		c.push(BR, 0x00);
 	}
 	c.push(END, END);
-	// 4-7 full chunks left: one 4-wide group
-	c.push(LOCAL_GET, 4, I32_CONST, 4, I32_ADD, LOCAL_GET, 1, I32_LE_U, IF, VOID);
-	emitI32Const(c, INPUT_OFF);
-	c.push(LOCAL_GET, 4, I32_CONST, 10, I32_SHL, I32_ADD);
-	c.push(LOCAL_GET, 4);
-	emitI32Const(c, CV_ARR_OFF);
-	c.push(LOCAL_GET, 4, I32_CONST, 5, I32_SHL, I32_ADD);
-	c.push(CALL, 0x02);
-	c.push(LOCAL_GET, 4, I32_CONST, 4, I32_ADD, LOCAL_SET, 4);
-	c.push(END);
+	// 4..leafWide-1 full chunks left: 4-wide groups
+	c.push(BLOCK, VOID, LOOP, VOID);
+	{
+		c.push(LOCAL_GET, 4, I32_CONST, 4, I32_ADD, LOCAL_GET, 1, I32_GT_U, BR_IF, 0x01);
+		emitI32Const(c, INPUT_OFF);
+		c.push(LOCAL_GET, 4, I32_CONST, 10, I32_SHL, I32_ADD);
+		c.push(LOCAL_GET, 4);
+		emitI32Const(c, CV_ARR_OFF);
+		c.push(LOCAL_GET, 4, I32_CONST, 5, I32_SHL, I32_ADD);
+		c.push(CALL, 0x02);
+		c.push(LOCAL_GET, 4, I32_CONST, 4, I32_ADD, LOCAL_SET, 4);
+		c.push(BR, 0x00);
+	}
+	c.push(END, END);
 	// tail of full chunks (1-3 remaining): run one more 4-wide group; the
 	// extra lanes read past the valid input (capacity guaranteed by JS) and
 	// their CVs are either never read or overwritten by the partial chunk below.
@@ -881,16 +914,23 @@ function buildHashOneShot(): Code {
 
 // ===== Module assembly =====
 
-// Interleave granularity for the 8-wide leaf kernel. Benchmarked on V8 11/2025
-// (Zen 5): "step" ≈ +17% over the 4-wide kernel; "quad" ≈ -60% (the whole
-// second state set stays live across each quad and the allocator thrashes).
-const LEAF8_INTERLEAVE: VecInterleave = "step";
+// Wide leaf kernel tuning, benchmarked on V8 13 (Zen 5), 11/2025:
+//  - interleave "step": +17% over the 4-wide kernel; "quad" is ~2.4x SLOWER
+//    than 4-wide (the whole second state set stays live across each quad and
+//    the register allocator thrashes).
+//  - groups: 2 (8-wide) is the sweet spot; 3 groups falls off a spill cliff
+//    (885 MB/s vs 1557 MB/s at 64KB). Note nGroups >= 4 would also need
+//    multi-byte LEB local declarations.
+const LEAF_INTERLEAVE: VecInterleave = "step";
+const LEAF_GROUPS = 2;
 
 function generateOneShotWasm(): Uint8Array {
 	const code: Code = [];
 
 	function put(bytes: number[]): void {
-		for (let i = 0; i < bytes.length; i++) {code.push(bytes[i]);}
+		for (let i = 0; i < bytes.length; i++) {
+			code.push(bytes[i]);
+		}
 	}
 
 	function section(id: number, contents: number[]): void {
@@ -906,7 +946,9 @@ function generateOneShotWasm(): Uint8Array {
 	const paramCounts = [6, 5, 3, 2, 1];
 	for (const n of paramCounts) {
 		types.push(0x60, n);
-		for (let i = 0; i < n; i++) {types.push(0x7f);}
+		for (let i = 0; i < n; i++) {
+			types.push(0x7f);
+		}
 		types.push(0x00);
 	}
 	section(0x01, types);
@@ -920,7 +962,9 @@ function generateOneShotWasm(): Uint8Array {
 	// Exports: hashOneShot -> func 4
 	const name = "hashOneShot";
 	const exp: Code = [0x01, name.length];
-	for (let i = 0; i < name.length; i++) {exp.push(name.charCodeAt(i));}
+	for (let i = 0; i < name.length; i++) {
+		exp.push(name.charCodeAt(i));
+	}
 	exp.push(0x00, 0x04);
 	section(0x07, exp);
 
@@ -930,13 +974,15 @@ function generateOneShotWasm(): Uint8Array {
 		buildChunkScalar(),
 		buildLeafGroup(),
 		buildParentGroup(),
-		buildHashOneShot(),
-		buildLeafGroup8(LEAF8_INTERLEAVE),
+		buildHashOneShot(LEAF_GROUPS * 4),
+		buildLeafGroupN(LEAF_GROUPS, LEAF_INTERLEAVE),
 	];
 	const codeSec: Code = [0x06];
 	for (const body of bodies) {
 		codeSec.push(...lebUPadded5(body.length));
-		for (let i = 0; i < body.length; i++) {codeSec.push(body[i]);}
+		for (let i = 0; i < body.length; i++) {
+			codeSec.push(body[i]);
+		}
 	}
 	section(0x0a, codeSec);
 
@@ -954,7 +1000,9 @@ let view32: Uint32Array = new Uint32Array(0);
 let initFailed = false;
 
 function refreshViews(): void {
-	if (!memory) {return;}
+	if (!memory) {
+		return;
+	}
 	view8 = new Uint8Array(memory.buffer);
 	view32 = new Uint32Array(memory.buffer);
 }
@@ -963,8 +1011,12 @@ function refreshViews(): void {
  * Initialize the one-shot engine (idempotent). Returns availability.
  */
 export function initOneShot(): boolean {
-	if (hashFn) {return true;}
-	if (initFailed || !IS_LE) {return false;}
+	if (hashFn) {
+		return true;
+	}
+	if (initFailed || !IS_LE) {
+		return false;
+	}
 	try {
 		if (
 			typeof WebAssembly === "undefined" ||
@@ -1003,7 +1055,9 @@ function generateSimdProbe(): Uint8Array {
 }
 
 function ensureCapacity(totalBytes: number): void {
-	if (view8.length >= totalBytes) {return;}
+	if (view8.length >= totalBytes) {
+		return;
+	}
 	const pages = Math.ceil((totalBytes - view8.length) / PAGE_SIZE);
 	(memory as WebAssembly.Memory).grow(pages);
 	refreshViews();
@@ -1026,10 +1080,14 @@ export interface OneShotOwner {
 let inputOwner: OneShotOwner | null = null;
 
 export function claimInput(owner: OneShotOwner | null): void {
-	if (inputOwner === owner) {return;}
+	if (inputOwner === owner) {
+		return;
+	}
 	const prev = inputOwner;
 	inputOwner = owner;
-	if (prev) {prev.evictOneShot();}
+	if (prev) {
+		prev.evictOneShot();
+	}
 }
 
 /**

--- a/packages/blake3-jit/src/wasm-oneshot.ts
+++ b/packages/blake3-jit/src/wasm-oneshot.ts
@@ -177,27 +177,42 @@ const V_SPLAT = [SIMD, 0x11]; // i32x4.splat
 const ROTR16 = [2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13];
 const ROTR8 = [1, 2, 3, 0, 5, 6, 7, 4, 9, 10, 11, 8, 13, 14, 15, 12];
 
-/**
- * Emit the 7 rounds of SIMD (4-wide) BLAKE3 mixing.
- * State lives in v128 locals [sBase..sBase+15], message in [mBase..mBase+15].
- */
-function emitVecRounds(c: Code, sBase: number, mBase: number): void {
-	let msgIdx = 0;
+/** One independent 4-lane SIMD mixing group: state + message local bases. */
+interface VecGroup {
+	s: number;
+	m: number;
+}
 
+/** Interleave granularity for multi-group emission (perf A/B knob). */
+export type VecInterleave = "step" | "quad";
+
+/**
+ * Emit the 7 rounds of SIMD (4-wide) BLAKE3 mixing for one or more
+ * independent groups. With several groups the instruction streams are
+ * interleaved to hide the serial add→xor→rotate dependency chains:
+ *  - "step": groups alternate at every G step (finest interleave)
+ *  - "quad": groups alternate per column/diagonal quad
+ */
+function emitVecRounds(c: Code, groups: VecGroup[], interleave: VecInterleave = "step"): void {
 	// One quad of independent G functions (4 columns or 4 diagonals), emitted
-	// interleaved step-by-step so the 4 dependency chains are adjacent in the
+	// interleaved step-by-step so the dependency chains are adjacent in the
 	// instruction stream (helps the register allocator / OoO scheduling).
-	function gQuad(quads: number[][]): void {
-		const mxs: number[] = [];
-		const mys: number[] = [];
-		for (let i = 0; i < 4; i++) {
-			mxs.push(mBase + MSG_ACCESS_ORDER[msgIdx++]);
-			mys.push(mBase + MSG_ACCESS_ORDER[msgIdx++]);
+	// msgBase indexes MSG_ACCESS_ORDER (shared schedule across groups).
+	function gQuad(quads: number[][], msgBase: number, gs: VecGroup[]): void {
+		const mxs: number[][] = [];
+		const mys: number[][] = [];
+		const sa: number[][] = [];
+		const sb: number[][] = [];
+		const sc: number[][] = [];
+		const sd: number[][] = [];
+		for (const g of gs) {
+			mxs.push(quads.map((_, i) => g.m + MSG_ACCESS_ORDER[msgBase + 2 * i]));
+			mys.push(quads.map((_, i) => g.m + MSG_ACCESS_ORDER[msgBase + 2 * i + 1]));
+			sa.push(quads.map((q) => g.s + q[0]));
+			sb.push(quads.map((q) => g.s + q[1]));
+			sc.push(quads.map((q) => g.s + q[2]));
+			sd.push(quads.map((q) => g.s + q[3]));
 		}
-		const sa = quads.map((q) => sBase + q[0]);
-		const sb = quads.map((q) => sBase + q[1]);
-		const sc = quads.map((q) => sBase + q[2]);
-		const sd = quads.map((q) => sBase + q[3]);
 
 		for (let half = 0; half < 2; half++) {
 			const msg = half === 0 ? mxs : mys;
@@ -206,43 +221,62 @@ function emitVecRounds(c: Code, sBase: number, mBase: number): void {
 			const shlB = half === 0 ? 20 : 25;
 
 			// s[a] = s[a] + s[b] + m
-			for (let i = 0; i < 4; i++) {
-				c.push(LOCAL_GET, sa[i], LOCAL_GET, sb[i], ...V_ADD, LOCAL_GET, msg[i], ...V_ADD, LOCAL_SET, sa[i]);
+			for (let gi = 0; gi < gs.length; gi++) {
+				for (let i = 0; i < 4; i++) {
+					c.push(LOCAL_GET, sa[gi][i], LOCAL_GET, sb[gi][i], ...V_ADD, LOCAL_GET, msg[gi][i], ...V_ADD, LOCAL_SET, sa[gi][i]);
+				}
 			}
 			// s[d] = rotr16/8(s[d] ^ s[a])
-			for (let i = 0; i < 4; i++) {
-				c.push(LOCAL_GET, sd[i], LOCAL_GET, sa[i], ...V_XOR, LOCAL_TEE, sd[i], LOCAL_GET, sd[i]);
-				emitShuffle(c, rotD);
-				c.push(LOCAL_SET, sd[i]);
+			for (let gi = 0; gi < gs.length; gi++) {
+				for (let i = 0; i < 4; i++) {
+					c.push(LOCAL_GET, sd[gi][i], LOCAL_GET, sa[gi][i], ...V_XOR, LOCAL_TEE, sd[gi][i], LOCAL_GET, sd[gi][i]);
+					emitShuffle(c, rotD);
+					c.push(LOCAL_SET, sd[gi][i]);
+				}
 			}
 			// s[c] = s[c] + s[d]
-			for (let i = 0; i < 4; i++) {
-				c.push(LOCAL_GET, sc[i], LOCAL_GET, sd[i], ...V_ADD, LOCAL_SET, sc[i]);
+			for (let gi = 0; gi < gs.length; gi++) {
+				for (let i = 0; i < 4; i++) {
+					c.push(LOCAL_GET, sc[gi][i], LOCAL_GET, sd[gi][i], ...V_ADD, LOCAL_SET, sc[gi][i]);
+				}
 			}
 			// s[b] = rotr12/7(s[b] ^ s[c])
-			for (let i = 0; i < 4; i++) {
-				c.push(LOCAL_GET, sb[i], LOCAL_GET, sc[i], ...V_XOR, LOCAL_TEE, sb[i]);
-				c.push(I32_CONST, shrB, ...V_SHR_U, LOCAL_GET, sb[i], I32_CONST, shlB, ...V_SHL, ...V_OR);
-				c.push(LOCAL_SET, sb[i]);
+			for (let gi = 0; gi < gs.length; gi++) {
+				for (let i = 0; i < 4; i++) {
+					c.push(LOCAL_GET, sb[gi][i], LOCAL_GET, sc[gi][i], ...V_XOR, LOCAL_TEE, sb[gi][i]);
+					c.push(I32_CONST, shrB, ...V_SHR_U, LOCAL_GET, sb[gi][i], I32_CONST, shlB, ...V_SHL, ...V_OR);
+					c.push(LOCAL_SET, sb[gi][i]);
+				}
 			}
 		}
 	}
 
+	const COLS = [
+		[0, 4, 8, 12],
+		[1, 5, 9, 13],
+		[2, 6, 10, 14],
+		[3, 7, 11, 15],
+	];
+	const DIAGS = [
+		[0, 5, 10, 15],
+		[1, 6, 11, 12],
+		[2, 7, 8, 13],
+		[3, 4, 9, 14],
+	];
+
 	for (let round = 0; round < 7; round++) {
-		// columns
-		gQuad([
-			[0, 4, 8, 12],
-			[1, 5, 9, 13],
-			[2, 6, 10, 14],
-			[3, 7, 11, 15],
-		]);
-		// diagonals
-		gQuad([
-			[0, 5, 10, 15],
-			[1, 6, 11, 12],
-			[2, 7, 8, 13],
-			[3, 4, 9, 14],
-		]);
+		const base = round * 16;
+		if (interleave === "step") {
+			gQuad(COLS, base, groups);
+			gQuad(DIAGS, base + 8, groups);
+		} else {
+			for (const g of groups) {
+				gQuad(COLS, base, [g]);
+			}
+			for (const g of groups) {
+				gQuad(DIAGS, base + 8, [g]);
+			}
+		}
 	}
 }
 
@@ -296,11 +330,12 @@ function emitTransposedLoad(
 	wg: number,
 	mBase: number,
 	tBase: number,
+	baseOff: number = 0,
 ): void {
 	// load rows r0..r3 into t0..t3
 	for (let lane = 0; lane < 4; lane++) {
 		c.push(LOCAL_GET, addrLocal);
-		emitV128Load(c, lane * laneStride + wg * 16);
+		emitV128Load(c, baseOff + lane * laneStride + wg * 16);
 		c.push(LOCAL_SET, tBase + lane);
 	}
 	// u0 = A(r0,r1), u1 = A(r2,r3), u2 = B(r0,r1), u3 = B(r2,r3)
@@ -336,10 +371,10 @@ function emitTransposedLoad(
  * stored at address in local(dstLocal) - CV j at dst + j*32.
  * s locals sBase..sBase+7 hold words 0..7 across lanes; t temps at tBase (4 used).
  */
-function emitUntransposeStore(c: Code, sBase: number, tBase: number, dstLocal: number): void {
+function emitUntransposeStore(c: Code, sBase: number, tBase: number, dstLocal: number, baseOff: number = 0): void {
 	for (let group = 0; group < 2; group++) {
 		const s0 = sBase + group * 4;
-		const byteOff = group * 16;
+		const byteOff = baseOff + group * 16;
 		c.push(LOCAL_GET, s0, LOCAL_GET, s0 + 1);
 		emitShuffle(c, SHUF_A);
 		c.push(LOCAL_SET, tBase);
@@ -531,7 +566,7 @@ function buildLeafGroup(): Code {
 		c.push(LOCAL_GET, 3, I32_CONST, 15, I32_EQ, I32_CONST, 1, I32_SHL);
 		c.push(I32_OR, I32_OR, ...V_SPLAT, LOCAL_SET, S + 15);
 
-		emitVecRounds(c, S, M);
+		emitVecRounds(c, [{ s: S, m: M }]);
 
 		// cv[i] = s[i] ^ s[i+8]
 		for (let i = 0; i < 8; i++) {
@@ -544,6 +579,100 @@ function buildLeafGroup(): Code {
 	c.push(END, END);
 
 	emitUntransposeStore(c, S, T, 2);
+	c.push(END);
+	return c;
+}
+
+/**
+ * Function 5: leafGroup8(inPtr, counterLo, cvOutPtr)
+ * Compress 8 consecutive FULL chunks (8192 bytes) as TWO independent 4-lane
+ * SIMD groups whose instruction streams are interleaved, hiding the serial
+ * add→xor→rotate dependency chains of a single group. Writes 8 lane-major
+ * CVs (256 bytes) to cvOutPtr.
+ */
+function buildLeafGroup8(interleave: VecInterleave): Code {
+	const c: Code = [];
+	// locals: 3 x i32 (pos=3, addr=4, flagsBase=5), 78 x v128 ($6..$83)
+	c.push(0x02, 0x03, 0x7f, 0x4e, 0x7b);
+	const MA = 6; // 6..21
+	const MB = 22; // 22..37
+	const SA = 38; // 38..53
+	const SB = 54; // 54..69
+	const T = 70; // 70..77
+	const CTRA = 78;
+	const CTRB = 79;
+
+	// flagsBase = mem[FLAGS]
+	emitI32Const(c, FLAGS_OFF);
+	emitI32Load(c, 0);
+	c.push(LOCAL_SET, 5);
+	// ctrA = splat(counterLo) + [0,1,2,3]; ctrB = splat(counterLo) + [4,5,6,7]
+	c.push(LOCAL_GET, 1, ...V_SPLAT);
+	emitV128Const(c, [0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]);
+	c.push(...V_ADD, LOCAL_SET, CTRA);
+	c.push(LOCAL_GET, 1, ...V_SPLAT);
+	emitV128Const(c, [4, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0]);
+	c.push(...V_ADD, LOCAL_SET, CTRB);
+	// sA0..7 = sB0..7 = splat(key[i]) - the CVs carry across all 16 blocks
+	for (let i = 0; i < 8; i++) {
+		emitI32Const(c, KEY_OFF);
+		emitI32Load(c, i * 4);
+		c.push(...V_SPLAT, LOCAL_TEE, SA + i, LOCAL_SET, SB + i);
+	}
+	// pos = 0
+	emitI32Const(c, 0);
+	c.push(LOCAL_SET, 3);
+
+	c.push(BLOCK, VOID, LOOP, VOID);
+	{
+		// addr = inPtr + (pos << 6)
+		c.push(LOCAL_GET, 0, LOCAL_GET, 3, I32_CONST, 6, I32_SHL, I32_ADD, LOCAL_SET, 4);
+		// load + transpose 16 message words per group (lane stride = 1024);
+		// group B lanes live 4096 bytes further in.
+		for (let wg = 0; wg < 4; wg++) {
+			emitTransposedLoad(c, 4, 1024, wg, MA, T);
+			emitTransposedLoad(c, 4, 1024, wg, MB, T, 4096);
+		}
+		// s8..s11 = IV[0..3]
+		for (let i = 0; i < 4; i++) {
+			emitV128Const(c, splatBytes(IV[i]));
+			c.push(LOCAL_TEE, SA + 8 + i, LOCAL_SET, SB + 8 + i);
+		}
+		// s12 = ctr, s13 = 0, s14 = 64
+		c.push(LOCAL_GET, CTRA, LOCAL_SET, SA + 12);
+		c.push(LOCAL_GET, CTRB, LOCAL_SET, SB + 12);
+		emitV128Const(c, new Array(16).fill(0));
+		c.push(LOCAL_TEE, SA + 13, LOCAL_SET, SB + 13);
+		emitV128Const(c, splatBytes(64));
+		c.push(LOCAL_TEE, SA + 14, LOCAL_SET, SB + 14);
+		// s15 = splat(flagsBase | (pos==0 ? CHUNK_START : 0) | (pos==15 ? CHUNK_END : 0))
+		c.push(LOCAL_GET, 5);
+		c.push(LOCAL_GET, 3, I32_EQZ);
+		c.push(LOCAL_GET, 3, I32_CONST, 15, I32_EQ, I32_CONST, 1, I32_SHL);
+		c.push(I32_OR, I32_OR, ...V_SPLAT, LOCAL_TEE, SA + 15, LOCAL_SET, SB + 15);
+
+		emitVecRounds(
+			c,
+			[
+				{ s: SA, m: MA },
+				{ s: SB, m: MB },
+			],
+			interleave,
+		);
+
+		// cv[i] = s[i] ^ s[i+8]
+		for (let i = 0; i < 8; i++) {
+			c.push(LOCAL_GET, SA + i, LOCAL_GET, SA + 8 + i, ...V_XOR, LOCAL_SET, SA + i);
+			c.push(LOCAL_GET, SB + i, LOCAL_GET, SB + 8 + i, ...V_XOR, LOCAL_SET, SB + i);
+		}
+		// pos++; loop while pos < 16
+		c.push(LOCAL_GET, 3, I32_CONST, 1, I32_ADD, LOCAL_TEE, 3);
+		c.push(I32_CONST, 16, I32_LT_U, BR_IF, 0x00);
+	}
+	c.push(END, END);
+
+	emitUntransposeStore(c, SA, T, 2);
+	emitUntransposeStore(c, SB, T, 2, 128);
 	c.push(END);
 	return c;
 }
@@ -589,7 +718,7 @@ function buildParentGroup(): Code {
 	emitI32Const(c, 4);
 	c.push(I32_OR, ...V_SPLAT, LOCAL_SET, S + 15);
 
-	emitVecRounds(c, S, M);
+	emitVecRounds(c, [{ s: S, m: M }]);
 
 	for (let i = 0; i < 8; i++) {
 		c.push(LOCAL_GET, S + i, LOCAL_GET, S + 8 + i, ...V_XOR, LOCAL_SET, S + i);
@@ -626,23 +755,33 @@ function buildHashOneShot(): Code {
 	c.push(CALL, 0x01, RETURN);
 	c.push(END);
 
-	// === leaves, 4-wide ===
+	// === leaves, 8-wide (two interleaved 4-lane groups) ===
 	// i = 0
 	emitI32Const(c, 0);
 	c.push(LOCAL_SET, 4);
 	c.push(BLOCK, VOID, LOOP, VOID);
 	{
-		c.push(LOCAL_GET, 4, I32_CONST, 4, I32_ADD, LOCAL_GET, 1, I32_GT_U, BR_IF, 0x01);
+		c.push(LOCAL_GET, 4, I32_CONST, 8, I32_ADD, LOCAL_GET, 1, I32_GT_U, BR_IF, 0x01);
 		emitI32Const(c, INPUT_OFF);
 		c.push(LOCAL_GET, 4, I32_CONST, 10, I32_SHL, I32_ADD);
 		c.push(LOCAL_GET, 4);
 		emitI32Const(c, CV_ARR_OFF);
 		c.push(LOCAL_GET, 4, I32_CONST, 5, I32_SHL, I32_ADD);
-		c.push(CALL, 0x02);
-		c.push(LOCAL_GET, 4, I32_CONST, 4, I32_ADD, LOCAL_SET, 4);
+		c.push(CALL, 0x05);
+		c.push(LOCAL_GET, 4, I32_CONST, 8, I32_ADD, LOCAL_SET, 4);
 		c.push(BR, 0x00);
 	}
 	c.push(END, END);
+	// 4-7 full chunks left: one 4-wide group
+	c.push(LOCAL_GET, 4, I32_CONST, 4, I32_ADD, LOCAL_GET, 1, I32_LE_U, IF, VOID);
+	emitI32Const(c, INPUT_OFF);
+	c.push(LOCAL_GET, 4, I32_CONST, 10, I32_SHL, I32_ADD);
+	c.push(LOCAL_GET, 4);
+	emitI32Const(c, CV_ARR_OFF);
+	c.push(LOCAL_GET, 4, I32_CONST, 5, I32_SHL, I32_ADD);
+	c.push(CALL, 0x02);
+	c.push(LOCAL_GET, 4, I32_CONST, 4, I32_ADD, LOCAL_SET, 4);
+	c.push(END);
 	// tail of full chunks (1-3 remaining): run one more 4-wide group; the
 	// extra lanes read past the valid input (capacity guaranteed by JS) and
 	// their CVs are either never read or overwritten by the partial chunk below.
@@ -742,6 +881,11 @@ function buildHashOneShot(): Code {
 
 // ===== Module assembly =====
 
+// Interleave granularity for the 8-wide leaf kernel. Benchmarked on V8 11/2025
+// (Zen 5): "step" ≈ +17% over the 4-wide kernel; "quad" ≈ -60% (the whole
+// second state set stays live across each quad and the allocator thrashes).
+const LEAF8_INTERLEAVE: VecInterleave = "step";
+
 function generateOneShotWasm(): Uint8Array {
 	const code: Code = [];
 
@@ -770,8 +914,8 @@ function generateOneShotWasm(): Uint8Array {
 	// Imports: memory js.mem
 	section(0x02, [0x01, 0x02, 0x6a, 0x73, 0x03, 0x6d, 0x65, 0x6d, 0x02, 0x00, INITIAL_PAGES]);
 
-	// Functions
-	section(0x03, [0x05, 0x00, 0x01, 0x02, 0x03, 0x04]);
+	// Functions (leafGroup8 shares leafGroup's 3-param type)
+	section(0x03, [0x06, 0x00, 0x01, 0x02, 0x03, 0x04, 0x02]);
 
 	// Exports: hashOneShot -> func 4
 	const name = "hashOneShot";
@@ -781,8 +925,15 @@ function generateOneShotWasm(): Uint8Array {
 	section(0x07, exp);
 
 	// Code section
-	const bodies = [buildCompressScalar(), buildChunkScalar(), buildLeafGroup(), buildParentGroup(), buildHashOneShot()];
-	const codeSec: Code = [0x05];
+	const bodies = [
+		buildCompressScalar(),
+		buildChunkScalar(),
+		buildLeafGroup(),
+		buildParentGroup(),
+		buildHashOneShot(),
+		buildLeafGroup8(LEAF8_INTERLEAVE),
+	];
+	const codeSec: Code = [0x06];
 	for (const body of bodies) {
 		codeSec.push(...lebUPadded5(body.length));
 		for (let i = 0; i < body.length; i++) {codeSec.push(body[i]);}

--- a/packages/blake3-jit/src/wasm-oneshot.ts
+++ b/packages/blake3-jit/src/wasm-oneshot.ts
@@ -758,26 +758,37 @@ function buildParentGroup(): Code {
 }
 
 /**
- * Function 4: hashOneShot(inputLen)
- * Full BLAKE3 of mem[INPUT .. INPUT+inputLen) with key/flags from memory.
- * Writes the 32-byte root hash to mem[OUT].
+ * Function 4: hashOneShot(inputPtr, inputLen)
+ * Full BLAKE3 of mem[inputPtr .. inputPtr+inputLen) with key/flags from
+ * memory. Writes the 32-byte root hash to mem[OUT].
+ * The caller must guarantee the final block is zero-padded in memory and
+ * that INPUT_SLACK readable bytes exist past the end of the input.
  */
 function buildHashOneShot(leafWide: number): Code {
 	const c: Code = [];
-	// locals: 7 x i32 - nf=1, rem=2, nc=3, i=4, cvCount=5, pairs=6, odd=7
+	const PTR = 0; // param: input pointer
+	const LEN = 1; // param: input length
+	const NF = 2; // locals...
+	const REM = 3;
+	const NC = 4;
+	const I = 5;
+	const CVCOUNT = 6;
+	const PAIRS = 7;
+	const ODD = 8;
+	// locals: 7 x i32
 	c.push(0x01, 0x07, 0x7f);
 
 	// nf = len >> 10; rem = len & 1023; nc = nf + (rem != 0)
-	c.push(LOCAL_GET, 0, I32_CONST, 10, I32_SHR_U, LOCAL_SET, 1);
-	c.push(LOCAL_GET, 0);
+	c.push(LOCAL_GET, LEN, I32_CONST, 10, I32_SHR_U, LOCAL_SET, NF);
+	c.push(LOCAL_GET, LEN);
 	emitI32Const(c, 1023);
-	c.push(I32_AND, LOCAL_SET, 2);
-	c.push(LOCAL_GET, 1, LOCAL_GET, 2, I32_CONST, 0, I32_NE, I32_ADD, LOCAL_SET, 3);
+	c.push(I32_AND, LOCAL_SET, REM);
+	c.push(LOCAL_GET, NF, LOCAL_GET, REM, I32_CONST, 0, I32_NE, I32_ADD, LOCAL_SET, NC);
 
 	// single-chunk (or empty) message: scalar chunk with ROOT
-	c.push(LOCAL_GET, 3, I32_CONST, 2, I32_LT_U, IF, VOID);
-	emitI32Const(c, INPUT_OFF);
-	c.push(LOCAL_GET, 0);
+	c.push(LOCAL_GET, NC, I32_CONST, 2, I32_LT_U, IF, VOID);
+	c.push(LOCAL_GET, PTR);
+	c.push(LOCAL_GET, LEN);
 	emitI32Const(c, 0);
 	emitI32Const(c, 8); // ROOT
 	emitI32Const(c, OUT_OFF);
@@ -787,88 +798,88 @@ function buildHashOneShot(leafWide: number): Code {
 	// === leaves, leafWide-wide (interleaved 4-lane groups) ===
 	// i = 0
 	emitI32Const(c, 0);
-	c.push(LOCAL_SET, 4);
+	c.push(LOCAL_SET, I);
 	c.push(BLOCK, VOID, LOOP, VOID);
 	{
-		c.push(LOCAL_GET, 4, I32_CONST, leafWide, I32_ADD, LOCAL_GET, 1, I32_GT_U, BR_IF, 0x01);
-		emitI32Const(c, INPUT_OFF);
-		c.push(LOCAL_GET, 4, I32_CONST, 10, I32_SHL, I32_ADD);
-		c.push(LOCAL_GET, 4);
+		c.push(LOCAL_GET, I, I32_CONST, leafWide, I32_ADD, LOCAL_GET, NF, I32_GT_U, BR_IF, 0x01);
+		c.push(LOCAL_GET, PTR);
+		c.push(LOCAL_GET, I, I32_CONST, 10, I32_SHL, I32_ADD);
+		c.push(LOCAL_GET, I);
 		emitI32Const(c, CV_ARR_OFF);
-		c.push(LOCAL_GET, 4, I32_CONST, 5, I32_SHL, I32_ADD);
+		c.push(LOCAL_GET, I, I32_CONST, 5, I32_SHL, I32_ADD);
 		c.push(CALL, 0x05);
-		c.push(LOCAL_GET, 4, I32_CONST, leafWide, I32_ADD, LOCAL_SET, 4);
+		c.push(LOCAL_GET, I, I32_CONST, leafWide, I32_ADD, LOCAL_SET, I);
 		c.push(BR, 0x00);
 	}
 	c.push(END, END);
 	// 4..leafWide-1 full chunks left: 4-wide groups
 	c.push(BLOCK, VOID, LOOP, VOID);
 	{
-		c.push(LOCAL_GET, 4, I32_CONST, 4, I32_ADD, LOCAL_GET, 1, I32_GT_U, BR_IF, 0x01);
-		emitI32Const(c, INPUT_OFF);
-		c.push(LOCAL_GET, 4, I32_CONST, 10, I32_SHL, I32_ADD);
-		c.push(LOCAL_GET, 4);
+		c.push(LOCAL_GET, I, I32_CONST, 4, I32_ADD, LOCAL_GET, NF, I32_GT_U, BR_IF, 0x01);
+		c.push(LOCAL_GET, PTR);
+		c.push(LOCAL_GET, I, I32_CONST, 10, I32_SHL, I32_ADD);
+		c.push(LOCAL_GET, I);
 		emitI32Const(c, CV_ARR_OFF);
-		c.push(LOCAL_GET, 4, I32_CONST, 5, I32_SHL, I32_ADD);
+		c.push(LOCAL_GET, I, I32_CONST, 5, I32_SHL, I32_ADD);
 		c.push(CALL, 0x02);
-		c.push(LOCAL_GET, 4, I32_CONST, 4, I32_ADD, LOCAL_SET, 4);
+		c.push(LOCAL_GET, I, I32_CONST, 4, I32_ADD, LOCAL_SET, I);
 		c.push(BR, 0x00);
 	}
 	c.push(END, END);
 	// tail of full chunks (1-3 remaining): run one more 4-wide group; the
 	// extra lanes read past the valid input (capacity guaranteed by JS) and
 	// their CVs are either never read or overwritten by the partial chunk below.
-	c.push(LOCAL_GET, 4, LOCAL_GET, 1, I32_LT_U, IF, VOID);
-	emitI32Const(c, INPUT_OFF);
-	c.push(LOCAL_GET, 4, I32_CONST, 10, I32_SHL, I32_ADD);
-	c.push(LOCAL_GET, 4);
+	c.push(LOCAL_GET, I, LOCAL_GET, NF, I32_LT_U, IF, VOID);
+	c.push(LOCAL_GET, PTR);
+	c.push(LOCAL_GET, I, I32_CONST, 10, I32_SHL, I32_ADD);
+	c.push(LOCAL_GET, I);
 	emitI32Const(c, CV_ARR_OFF);
-	c.push(LOCAL_GET, 4, I32_CONST, 5, I32_SHL, I32_ADD);
+	c.push(LOCAL_GET, I, I32_CONST, 5, I32_SHL, I32_ADD);
 	c.push(CALL, 0x02);
 	c.push(END);
 	// trailing partial chunk (scalar)
-	c.push(LOCAL_GET, 2, IF, VOID);
-	emitI32Const(c, INPUT_OFF);
-	c.push(LOCAL_GET, 1, I32_CONST, 10, I32_SHL, I32_ADD);
-	c.push(LOCAL_GET, 2);
-	c.push(LOCAL_GET, 1);
+	c.push(LOCAL_GET, REM, IF, VOID);
+	c.push(LOCAL_GET, PTR);
+	c.push(LOCAL_GET, NF, I32_CONST, 10, I32_SHL, I32_ADD);
+	c.push(LOCAL_GET, REM);
+	c.push(LOCAL_GET, NF);
 	emitI32Const(c, 0);
 	emitI32Const(c, CV_ARR_OFF);
-	c.push(LOCAL_GET, 1, I32_CONST, 5, I32_SHL, I32_ADD);
+	c.push(LOCAL_GET, NF, I32_CONST, 5, I32_SHL, I32_ADD);
 	c.push(CALL, 0x01);
 	c.push(END);
 
 	// === merge levels (pairwise, odd CV carries up) ===
-	c.push(LOCAL_GET, 3, LOCAL_SET, 5); // cvCount = nc
+	c.push(LOCAL_GET, NC, LOCAL_SET, CVCOUNT); // cvCount = nc
 	c.push(BLOCK, VOID, LOOP, VOID);
 	{
-		c.push(LOCAL_GET, 5, I32_CONST, 2, I32_LE_U, BR_IF, 0x01);
-		c.push(LOCAL_GET, 5, I32_CONST, 1, I32_SHR_U, LOCAL_SET, 6); // pairs
-		c.push(LOCAL_GET, 5, I32_CONST, 1, I32_AND, LOCAL_SET, 7); // odd
+		c.push(LOCAL_GET, CVCOUNT, I32_CONST, 2, I32_LE_U, BR_IF, 0x01);
+		c.push(LOCAL_GET, CVCOUNT, I32_CONST, 1, I32_SHR_U, LOCAL_SET, PAIRS); // pairs
+		c.push(LOCAL_GET, CVCOUNT, I32_CONST, 1, I32_AND, LOCAL_SET, ODD); // odd
 		emitI32Const(c, 0);
-		c.push(LOCAL_SET, 4);
+		c.push(LOCAL_SET, I);
 		// 4-wide parents
 		c.push(BLOCK, VOID, LOOP, VOID);
 		{
-			c.push(LOCAL_GET, 4, I32_CONST, 4, I32_ADD, LOCAL_GET, 6, I32_GT_U, BR_IF, 0x01);
+			c.push(LOCAL_GET, I, I32_CONST, 4, I32_ADD, LOCAL_GET, PAIRS, I32_GT_U, BR_IF, 0x01);
 			emitI32Const(c, CV_ARR_OFF);
-			c.push(LOCAL_GET, 4, I32_CONST, 6, I32_SHL, I32_ADD);
+			c.push(LOCAL_GET, I, I32_CONST, 6, I32_SHL, I32_ADD);
 			emitI32Const(c, CV_ARR_OFF);
-			c.push(LOCAL_GET, 4, I32_CONST, 5, I32_SHL, I32_ADD);
+			c.push(LOCAL_GET, I, I32_CONST, 5, I32_SHL, I32_ADD);
 			c.push(CALL, 0x03);
-			c.push(LOCAL_GET, 4, I32_CONST, 4, I32_ADD, LOCAL_SET, 4);
+			c.push(LOCAL_GET, I, I32_CONST, 4, I32_ADD, LOCAL_SET, I);
 			c.push(BR, 0x00);
 		}
 		c.push(END, END);
 		// scalar tail parents
 		c.push(BLOCK, VOID, LOOP, VOID);
 		{
-			c.push(LOCAL_GET, 4, LOCAL_GET, 6, I32_GE_U, BR_IF, 0x01);
+			c.push(LOCAL_GET, I, LOCAL_GET, PAIRS, I32_GE_U, BR_IF, 0x01);
 			emitI32Const(c, CV_ARR_OFF);
-			c.push(LOCAL_GET, 4, I32_CONST, 6, I32_SHL, I32_ADD); // msg = CV_ARR + i*64
+			c.push(LOCAL_GET, I, I32_CONST, 6, I32_SHL, I32_ADD); // msg = CV_ARR + i*64
 			emitI32Const(c, KEY_OFF); // cv = key
 			emitI32Const(c, CV_ARR_OFF);
-			c.push(LOCAL_GET, 4, I32_CONST, 5, I32_SHL, I32_ADD); // out = CV_ARR + i*32
+			c.push(LOCAL_GET, I, I32_CONST, 5, I32_SHL, I32_ADD); // out = CV_ARR + i*32
 			emitI32Const(c, 0); // counter
 			emitI32Const(c, 64); // blockLen
 			emitI32Const(c, FLAGS_OFF);
@@ -876,23 +887,23 @@ function buildHashOneShot(leafWide: number): Code {
 			emitI32Const(c, 4);
 			c.push(I32_OR); // flags | PARENT
 			c.push(CALL, 0x00);
-			c.push(LOCAL_GET, 4, I32_CONST, 1, I32_ADD, LOCAL_SET, 4);
+			c.push(LOCAL_GET, I, I32_CONST, 1, I32_ADD, LOCAL_SET, I);
 			c.push(BR, 0x00);
 		}
 		c.push(END, END);
 		// odd: carry last CV up - copy CV[cvCount-1] to CV[pairs]
-		c.push(LOCAL_GET, 7, IF, VOID);
+		c.push(LOCAL_GET, ODD, IF, VOID);
 		for (let half = 0; half < 2; half++) {
 			emitI32Const(c, CV_ARR_OFF);
-			c.push(LOCAL_GET, 6, I32_CONST, 5, I32_SHL, I32_ADD);
+			c.push(LOCAL_GET, PAIRS, I32_CONST, 5, I32_SHL, I32_ADD);
 			emitI32Const(c, CV_ARR_OFF);
-			c.push(LOCAL_GET, 5, I32_CONST, 1, I32_SUB, I32_CONST, 5, I32_SHL, I32_ADD);
+			c.push(LOCAL_GET, CVCOUNT, I32_CONST, 1, I32_SUB, I32_CONST, 5, I32_SHL, I32_ADD);
 			emitV128Load(c, half * 16);
 			emitV128Store(c, half * 16);
 		}
 		c.push(END);
 		// cvCount = pairs + odd
-		c.push(LOCAL_GET, 6, LOCAL_GET, 7, I32_ADD, LOCAL_SET, 5);
+		c.push(LOCAL_GET, PAIRS, LOCAL_GET, ODD, I32_ADD, LOCAL_SET, CVCOUNT);
 		c.push(BR, 0x00);
 	}
 	c.push(END, END);
@@ -956,8 +967,8 @@ function generateOneShotWasm(): Uint8Array {
 	// Imports: memory js.mem
 	section(0x02, [0x01, 0x02, 0x6a, 0x73, 0x03, 0x6d, 0x65, 0x6d, 0x02, 0x00, INITIAL_PAGES]);
 
-	// Functions (leafGroup8 shares leafGroup's 3-param type)
-	section(0x03, [0x06, 0x00, 0x01, 0x02, 0x03, 0x04, 0x02]);
+	// Functions (hashOneShot uses the 2-param type 3; leafGroupN the 3-param type 2)
+	section(0x03, [0x06, 0x00, 0x01, 0x02, 0x03, 0x03, 0x02]);
 
 	// Exports: hashOneShot -> func 4
 	const name = "hashOneShot";
@@ -994,7 +1005,7 @@ function generateOneShotWasm(): Uint8Array {
 const IS_LE = new Uint8Array(new Uint32Array([0x01020304]).buffer)[0] === 0x04;
 
 let memory: WebAssembly.Memory | null = null;
-let hashFn: ((len: number) => void) | null = null;
+let hashFn: ((ptr: number, len: number) => void) | null = null;
 let view8: Uint8Array = new Uint8Array(0);
 let view32: Uint32Array = new Uint32Array(0);
 let initFailed = false;
@@ -1029,7 +1040,7 @@ export function initOneShot(): boolean {
 		memory = new WebAssembly.Memory({ initial: INITIAL_PAGES });
 		const module = new WebAssembly.Module(bytes.buffer as ArrayBuffer);
 		const instance = new WebAssembly.Instance(module, { js: { mem: memory } });
-		hashFn = instance.exports.hashOneShot as (len: number) => void;
+		hashFn = instance.exports.hashOneShot as (ptr: number, len: number) => void;
 		refreshViews();
 		return true;
 	} catch {
@@ -1055,12 +1066,16 @@ function generateSimdProbe(): Uint8Array {
 }
 
 function ensureCapacity(totalBytes: number): void {
-	if (view8.length >= totalBytes) {
-		return;
+	// Consult the memory itself (not the cached view): the shared-memory path
+	// lets external callers hold this memory too, and any grow() detaches the
+	// old buffer, zeroing the cached view's length.
+	const mem = memory as WebAssembly.Memory;
+	if (mem.buffer.byteLength < totalBytes) {
+		mem.grow(Math.ceil((totalBytes - mem.buffer.byteLength) / PAGE_SIZE));
 	}
-	const pages = Math.ceil((totalBytes - view8.length) / PAGE_SIZE);
-	(memory as WebAssembly.Memory).grow(pages);
-	refreshViews();
+	if (view8.buffer !== mem.buffer) {
+		refreshViews();
+	}
 }
 
 // Extra readable/writable slack past the input: the 4-wide leaf tail may
@@ -1115,7 +1130,7 @@ export function runOneShot(keyWords: Uint32Array, flags: number, len: number, ou
 	// zero-pad the final block (wasm always reads full 64-byte blocks)
 	const padEnd = INPUT_OFF + ((len + 63) & ~63 || 64);
 	view8.fill(0, INPUT_OFF + len, padEnd);
-	(hashFn as (len: number) => void)(len);
+	(hashFn as (ptr: number, len: number) => void)(INPUT_OFF, len);
 	out.set(view8.subarray(OUT_OFF, OUT_OFF + outLen));
 }
 
@@ -1124,4 +1139,71 @@ export function runOneShot(keyWords: Uint32Array, flags: number, len: number, ou
  */
 export function oneShotReady(): boolean {
 	return hashFn !== null;
+}
+
+// ===== Shared-memory API =====
+//
+// Lets a cooperating module (e.g. the xet chunker) place input bytes in THIS
+// wasm memory once and hash arbitrary [ptr, ptr+len) regions of it in place,
+// eliminating a full input memcpy. External regions must start at or after
+// ONESHOT_RESERVED_END; the engine's fixed regions and its (growable) input
+// staging area live below it.
+
+/** First byte offset safe for external use in the shared memory. */
+export const ONESHOT_RESERVED_END = INPUT_OFF + ONESHOT_MAX_INPUT + INPUT_SLACK;
+
+/**
+ * Shared-memory context: init the engine and expose its memory.
+ * Returns null when the wasm one-shot engine is unavailable.
+ */
+export function getOneShotContext(): { memory: WebAssembly.Memory; reservedEnd: number } | null {
+	if (!initOneShot()) {
+		return null;
+	}
+	return { memory: memory as WebAssembly.Memory, reservedEnd: ONESHOT_RESERVED_END };
+}
+
+/**
+ * Grow the shared memory (if needed) to hold `totalBytes` and return a fresh
+ * byte view (valid until the next grow from any party).
+ */
+export function ensureOneShotCapacity(totalBytes: number): Uint8Array {
+	ensureCapacity(totalBytes);
+	return view8;
+}
+
+// Saved bytes clobbered by final-block zero-padding in runOneShotRegion.
+const padSave = new Uint8Array(64);
+
+/**
+ * Hash `len` bytes already residing in the shared memory at `ptr` (an
+ * absolute offset >= ONESHOT_RESERVED_END). The engine zero-pads the final
+ * 64-byte block in place and restores the clobbered bytes afterwards, so
+ * neighbouring data survives. Writes `outLen` (<= 32) hash bytes to `out`.
+ */
+export function runOneShotRegion(
+	keyWords: Uint32Array,
+	flags: number,
+	ptr: number,
+	len: number,
+	out: Uint8Array,
+	outLen: number,
+): void {
+	ensureCapacity(ptr + len + INPUT_SLACK);
+	view32.set(keyWords, 0);
+	view32[FLAGS_OFF >> 2] = flags;
+	// zero-pad the final block in place (wasm always reads full 64-byte
+	// blocks), saving the clobbered bytes for restore below
+	const padStart = ptr + len;
+	const padEnd = ptr + (((len + 63) & ~63) || 64);
+	const padLen = padEnd - padStart;
+	if (padLen > 0) {
+		padSave.set(view8.subarray(padStart, padEnd));
+		view8.fill(0, padStart, padEnd);
+	}
+	(hashFn as (ptr: number, len: number) => void)(ptr, len);
+	if (padLen > 0) {
+		view8.set(padSave.subarray(0, padLen), padStart);
+	}
+	out.set(view8.subarray(OUT_OFF, OUT_OFF + outLen));
 }

--- a/packages/blake3-jit/src/wasm-oneshot.ts
+++ b/packages/blake3-jit/src/wasm-oneshot.ts
@@ -1117,6 +1117,14 @@ export function appendInput(data: Uint8Array, offset: number): void {
  * View over currently buffered input (valid until next append/grow).
  */
 export function bufferedInput(len: number): Uint8Array {
+	// The shared-memory path lets external callers (e.g. gearhash-jit's
+	// instantiateGearScanner) grow this memory directly, detaching the cached
+	// view. grow() preserves contents, so after a refresh the buffered bytes
+	// are still at INPUT_OFF; without it a detached view8 reads as empty and
+	// an evicted hasher would silently replay zero bytes.
+	if (view8.buffer !== (memory as WebAssembly.Memory).buffer) {
+		refreshViews();
+	}
 	return view8.subarray(INPUT_OFF, INPUT_OFF + len);
 }
 

--- a/packages/blake3-jit/test/index.test.ts
+++ b/packages/blake3-jit/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Hasher, hash, hashInto, createKeyed, createDeriveKey, createHasher } from "../src/index.js";
+import { Hasher, hash, hashInto, createKeyed, createDeriveKey, createHasher, getOneShotContext } from "../src/index.js";
 // Official BLAKE3 test vectors from https://github.com/BLAKE3-team/BLAKE3
 import * as vectorsJson from "./test-vectors.json";
 
@@ -185,5 +185,57 @@ describe("misc", () => {
 		expect(toHex(Hasher.newKeyed(KEY).update(view).finalize(32))).toBe(
 			toHex(Hasher.newKeyed(KEY).update(copy).finalize(32)),
 		);
+	});
+});
+
+// Regression tests: the shared-memory API hands the one-shot engine's
+// WebAssembly.Memory to external callers (e.g. gearhash-jit's
+// instantiateGearScanner), which may grow it directly. grow() detaches the
+// engine's cached views; an in-flight hasher buffering its message in the
+// staging area must still replay the correct bytes when evicted afterwards.
+describe("external memory growth (shared-memory path)", () => {
+	function growExternally(): boolean {
+		const ctx = getOneShotContext();
+		if (!ctx) {
+			return false; // wasm one-shot engine unavailable: fast path off, nothing to test
+		}
+		ctx.memory.grow(1); // detaches all views cached before this call
+		return true;
+	}
+
+	it("eviction by another hasher replays buffered bytes after external grow", () => {
+		const input = makeInput(1000);
+		const expected = toHex(new Hasher().update(input).finalize(32));
+
+		const a = new Hasher().update(input); // buffers into wasm staging (fast path)
+		if (!growExternally()) {
+			return;
+		}
+		new Hasher().update(makeInput(10)).finalize(32); // claims staging → evicts `a`
+		expect(toHex(a.finalize(32))).toBe(expected);
+	});
+
+	it("eviction by keyed one-shot claim replays buffered bytes after external grow", () => {
+		const input = makeInput(4096);
+		const expected = toHex(Hasher.newKeyed(KEY).update(input).finalize(32));
+
+		const a = Hasher.newKeyed(KEY).update(input);
+		if (!growExternally()) {
+			return;
+		}
+		hash(makeInput(5)); // one-shot hash() claims staging → evicts `a`
+		expect(toHex(a.finalize(32))).toBe(expected);
+	});
+
+	it("XOF finalize (>32B) replays buffered bytes after external grow", () => {
+		const input = makeInput(2048);
+		const expected = toHex(hash(input, 64));
+
+		const a = new Hasher().update(input);
+		if (!growExternally()) {
+			return;
+		}
+		// outputLength > 32 forces the scalar output machinery → evictOneShot
+		expect(toHex(a.finalize(64))).toBe(expected);
 	});
 });

--- a/packages/gearhash-jit/src/index.ts
+++ b/packages/gearhash-jit/src/index.ts
@@ -17,6 +17,7 @@ import {
 } from "./wasm.js";
 
 export { GEAR_TABLE } from "./table.js";
+export { instantiateGearScanner } from "./wasm.js";
 
 export class Hasher {
 	private readonly maskBytes: Uint8Array;

--- a/packages/gearhash-jit/src/wasm.ts
+++ b/packages/gearhash-jit/src/wasm.ts
@@ -79,7 +79,11 @@ function toLebU32Padded5(n: number): number[] {
  * for `inputLen` bytes, writes updated hash back.
  * Returns 1-based match position within the scanned range, or -1.
  */
-function generateWasmBytes(): Uint8Array {
+function generateWasmBytes(
+	tableOffset: number = TABLE_OFFSET,
+	hashOffset: number = HASH_OFFSET,
+	maskOffset: number = MASK_OFFSET,
+): Uint8Array {
 	const code: number[] = [];
 	function emit(...bytes: number[]): void {
 		code.push(...bytes);
@@ -126,12 +130,12 @@ function generateWasmBytes(): Uint8Array {
 	emit(0x02, 0x02, 0x7e, 0x03, 0x7f);
 
 	// hash = mem64[HASH_OFFSET]
-	emit(0x41, ...toSignedLeb128(HASH_OFFSET));
+	emit(0x41, ...toSignedLeb128(hashOffset));
 	emit(0x29, 0x03, 0x00);
 	emit(0x21, HASH);
 
 	// mask = mem64[MASK_OFFSET]
-	emit(0x41, ...toSignedLeb128(MASK_OFFSET));
+	emit(0x41, ...toSignedLeb128(maskOffset));
 	emit(0x29, 0x03, 0x00);
 	emit(0x21, MASK);
 
@@ -157,7 +161,7 @@ function generateWasmBytes(): Uint8Array {
 		emit(0x2d, 0x00, ...toUnsignedLeb128(k)); // i32.load8_u align=0 offset=k
 		emit(0x41, 0x03); // i32.const 3
 		emit(0x74); // i32.shl
-		emit(0x29, 0x03, ...toUnsignedLeb128(TABLE_OFFSET)); // i64.load align=3
+		emit(0x29, 0x03, ...toUnsignedLeb128(tableOffset)); // i64.load align=3
 	}
 
 	// Emits: test i64 on stack against mask; if (v & mask) == 0,
@@ -168,7 +172,7 @@ function generateWasmBytes(): Uint8Array {
 		emit(0x83); // i64.and
 		emit(0x50); // i64.eqz
 		emit(0x04, 0x40); // if (void)
-		emit(0x41, ...toSignedLeb128(HASH_OFFSET)); // i32.const HASH_OFFSET
+		emit(0x41, ...toSignedLeb128(hashOffset)); // i32.const HASH_OFFSET
 		emit(0x20, local); // local.get <matched hash>
 		emit(0x37, 0x03, 0x00); // i64.store align=3
 		emit(0x20, PTR); // local.get ptr
@@ -249,7 +253,7 @@ function generateWasmBytes(): Uint8Array {
 	emit(0x0b); // end block
 
 	// no match: store hash, return -1
-	emit(0x41, ...toSignedLeb128(HASH_OFFSET));
+	emit(0x41, ...toSignedLeb128(hashOffset));
 	emit(0x20, HASH);
 	emit(0x37, 0x03, 0x00);
 	emit(0x41, 0x7f);
@@ -266,6 +270,48 @@ function generateWasmBytes(): Uint8Array {
 	for (let i = 0; i < 5; i++) code[sectionSizeOff + i] = ssPatch[i];
 
 	return new Uint8Array(code);
+}
+
+/**
+ * Instantiate an additional gear scanner bound to an EXTERNAL (shared)
+ * WebAssembly.Memory, with its fixed regions (table/hash/mask) rebased to
+ * `baseOffset` (2064 bytes are used). Input windows are addressed absolutely
+ * within the shared memory via `nextMatch(inputStart, inputLen)`.
+ *
+ * The caller owns hash/mask state management (8 LE bytes each at the returned
+ * offsets) and must tolerate `memory.grow` detaching prior buffer views.
+ */
+export function instantiateGearScanner(
+	memory: WebAssembly.Memory,
+	baseOffset: number,
+): {
+	nextMatch: (inputStart: number, inputLen: number) => number;
+	hashOffset: number;
+	maskOffset: number;
+} {
+	const tableOffset = baseOffset;
+	const hashOffset = baseOffset + 2048;
+	const maskOffset = baseOffset + 2056;
+
+	const needed = baseOffset + 2064;
+	if (memory.buffer.byteLength < needed) {
+		memory.grow(Math.ceil((needed - memory.buffer.byteLength) / 65536));
+	}
+
+	const bytes = generateWasmBytes(tableOffset, hashOffset, maskOffset);
+	const module = new WebAssembly.Module(bytes);
+	const instance = new WebAssembly.Instance(module, { js: { mem: memory } });
+
+	const dv = new DataView(memory.buffer);
+	for (let i = 0; i < 256; i++) {
+		dv.setBigUint64(tableOffset + i * 8, GEAR_TABLE[i], true);
+	}
+
+	return {
+		nextMatch: instance.exports.nextMatch as (start: number, len: number) => number,
+		hashOffset,
+		maskOffset,
+	};
 }
 
 export function initWasm(): void {

--- a/packages/xetchunk-wasm/src/xet-chunker.ts
+++ b/packages/xetchunk-wasm/src/xet-chunker.ts
@@ -1,5 +1,11 @@
-import { Hasher } from "gearhash-jit";
-import { Hasher as Blake3Hasher } from "@huggingface/blake3-jit";
+import { Hasher, instantiateGearScanner } from "gearhash-jit";
+import {
+	Hasher as Blake3Hasher,
+	getOneShotContext,
+	ensureOneShotCapacity,
+	runOneShotRegion,
+	KEYED_HASH,
+} from "@huggingface/blake3-jit";
 
 const TARGET_CHUNK_SIZE = 64 * 1024; // 64KB
 const MINIMUM_CHUNK_DIVISOR = 8;
@@ -19,6 +25,63 @@ export interface Chunk {
 	length: number;
 }
 
+/**
+ * Shared-memory fast path: gearhash scanner + blake3 one-shot engine bound to
+ * ONE WebAssembly.Memory (blake3's), with the input segment loaded once.
+ * Gearhash scans it in place and blake3 hashes [chunkStart, chunkEnd) in
+ * place, eliminating a full extra memcpy of all input.
+ *
+ * The gear table/hash/mask and the input region live above the blake3
+ * engine's reserved area, so regular blake3 Hasher users (xorb hashing etc.)
+ * can keep using the same memory concurrently. Gear hash/mask state is copied
+ * in/out around every scan (8 bytes each), so multiple chunkers stay
+ * independent, exactly like gearhash-jit's own Hasher.
+ */
+interface SharedCtx {
+	memory: WebAssembly.Memory;
+	nextMatch: (inputStart: number, inputLen: number) => number;
+	hashOffset: number;
+	maskOffset: number;
+	inputBase: number;
+	view: Uint8Array;
+}
+
+let sharedCtx: SharedCtx | null | undefined;
+
+function getSharedCtx(): SharedCtx | null {
+	if (sharedCtx !== undefined) {
+		return sharedCtx;
+	}
+	try {
+		const blake3Ctx = getOneShotContext();
+		if (!blake3Ctx) {
+			sharedCtx = null;
+			return sharedCtx;
+		}
+		const gearBase = (blake3Ctx.reservedEnd + 63) & ~63;
+		const scanner = instantiateGearScanner(blake3Ctx.memory, gearBase);
+		sharedCtx = {
+			memory: blake3Ctx.memory,
+			nextMatch: scanner.nextMatch,
+			hashOffset: scanner.hashOffset,
+			maskOffset: scanner.maskOffset,
+			inputBase: (gearBase + 2064 + 63) & ~63,
+			view: new Uint8Array(blake3Ctx.memory.buffer),
+		};
+	} catch {
+		sharedCtx = null;
+	}
+	return sharedCtx;
+}
+
+/** Current byte view of the shared memory (grow-safe). */
+function sharedView(ctx: SharedCtx): Uint8Array {
+	if (ctx.view.buffer !== ctx.memory.buffer) {
+		ctx.view = new Uint8Array(ctx.memory.buffer);
+	}
+	return ctx.view;
+}
+
 interface NextResult {
 	chunk: Chunk | null;
 	bytesConsumed: number;
@@ -31,6 +94,8 @@ class XetChunker {
 	private curChunkLen: number;
 	private gear: Hasher;
 	private blake3: Blake3Hasher;
+	private maskBytes: Uint8Array;
+	private keyWords: Uint32Array;
 
 	constructor(targetChunkSize: number = TARGET_CHUNK_SIZE) {
 		if (targetChunkSize <= 0) {
@@ -64,6 +129,30 @@ class XetChunker {
 		this.curChunkLen = 0;
 		this.gear = new Hasher(mask);
 		this.blake3 = Blake3Hasher.newKeyed(BLAKE3_DATA_KEY);
+		this.maskBytes = new Uint8Array(8);
+		new DataView(this.maskBytes.buffer).setBigUint64(0, mask, true);
+		// Key words for the shared-memory blake3 path (only used when the
+		// one-shot engine is available, which implies little-endian).
+		this.keyWords = new Uint32Array(BLAKE3_DATA_KEY.buffer, BLAKE3_DATA_KEY.byteOffset, 8);
+	}
+
+	/**
+	 * Scan a window of the shared input region ([offset, offset+length) is
+	 * relative to the loaded segment). Mirrors gearhash-jit's nextMatchIn:
+	 * per-hasher hash/mask state is copied in and out around the wasm call,
+	 * reusing `this.gear.hash` so state stays consistent with the streaming
+	 * path in next().
+	 */
+	private sharedScan(ctx: SharedCtx, offset: number, length: number): number {
+		if (length <= 0) {
+			return -1;
+		}
+		const view = sharedView(ctx);
+		view.set(this.gear.hash, ctx.hashOffset);
+		view.set(this.maskBytes, ctx.maskOffset);
+		const pos = ctx.nextMatch(ctx.inputBase + offset, length);
+		this.gear.hash.set(view.subarray(ctx.hashOffset, ctx.hashOffset + 8));
+		return pos;
 	}
 
 	/**
@@ -167,10 +256,13 @@ class XetChunker {
 
 		const minSkip = this.minimumChunk > HASH_WINDOW_SIZE ? this.minimumChunk - HASH_WINDOW_SIZE - 1 : 0;
 
-		// Copy the input into gearhash wasm memory in large segments so each
-		// scan window is a zero-copy view (a per-window nextMatch would re-copy
+		// Copy the input into wasm memory in large segments so each scan
+		// window is a zero-copy view (a per-window nextMatch would re-copy
 		// up to maximumChunk bytes per chunk — ~2× the data). Segments overlap
 		// by at most maximumChunk when a chunk straddles a segment end.
+		// With the shared-memory fast path the segment is the ONLY input copy:
+		// gearhash scans it in place and blake3 hashes chunk regions in place.
+		const shared = getSharedCtx();
 		const loadSize = Math.max(LOAD_SEGMENT_SIZE, 4 * this.maximumChunk);
 		let loadedStart = 0;
 		let loadedEnd = 0;
@@ -183,7 +275,14 @@ class XetChunker {
 			if (pos < loadedStart || scanEnd > loadedEnd) {
 				loadedStart = pos;
 				loadedEnd = Math.min(data.length, pos + loadSize);
-				this.gear.loadInput(data.subarray(loadedStart, loadedEnd));
+				if (shared) {
+					// +8256: final-block padding (64) + 4-wide leaf overshoot
+					// slack (4096+64) required by the one-shot engine, rounded up.
+					const view = ensureOneShotCapacity(shared.inputBase + (loadedEnd - loadedStart) + 8256);
+					view.set(data.subarray(loadedStart, loadedEnd), shared.inputBase);
+				} else {
+					this.gear.loadInput(data.subarray(loadedStart, loadedEnd));
+				}
 			}
 
 			// As in next(), reject matches before the minimum without resetting
@@ -193,7 +292,9 @@ class XetChunker {
 			let foundBoundary = false;
 
 			while (searchStart < scanEnd) {
-				const position = this.gear.nextMatchIn(searchStart - loadedStart, scanEnd - searchStart);
+				const position = shared
+					? this.sharedScan(shared, searchStart - loadedStart, scanEnd - searchStart)
+					: this.gear.nextMatchIn(searchStart - loadedStart, scanEnd - searchStart);
 				if (position === -1) {
 					break;
 				}
@@ -213,12 +314,12 @@ class XetChunker {
 			}
 
 			if (foundBoundary) {
-				const hash = this.blake3.reset().update(data.subarray(chunkStart, chunkEnd)).finalize(32);
+				const hash = this.hashLoaded(shared, data, chunkStart, chunkEnd, loadedStart);
 				chunks.push({ length: chunkEnd - chunkStart, hash });
 				pos = chunkEnd;
 				this.gear.resetHash();
 			} else if (isFinal) {
-				const hash = this.blake3.reset().update(data.subarray(chunkStart)).finalize(32);
+				const hash = this.hashLoaded(shared, data, chunkStart, data.length, loadedStart);
 				chunks.push({ length: data.length - chunkStart, hash });
 				pos = data.length;
 			} else {
@@ -229,6 +330,26 @@ class XetChunker {
 		}
 
 		return chunks;
+	}
+
+	/**
+	 * Hash [chunkStart, chunkEnd) of `data`. On the shared-memory path the
+	 * bytes are already in wasm memory (the loop guarantees the chunk lies
+	 * within the loaded segment) and are hashed in place.
+	 */
+	private hashLoaded(
+		shared: SharedCtx | null,
+		data: Uint8Array,
+		chunkStart: number,
+		chunkEnd: number,
+		loadedStart: number,
+	): Uint8Array {
+		if (shared) {
+			const hash = new Uint8Array(32);
+			runOneShotRegion(this.keyWords, KEYED_HASH, shared.inputBase + (chunkStart - loadedStart), chunkEnd - chunkStart, hash, 32);
+			return hash;
+		}
+		return this.blake3.reset().update(data.subarray(chunkStart, chunkEnd)).finalize(32);
 	}
 
 	finish(): Chunk | null {

--- a/packages/xetchunk-wasm/src/xet-chunker.ts
+++ b/packages/xetchunk-wasm/src/xet-chunker.ts
@@ -346,7 +346,14 @@ class XetChunker {
 	): Uint8Array {
 		if (shared) {
 			const hash = new Uint8Array(32);
-			runOneShotRegion(this.keyWords, KEYED_HASH, shared.inputBase + (chunkStart - loadedStart), chunkEnd - chunkStart, hash, 32);
+			runOneShotRegion(
+				this.keyWords,
+				KEYED_HASH,
+				shared.inputBase + (chunkStart - loadedStart),
+				chunkEnd - chunkStart,
+				hash,
+				32,
+			);
 			return hash;
 		}
 		return this.blake3.reset().update(data.subarray(chunkStart, chunkEnd)).finalize(32);

--- a/packages/xetchunk-wasm/tests/bench.js
+++ b/packages/xetchunk-wasm/tests/bench.js
@@ -1,7 +1,14 @@
 import { parseArgs } from "node:util";
 import { createChunker, finalize, nextBlock, hashToHex } from "../dist/esm/index.js";
 import { createReadStream } from "node:fs";
-import { Chunker } from "../vendor/chunker_wasm.js";
+// Fresh xet-core wasm build vendored in @huggingface/hub (same ground truth as
+// tests/conformance.test.ts). The local ../vendor copy is a stale pre-#2422
+// build with different minimum-boundary semantics. Node >= 23 (or 22 with
+// --experimental-strip-types) is required to load the .ts base64 module.
+import initWasm, { Chunker } from "../../hub/src/vendor/xet-chunk/chunker_wasm_bg.js";
+import { wasmBinary } from "../../hub/src/vendor/xet-chunk/chunker_wasm_bg.wasm.base64.ts";
+
+await initWasm({ module_or_path: wasmBinary });
 
 const { positionals } = parseArgs({
 	args: process.argv.slice(2),

--- a/packages/xetchunk-wasm/tests/index.test.ts
+++ b/packages/xetchunk-wasm/tests/index.test.ts
@@ -13,6 +13,8 @@ import {
 } from "../src/index.js";
 import type { Chunk } from "../src/index.js";
 import { createRandomArray } from "@huggingface/splitmix64-wasm";
+import { Hasher as Blake3Hasher, getOneShotContext } from "@huggingface/blake3-jit";
+import { instantiateGearScanner } from "gearhash-jit";
 
 // Helper function to get chunk boundaries from chunks
 function getChunkBoundaries(chunks: Array<{ length: number; hash: Uint8Array }>): number[] {
@@ -559,6 +561,45 @@ describe("xetchunk-wasm", () => {
 		it("hexToBytes round-trip", () => {
 			const hex = "118bbac5c38b2bca9c2b7ae8307786de066696b91b2b5ccb7dbbd4608c966882";
 			expect(hashToHex(hexToBytes(hex))).toBe(hex);
+		});
+	});
+
+	describe("shared wasm memory coexistence with blake3-jit hashers", () => {
+		// Regression: instantiateGearScanner grows the blake3 one-shot engine's
+		// memory directly, detaching its cached views. An in-flight blake3
+		// Hasher buffering its message in the engine's staging area must still
+		// replay the correct bytes when evicted after such a grow (previously
+		// it replayed an empty detached view → wrong digest).
+		it("in-flight hasher survives a gear-scanner-triggered memory grow", () => {
+			const ctx = getOneShotContext();
+			if (!ctx) {
+				return; // wasm engine unavailable: shared path is off
+			}
+
+			const key = new Uint8Array(32).fill(7);
+			const input = new Uint8Array(createRandomArray(100000, 42n));
+			const expected = hashToHex(Blake3Hasher.newKeyed(key).update(input).finalize(32));
+
+			const a = Blake3Hasher.newKeyed(key).update(input); // buffers in wasm staging
+			// Bind a scanner past the current end of memory: forces memory.grow,
+			// exactly what XetChunker construction does via getSharedCtx().
+			instantiateGearScanner(ctx.memory, ctx.memory.buffer.byteLength);
+			new Blake3Hasher().update(new Uint8Array(8)).finalize(32); // claims staging → evicts `a`
+			expect(hashToHex(a.finalize(32))).toBe(expected);
+		});
+
+		// End-to-end sanity: chunking (which instantiates the shared scanner and
+		// grows memory on first use) must not corrupt a concurrent hasher.
+		it("in-flight hasher survives chunker creation and use", () => {
+			const key = new Uint8Array(32).fill(9);
+			const input = new Uint8Array(createRandomArray(200000, 7n));
+			const expected = hashToHex(Blake3Hasher.newKeyed(key).update(input).finalize(32));
+
+			const a = Blake3Hasher.newKeyed(key).update(input);
+			const data = new Uint8Array(createRandomArray(1000000, 1n));
+			const viaStream = nextBlock(createChunker(), data);
+			expect(viaStream.length).toBeGreaterThan(0);
+			expect(hashToHex(a.finalize(32))).toBe(expected);
 		});
 	});
 });


### PR DESCRIPTION
Second-round perf push on the xet chunking pipeline (`blake3-jit`, `gearhash-jit`, `xetchunk-wasm`), following #2419 / #2420 / #2422 / #2423. Method: fresh baseline on main, one commit per experiment, same-core-pinned A/B, keep only what wins.

## 0. Baseline + bench.js parity-gate fix (`d92fd711`)

The `tests/bench.js` byte-parity gate was **failing on unmodified main**: it compared against the stale pre-#2422 build in `packages/xetchunk-wasm/vendor/` (untouched since #2103), whose minimum-boundary semantics no longer match. Repointed it at the #2423 conformance oracle under `packages/hub/src/vendor/xet-chunk`. Parity has passed on every run since (fresh random data each time).

> Follow-up suggestion: the stale `packages/xetchunk-wasm/vendor/` directory could probably be removed entirely now that the fresh oracle lives in `@huggingface/hub`.

## 1. Experiment 1 — 8-way interleaved SIMD leaf kernel (kept; `2845c439`, `5db9a820`)

The one-shot blake3 engine previously compressed 4 blake3-chunks per group (i32x4 lanes). It now emits **two independent 4-lane groups with their instruction streams interleaved step-by-step**, hiding the serial add→xor→rotate dependency chains: **blake3 stage +18%**.

Negative results, documented in-code because they are load-bearing:
- **Interleave granularity matters**: interleaving per column/diagonal *quad* instead of per G-step is **2.4x slower than the 4-wide baseline** (542 MB/s vs 1296 — the whole second state set stays live across each quad and V8's register allocator thrashes).
- **Group count matters**: sweep gave 1 group 1296 / **2 groups 1557** / 3 groups **885 MB/s** (spill cliff). The emitter is generalized to N groups with the winning configuration (2, "step") hardcoded and the sweep results in a comment.

## 2. Experiment 2 — shared `WebAssembly.Memory` (kept, but marginal; `19b1b321`)

The chunker now loads each input segment **once** into the blake3 one-shot engine's memory; a rebased gearhash scanner instance scans it in place, and blake3 hashes `[chunkStart, chunkEnd)` in place via a new `hashOneShot(ptr, len)` entry point (zero-pads the final block in place, restores the clobbered neighbour bytes). Kills one full pass of input memcpy.

Honest result: **+1.5–2% E2E** in interleaved same-process A/B (102.2 vs 103.8 ms per 100MB) — much less than the naive "one full input pass" estimate, because the eliminated per-chunk staging copy was gearhash-hot (L2-resident) and nearly free. Kept for the consistent win and halved memory traffic, but **it's a cleanly separable commit** if reviewers prefer less public API surface (new exports: `getOneShotContext` / `ensureOneShotCapacity` / `runOneShotRegion` / `ONESHOT_RESERVED_END` / `KEYED_HASH` on blake3-jit, `instantiateGearScanner` on gearhash-jit; standalone use of both packages is unchanged and backward-compatible).

## 3. Results

Machine: AMD Ryzen AI 9 HX 370 (heterogeneous: Zen 5 @ 5.16 GHz + Zen 5c @ 3.29 GHz), Node 24 / V8 13. **Methodology note:** all A/B comparisons were pinned to the same core (`taskset`), medians of ≥5 rounds with interleaved A/B where possible; cross-core numbers are not comparable on this CPU.

Fast core (Zen 5), 100MB random, 64KB target:

| Stage | Baseline (main) | This PR | Δ |
|---|---|---|---|
| gearhash scan | 4.31 GB/s | 4.34 GB/s | — (untouched) |
| blake3 keyed 64KB / 100MB-in-64KB | 1935 / 1881 MB/s | **2287 / 2190 MB/s** | **+18% / +16%** |
| **E2E streaming** | 1.27 GB/s | **1.49 GB/s** | **+17%** |
| bench.js (incl. hex, parity gate) | 1254 MB/s | **1425 MB/s** | +14% |

Efficiency core (Zen 5c): E2E 854 → ~980 MB/s (**+15%**).

vs reference implementations — **corrected, same-core** (see correction note below):

| Core | JS e2e streaming / bench.js | native Rust `--release` | native Rust `target-cpu=native` | JS vs `--release` | JS vs `cpu-native` |
|---|---|---|---|---|---|
| Performance (Zen 5 @ 5.16 GHz) | 1350 / 1296 MB/s | 1978 MB/s | 2106 MB/s | **~0.68x** | **~0.64x** |
| Efficiency (Zen 5c @ 3.29 GHz) | 983 / 962 MB/s | 1416 MB/s | 1466 MB/s | **~0.69x** | **~0.67x** |

- **~1.7–1.8x** the vendored Rust-wasm chunker in the same process (unchanged)

> **Correction & methodology (2026-08-27):** an earlier revision of this PR claimed "143% of native Rust `--release` (1038 MB/s) / 107% of `target-cpu=native` (1393 MB/s)". Those ratios compared a performance-core (Zen 5) JS number against native reference numbers that had been measured on an *efficiency* core (Zen 5c) — an invalid cross-core comparison on this heterogeneous CPU. (The old 1038 MB/s `--release` reference also looks depressed by cold-core frequency ramp-up: the first pass on an idle Zen 5c core reproducibly lands at ~1020–1030 MB/s, while a warmed core sustains ~1.4 GB/s.) The table above re-measures everything same-core: the native harness is a scratch bin crate calling current xet-core `xet_data`'s `Chunker::new(65536)` + `next_block`/`finish` (per-chunk keyed blake3 in `Chunk::new`, single-threaded), with a workload identical to `tests/bench.js` — same 100MB random file fed in 10MB blocks; chunk counts match exactly (1546). All candidates were interleaved round-robin pinned to the same core (`taskset`), median of 10 full runs each (5 for e2e streaming), each run itself a median of 5 rounds, noisy passes present but absorbed by the median. Bottom line: the JS pipeline reaches **roughly two-thirds of native Rust single-core throughput** on both core classes — not parity, and not faster. The **+15–17% same-core E2E improvement** delivered by this PR is measured independently of native (A/B vs main) and stands.

## 4. Correctness gates (all green at every commit)

- `blake3-jit`: 119 tests (official vectors)
- `gearhash-jit`: 5 tests
- `xetchunk-wasm`: 97 tests, incl. the 59-case conformance matrix vs vendored xet-core wasm (#2423)
- Bugbot's detached-view finding (evicted hasher replaying an empty view after an external `memory.grow`) was real and is fixed in `1f0dbd81`, with regression tests in both `blake3-jit` (grow + eviction via second hasher / one-shot claim / XOF finalize) and `xetchunk-wasm` (cross-package gear-scanner grow repro)
- `tests/bench.js` hard byte-parity gate vs xet-core (fresh random 100MB per run)
- New in-place region hashing additionally verified for unaligned pointers and pad save/restore across a len × offset matrix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes JIT-generated WASM hashing, shared memory layout, and in-place padding semantics; incorrect eviction or pointer/slack handling could yield wrong chunk hashes, though vectors and conformance tests target this.
> 
> **Overview**
> Speeds up xet chunking by **~15–17% E2E** through a faster BLAKE3 one-shot WASM leaf path and optional **single shared `WebAssembly.Memory`** for gearhash + keyed BLAKE3 in `xetchunk-wasm`.
> 
> **BLAKE3 one-shot (`wasm-oneshot.ts`)** adds an **8-wide leaf kernel**: two independent 4-lane SIMD groups with **step-interleaved** `emitVecRounds`, a new `buildLeafGroupN` WASM function, and `hashOneShot` now hashes **`mem[inputPtr .. inputPtr+len)`** instead of a fixed staging offset. **Public shared-memory helpers** (`getOneShotContext`, `ensureOneShotCapacity`, `runOneShotRegion`, `ONESHOT_RESERVED_END`) plus **`KEYED_HASH`** are re-exported from `@huggingface/blake3-jit`. **Grow-safety**: capacity checks use the live memory buffer; `bufferedInput` refreshes detached views so evicted hashers do not replay zeros after external `memory.grow()`.
> 
> **gearhash-jit** adds **`instantiateGearScanner(memory, baseOffset)`** to bind a scanner to an external memory with rebased table/hash/mask regions.
> 
> **`XetChunker`** uses one BLAKE3 memory when available: load each segment once, scan in place, hash chunk bounds via **`runOneShotRegion`** (with in-place final-block padding restore). Falls back to the prior dual-buffer path when WASM is unavailable.
> 
> **Tests/bench**: regression coverage for external grow + concurrent hashers; `tests/bench.js` parity oracle pointed at fresh xet-core wasm in `@huggingface/hub`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f0dbd819b916f2f658a4cc9a445d9006369a886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

