### PR TITLE
Add Aiqre inference provider

### DIFF
--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -65,6 +65,7 @@ Currently, we support the following providers:
 - [Groq](https://groq.com)
 - [Wavespeed.ai](https://wavespeed.ai/)
 - [Z.ai](https://z.ai/)
+- [Aiqre](https://aiqre.com)
 
 To send requests to a third-party provider, you have to pass the `provider` parameter to the inference function. The default value of the `provider` parameter is "auto", which will select the first of the providers available for the model, sorted by your preferred order in https://hf.co/settings/inference-providers.
 
@@ -101,6 +102,7 @@ Only a subset of models are supported when requesting third-party providers. You
 - [Novita AI supported models](https://huggingface.co/api/partners/novita/models)
 - [Wavespeed.ai supported models](https://huggingface.co/api/partners/wavespeed/models)
 - [Z.ai supported models](https://huggingface.co/api/partners/zai-org/models)
+- [Aiqre supported models](https://huggingface.co/api/partners/aiqre/models)
 
 ❗**Important note:** To be compatible, the third-party API must adhere to the "standard" shape API we expect on HF model pages for each pipeline task type.
 This is not an issue for LLMs as everyone converged on the OpenAI API anyways, but can be more tricky for other tasks like "text-to-image" or "automatic-speech-recognition" where there exists no standard API. Let us know if any help is needed or if we can make things easier for you!

--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -1,3 +1,4 @@
+import * as Aiqre from "../providers/aiqre.js";
 import * as Baseten from "../providers/baseten.js";
 import * as Cerebras from "../providers/cerebras.js";
 import * as Cohere from "../providers/cohere.js";
@@ -56,6 +57,9 @@ import type { InferenceProvider, InferenceProviderOrPolicy, InferenceTask } from
 import { InferenceClientInputError } from "../errors.js";
 
 export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, TaskProviderHelper>>> = {
+	aiqre: {
+		conversational: new Aiqre.AiqreConversationalTask(),
+	},
 	baseten: {
 		conversational: new Baseten.BasetenConversationalTask(),
 	},

--- a/packages/inference/src/providers/aiqre.ts
+++ b/packages/inference/src/providers/aiqre.ts
@@ -1,0 +1,26 @@
+/**
+ * See the registered mapping of HF model ID => Aiqre model ID here:
+ *
+ * https://huggingface.co/api/partners/aiqre/models
+ *
+ * This is a publicly available mapping.
+ *
+ * If you want to try to run inference for a new model locally before it's registered on huggingface.co,
+ * you can add it to the dictionary "HARDCODED_MODEL_ID_MAPPING" in consts.ts, for dev purposes.
+ *
+ * - If you work at Aiqre and want to update this mapping, please use the model mapping API we provide on huggingface.co
+ * - If you're a community member and want to add a new supported HF model to Aiqre, please open an issue on the present repo
+ * and we will tag Aiqre team members.
+ *
+ * Thanks!
+ */
+
+import { BaseConversationalTask } from "./providerHelper.js";
+
+const AIQRE_API_BASE_URL = "https://api.aiqre.com";
+
+export class AiqreConversationalTask extends BaseConversationalTask {
+	constructor() {
+		super("aiqre", AIQRE_API_BASE_URL);
+	}
+}

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -45,6 +45,7 @@ export interface Options {
 export type InferenceTask = Exclude<PipelineType, "other"> | "conversational";
 
 export const INFERENCE_PROVIDERS = [
+	"aiqre",
 	"baseten",
 	"cerebras",
 	"cohere",


### PR DESCRIPTION
This PR registers Aiqre (https://aiqre.com) as a conversational inference provider, following the register-as-a-provider guide.

Aiqre is an EU inference provider (Advanced AI s.r.o., Czech Republic) serving open-weight models. The API is strictly OpenAI-compatible chat completions with streaming, tool calling and structured outputs, live at https://api.aiqre.com/v1 (catalogue with pricing and context_length: https://api.aiqre.com/hf/v1/models).

The provider class follows the BaseConversationalTask pattern used by Cerebras and Fireworks. Billing endpoint (nano-USD, idempotent) and Inference-Id response headers are implemented on our side per the provider docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider registration with no changes to auth, routing, or existing providers; only conversational chat is exposed via the shared base helper.
> 
> **Overview**
> Registers **Aiqre** as a third-party inference partner so clients can call **`provider: "aiqre"`** for chat completion against `https://api.aiqre.com`, using the same OpenAI-compatible **`BaseConversationalTask`** pattern as providers like Cerebras.
> 
> Wiring adds `AiqreConversationalTask`, maps **`aiqre` → conversational** in `PROVIDERS`, and extends **`INFERENCE_PROVIDERS`** so the slug is valid at the type level. The inference package README lists Aiqre and links to the HF partner models API (`/api/partners/aiqre/models`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0871a12ebf409ffda7a0edaa69994d7611cb8161. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->