### PR TITLE
Add Berget as an inference provider

### DIFF
--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -59,6 +59,7 @@ Currently, we support the following providers:
 - [Scaleway](https://www.scaleway.com/en/generative-apis/)
 - [Together](https://together.xyz)
 - [Baseten](https://baseten.co)
+- [Berget](https://berget.ai)
 - [Cohere](https://cohere.com)
 - [Cerebras](https://cerebras.ai/)
 - [DeepInfra](https://deepinfra.com)

--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -1,4 +1,5 @@
 import * as Baseten from "../providers/baseten.js";
+import * as Berget from "../providers/berget.js";
 import * as Cerebras from "../providers/cerebras.js";
 import * as Cohere from "../providers/cohere.js";
 import * as DeepInfra from "../providers/deepinfra.js";
@@ -58,6 +59,9 @@ import { InferenceClientInputError } from "../errors.js";
 export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, TaskProviderHelper>>> = {
 	baseten: {
 		conversational: new Baseten.BasetenConversationalTask(),
+	},
+	berget: {
+		conversational: new Berget.BergetConversationalTask(),
 	},
 	cerebras: {
 		conversational: new Cerebras.CerebrasConversationalTask(),

--- a/packages/inference/src/providers/berget.ts
+++ b/packages/inference/src/providers/berget.ts
@@ -1,0 +1,24 @@
+/**
+ * See the registered mapping of HF model ID => Berget model ID here:
+ *
+ * https://huggingface.co/api/partners/berget/models
+ *
+ * This is a publicly available mapping.
+ *
+ * If you want to try to run inference for a new model locally before it's registered on huggingface.co,
+ * you can add it to the dictionary "HARDCODED_MODEL_ID_MAPPING" in consts.ts, for dev purposes.
+ *
+ * - If you work at Berget and want to update this mapping, please use the model mapping API we provide on huggingface.co
+ * - If you're a community member and want to add a new supported HF model to Berget, please open an issue on the present repo
+ * and we will tag Berget team members.
+ *
+ * Thanks!
+ */
+
+import { BaseConversationalTask } from "./providerHelper.js";
+
+export class BergetConversationalTask extends BaseConversationalTask {
+	constructor() {
+		super("berget", "https://api.berget.ai");
+	}
+}

--- a/packages/inference/src/providers/berget.ts
+++ b/packages/inference/src/providers/berget.ts
@@ -6,7 +6,7 @@
  * This is a publicly available mapping.
  *
  * If you want to try to run inference for a new model locally before it's registered on huggingface.co,
- * you can add it to the dictionary "HARDCODED_MODEL_ID_MAPPING" in consts.ts, for dev purposes.
+ * you can add it to the dictionary "HARDCODED_MODEL_INFERENCE_MAPPING" in consts.ts, for dev purposes.
  *
  * - If you work at Berget and want to update this mapping, please use the model mapping API we provide on huggingface.co
  * - If you're a community member and want to add a new supported HF model to Berget, please open an issue on the present repo

--- a/packages/inference/src/providers/consts.ts
+++ b/packages/inference/src/providers/consts.ts
@@ -19,6 +19,7 @@ export const HARDCODED_MODEL_INFERENCE_MAPPING: Record<
 	 * "Qwen/Qwen2.5-Coder-32B-Instruct": "Qwen2.5-Coder-32B-Instruct",
 	 */
 	baseten: {},
+	berget: {},
 	cerebras: {},
 	cohere: {},
 	deepinfra: {},

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -46,6 +46,7 @@ export type InferenceTask = Exclude<PipelineType, "other"> | "conversational";
 
 export const INFERENCE_PROVIDERS = [
 	"baseten",
+	"berget",
 	"cerebras",
 	"cohere",
 	"deepinfra",
@@ -79,6 +80,7 @@ export type InferenceProviderOrPolicy = (typeof PROVIDERS_OR_POLICIES)[number];
  */
 export const PROVIDERS_HUB_ORGS: Record<InferenceProvider, string> = {
 	baseten: "baseten",
+	berget: "berget",
 	cerebras: "cerebras",
 	cohere: "CohereLabs",
 	deepinfra: "DeepInfra",

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -2454,13 +2454,12 @@ describe.skip("InferenceClient", () => {
 				const res = await client.chatCompletion({
 					model: "openai/gpt-oss-120b",
 					provider: "berget",
-					messages: [
-						{ role: "user", content: "Complete this sentence with words, one plus one is equal " },
-					],
+					messages: [{ role: "user", content: "Complete this sentence with words, one plus one is equal " }],
+					max_tokens: 10,
 				});
 				if (res.choices && res.choices.length > 0) {
 					const completion = res.choices[0].message?.content;
-					expect(completion).toContain("two");
+					expect(completion ?? "").toMatch(/two|2/i);
 				}
 			});
 
@@ -2469,6 +2468,7 @@ describe.skip("InferenceClient", () => {
 					model: "openai/gpt-oss-120b",
 					provider: "berget",
 					messages: [{ role: "user", content: "Say 'this is a test'" }],
+					max_tokens: 10,
 					stream: true,
 				}) as AsyncGenerator<ChatCompletionStreamOutput>;
 

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -2441,18 +2441,18 @@ describe.skip("InferenceClient", () => {
 			const client = new InferenceClient(env.HF_BERGET_KEY ?? "dummy");
 
 			HARDCODED_MODEL_INFERENCE_MAPPING["berget"] = {
-				"openai/gpt-oss-120b": {
+				"google/gemma-4-31B-it": {
 					provider: "berget",
-					hfModelId: "openai/gpt-oss-120b",
-					providerId: "openai/gpt-oss-120b",
+					hfModelId: "google/gemma-4-31B-it",
+					providerId: "google/gemma-4-31B-it",
 					status: "live",
 					task: "conversational",
 				},
 			};
 
-			it("chatCompletion - gpt-oss 120b", async () => {
+			it("chatCompletion - gemma-4 31B", async () => {
 				const res = await client.chatCompletion({
-					model: "openai/gpt-oss-120b",
+					model: "google/gemma-4-31B-it",
 					provider: "berget",
 					messages: [{ role: "user", content: "Complete this sentence with words, one plus one is equal " }],
 					max_tokens: 10,
@@ -2463,9 +2463,9 @@ describe.skip("InferenceClient", () => {
 				}
 			});
 
-			it("chatCompletion stream - gpt-oss 120b", async () => {
+			it("chatCompletion stream - gemma-4 31B", async () => {
 				const stream = client.chatCompletionStream({
-					model: "openai/gpt-oss-120b",
+					model: "google/gemma-4-31B-it",
 					provider: "berget",
 					messages: [{ role: "user", content: "Say 'this is a test'" }],
 					max_tokens: 10,

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -2434,4 +2434,59 @@ describe.skip("InferenceClient", () => {
 		},
 		TIMEOUT,
 	);
+
+	describe.concurrent(
+		"Berget",
+		() => {
+			const client = new InferenceClient(env.HF_BERGET_KEY ?? "dummy");
+
+			HARDCODED_MODEL_INFERENCE_MAPPING["berget"] = {
+				"openai/gpt-oss-120b": {
+					provider: "berget",
+					hfModelId: "openai/gpt-oss-120b",
+					providerId: "openai/gpt-oss-120b",
+					status: "live",
+					task: "conversational",
+				},
+			};
+
+			it("chatCompletion - gpt-oss 120b", async () => {
+				const res = await client.chatCompletion({
+					model: "openai/gpt-oss-120b",
+					provider: "berget",
+					messages: [
+						{ role: "user", content: "Complete this sentence with words, one plus one is equal " },
+					],
+				});
+				if (res.choices && res.choices.length > 0) {
+					const completion = res.choices[0].message?.content;
+					expect(completion).toContain("two");
+				}
+			});
+
+			it("chatCompletion stream - gpt-oss 120b", async () => {
+				const stream = client.chatCompletionStream({
+					model: "openai/gpt-oss-120b",
+					provider: "berget",
+					messages: [{ role: "user", content: "Say 'this is a test'" }],
+					stream: true,
+				}) as AsyncGenerator<ChatCompletionStreamOutput>;
+
+				let fullResponse = "";
+				for await (const chunk of stream) {
+					if (chunk.choices && chunk.choices.length > 0) {
+						const content = chunk.choices[0].delta?.content;
+						if (content) {
+							fullResponse += content;
+						}
+					}
+				}
+
+				// Verify we got a meaningful response
+				expect(fullResponse).toBeTruthy();
+				expect(fullResponse.length).toBeGreaterThan(0);
+			});
+		},
+		TIMEOUT,
+	);
 });


### PR DESCRIPTION
Hi! We're [Berget](https://berget.ai) and we'd like to register as an inference provider on the Hub, following the [registration guide](https://huggingface.co/docs/inference-providers/en/register-as-a-provider).

**Provider:** `berget`
**Base URL:** `https://api.berget.ai`
**Task:** conversational only (OpenAI-compatible `/v1/chat/completions`)
**Developer Docs:** https://docs.berget.ai

This PR adds the provider helper (`BergetConversationalTask` extending `BaseConversationalTask` — no overrides needed since the API is OpenAI-compatible), registers it in `getProviderHelper.ts`/`types.ts`/`consts.ts`, updates the README list, and adds the usual `InferenceClient.spec.ts` block (`HF_BERGET_KEY`).

Notes:
- We're starting with direct requests (users bring their own Berget API key). Routed-request billing will follow in a later phase.
- The registered HF org namespace for `PROVIDERS_HUB_ORGS` is `berget` (matching the provider slug); we'll get the org created and upgraded to a Team plan as part of the registration. Happy to adjust if you prefer a different slug.
- We'll contact you via the usual channels to get the partner account enabled server-side so we can register model mappings (staging first).

Verified locally: `pnpm build` and eslint pass; the test suite collects the new `Berget` block (live tests skip without keys, as for other providers).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider registration with no changes to existing routing or auth; risk is limited to new optional code paths when `provider: "berget"` is selected.
> 
> **Overview**
> Registers **Berget** (`berget`) as a third-party inference provider so clients can call `provider: "berget"` with a Berget API key (direct routing; Hub billing is out of scope for this change).
> 
> Implementation follows other OpenAI-compatible chat providers: `BergetConversationalTask` targets `https://api.berget.ai` and only supports **conversational** (`chatCompletion` / streaming). Wiring adds the slug to `INFERENCE_PROVIDERS`, `PROVIDERS_HUB_ORGS`, the provider registry in `getProviderHelper.ts`, an empty dev mapping entry in `consts.ts`, README listing, and live integration tests keyed off `HF_BERGET_KEY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f80d53bed1a6d6eb944ca7b1983bbe9a89bbd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->