### PR TITLE
[Inference Providers] Key conversational snippets on the pipeline tag instead of the conversational tag

### DIFF
--- a/packages/inference/src/snippets/getInferenceSnippets.ts
+++ b/packages/inference/src/snippets/getInferenceSnippets.ts
@@ -154,11 +154,7 @@ const snippetGenerator = (templateName: string, inputPreparationFn?: InputPrepar
 		const providerModelId = inferenceProviderMapping?.providerId ?? model.id;
 		/// Hacky: hard-code conversational templates here
 		let task = model.pipeline_tag as InferenceTask;
-		if (
-			model.pipeline_tag &&
-			["text-generation", "image-text-to-text"].includes(model.pipeline_tag) &&
-			model.tags.includes("conversational")
-		) {
+		if (model.pipeline_tag && ["text-generation", "image-text-to-text"].includes(model.pipeline_tag)) {
 			templateName = opts?.streaming ? "conversationalStream" : "conversational";
 			inputPreparationFn = prepareConversationalInput;
 			task = "conversational";

--- a/packages/tasks/src/snippets/inputs.ts
+++ b/packages/tasks/src/snippets/inputs.ts
@@ -41,30 +41,26 @@ const inputsTextClassification = () => `"I like you. I love you"`;
 
 const inputsTokenClassification = () => `"My name is Sarah Jessica Parker but you can call me Jessica"`;
 
-const inputsTextGeneration = (model: ModelDataMinimal): string | ChatCompletionInputMessage[] => {
-	if (model.tags.includes("conversational")) {
-		return model.pipeline_tag === "text-generation"
-			? [{ role: "user", content: "What is the capital of France?" }]
-			: [
-					{
-						role: "user",
-						content: [
-							{
-								type: "text",
-								text: "Describe this image in one sentence.",
+const inputsTextGeneration = (model: ModelDataMinimal): ChatCompletionInputMessage[] =>
+	model.pipeline_tag === "text-generation"
+		? [{ role: "user", content: "What is the capital of France?" }]
+		: [
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "Describe this image in one sentence.",
+						},
+						{
+							type: "image_url",
+							image_url: {
+								url: "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg",
 							},
-							{
-								type: "image_url",
-								image_url: {
-									url: "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg",
-								},
-							},
-						],
-					},
-				];
-	}
-	return `"Can you please let us know more details about your "`;
-};
+						},
+					],
+				},
+			];
 
 // `mask_token` is author-controlled (tokenizer/config.json); build the string then
 // JSON.stringify it so quotes/backslashes are escaped into a valid string literal


### PR DESCRIPTION
The Hub is dropping the `conversational` tag requirement for inference providers (internal PR: huggingface-internal/moon-landing#19696): any model with pipeline tag `text-generation` or `image-text-to-text` can be registered as a chat-completion model, and the `text-generation` inference task no longer exists provider-side. The registered mapping decides, not the model's tags.

This mirrors the rule in the snippets: chat-completion snippets are picked from the pipeline tag, so models without the `conversational` tag (many chat models are missing a detectable chat template) get correct chat-completion code examples instead of `text-generation` ones.

- `getInferenceSnippets`: drop the `tags.includes("conversational")` condition, keep the pipeline check.
- `inputsTextGeneration`: always return chat messages (the function is only registered for `text-generation` / `image-text-to-text`); the raw-prompt fallback is dead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Snippet and example-input selection only; no runtime auth, routing, or data-path changes beyond showing different generated code on model pages.
> 
> **Overview**
> Inference code examples for **`text-generation`** and **`image-text-to-text`** models now always use **chat-completion** snippets and sample **messages**, keyed only on **pipeline tag**—the **`conversational` model tag** is no longer required.
> 
> In **`getInferenceSnippets`**, the override that picks **`conversational`** / **`conversationalStream`** templates and the **`conversational`** task drops **`model.tags.includes("conversational")`**, so models without that tag still get router **`/chat/completions`**-style examples when registered as chat models.
> 
> In **`inputsTextGeneration`**, sample inputs are always **`ChatCompletionInputMessage[]`** (text vs multimodal by pipeline tag); the old raw-string prompt fallback for non-conversational models is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdc8100b120d904f0d595295855cc65ad8b5e549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->