### PR TITLE
🐛 dduf: validate each entry disk number

### DIFF
--- a/packages/dduf/src/check-dduf.spec.ts
+++ b/packages/dduf/src/check-dduf.spec.ts
@@ -1,7 +1,51 @@
 import { describe, expect, it } from "vitest";
 import { checkDDUF, type DDUFFileEntry } from "./check-dduf";
 
+function createCentralDirectoryEntry(name: string, diskNumber: number): Uint8Array {
+	const nameBytes = new TextEncoder().encode(name);
+	const entry = new Uint8Array(46 + nameBytes.length);
+	const view = new DataView(entry.buffer);
+
+	view.setUint32(0, 0x02014b50, true);
+	view.setUint16(28, nameBytes.length, true);
+	view.setUint16(34, diskNumber, true);
+	entry.set(nameBytes, 46);
+
+	return entry;
+}
+
+function createArchive(entries: Uint8Array[]): Blob {
+	const centralDirectorySize = entries.reduce((size, entry) => size + entry.byteLength, 0);
+	const footer = new Uint8Array(22);
+	const footerView = new DataView(footer.buffer);
+
+	footerView.setUint32(0, 0x06054b50, true);
+	footerView.setUint16(8, entries.length, true);
+	footerView.setUint16(10, entries.length, true);
+	footerView.setUint32(12, centralDirectorySize, true);
+	footerView.setUint32(16, 0, true);
+
+	return new Blob([...entries, footer]);
+}
+
 describe("check-dduf", () => {
+	it("rejects a later central directory entry from another disk", async () => {
+		const archive = createArchive([
+			createCentralDirectoryEntry("first.txt", 0),
+			createCentralDirectoryEntry("second.txt", 1),
+		]);
+
+		const files = async () => {
+			const entries: DDUFFileEntry[] = [];
+			for await (const entry of checkDDUF(archive)) {
+				entries.push(entry);
+			}
+			return entries;
+		};
+
+		await expect(files()).rejects.toThrow("Multi-disk archives not supported");
+	});
+
 	it("should work", async () => {
 		const files: DDUFFileEntry[] = [];
 		for await (const file of checkDDUF(

--- a/packages/dduf/src/check-dduf.ts
+++ b/packages/dduf/src/check-dduf.ts
@@ -145,7 +145,7 @@ export async function* checkDDUF(url: Blob | URL, opts?: { log?: (x: string) => 
 
 		checkFilename(fileName);
 
-		const fileDiskNumber = centralDirView.getUint16(34, true);
+		const fileDiskNumber = centralDirView.getUint16(offset + 34, true);
 
 		if (fileDiskNumber !== 0 && fileDiskNumber !== 0xffff) {
 			throw new Error("Multi-disk archives not supported");


### PR DESCRIPTION
`checkDDUF` reads each central-directory record's disk number from byte 34 of that record. The current implementation omits the record offset, so every iteration rechecks the first entry and can silently accept a later entry that belongs to another disk.

Add the current record offset when reading the field. A deterministic two-entry archive regression verifies that an unsupported disk number on the second entry is rejected.

Validation:

- Regression before the fix: 1 failed, 1 passed.
- Full `@huggingface/dduf` suite after the fix: 2 passed.
- TypeScript check, ESLint, formatting, build, and `git diff --check` pass.
- No dependencies or lockfiles changed.

AI disclosure: The patch, tests, and this description were prepared with AI assistance and have not yet been reviewed by a human.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized parser fix with a targeted regression test; no API or dependency changes.
> 
> **Overview**
> Fixes a validation bug in **`checkDDUF`** where each central-directory record’s **disk number** was read at a fixed byte index instead of **`offset + 34`**, so every loop iteration re-checked the first entry and could **miss multi-disk entries** on later records.
> 
> The change aligns disk-number parsing with the other per-entry fields. A new **in-memory ZIP fixture** and regression test assert that an archive whose **second** entry has a non-zero disk number is rejected with **"Multi-disk archives not supported"**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac395844860108622916d1ec70fd0926fd238252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->