### PR TITLE
🐛 hub: preserve lazy blobs in SplicedBlob slices

### DIFF
--- a/packages/hub/src/utils/SplicedBlob.spec.ts
+++ b/packages/hub/src/utils/SplicedBlob.spec.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { SplicedBlob } from "./SplicedBlob";
+import { WebBlob } from "./WebBlob";
+
+function createRangeFetch(content: string): typeof fetch {
+	return async (_input, init) => {
+		const range = new Headers(init?.headers).get("range");
+		if (!range) {
+			return new Response(content);
+		}
+
+		const match = /^bytes=(\d+)-(\d+)$/.exec(range);
+		if (!match) {
+			return new Response(null, { status: 416 });
+		}
+
+		return new Response(content.slice(Number(match[1]), Number(match[2]) + 1), { status: 206 });
+	};
+}
 
 describe("SplicedBlob", () => {
 	let originalBlob: Blob;
@@ -131,10 +148,50 @@ describe("SplicedBlob", () => {
 			expect(text).toBe("789"); // Only gets what's available
 		});
 
+		it("should return an empty blob for NaN bounds", async () => {
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
+
+			expect(await splicedBlob.slice(Number.NaN).text()).toBe("");
+			expect(await splicedBlob.slice(0, Number.NaN).text()).toBe("");
+		});
+
 		it("should throw error for negative start/end", () => {
 			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: insertBlob, start: 5, end: 5 }]);
 			expect(() => splicedBlob.slice(-1, 5)).toThrow("Unsupported negative start/end on SplicedBlob.slice");
 			expect(() => splicedBlob.slice(0, -1)).toThrow("Unsupported negative start/end on SplicedBlob.slice");
+		});
+
+		it("should preserve a lazy original blob when slicing", async () => {
+			const content = "0123456789";
+			const lazyOriginal = new WebBlob(
+				new URL("https://huggingface.co/file"),
+				0,
+				content.length,
+				"text/plain",
+				true,
+				createRangeFetch(content),
+				undefined,
+			);
+			const splicedBlob = SplicedBlob.create(lazyOriginal, [{ insert: insertBlob, start: 5, end: 5 }]);
+
+			expect(await splicedBlob.slice(0, 4).text()).toBe("0123");
+			expect(await splicedBlob.slice(0, 8).text()).toBe("01234ABC");
+		});
+
+		it("should preserve a lazy insert blob when slicing", async () => {
+			const content = "ABC";
+			const lazyInsert = new WebBlob(
+				new URL("https://huggingface.co/insert"),
+				0,
+				content.length,
+				"text/plain",
+				true,
+				createRangeFetch(content),
+				undefined,
+			);
+			const splicedBlob = SplicedBlob.create(originalBlob, [{ insert: lazyInsert, start: 5, end: 5 }]);
+
+			expect(await splicedBlob.slice(4, 9).text()).toBe("4ABC5");
 		});
 	});
 

--- a/packages/hub/src/utils/SplicedBlob.ts
+++ b/packages/hub/src/utils/SplicedBlob.ts
@@ -155,7 +155,23 @@ export class SplicedBlob extends Blob {
 			}
 		}
 
-		return new Blob(resultSegments);
+		if (resultSegments.length === 0) {
+			return new Blob([]);
+		}
+
+		const [firstSegment, ...remainingSegments] = resultSegments;
+		if (remainingSegments.length === 0) {
+			return firstSegment;
+		}
+
+		return SplicedBlob.create(
+			firstSegment,
+			remainingSegments.map((insert) => ({
+				insert,
+				start: firstSegment.size,
+				end: firstSegment.size,
+			})),
+		);
 	}
 
 	get firstSpliceIndex(): number {


### PR DESCRIPTION
Addresses the `SplicedBlob.slice()` checklist item in #2408.

`SplicedBlob.slice()` wrapped its selected segments in a native `Blob`. That drops bytes from lazy subclasses such as `WebBlob` and `XetBlob`, because their data is exposed through overridden read methods rather than the native Blob's internal storage. For edited Xet-backed files, this could make the 512-byte preupload sample incomplete and affect text/binary detection.

This change returns a single selected segment directly and uses `SplicedBlob` to compose multiple segments. It also preserves the existing empty-Blob behavior for NaN bounds.

Validation:

- `SplicedBlob.spec.ts`: 57/57 in Node
- `SplicedBlob.spec.ts`: 57/57 in headless Chrome
- TypeScript, ESLint, formatting, and diff checks pass

The full hub run reported 519 passing tests and 6 failures involving S3 authorization and network/live-test timeouts; the full suite is not green in this environment. No successful live upload validation is claimed.

A slice made from a typed lazy segment can now retain that segment's MIME type.

AI assistance disclosure: This patch and its tests were prepared with AI assistance and have not yet been reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes blob slicing on the upload/edit path where lazy Xet/Web blobs are spliced; behavior is narrow and well tested but can affect preupload sampling and content-type detection if regressions slip through.
> 
> **Overview**
> **`SplicedBlob.slice()`** no longer wraps slice results in a native **`Blob`**. That wrapper dropped lazy subclasses like **`WebBlob`** / **`XetBlob`**, whose bytes come from overridden reads rather than in-memory parts—breaking range reads on slices of edited remote files (e.g. incomplete preupload samples).
> 
> The method now returns an empty **`Blob`** when nothing matches, returns the **single** segment unchanged when the slice fits one part, and builds a new **`SplicedBlob`** when the slice spans multiple segments (appending the rest at the end of the first segment). Tests cover **NaN** bounds (empty slice) and lazy **`WebBlob`** originals and inserts via a range **`fetch`** mock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14f939a78f3af46c6b75990f277090bbd7961369. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->