### PR TITLE
[tasks] Add ZeroModels model-loading snippet

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -910,6 +910,21 @@ model = keras.saving.load_model("hf://${model.id}")
 `,
 ];
 
+export const zeromodels = (model: ModelData): string[] => [
+	`# pip install -U zeromodels
+# ZeroModels is pure Keras 3, so pick a backend: "jax", "torch" or "tensorflow".
+import os
+os.environ["KERAS_BACKEND"] = "jax"
+
+from zeromodels import AutoZModel
+
+# AutoZModel reads the repo's model_type and loads the matching class.
+# For a task head use the matching loader, e.g. AutoZMImageClassify / AutoZMDetect /
+# AutoZMSemanticSegment / AutoZMTextGenerate (see zeromodels.auto).
+model = AutoZModel.from_weights("${model.id}")
+`,
+];
+
 const _keras_hub_causal_lm = (modelId: string): string => `
 import keras_hub
 

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -769,6 +769,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "ZeroModels",
 		repoUrl: "https://github.com/IMvision12/ZeroModels",
 		docsUrl: "https://imvision12.github.io/ZeroModels/",
+		snippets: snippets.zeromodels,
 		countDownloads: `path:"model.weights.h5" OR path:"model.weights.json"`,
 		filter: false,
 	},


### PR DESCRIPTION
Adds a "Use this model" code snippet for the ZeroModels library (packages/tasks): the zeromodels snippet in model-libraries-snippets.ts showing AutoZModel.from_weights("<repo>"), wired into the existing zeromodels entry in model-libraries.ts via snippets: snippets.zeromodels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only snippet wiring in packages/tasks; no runtime or auth changes.
> 
> **Overview**
> Adds a **Use this model** code sample for Hub repos tagged with the **ZeroModels** library.
> 
> A new `zeromodels` snippet generator documents installing `zeromodels`, choosing a Keras 3 backend (`jax`, `torch`, or `tensorflow`), and loading weights with `AutoZModel.from_weights("<repo_id>")`, with a short note pointing to task-specific loaders (`AutoZMImageClassify`, etc.).
> 
> The existing `zeromodels` entry in `model-libraries.ts` now references `snippets.zeromodels`, so model pages show this snippet alongside the library metadata and download counting that were already configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5d76a304be734e1d16746789e5f1a21007853a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->