### PR TITLE
🐛 hub: clamp lazy Blob slices to valid bounds

### DIFF
--- a/packages/hub/src/utils/FileBlob.spec.ts
+++ b/packages/hub/src/utils/FileBlob.spec.ts
@@ -49,4 +49,14 @@ describe("FileBlob", () => {
 		expect(() => fileBlob.slice(-5)).toThrow(TypeError);
 		expect(() => fileBlob.slice(0, -1)).toThrow(TypeError);
 	});
+
+	it("should clamp slices outside the file", async () => {
+		const fileBlob = await FileBlob.create("package.json");
+
+		for (const slice of [fileBlob.slice(fileBlob.size + 1), fileBlob.slice(20, 10)]) {
+			expect(slice.size).toBe(0);
+			expect(await slice.text()).toBe("");
+			expect(await new Response(slice.stream()).text()).toBe("");
+		}
+	});
 });

--- a/packages/hub/src/utils/FileBlob.ts
+++ b/packages/hub/src/utils/FileBlob.ts
@@ -69,6 +69,9 @@ export class FileBlob extends Blob {
 			throw new TypeError("Unsupported negative start/end on FileBlob.slice");
 		}
 
+		start = Math.min(start, this.size);
+		end = Math.max(start, Math.min(end, this.size));
+
 		const slice = new FileBlob(this.path, this.start + start, Math.min(this.start + end, this.end));
 
 		return slice;

--- a/packages/hub/src/utils/WebBlob.spec.ts
+++ b/packages/hub/src/utils/WebBlob.spec.ts
@@ -103,4 +103,15 @@ describe("WebBlob", () => {
 		expect(() => webBlob.slice(-5)).toThrow(TypeError);
 		expect(() => webBlob.slice(0, -1)).toThrow(TypeError);
 	});
+
+	it("should clamp slices outside the resource", async () => {
+		const unexpectedFetch = (() => Promise.reject(new Error("empty slices must not fetch"))) as typeof fetch;
+		const webBlob = new WebBlob(resourceUrl, 0, 100, "text/plain", true, unexpectedFetch, undefined);
+
+		for (const slice of [webBlob.slice(101), webBlob.slice(20, 10)]) {
+			expect(slice.size).toBe(0);
+			expect(await slice.text()).toBe("");
+			expect(await new Response(slice.stream()).text()).toBe("");
+		}
+	});
 });

--- a/packages/hub/src/utils/WebBlob.ts
+++ b/packages/hub/src/utils/WebBlob.ts
@@ -114,6 +114,9 @@ export class WebBlob extends Blob {
 			throw new TypeError("Unsupported negative start/end on WebBlob.slice");
 		}
 
+		start = Math.min(start, this.size);
+		end = Math.max(start, Math.min(end, this.size));
+
 		const slice = new WebBlob(
 			this.url,
 			this.start + start,
@@ -140,6 +143,10 @@ export class WebBlob extends Blob {
 	}
 
 	override stream(): ReturnType<Blob["stream"]> {
+		if (this.size === 0) {
+			return new Blob([]).stream();
+		}
+
 		const stream = new TransformStream();
 
 		this.fetchRange()
@@ -150,6 +157,10 @@ export class WebBlob extends Blob {
 	}
 
 	private fetchRange(): Promise<Response> {
+		if (this.size === 0) {
+			return Promise.resolve(new Response());
+		}
+
 		const fetch = this.fetch; // to avoid this.fetch() which is bound to the instance instead of globalThis
 		if (this.full) {
 			return fetch(this.url, {

--- a/packages/hub/src/utils/XetBlob.spec.ts
+++ b/packages/hub/src/utils/XetBlob.spec.ts
@@ -1507,6 +1507,20 @@ describe("XetBlob", () => {
 		expect(() => blob.slice(-5)).toThrow(TypeError);
 		expect(() => blob.slice(0, -1)).toThrow(TypeError);
 	});
+
+	it("should clamp slices outside the resource", async () => {
+		const blob = new XetBlob({
+			hash: "test",
+			size: 100,
+			refreshUrl: "https://huggingface.co",
+		});
+
+		for (const slice of [blob.slice(101), blob.slice(20, 10)]) {
+			expect(slice.size).toBe(0);
+			expect(await slice.text()).toBe("");
+			expect(await new Response(slice.stream()).text()).toBe("");
+		}
+	});
 });
 
 function makeChunk(content: string) {

--- a/packages/hub/src/utils/XetBlob.ts
+++ b/packages/hub/src/utils/XetBlob.ts
@@ -362,6 +362,9 @@ export class XetBlob extends Blob {
 			throw new TypeError("Unsupported negative start/end on XetBlob.slice");
 		}
 
+		start = Math.min(start, this.size);
+		end = Math.max(start, Math.min(end, this.size));
+
 		const slice = this.#clone();
 
 		slice.start = this.start + start;


### PR DESCRIPTION
Follow-up to #2365.

`FileBlob`, `WebBlob`, and `XetBlob` produced negative-size slices when the start was beyond the resource or the end preceded the start. Reading those slices could throw locally or send an invalid HTTP range.

This clamps non-negative bounds to the current blob size and collapses reversed ranges to an empty slice. Empty `WebBlob` reads and streams also return locally without a network request.

Validation:

- focused Node tests: 48/48
- `WebBlob` and `XetBlob` in headless Chrome: 44/44
- TypeScript, ESLint, formatting, and diff checks pass

AI assistance disclosure: This patch and its tests were prepared with AI assistance and have not yet been reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted edge-case fixes in blob slicing and empty WebBlob reads, with matching tests and no auth or data-model changes.
> 
> **Overview**
> **Fixes invalid `slice()` behavior** on hub lazy blobs (`FileBlob`, `WebBlob`, `XetBlob`) so out-of-range or reversed non-negative ranges no longer produce negative `size` or bad reads/range requests.
> 
> Each implementation still **throws `TypeError` on negative `start`/`end`**, but now **clamps** `start` to the blob size and sets `end` so reversed ranges become **empty slices** (`size` 0, empty `text()`/`stream()`). **`WebBlob`** additionally skips **`fetchRange()`** and returns an empty stream locally when the slice has **zero size**, so empty slices do not hit the network.
> 
> New unit tests cover slices past the end and `slice(20, 10)` for all three types; **`WebBlob`** tests assert fetch is not called on empty slices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730e1c2e6e8ea8e120ce3aeed7040d0344dda9c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->