### PR TITLE
gguf: add BPOSIT8 quantization type (tensor type 43)

### DIFF
--- a/packages/gguf/src/gguf.spec.ts
+++ b/packages/gguf/src/gguf.spec.ts
@@ -337,6 +337,7 @@ describe("gguf", () => {
 		expect(parseGGUFQuantLabel("Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf")).toEqual("Q4_K_M");
 		expect(parseGGUFQuantLabel("subdir/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf")).toEqual("Q4_K_M");
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-Q2_K.gguf")).toEqual("Q2_K");
+		expect(parseGGUFQuantLabel("SmolLM2-135M-Instruct-bposit8.gguf")).toEqual("BPOSIT8");
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1.gguf")).toEqual(undefined);
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-F32-Q2_K.gguf")).toEqual("Q2_K"); // gguf name with two quant labels [F32, Q2_K]
 		expect(parseGGUFQuantLabel("Codestral-22B-v0.1-IQ3_XS.gguf")).toEqual("IQ3_XS");

--- a/packages/gguf/src/quant-descriptions.ts
+++ b/packages/gguf/src/quant-descriptions.ts
@@ -140,6 +140,10 @@ export const GGUF_QUANT_DESCRIPTIONS: Record<GGMLQuantizationType, { txt: string
 		txt: "4-bit Microscaling Block Floating Point with global scale.",
 		src_url: "https://github.com/ggml-org/llama.cpp/pull/19769",
 	},
+	[GGMLQuantizationType.BPOSIT8]: {
+		txt: "8-bit b-posit quantization (Anomly). Each block has 32 weights and one signed 8-bit power-of-two scale. Weight formula: `w = posit8(q) * 2^scale`. Designed for exact accumulation in a 256-bit quire so that inference is bit-identical across hardware.",
+		src_url: "https://github.com/anomly-labs/invar/blob/main/docs/EXACT-PROFILE-SPEC.md",
+	},
 	[GGMLQuantizationType.Q1_0]: {
 		txt: "1-bit quantization with fp16 block scale. Each block has 128 weights, where 0 represents -block_scale and 1 represents +block_scale.",
 		src_url: "https://github.com/ggml-org/llama.cpp/pull/21273",
@@ -191,6 +195,7 @@ export const GGML_QUANT_SIZES = {
 	[GGMLQuantizationType.TQ2_0]: calcBPW(256, 2 + 64),
 	[GGMLQuantizationType.MXFP4]: calcBPW(32, 1 + 16),
 	[GGMLQuantizationType.NVFP4]: calcBPW(64, 4 + 32),
+	[GGMLQuantizationType.BPOSIT8]: calcBPW(32, 1 + 32),
 	[GGMLQuantizationType.Q1_0]: calcBPW(128, 2 + 16),
 	[GGMLQuantizationType.Q2_0]: calcBPW(64, 2 + 16),
 };

--- a/packages/tasks/src/gguf.ts
+++ b/packages/tasks/src/gguf.ts
@@ -44,6 +44,7 @@ export enum GGMLFileQuantizationType {
 	NVFP4 = 39,
 	Q1_0 = 40,
 	Q2_0 = 41,
+	BPOSIT8 = 42,
 
 	// custom quants used by unsloth
 	// they are not officially a scheme enum value in GGUF, but only here for naming
@@ -89,6 +90,7 @@ export const GGUF_QUANT_ORDER: GGMLFileQuantizationType[] = [
 	GGMLFileQuantizationType.F16,
 	GGMLFileQuantizationType.Q8_K_XL,
 	GGMLFileQuantizationType.Q8_0,
+	GGMLFileQuantizationType.BPOSIT8,
 
 	// 6-bit quantizations
 	GGMLFileQuantizationType.Q6_K_XL,
@@ -225,4 +227,5 @@ export enum GGMLQuantizationType {
 	NVFP4 = 40,
 	Q1_0 = 41,
 	Q2_0 = 42,
+	BPOSIT8 = 43,
 }


### PR DESCRIPTION
Adds the `BPOSIT8` quantization type so repositories publishing these GGUF files get a quantization label instead of "not able to determine the quantization variants" (for example https://huggingface.co/Anomly/SmolLM2-135M-Instruct-bposit8).

- `packages/tasks/src/gguf.ts`: `GGMLQuantizationType.BPOSIT8 = 43`, `GGMLFileQuantizationType.BPOSIT8 = 42` (the next free ids after `Q2_0`), and `BPOSIT8` in `GGUF_QUANT_ORDER` right after `Q8_0` (8.25 bits per weight vs 8.5).
- `packages/gguf/src/quant-descriptions.ts`: description and bits-per-weight (`calcBPW(32, 1 + 32)`: 32 weights, one signed 8-bit power-of-two scale, 8-bit posit codes).
- `packages/gguf/src/gguf.spec.ts`: filename label test.

What the type is: 8-bit b-posit (posit with a bounded exponent) block quantization, `w = posit8(q) * 2^scale`, designed for exact accumulation in a 256-bit quire so that inference is bit-identical across hardware. The format is specified in [EXACT-PROFILE-SPEC.md](https://github.com/anomly-labs/invar/blob/main/docs/EXACT-PROFILE-SPEC.md) (block layout, the scale rule, the quire readout) with conformance fixtures in the same repository, and two independent implementations of the dequantization and exact dot product exist there in [Python](https://github.com/anomly-labs/invar/blob/main/invar/reexec.py) and [Go](https://github.com/anomly-labs/invar/blob/main/go/crverify/reexec.go). Six models in this format are published under https://huggingface.co/Anomly.

Scope note: the type is implemented in a deterministic fork of llama.cpp (Apache-2.0) rather than in upstream ggml yet; a ggml PR will follow. If the project prefers to list only upstream-merged types, say so and we will return once that lands.

Checks run locally: `pnpm run check` in `packages/tasks` and `packages/gguf`, `vitest run -t quant` in `packages/gguf` (the `GGUF_QUANT_ORDER` sync test and the new label test pass), `oxfmt` on the changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive enum, description, and test changes only; no runtime inference or security-sensitive logic.
> 
> **Overview**
> Adds **BPOSIT8** so Hugging Face can recognize Anomly b-posit GGUFs (e.g. `*-bposit8.gguf`) instead of failing to infer quantization variants.
> 
> **Enum and ordering:** `GGMLFileQuantizationType.BPOSIT8 = 42` and `GGMLQuantizationType.BPOSIT8 = 43` are registered after `Q2_0`. `BPOSIT8` is inserted in `GGUF_QUANT_ORDER` immediately after `Q8_0` (~8.25 bpw).
> 
> **Metadata:** `quant-descriptions.ts` documents the format (32-weight blocks, power-of-two scale, exact quire accumulation) and sets bits-per-weight via `calcBPW(32, 1 + 32)`.
> 
> **Tests:** One `parseGGUFQuantLabel` case asserts `SmolLM2-135M-Instruct-bposit8.gguf` → `BPOSIT8`; the existing `GGUF_QUANT_ORDER` sync test covers the new file type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba3302d8d439a946e24e7e63eae989b9eaa6d9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->