### PR TITLE
Add Saient to local apps

### DIFF
--- a/packages/tasks/src/local-apps.spec.ts
+++ b/packages/tasks/src/local-apps.spec.ts
@@ -262,6 +262,31 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \\
 		expect(snippet).toEqual(`docker model run hf.co/bartowski/Llama-3.2-3B-Instruct-GGUF:{{QUANT_TAG}}`);
 	});
 
+	it("saient deeplink", async () => {
+		const { displayOnModelPage, deeplink } = LOCAL_APPS["saient"];
+		const model: ModelData = {
+			id: "bartowski/Llama-3.2-3B-Instruct-GGUF",
+			tags: ["conversational"],
+			gguf: { total: 1, context_length: 4096 },
+			inference: "",
+		};
+
+		expect(displayOnModelPage(model)).toBe(true);
+		expect(deeplink(model).href).toBe("saient://models/huggingface/bartowski/Llama-3.2-3B-Instruct-GGUF");
+	});
+
+	it("saient not shown for a non-gguf model", async () => {
+		const { displayOnModelPage } = LOCAL_APPS["saient"];
+		const model: ModelData = {
+			id: "meta-llama/Llama-3.2-3B-Instruct",
+			tags: ["conversational"],
+			pipeline_tag: "text-generation",
+			inference: "",
+		};
+
+		expect(displayOnModelPage(model)).toBe(false);
+	});
+
 	it("atomic chat deeplink", async () => {
 		const { displayOnModelPage, deeplink } = LOCAL_APPS["atomic-chat"];
 		const model: ModelData = {

--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -660,6 +660,13 @@ export const LOCAL_APPS = {
 		displayOnModelPage: (model) => isLlamaCppGgufModel(model) || isMlxModel(model),
 		deeplink: (model) => new URL(`atomic-chat://models/huggingface/${model.id}`),
 	},
+	saient: {
+		prettyLabel: "Saient",
+		docsUrl: "https://saient.co.uk",
+		mainTask: "text-generation",
+		displayOnModelPage: isLlamaCppGgufModel,
+		deeplink: (model) => new URL(`saient://models/huggingface/${model.id}`),
+	},
 	backyard: {
 		prettyLabel: "Backyard AI",
 		docsUrl: "https://backyard.ai",


### PR DESCRIPTION
## What

Adds **Saient** to `LOCAL_APPS`.

Saient is a local-first desktop AI app (Apache-2.0, https://saient.co.uk) that runs GGUF models entirely on the user's own machine via its own Rust inference engine — no cloud, no API keys. It registers the `saient://` URL scheme, so "Use this model → Saient" hands it a repo id:

```
saient://models/huggingface/{model.id}
```

`displayOnModelPage` is `isLlamaCppGgufModel`, since GGUF is what the engine loads. `mainTask` is `text-generation`.

## Behaviour

Opening a link downloads nothing on its own. Saient shows a confirmation dialog naming the repo, then lists the GGUF files so the user picks a quant — only that click starts a download. Network access in the app is off by default and a deep link carries no authority to change it: with networking off the link just surfaces the app's usual "turn it on in Settings" message. Repo ids are validated before they can reach the Hub API.

## Verified

- **Linux** — `.deb` and AppImage, installed, opened via `xdg-open`
- **Windows** — NSIS installer, protocol registered at install time, opened via a `saient://` URL
- Both show the prompt with the correct repo id, and importing lands the chosen `.gguf` in the app's model folder

Sources: [SaientAI/ai-workshop](https://github.com/SaientAI/ai-workshop) (app) and [SaientAI/saient-quartz](https://github.com/SaientAI/saient-quartz) (inference engine), both public and built by GitHub Actions.

## Two things worth saying plainly

**Code signing.** The Windows installer is not yet Authenticode-signed, so Windows reports an unknown publisher. We're actively working on obtaining a certificate, and the release workflow is already wired to sign automatically the moment one is available — it isn't a step we've skipped. Linux packages ship with SHA-256 checksums in a public release manifest. If an unsigned Windows build is a blocker for listing, please say so and we'll come back when it's signed rather than take up your time now.

**Platform maturity.** The Linux build has had the closer attention and was finished first — it's what Saient is developed and tested on daily. The Windows build is newer and rougher around the edges. The deep link itself is verified on both.

Thanks for maintaining this list, and for the time it takes to review additions to it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a registry entry and tests only; no auth, data, or core inference paths change.
> 
> **Overview**
> Registers **Saient** in `LOCAL_APPS` so GGUF model pages can offer “Use this model → Saient” with a `saient://models/huggingface/{model.id}` deeplink, matching other desktop clients like Jan and Atomic Chat.
> 
> Visibility is gated with `isLlamaCppGgufModel` and `mainTask` is `text-generation`. Vitest covers the deeplink URL and that non-GGUF models do not show the option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee8772cc9cc2d860c70a9c93eb79ef65e5b482b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

