### PR TITLE
[hub] Friendlier bucket file edits: edits param on uploadFile(s)

### DIFF
--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -83,15 +83,13 @@ for await (const progressEvent of await hub.uploadFilesWithProgress({
 }
 
 // Edit a file in place, without downloading/uploading its unchanged data
-const originalFile = await hub.downloadFile({ repo, path: "myfile.bin", accessToken: "hf_..." });
-await hub.commit({
+const file = await hub.downloadFile({ repo, path: "myfile.bin", accessToken: "hf_..." });
+await hub.uploadFile({
   repo,
   accessToken: "hf_...",
-  title: "edit myfile.bin",
-  operations: [{
-    operation: "edit",
+  file: {
     path: "myfile.bin",
-    originalContent: originalFile,
+    originalContent: file,
     edits: [{
       // Replace bytes [0, 4)
       start: 0,
@@ -99,11 +97,11 @@ await hub.commit({
       content: new Blob(["new prefix"])
     }, {
       // Append at the end
-      start: originalFile.size,
-      end: originalFile.size,
+      start: file.size,
+      end: file.size,
       content: new Blob(["suffix"])
     }]
-  }]
+  }
 });
 
 await hub.deleteFile({repo, accessToken: "hf_...", path: "myfile.bin"});

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@huggingface/hub",
-	"version": "2.16.3",
+	"version": "2.17.0",
 	"description": "Utilities to interact with the Hugging Face hub",
 	"keywords": [
 		"api",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@huggingface/hub",
-	"version": "2.17.0",
+	"version": "2.16.3",
 	"description": "Utilities to interact with the Hugging Face hub",
 	"keywords": [
 		"api",

--- a/packages/hub/src/lib/upload-file.spec.ts
+++ b/packages/hub/src/lib/upload-file.spec.ts
@@ -96,4 +96,57 @@ describe("uploadFile", () => {
 			});
 		}
 	});
+
+	it("should edit a file via an `edits` param", async () => {
+		const repoName = `${TEST_USER}/TEST-${insecureRandomString()}`;
+		const repo = { type: "model", name: repoName } satisfies RepoId;
+
+		try {
+			await createRepo({
+				accessToken: TEST_ACCESS_TOKEN,
+				repo,
+				hubUrl: TEST_HUB_URL,
+			});
+
+			await uploadFile({
+				accessToken: TEST_ACCESS_TOKEN,
+				repo,
+				file: { content: new Blob(["Hello, World!"]), path: "file1" },
+				hubUrl: TEST_HUB_URL,
+			});
+
+			const original = await downloadFile({
+				accessToken: TEST_ACCESS_TOKEN,
+				repo,
+				path: "file1",
+				hubUrl: TEST_HUB_URL,
+			});
+			assert(original);
+
+			await uploadFile({
+				accessToken: TEST_ACCESS_TOKEN,
+				repo,
+				file: {
+					path: "file1",
+					originalContent: original,
+					edits: [{ content: new Blob(["Beautiful "]), start: 7, end: 7 }],
+				},
+				hubUrl: TEST_HUB_URL,
+			});
+
+			const content = await downloadFile({
+				repo,
+				path: "file1",
+				hubUrl: TEST_HUB_URL,
+			});
+
+			assert.strictEqual(await content?.text(), "Hello, Beautiful World!");
+		} finally {
+			await deleteRepo({
+				repo,
+				accessToken: TEST_ACCESS_TOKEN,
+				hubUrl: TEST_HUB_URL,
+			});
+		}
+	});
 });

--- a/packages/hub/src/lib/upload-file.ts
+++ b/packages/hub/src/lib/upload-file.ts
@@ -1,11 +1,45 @@
 import type { CredentialsParams } from "../types/public";
-import type { CommitOutput, CommitParams, ContentSource } from "./commit";
+import type { CommitOperation, CommitOutput, CommitParams, ContentSource } from "./commit";
 import { commit } from "./commit";
+
+/**
+ * Edit an existing file by replacing byte ranges of its original content, without
+ * re-uploading the whole file.
+ *
+ * When `originalContent` comes from {@link downloadFile} on a xet-backed file, the
+ * unchanged parts are neither downloaded nor re-uploaded: only the modified byte ranges
+ * (and their chunk-boundary neighborhood) are transferred. This works fully remotely —
+ * without downloading the unchanged data at all — when uploading to a bucket.
+ *
+ * @example
+ * const original = await downloadFile({ repo: "buckets/me/repo", path: "model.gguf" });
+ * await uploadFile({
+ *   repo: "buckets/me/repo",
+ *   file: {
+ *     path: "model.gguf",
+ *     originalContent: original,
+ *     edits: [{ start: 0, end: 100, content: new Blob([patchedHeader]) }],
+ *   },
+ * });
+ */
+export interface CommitEditFileParams {
+	path: string;
+	/** The file's current content, eg as returned by {@link downloadFile} */
+	originalContent: Blob;
+	edits: Array<{
+		/** `originalContent` from [start, end) will be replaced by this */
+		content: Blob;
+		/** The start position of the edit in the original content */
+		start: number;
+		/** The end position of the edit in the original content */
+		end: number;
+	}>;
+}
 
 export function uploadFile(
 	params: {
 		repo: CommitParams["repo"];
-		file: URL | File | { path: string; content: ContentSource };
+		file: URL | File | { path: string; content: ContentSource } | CommitEditFileParams;
 		commitTitle?: CommitParams["title"];
 		commitDescription?: CommitParams["description"];
 		hubUrl?: CommitParams["hubUrl"];
@@ -16,6 +50,7 @@ export function uploadFile(
 		useWebWorkers?: CommitParams["useWebWorkers"];
 		abortSignal?: CommitParams["abortSignal"];
 		useXet?: CommitParams["useXet"];
+		rangeEditCache?: CommitParams["rangeEditCache"];
 	} & Partial<CredentialsParams>,
 ): Promise<CommitOutput | undefined> {
 	const path =
@@ -25,17 +60,25 @@ export function uploadFile(
 				? params.file.path
 				: params.file.name;
 
+	const operation: CommitOperation =
+		typeof params.file === "object" && "edits" in params.file
+			? {
+					operation: "edit",
+					path,
+					originalContent: params.file.originalContent,
+					edits: params.file.edits,
+				}
+			: {
+					operation: "addOrUpdate",
+					path,
+					content: "content" in params.file ? params.file.content : params.file,
+				};
+
 	return commit({
 		...(params.accessToken ? { accessToken: params.accessToken } : { credentials: params.credentials }),
 		repo: params.repo,
-		operations: [
-			{
-				operation: "addOrUpdate",
-				path,
-				content: "content" in params.file ? params.file.content : params.file,
-			},
-		],
-		title: params.commitTitle ?? `Add ${path}`,
+		operations: [operation],
+		title: params.commitTitle ?? `${operation.operation === "edit" ? "Edit" : "Add"} ${path}`,
 		description: params.commitDescription,
 		hubUrl: params.hubUrl,
 		branch: params.branch,
@@ -45,5 +88,6 @@ export function uploadFile(
 		useWebWorkers: params.useWebWorkers,
 		abortSignal: params.abortSignal,
 		useXet: params.useXet,
+		rangeEditCache: params.rangeEditCache,
 	});
 }

--- a/packages/hub/src/lib/upload-files-with-progress.ts
+++ b/packages/hub/src/lib/upload-files-with-progress.ts
@@ -1,7 +1,8 @@
 import type { CredentialsParams } from "../types/public";
 import { typedInclude } from "../utils/typedInclude";
-import type { CommitOutput, CommitParams, CommitProgressEvent, ContentSource } from "./commit";
+import type { CommitOperation, CommitOutput, CommitParams, CommitProgressEvent, ContentSource } from "./commit";
 import { commitIter } from "./commit";
+import type { CommitEditFileParams } from "./upload-file";
 
 const multipartUploadTracking = new WeakMap<
 	(progress: number) => void,
@@ -20,7 +21,7 @@ const multipartUploadTracking = new WeakMap<
 export async function* uploadFilesWithProgress(
 	params: {
 		repo: CommitParams["repo"];
-		files: Array<URL | File | { path: string; content: ContentSource }>;
+		files: Array<URL | File | { path: string; content: ContentSource } | CommitEditFileParams>;
 		commitTitle?: CommitParams["title"];
 		commitDescription?: CommitParams["description"];
 		hubUrl?: CommitParams["hubUrl"];
@@ -30,20 +31,36 @@ export async function* uploadFilesWithProgress(
 		abortSignal?: CommitParams["abortSignal"];
 		maxFolderDepth?: CommitParams["maxFolderDepth"];
 		useXet?: CommitParams["useXet"];
+		rangeEditCache?: CommitParams["rangeEditCache"];
 		/**
 		 * Set this to true in order to have progress events for hashing
 		 */
 		useWebWorkers?: CommitParams["useWebWorkers"];
 	} & Partial<CredentialsParams>,
 ): AsyncGenerator<CommitProgressEvent, CommitOutput | undefined> {
+	const operations: CommitOperation[] = params.files.map((file) => {
+		const path =
+			file instanceof URL ? (file.pathname.split("/").at(-1) ?? "file") : "path" in file ? file.path : file.name;
+
+		if (typeof file === "object" && "edits" in file) {
+			return {
+				operation: "edit",
+				path,
+				originalContent: file.originalContent,
+				edits: file.edits,
+			};
+		}
+		return {
+			operation: "addOrUpdate",
+			path,
+			content: "content" in file ? file.content : file,
+		};
+	});
+
 	return yield* commitIter({
 		...(params.accessToken ? { accessToken: params.accessToken } : { credentials: params.credentials }),
 		repo: params.repo,
-		operations: params.files.map((file) => ({
-			operation: "addOrUpdate",
-			path: file instanceof URL ? (file.pathname.split("/").at(-1) ?? "file") : "path" in file ? file.path : file.name,
-			content: "content" in file ? file.content : file,
-		})),
+		operations,
 		title: params.commitTitle ?? `Add ${params.files.length} files`,
 		description: params.commitDescription,
 		hubUrl: params.hubUrl,
@@ -53,6 +70,7 @@ export async function* uploadFilesWithProgress(
 		useWebWorkers: params.useWebWorkers,
 		abortSignal: params.abortSignal,
 		useXet: params.useXet,
+		rangeEditCache: params.rangeEditCache,
 		fetch: async (input, init) => {
 			if (!init) {
 				return fetch(input);

--- a/packages/hub/src/lib/upload-files.ts
+++ b/packages/hub/src/lib/upload-files.ts
@@ -1,11 +1,12 @@
 import type { CredentialsParams } from "../types/public";
-import type { CommitOutput, CommitParams, ContentSource } from "./commit";
+import type { CommitOperation, CommitOutput, CommitParams, ContentSource } from "./commit";
 import { commit } from "./commit";
+import type { CommitEditFileParams } from "./upload-file";
 
 export function uploadFiles(
 	params: {
 		repo: CommitParams["repo"];
-		files: Array<URL | File | { path: string; content: ContentSource }>;
+		files: Array<URL | File | { path: string; content: ContentSource } | CommitEditFileParams>;
 		commitTitle?: CommitParams["title"];
 		commitDescription?: CommitParams["description"];
 		hubUrl?: CommitParams["hubUrl"];
@@ -17,16 +18,32 @@ export function uploadFiles(
 		maxFolderDepth?: CommitParams["maxFolderDepth"];
 		abortSignal?: CommitParams["abortSignal"];
 		useXet?: CommitParams["useXet"];
+		rangeEditCache?: CommitParams["rangeEditCache"];
 	} & Partial<CredentialsParams>,
 ): Promise<CommitOutput | undefined> {
+	const operations: CommitOperation[] = params.files.map((file) => {
+		const path =
+			file instanceof URL ? (file.pathname.split("/").at(-1) ?? "file") : "path" in file ? file.path : file.name;
+
+		if (typeof file === "object" && "edits" in file) {
+			return {
+				operation: "edit",
+				path,
+				originalContent: file.originalContent,
+				edits: file.edits,
+			};
+		}
+		return {
+			operation: "addOrUpdate",
+			path,
+			content: "content" in file ? file.content : file,
+		};
+	});
+
 	return commit({
 		...(params.accessToken ? { accessToken: params.accessToken } : { credentials: params.credentials }),
 		repo: params.repo,
-		operations: params.files.map((file) => ({
-			operation: "addOrUpdate",
-			path: file instanceof URL ? (file.pathname.split("/").at(-1) ?? "file") : "path" in file ? file.path : file.name,
-			content: "content" in file ? file.content : file,
-		})),
+		operations,
 		title: params.commitTitle ?? `Add ${params.files.length} files`,
 		description: params.commitDescription,
 		hubUrl: params.hubUrl,
@@ -37,5 +54,6 @@ export function uploadFiles(
 		useWebWorkers: params.useWebWorkers,
 		abortSignal: params.abortSignal,
 		useXet: params.useXet,
+		rangeEditCache: params.rangeEditCache,
 	});
 }

--- a/packages/hub/src/utils/SplicedBlob.spec.ts
+++ b/packages/hub/src/utils/SplicedBlob.spec.ts
@@ -50,6 +50,13 @@ describe("SplicedBlob", () => {
 				"Invalid start/end positions for SplicedBlob",
 			);
 		});
+
+		it("should accept a single operation object (not wrapped in an array)", () => {
+			const splicedBlob = SplicedBlob.create(originalBlob, { insert: insertBlob, start: 5, end: 5 });
+			expect(splicedBlob).toBeInstanceOf(SplicedBlob);
+			expect(splicedBlob.size).toBe(13);
+			expect(splicedBlob.spliceOperations).toHaveLength(1);
+		});
 	});
 
 	describe("size and type", () => {

--- a/packages/hub/src/utils/SplicedBlob.ts
+++ b/packages/hub/src/utils/SplicedBlob.ts
@@ -21,7 +21,7 @@ interface SpliceOperation {
  * @example
  * const originalBlob = new Blob(["Hello, World!"]);
  * const insertBlob = new Blob(["Beautiful "]);
- * const splicedBlob = SplicedBlob.create(originalBlob, insertBlob, 7, 7);
+ * const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 7, end: 7 }]);
  * // Result represents: "Hello, Beautiful World!"
  */
 export class SplicedBlob extends Blob {
@@ -35,7 +35,22 @@ export class SplicedBlob extends Blob {
 		this.spliceOperations = spliceOperations; // Create a copy to prevent external mutation
 	}
 
-	static create(originalBlob: Blob, operations: SpliceOperation[]): SplicedBlob {
+	/**
+	 * Create a SplicedBlob from an original blob and a set of splice operations.
+	 *
+	 * Each operation replaces the original content in `[start, end)` with `insert`
+	 * (a pure insertion when `start === end`). Positions are byte offsets in the
+	 * original blob, are relative to the **original** content (not shifted by other
+	 * operations), and operations must not overlap (they can be passed in any order).
+	 *
+	 * As a convenience, a single `{ insert, start, end }` object is also accepted
+	 * instead of a one-element array.
+	 */
+	static create(originalBlob: Blob, operations: SpliceOperation | SpliceOperation[]): SplicedBlob {
+		if (!Array.isArray(operations)) {
+			operations = [operations];
+		}
+
 		// Validate all operations
 		for (const op of operations) {
 			if (op.start < 0 || op.end < 0) {

--- a/packages/hub/src/utils/createXorbs.ts
+++ b/packages/hub/src/utils/createXorbs.ts
@@ -247,37 +247,15 @@ export async function* createXorbs(
 			// Prime the chunk cache with the original file's dedup info (one query on its first
 			// chunk returns the whole shard, ie the chunk => xorb mapping of the original file),
 			// so unchanged window bytes dedup against the original xorbs instead of re-uploading.
-			if (rangeEditPlan !== undefined) {
-				await loadDedupInfoToCache(
-					(fileSource.content as SplicedBlob).originalBlob.slice(0, MAX_CHUNK_SIZE),
-					remoteXorbHashes,
-					params,
-					chunkCache,
-					computeHmacHex,
-					{
-						maxChunks: 1,
-						isAtBeginning: true,
-					},
-				);
-			}
-
-			// Load dedup info for the first chunk of the file, if it's potentially modified by the splice
+			//
+			// Only the first chunk's bytes are needed: for a XetBlob the slice is fetched with a
+			// range-scoped CAS reconstruction, so only that chunk's byte range is downloaded,
+			// not the whole xorb.
 			if (
-				rangeEditPlan === undefined &&
 				fileSource.content instanceof SplicedBlob &&
-				fileSource.content.firstSpliceIndex < MAX_CHUNK_SIZE
+				(rangeEditPlan !== undefined || fileSource.content.firstSpliceIndex < MAX_CHUNK_SIZE)
 			) {
-				await loadDedupInfoToCache(
-					fileSource.content.originalBlob.slice(0, MAX_CHUNK_SIZE),
-					remoteXorbHashes,
-					params,
-					chunkCache,
-					computeHmacHex,
-					{
-						maxChunks: 1,
-						isAtBeginning: true,
-					},
-				);
+				await loadFirstChunkDedupInfo(fileSource.content, remoteXorbHashes, params, chunkCache);
 			}
 			let bytesSinceRemoteDedup = Infinity;
 			let bytesSinceLastProgressEvent = 0;
@@ -453,6 +431,9 @@ export async function* createXorbs(
 					dedupNextChunk = true;
 					const startIndex = fileChunks.length;
 
+					// The window's segments are XetBlob slices: the CAS reconstruction request is
+					// range-scoped, so only the window's chunk byte ranges are fetched, not the
+					// whole xorb.
 					for (const segment of windowSegments(window, originalBlob)) {
 						yield* pumpBlob(chunker, segment);
 					}
@@ -788,6 +769,35 @@ const buildFileRepresentation = (
 
 	return representation;
 };
+
+/**
+ * Prime the chunk cache with the original file's dedup info (one query on its first chunk
+ * returns the whole shard, ie the chunk => xorb mapping of the original file), so unchanged
+ * bytes of a splice/edit dedup against the file's existing xorbs instead of being
+ * re-uploaded.
+ *
+ * Only the first chunk's bytes are needed; for a {@link XetBlob} the slice is fetched with
+ * a range-scoped CAS reconstruction, so only that chunk's byte range is downloaded rather
+ * than the whole xorb.
+ */
+async function loadFirstChunkDedupInfo(
+	content: SplicedBlob,
+	remoteXorbHashes: string[],
+	params: XetWriteTokenParams,
+	chunkCache: ChunkCache,
+): Promise<void> {
+	await loadDedupInfoToCache(
+		content.originalBlob.slice(0, MAX_CHUNK_SIZE),
+		remoteXorbHashes,
+		params,
+		chunkCache,
+		computeHmacHex,
+		{
+			maxChunks: 1,
+			isAtBeginning: true,
+		},
+	);
+}
 
 /**
  * Helper to load dedup info for blob contents into cache.


### PR DESCRIPTION
uploadFile / uploadFiles / uploadFilesWithProgress now accept an edit form
{ path, originalContent, edits } so an existing file can be patched from its
downloadFile() handle in one call. On buckets, the unchanged bytes are neither
downloaded nor re-uploaded (xet chunk dedup + /v2/file-chunk-hashes gap
subtrees): appends and small edits transfer only the modified regions.

Also:
- SplicedBlob.create accepts a single splice op object (not just an array).
- createXorbs: seed dedup info for both the range-edit and plain-splice paths
  via a single range-scoped CAS read of the file's first chunk, instead of
  re-downloading the first xorb.

Bump @huggingface/hub to 2.17.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public upload API and xet chunk-dedup path for in-place edits; incorrect edit/dedup behavior could corrupt large bucket files, but logic builds on existing commit edit support with new tests.
> 
> **Overview**
> **`uploadFile`**, **`uploadFiles`**, and **`uploadFilesWithProgress`** now accept an edit-shaped `file` object (`path`, `originalContent`, `edits`) that maps to a commit **`edit`** operation instead of requiring a raw **`commit`** call. Default commit titles use **Edit** vs **Add**, and **`rangeEditCache`** is forwarded for repeated appends on bucket/xet files.
> 
> Docs switch the in-place edit example from **`commit`** to **`uploadFile`**. An integration test covers inserting bytes via **`edits`**.
> 
> **`SplicedBlob.create`** optionally takes a single splice op object (not only an array). In **`createXorbs`**, first-chunk dedup seeding for range edits and early splices is consolidated into **`loadFirstChunkDedupInfo`**, with comments clarifying range-scoped CAS reads so unchanged bytes are not fully re-downloaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 336054e124d59c4ee819e7aa724c8ed72452d0fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->