### PR TITLE
Add shadow library for model download counting

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1424,7 +1424,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		filter: true,
 	},
 	shadow: {
-		prettyLabel: "shadow",
+		prettyLabel: "Shadow",
 		repoName: "SHADOW",
 		repoUrl: "https://github.com/QLNI/SHADOW-250M-Instruct",
 		filter: false,

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1423,6 +1423,13 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		snippets: snippets.setfit,
 		filter: true,
 	},
+	shadow: {
+		prettyLabel: "shadow",
+		repoName: "SHADOW",
+		repoUrl: "https://github.com/QLNI/SHADOW-250M-Instruct",
+		filter: false,
+		countDownloads: `path_extension:"shdw"`,
+	},
 	sklearn: {
 		prettyLabel: "Scikit-learn",
 		repoName: "Scikit-learn",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1425,7 +1425,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	},
 	shadow: {
 		prettyLabel: "Shadow",
-		repoName: "SHADOW",
+		repoName: "Shadow",
 		repoUrl: "https://github.com/QLNI/SHADOW-250M-Instruct",
 		filter: false,
 		countDownloads: `path_extension:"shdw"`,


### PR DESCRIPTION
Registers the `shadow` model library so downloads are counted for repos whose weights ship as `.shdw` deployment files.

- Library: SHADOW — small CPU-first language models with single-file deployment format (`.shdw`)
- Example repo: https://huggingface.co/NODEMIND/SHADOW-250M (weights + runtime download `deployment/*.shdw`; the repo currently shows 0 downloads despite real traffic because nothing counted)
- `countDownloads`: `path_extension:"shdw"`

Follows the pattern of neighboring entries (seedvr, self-forcing, sapiens).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry addition for download analytics only; no auth, inference, or filter UI changes.
> 
> **Overview**
> Registers the **`shadow`** modeling library in `MODEL_LIBRARIES_UI_ELEMENTS` so Hub models tagged with `library_name: shadow` get accurate download stats when users fetch **`.shdw`** deployment artifacts (instead of showing zero).
> 
> The entry points at the SHADOW reference repo, sets **`countDownloads`** to `path_extension:"shdw"`, and keeps **`filter: false`** so it does not appear on the main models library filter—matching nearby niche libraries like `seedvr` and `sapiens`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbf03cee4ed8539e05bcfe000d974204b0f1e33b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->