### PR TITLE
🐛 mcp-client: close servers with no advertised tools

### DIFF
--- a/packages/mcp-client/src/McpClient.ts
+++ b/packages/mcp-client/src/McpClient.ts
@@ -32,6 +32,7 @@ export class McpClient {
 
 	protected model: string;
 	private clients: Map<ToolName, Client> = new Map();
+	private connectedClients: Set<Client> = new Set();
 	public readonly availableTools: ChatCompletionInputTool[] = [];
 
 	constructor({
@@ -90,6 +91,7 @@ export class McpClient {
 		}
 		const mcp = new Client({ name: "@huggingface/mcp-client", version: packageVersion });
 		await mcp.connect(transport);
+		this.connectedClients.add(mcp);
 
 		const toolsResult = await mcp.listTools();
 		debug(
@@ -249,8 +251,7 @@ export class McpClient {
 	}
 
 	async cleanup(): Promise<void> {
-		const clients = new Set(this.clients.values());
-		await Promise.all([...clients].map((client) => client.close()));
+		await Promise.all([...this.connectedClients].map((client) => client.close()));
 	}
 
 	async [Symbol.dispose](): Promise<void> {

--- a/packages/mcp-client/test/McpClient.spec.ts
+++ b/packages/mcp-client/test/McpClient.spec.ts
@@ -1,11 +1,37 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { McpClient } from "../src";
+
+const mcpClientMocks = vi.hoisted(() => ({
+	close: vi.fn(),
+	connect: vi.fn(),
+	listTools: vi.fn().mockResolvedValue({ tools: [] }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+	Client: class {
+		connect(...args: unknown[]) {
+			return mcpClientMocks.connect(...args);
+		}
+
+		listTools(...args: unknown[]) {
+			return mcpClientMocks.listTools(...args);
+		}
+
+		close(...args: unknown[]) {
+			return mcpClientMocks.close(...args);
+		}
+	},
+}));
 
 if (!process.env.HF_TOKEN) {
 	console.warn("Set HF_TOKEN in the env to run the tests for better rate limits");
 }
 
 describe("McpClient", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
 	it("You can create a mcp client", async () => {
 		const client = new McpClient({
 			provider: "together",
@@ -14,5 +40,17 @@ describe("McpClient", () => {
 		});
 		expect(client).toBeDefined();
 		expect(client.availableTools.length).toBe(0);
+	});
+
+	it("closes connected MCP servers that expose no tools", async () => {
+		const client = new McpClient({
+			provider: "together",
+			model: "Qwen/Qwen2.5-72B-Instruct",
+		});
+
+		await client.addMcpServer({ command: "unused" });
+		await client.cleanup();
+
+		expect(mcpClientMocks.close).toHaveBeenCalledOnce();
 	});
 });


### PR DESCRIPTION
An MCP server can connect successfully while advertising no tools, for example when its tool set is disabled or dynamically configured. `McpClient` only retained sessions through their advertised tool names, so `cleanup()` never closed a connected server whose `tools/list` response was empty.

This tracks connected clients independently from the tool-name routing map and closes that complete set during cleanup. Tool lookup behavior remains unchanged.

The regression exercises the real `McpClient.addMcpServer()` and `cleanup()` flow with only the MCP SDK client boundary mocked. It confirms that a successful connection returning an empty tool list is still closed.

Validation:

- `pnpm test ./test/McpClient.spec.ts` (2 passed)
- `pnpm test` (16 passed)
- `pnpm check`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm build`
- `git diff --check HEAD^ HEAD`

No dependency or lockfile changes are included.

AI assistance disclosure: This patch and its tests were prepared with AI assistance and have not yet been reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lifecycle fix in MCP client teardown with a targeted regression test; no auth or data-path changes.
> 
> **Overview**
> Fixes a resource leak where **successfully connected MCP servers that advertise zero tools** were never closed, because `cleanup()` only iterated clients referenced from the tool-name map.
> 
> `McpClient` now keeps a separate **`connectedClients`** set, registers each session after `connect`, and **`cleanup()` closes that full set**; tool routing via `clients` is unchanged.
> 
> Adds a unit test that mocks the MCP SDK boundary and asserts **`close()` runs once** when `listTools` returns an empty list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1805f433930d16cac5d18024d321cb47a78da660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->