### PR TITLE
Add GTX 960M to NVIDIA hardware list

### DIFF
--- a/packages/tasks/src/hardware-nvidia.ts
+++ b/packages/tasks/src/hardware-nvidia.ts
@@ -853,6 +853,13 @@ export const NVIDIA_SKUS: Record<string, NvidiaHardwareSpec> = {
 		power: 75,
 		releaseYear: 2016,
 	},
+	"GTX 960M": {
+		tflops: 1.51, // float32 (GPU does not support native float16)
+		memory: [2, 4],
+		computeCapability: 5.0,
+		power: 75,
+		releaseYear: 2015,
+	},
 	"RTX Titan": {
 		tflops: 32.62,
 		memory: [24],


### PR DESCRIPTION
## Summary
- Adds **GTX 960M** to `packages/tasks/src/hardware-nvidia.ts` so it can be selected in Hub Local Apps / My Hardware.
- Specs match [#2447](https://github.com/huggingface/huggingface.js/issues/2447): 1.51 FP32 TFLOPS, 2/4 GB VRAM, compute capability 5.0, 75 W TDP, 2015. Same float32 convention as neighboring GTX 10-series entries.

Closes #2447

## Test plan
- [ ] `GTX 960M` appears in the NVIDIA SKU object next to `GTX 1050 Ti`
- [ ] After merge, the GPU can be added at https://huggingface.co/settings/local-apps


Made with [Cursor](https://cursor.com)