### PR TITLE
🐛 jinja: return undefined for out-of-range string indexes

### DIFF
--- a/packages/jinja/src/runtime.ts
+++ b/packages/jinja/src/runtime.ts
@@ -1832,9 +1832,11 @@ export class Interpreter {
 				(object instanceof ObjectValue ? object.builtins.get(property.value) : undefined);
 		} else if (object instanceof ArrayValue || object instanceof StringValue) {
 			if (property instanceof IntegerValue) {
-				value = object.value.at(property.value);
 				if (object instanceof StringValue) {
-					value = new StringValue(object.value.at(property.value));
+					const character = object.value.at(property.value);
+					value = character === undefined ? undefined : new StringValue(character);
+				} else {
+					value = object.value.at(property.value);
 				}
 			} else if (property instanceof StringValue) {
 				value = object.builtins.get(property.value);

--- a/packages/jinja/test/templates.test.js
+++ b/packages/jinja/test/templates.test.js
@@ -6382,6 +6382,16 @@ function expectTemplateToRender(source, expected) {
 }
 
 describe("Feature regressions", () => {
+	describe("Member access", () => {
+		it.each([3, -4])("returns undefined for out-of-range string index %i", (index) => {
+			const template = new Template(
+				`[{{ "abc"[${index}] }}]|{{ "abc"[${index}] | default("missing") }}|{{ "abc"[${index}] is defined }}`,
+			);
+
+			expect(template.render()).toBe("[]|missing|false");
+		});
+	});
+
 	describe("Namespaces", () => {
 		it("supports namespace attributes in collection filters", () => {
 			const template = new Template(`{%- set a = namespace(x=2, active=true, inner=namespace(value=2)) -%}


### PR DESCRIPTION
Out-of-range string indexes currently become `StringValue(undefined)` instead of Jinja's undefined value. Templates therefore render the literal text `undefined`, skip the `default` filter, and report the missing character as defined.

Only wrap a string-index result when `String.prototype.at()` found a character, allowing the interpreter's existing missing-value fallback to return `UndefinedValue`. Regression coverage checks positive and negative out-of-range indexes through direct rendering, `default`, and `is defined`.

Validation:

- Regression before the fix: 2 failed, 728 passed.
- Full `@huggingface/jinja` suite after the fix: 730 passed.
- TypeScript check, ESLint, formatting, build, and `git diff --check` pass.
- No dependencies or lockfiles changed.

AI disclosure: The patch, tests, and this description were prepared with AI assistance and have not yet been reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to string member access in the Jinja interpreter, covered by new regression tests.
> 
> **Overview**
> Fixes **string subscript** behavior when the index is out of range: the runtime no longer wraps a missing character in `StringValue`, so `evaluateMemberExpression` can fall through to **`UndefinedValue`** like Jinja expects.
> 
> Previously, `new StringValue(undefined)` made templates print the literal `undefined`, bypass **`default`**, and treat the access as **defined**. In-range access is unchanged (still a one-character `StringValue`); array integer indexing is unchanged.
> 
> Adds regression tests for positive and negative out-of-range indexes via direct output, `default`, and `is defined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b868d965b7e38a759a51a06c1c5d47beb70f41ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->