### PR TITLE
Add deel to local apps

### DIFF
--- a/packages/tasks/src/local-apps.ts
+++ b/packages/tasks/src/local-apps.ts
@@ -527,6 +527,34 @@ const snippetOpenClaw = (model: ModelData, filepath?: string): LocalAppSnippet[]
 	];
 };
 
+const snippetDeel = (model: ModelData, filepath?: string): LocalAppSnippet[] => {
+	const serverStep = getLocalServerStep(model, filepath);
+
+	return [
+		serverStep,
+		{
+			title: "Register the local server with deel",
+			setup: "# No install step needed - npx runs it (Node 20+, zero dependencies):",
+			content: [
+				"# Probes 127.0.0.1 only, finds the running server and saves it:",
+				"npx -y deel-local-cli scan --save",
+				"",
+				"# If the server listens somewhere else:",
+				"# npx -y deel-local-cli scan --save --ports 9000,9100",
+			].join("\n"),
+		},
+		{
+			title: "Run deel in your project",
+			content: [
+				"cd /path/to/your/project",
+				"npx -y deel-local-cli",
+				"",
+				"# Switch server or model any time with /model",
+			].join("\n"),
+		},
+	];
+};
+
 const snippetDockerModelRunner = (model: ModelData, filepath?: string): string => {
 	// Only add quant tag for GGUF models, not safetensors
 	const quantTag = isLlamaCppGgufModel(model) ? getQuantTag(filepath) : "";
@@ -795,6 +823,13 @@ export const LOCAL_APPS = {
 		mainTask: "text-generation",
 		displayOnModelPage: isToolCallingLocalAgentModel,
 		snippet: snippetOpenClaw,
+	},
+	deel: {
+		prettyLabel: "deel",
+		docsUrl: "https://github.com/jysvai/deel-local-cli",
+		mainTask: "text-generation",
+		displayOnModelPage: isToolCallingLocalAgentModel,
+		snippet: snippetDeel,
 	},
 } satisfies Record<string, LocalApp>;
 


### PR DESCRIPTION
Adds [**deel**](https://github.com/jysvai/deel-local-cli) to `LOCAL_APPS`, next to the other tool-calling agents (Pi, Hermes Agent, OpenClaw) and gated on the same `isToolCallingLocalAgentModel` predicate.

### What it is

A terminal coding agent for local models. It does **not** run models itself — it points at an already-running OpenAI-compatible server, so it reuses the existing `getLocalServerStep` (llama.cpp / MLX) exactly like the other agent entries.

### Why the snippet is short

`deel scan --save` probes `127.0.0.1` on the known local-server ports (11434 Ollama, 1234 LM Studio, 8080 llama.cpp/LocalAI, and others), finds what is listening, asks it what models it serves, and saves the connection. So there is no config file to hand-edit — the server step above it is enough.

```
llama serve -hf <model>          # existing server step
npx -y deel-local-cli scan --save
npx -y deel-local-cli
```

### Notes for review

- **No install step.** Zero runtime dependencies, Node 20+, no postinstall, no bundled binaries — `npx -y` is the whole thing.
- **`scan` only touches `127.0.0.1`.** It does not reach outside the machine; that is stated in its own output.
- **One network destination at runtime.** deel talks to the endpoint you configured and nowhere else, and there is a test in that repo that fails the build if a second host appears in the source. No telemetry.
- MIT, published to npm with SLSA provenance: https://www.npmjs.com/package/deel-local-cli

Happy to adjust the snippet wording, the key, or the `displayOnModelPage` predicate — whatever fits the list best.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only local-app metadata and copy-paste snippets; no runtime or auth changes in this repo.
> 
> **Overview**
> Adds **deel** (`deel-local-cli`) as a local app option on model pages, alongside Pi, Hermes Agent, and OpenClaw. It uses the same **`isToolCallingLocalAgentModel`** gate (GGUF or MLX, conversational, chat template with tools).
> 
> The new **`snippetDeel`** flow reuses the existing **`getLocalServerStep`** (MLX or llama.cpp server), then documents **`npx -y deel-local-cli scan --save`** to discover a localhost OpenAI-compatible server and **`npx -y deel-local-cli`** to run the agent—no manual JSON/config snippet like the other agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c81ce3bd54c7470dd043503dec02150f48e434ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->