### PR TITLE
Update TimesFM download counting rule for config.json and safetensors

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1636,7 +1636,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "timesfm",
 		repoUrl: "https://github.com/google-research/timesfm",
 		filter: false,
-		countDownloads: `path:"checkpoints/checkpoint_1100000/state/checkpoint" OR path:"checkpoints/checkpoint_2150000/state/checkpoint" OR path_extension:"ckpt"`,
+		countDownloads: `path:"config.json" OR path:"model.safetensors" OR path_extension:"safetensors" OR path_extension:"ckpt" OR path_prefix:"checkpoints/"`,
 	},
 	"timee-ts": {
 		prettyLabel: "timee-ts",

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1636,7 +1636,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoName: "timesfm",
 		repoUrl: "https://github.com/google-research/timesfm",
 		filter: false,
-		countDownloads: `path:"config.json" OR path:"model.safetensors" OR path_extension:"safetensors" OR path_extension:"ckpt" OR path_prefix:"checkpoints/"`,
+		countDownloads: `path:"config.json" OR path:"torch_model.ckpt" OR path:"checkpoints/checkpoint_1100000/state/checkpoint" OR path:"checkpoints/checkpoint_2150000/state/checkpoint"`,
 	},
 	"timee-ts": {
 		prettyLabel: "timee-ts",


### PR DESCRIPTION
### Description
This PR updates the `countDownloads` query rule for the `timesfm` library in `packages/tasks/src/model-libraries.ts`.

### Background
TimesFM 1.0 used PaxML/JAX checkpoints (`checkpoints/checkpoint_1100000/...`), and TimesFM 2.0 used PyTorch `.ckpt` files (`torch_model.ckpt`). 

Recent releases (TimesFM 2.5 and TimesFM 3.0, e.g. [google/timesfm-3.0-pytorch](https://huggingface.co/google/timesfm-3.0-pytorch)) use standard `config.json` and `model.safetensors` via `PyTorchModelHubMixin`.

The previous `countDownloads` rule:
```typescript
countDownloads: `path:"checkpoints/checkpoint_1100000/state/checkpoint" OR path:"checkpoints/checkpoint_2150000/state/checkpoint" OR path_extension:"ckpt"`,
```
ignored requests for `config.json` and `.safetensors`, resulting in 0 tracked downloads for modern TimesFM models.

### Changes
Added `path:"config.json"` and `path_extension:"safetensors"` while preserving backwards compatibility for `.ckpt` and JAX checkpoints:
```typescript
countDownloads: `path:"config.json" OR path:"model.safetensors" OR path_extension:"safetensors" OR path_extension:"ckpt" OR path_prefix:"checkpoints/"`,
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata query change for one library; only affects how TimesFM download metrics are aggregated, with no runtime or auth impact.
> 
> **Overview**
> Updates the **TimesFM** library’s Elasticsearch `countDownloads` rule so recent Hub models (e.g. `config.json` + PyTorch weights) are included in download stats.
> 
> The query now matches **`config.json`** and **`torch_model.ckpt`**, while keeping the existing JAX checkpoint paths. The previous blanket **`path_extension:"ckpt"`** clause is dropped in favor of the explicit **`torch_model.ckpt`** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5c35667e0d91e2dc4c981fb27fe25fe3bda30b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->