### PR TITLE
eval: add fidelity-kld evaluation framework

### DIFF
--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -177,6 +177,6 @@ export const EVALUATION_FRAMEWORKS = {
 		name: "fidelity-kld",
 		description:
 			"Distribution-fidelity measurement: full-vocabulary KL divergence between a candidate model and an unquantized reference model, over frozen token IDs, teacher-forced, accumulated in fp64. Measures what quantization costs rather than task accuracy. Lower is better; 0.0 means the candidate reproduces the reference distribution exactly.",
-		url: "https://github.com/malaiwah/glm53-flash-fidelity-suite",
+		url: "https://github.com/malaiwah/quant-fidelity-suite",
 	},
 } as const;

--- a/packages/tasks/src/eval.ts
+++ b/packages/tasks/src/eval.ts
@@ -173,4 +173,10 @@ export const EVALUATION_FRAMEWORKS = {
 			"ExtractBench is a benchmark for schema-guided data extraction from enterprise documents, scoring schema-valid JSON extraction and evidence grounding without an LLM judge.",
 		url: "https://github.com/run-llama/ExtractBench",
 	},
+	"fidelity-kld": {
+		name: "fidelity-kld",
+		description:
+			"Distribution-fidelity measurement: full-vocabulary KL divergence between a candidate model and an unquantized reference model, over frozen token IDs, teacher-forced, accumulated in fp64. Measures what quantization costs rather than task accuracy. Lower is better; 0.0 means the candidate reproduces the reference distribution exactly.",
+		url: "https://github.com/malaiwah/glm53-flash-fidelity-suite",
+	},
 } as const;


### PR DESCRIPTION
Adds `fidelity-kld` to `EVALUATION_FRAMEWORKS`, per the note in [Evaluation Results](https://huggingface.co/docs/hub/eval-results) that new frameworks are added to this list.

### What it measures

Not accuracy against human-authored answers. Given a frozen set of token IDs, it runs a **reference** model (e.g. `zai-org/GLM-5.3-Flash-BF16`) and a **candidate** — typically a quantization of that same model — over the same positions, teacher-forced, and computes mean `KL(reference ‖ candidate)` over the **full vocabulary** in fp64. Lower is better; exactly `0.0` means the candidate reproduces the reference distribution bit-for-bit.

This is how you find out what a 4-bit quantization actually costs, and it is cheap — roughly $6 of rented GPU per model.

### Why it doesn't fit an existing entry

Every framework currently in the enum scores a model against human-authored ground truth (QA, agentic, OCR, retrieval, structured output). This one is **reference-relative and distributional**: the "ground truth" is another model's output distribution, and the metric is a divergence in nats rather than a score in [0,1].

### Worked example

A ladder we published for one model family, all on one panel and one lane:

| bpw | mean KLD (nats) | top-1 |
|---:|---:|---:|
| 16 (unquantized reference floor) | 0.011506 | — |
| 8 | 0.012384 | — |
| 6 | 0.013715 | 0.9656 |
| 4 | 0.025503 | 0.9531 |
| 3 | 0.050501 | 0.9300 |
| 2 | 0.155210 | 0.8727 |

Every row is two bitwise-identical cold runs with a digest-pinned receipt.

### Notes

- Repo (MIT): https://github.com/malaiwah/quant-fidelity-suite
- Method, including the comparability rules that decide when two of these numbers may be ranked against each other: [WHAT-WE-MEASURE.md](https://github.com/malaiwah/quant-fidelity-suite/blob/main/WHAT-WE-MEASURE.md)
- Public registry of ~70 such measurements across three model families and six quantization formats: https://huggingface.co/datasets/malaiwah/quant-fidelity-registry
- A companion `eval.yaml` and the allow-list request are drafted [here](https://github.com/malaiwah/quant-fidelity-suite/tree/main/docs/hf-eval-results); happy to open that conversation wherever you prefer.

One caveat stated up front: this framework has no `verifyToken` path today, since it isn't an inspect-ai task and doesn't run in HF Jobs. What it has instead is bitwise determinism — repeated cold runs produce identical means — and a digest-pinned receipt per result. If there's a route to auditable verification for a non-inspect framework, I'd be glad to follow it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry entry with name, description, and URL only; no runtime eval harness or auth changes in this diff.
> 
> **Overview**
> Registers **`fidelity-kld`** in `EVALUATION_FRAMEWORKS` so benchmark datasets can declare it in `eval.yaml` alongside existing frameworks.
> 
> The new entry documents a **reference-relative** metric: mean full-vocabulary KL divergence (fp64, teacher-forced on frozen token IDs) between a candidate model and an unquantized reference, aimed at quantifying quantization cost rather than task accuracy (lower is better; 0.0 is exact match). It points to the quant-fidelity-suite repo for methodology and tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35d26116e11cf5c892df1adb35ebbc970ec2705f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

