### PR TITLE
feat(tasks): register SandBase Harness

### DIFF
--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -161,7 +161,6 @@ export const AGENT_HARNESSES = {
 		repoUrl: "https://github.com/sandbaseai/sandbase-harness",
 		docsUrl: "https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md",
 		description: "Local-first, self-hosted runtime for persistent AI agent sessions and MCP tools.",
-		envVars: { MANAGED_AGENTS_HOME: "*" },
 	},
 	opencode: {
 		prettyLabel: "opencode",

--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -156,6 +156,13 @@ export const AGENT_HARNESSES = {
 		description: "Open-source, self-hosted personal AI assistant that runs on your own devices.",
 		envVars: { OPENCLAW_SHELL: "*" },
 	},
+	"sandbase-harness": {
+		prettyLabel: "SandBase Harness",
+		repoUrl: "https://github.com/sandbaseai/sandbase-harness",
+		docsUrl: "https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md",
+		description: "Local-first, self-hosted runtime for persistent AI agent sessions and MCP tools.",
+		envVars: { MANAGED_AGENTS_HOME: "*" },
+	},
 	opencode: {
 		prettyLabel: "opencode",
 		repoUrl: "https://github.com/anomalyco/opencode",


### PR DESCRIPTION
## What
Register SandBase Harness in the Hugging Face Hub agent-harness attribution map.

## Why
SandBase Harness is a local-first, self-hosted AI agent runtime. Its `MANAGED_AGENTS_HOME` environment variable is a project-specific signal that can identify Hub activity originating from the Harness without changing the runtime or claiming universal detection.

## Verification
- `corepack pnpm --filter @huggingface/tasks format:check`
- `corepack pnpm --filter @huggingface/tasks check`

Both pass. Repository: https://github.com/sandbaseai/sandbase-harness
Documentation: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only registry addition with no changes to detection logic or runtime behavior.
> 
> **Overview**
> Adds **SandBase Harness** (`sandbase-harness`) to the Hub `AGENT_HARNESSES` registry in `agent-harnesses.ts`, with display label, GitHub repo, installation docs URL, and a short description of it as a local-first agent runtime.
> 
> The new entry has no `envVars` block in this diff, so attribution would rely on the standard `AI_AGENT` / `AGENT` identifiers (or a follow-up to add a harness-specific env signal such as `MANAGED_AGENTS_HOME`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4407827bc9c5564f1abdcc327fb23fdc0060a2e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->