### PR TITLE
🐛 mcp-client: surface CallToolResult.isError to the model

### DIFF
--- a/packages/mcp-client/src/ResultFormatter.ts
+++ b/packages/mcp-client/src/ResultFormatter.ts
@@ -13,11 +13,24 @@ export class ResultFormatter {
 	 * Formats a CallToolResult's contents into a single string.
 	 * - Text content is included directly
 	 * - Binary content (images, audio, blobs) is summarized
+	 * - `isError: true` is prefixed so the model can see MCP-level tool failures
+	 *   (the protocol reports those as a successful RPC with `isError`, not an exception)
 	 *
 	 * @param result The CallToolResult to format
 	 * @returns A human-readable string representation of the result contents
 	 */
 	static format(result: CompatibilityCallToolResult): string {
+		const body = this.formatContent(result);
+		if (!result.isError) {
+			return body;
+		}
+		if (body.startsWith("Error:")) {
+			return body;
+		}
+		return `Error: MCP tool returned isError=true\n${body}`;
+	}
+
+	private static formatContent(result: CompatibilityCallToolResult): string {
 		if (!result.content || !Array.isArray(result.content) || result.content.length === 0) {
 			return "[No content]";
 		}

--- a/packages/mcp-client/test/ResultFormatter.spec.ts
+++ b/packages/mcp-client/test/ResultFormatter.spec.ts
@@ -76,6 +76,45 @@ describe("CallToolResultFormatter", () => {
 		expect(formatted).toContain("bytes]");
 	});
 
+	it("should prefix MCP isError=true so the model does not treat a failed tool as success", () => {
+		const result: CallToolResult = {
+			isError: true,
+			content: [
+				{
+					type: "text",
+					text: "file not found: /tmp/missing.txt",
+				},
+			],
+		};
+
+		expect(ResultFormatter.format(result)).toBe(
+			"Error: MCP tool returned isError=true\nfile not found: /tmp/missing.txt",
+		);
+	});
+
+	it("should prefix isError even when content is empty", () => {
+		const result: CallToolResult = {
+			isError: true,
+			content: [],
+		};
+
+		expect(ResultFormatter.format(result)).toBe("Error: MCP tool returned isError=true\n[No content]");
+	});
+
+	it("should not double-prefix when content already starts with Error:", () => {
+		const result: CallToolResult = {
+			isError: true,
+			content: [
+				{
+					type: "text",
+					text: "Error: permission denied",
+				},
+			],
+		};
+
+		expect(ResultFormatter.format(result)).toBe("Error: permission denied");
+	});
+
 	it("should handle mixed content types", () => {
 		const result: CallToolResult = {
 			content: [


### PR DESCRIPTION
## What

MCP tool failures are a successful RPC with `isError: true`, not a thrown error. `ResultFormatter.format()` previously only concatenated `content`, so Tiny Agents / `McpClient` fed those failures back to the model as a normal tool result.

`format()` now prefixes those results with `Error: MCP tool returned isError=true`, unless the content already starts with `Error:`. Successful results (`isError` missing or false) are unchanged.

## Why

The MCP spec says tool errors belong in the result object so the model can see them and self-correct. The existing `try/catch` around `client.callTool()` only covers thrown RPC/transport errors.

## Test plan

```bash
pnpm --filter @huggingface/mcp-client test
```

- Existing ResultFormatter cases still pass (empty, text, binary, resource, mixed)
- New cases: prefix on `isError: true`, prefix when content is empty, no double-prefix when content already starts with `Error:`