### PR TITLE
🐛 inference: preserve plain-text error details

### DIFF
--- a/packages/inference/src/utils/request.ts
+++ b/packages/inference/src/utils/request.ts
@@ -57,6 +57,7 @@ export async function innerRequest<T>(
 
 	if (!response.ok) {
 		const contentType = response.headers.get("Content-Type");
+		const mediaType = contentType?.split(";", 1)[0].trim().toLowerCase();
 		if (["application/json", "application/problem+json"].some((ct) => contentType?.startsWith(ct))) {
 			const output = await response.json();
 			if ([400, 422, 404, 500].includes(response.status) && options?.chatCompletion) {
@@ -97,7 +98,7 @@ export async function innerRequest<T>(
 				);
 			}
 		}
-		const message = contentType?.startsWith("text/plain;") ? await response.text() : undefined;
+		const message = mediaType === "text/plain" ? await response.text() : undefined;
 		throw new InferenceClientProviderApiError(
 			`Failed to perform inference: ${message ?? "an HTTP error occurred when requesting the provider"}`,
 			{

--- a/packages/inference/test/plain-text-error.spec.ts
+++ b/packages/inference/test/plain-text-error.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { InferenceClient } from "../src/InferenceClient.js";
+
+describe("plain-text provider errors", () => {
+	it.each(["text/plain", "text/plain; charset=utf-8", "TEXT/PLAIN ; charset=UTF-8"])(
+		"preserves an error body for Content-Type %s",
+		async (contentType) => {
+			const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() =>
+				Promise.resolve(
+					new Response("provider quota exceeded", {
+						status: 429,
+						headers: { "Content-Type": contentType, "x-request-id": "request-id" },
+					}),
+				),
+			);
+			const client = new InferenceClient("", {
+				endpointUrl: "https://example.com/inference",
+				fetch: fetchMock,
+			});
+
+			await expect(client.textGeneration({ inputs: "Hello" })).rejects.toMatchObject({
+				message: "Failed to perform inference: provider quota exceeded",
+				httpResponse: {
+					body: "provider quota exceeded",
+					requestId: "request-id",
+					status: 429,
+				},
+			});
+			expect(fetchMock).toHaveBeenCalledOnce();
+		},
+	);
+
+	it("does not treat a prefixed subtype as plain text", async () => {
+		const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>(() =>
+			Promise.resolve(
+				new Response("provider quota exceeded", {
+					status: 429,
+					headers: { "Content-Type": "text/plaintext", "x-request-id": "request-id" },
+				}),
+			),
+		);
+		const client = new InferenceClient("", {
+			endpointUrl: "https://example.com/inference",
+			fetch: fetchMock,
+		});
+
+		await expect(client.textGeneration({ inputs: "Hello" })).rejects.toMatchObject({
+			message: "Failed to perform inference: an HTTP error occurred when requesting the provider",
+			httpResponse: {
+				body: "",
+				requestId: "request-id",
+				status: 429,
+			},
+		});
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+});


### PR DESCRIPTION
Providers can return useful error details with the valid header `Content-Type: text/plain`, but the inference client only read the body when the value started with `text/plain;`. Parameterless responses therefore surfaced a generic message and recorded an empty response body.

This normalizes the media type before comparing it with the exact `text/plain` type. It preserves error details for parameterless, parameterized, and case-varied headers while avoiding prefix matches such as `text/plaintext`.

The regression exercises the public `InferenceClient.textGeneration` path with a deterministic fetch boundary and checks both the thrown message and structured `httpResponse` details.

Validation:

- `pnpm --filter inference test` (30 passed, 119 existing credential-gated tests skipped)
- `pnpm --filter inference check`
- `pnpm --filter inference lint:check`
- `pnpm --filter inference format:check`
- `git diff --check`

No dependency or lockfile changes are included. The 119 skipped cases belong to the repository's existing credential-gated inference suite; the deterministic regression itself is not skipped.

AI assistance disclosure: This patch and its tests were prepared with AI assistance and have not yet been reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to non-OK response handling in the inference HTTP helper, with regression tests and no auth or data-model impact.
> 
> **Overview**
> **Fixes a regression** where inference failures with `Content-Type: text/plain` (no charset/parameters) dropped the response body and surfaced a generic HTTP error.
> 
> `innerRequest` now **parses the media type** from `Content-Type` (strip parameters, trim, lowercase) and reads the body only when it is exactly `text/plain`, so parameterized and case-varied headers still work while values like `text/plaintext` are not matched.
> 
> Adds **Vitest coverage** on `InferenceClient.textGeneration` with a mocked `fetch`, asserting both the thrown message and `httpResponse` for valid plain-text types and for the non-plain `text/plaintext` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3663010c03fdac99ade08bbb839f48e44124514f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->