### PR TITLE
Add Bridge inference provider

### DIFF
--- a/packages/inference/README.md
+++ b/packages/inference/README.md
@@ -59,6 +59,7 @@ Currently, we support the following providers:
 - [Scaleway](https://www.scaleway.com/en/generative-apis/)
 - [Together](https://together.xyz)
 - [Baseten](https://baseten.co)
+- [Bridge](https://chyyx.github.io/Bridge-ai/)
 - [Cohere](https://cohere.com)
 - [Cerebras](https://cerebras.ai/)
 - [DeepInfra](https://deepinfra.com)

--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -1,4 +1,5 @@
 import * as Baseten from "../providers/baseten.js";
+import * as Bridge from "../providers/bridge.js";
 import * as Cerebras from "../providers/cerebras.js";
 import * as Cohere from "../providers/cohere.js";
 import * as DeepInfra from "../providers/deepinfra.js";
@@ -58,6 +59,9 @@ import { InferenceClientInputError } from "../errors.js";
 export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, TaskProviderHelper>>> = {
 	baseten: {
 		conversational: new Baseten.BasetenConversationalTask(),
+	},
+	bridge: {
+		conversational: new Bridge.BridgeConversationalTask(),
 	},
 	cerebras: {
 		conversational: new Cerebras.CerebrasConversationalTask(),

--- a/packages/inference/src/providers/bridge.ts
+++ b/packages/inference/src/providers/bridge.ts
@@ -1,0 +1,24 @@
+/**
+ * See the registered mapping of HF model ID => Bridge model ID here:
+ *
+ * https://huggingface.co/api/partners/bridge/models
+ *
+ * This is a publicly available mapping.
+ *
+ * If you want to try to run inference for a new model locally before it's
+ * registered on huggingface.co, you can add it to
+ * "HARDCODED_MODEL_INFERENCE_MAPPING" in consts.ts, for dev purposes.
+ *
+ * - If you work at Bridge and want to update this mapping, please use the
+ *   model mapping API provided on huggingface.co.
+ * - If you're a community member and want to add a new supported HF model
+ *   to Bridge, please open an issue on this repository.
+ */
+
+import { BaseConversationalTask } from "./providerHelper.js";
+
+export class BridgeConversationalTask extends BaseConversationalTask {
+	constructor() {
+		super("bridge", "https://hf.38.60.227.125.sslip.io");
+	}
+}

--- a/packages/inference/src/providers/consts.ts
+++ b/packages/inference/src/providers/consts.ts
@@ -19,6 +19,7 @@ export const HARDCODED_MODEL_INFERENCE_MAPPING: Record<
 	 * "Qwen/Qwen2.5-Coder-32B-Instruct": "Qwen2.5-Coder-32B-Instruct",
 	 */
 	baseten: {},
+	bridge: {},
 	cerebras: {},
 	cohere: {},
 	deepinfra: {},

--- a/packages/inference/src/types.ts
+++ b/packages/inference/src/types.ts
@@ -46,6 +46,7 @@ export type InferenceTask = Exclude<PipelineType, "other"> | "conversational";
 
 export const INFERENCE_PROVIDERS = [
 	"baseten",
+	"bridge",
 	"cerebras",
 	"cohere",
 	"deepinfra",
@@ -79,6 +80,7 @@ export type InferenceProviderOrPolicy = (typeof PROVIDERS_OR_POLICIES)[number];
  */
 export const PROVIDERS_HUB_ORGS: Record<InferenceProvider, string> = {
 	baseten: "baseten",
+	bridge: "LanSeq-Bridge",
 	cerebras: "cerebras",
 	cohere: "CohereLabs",
 	deepinfra: "DeepInfra",

--- a/packages/inference/test/InferenceClient.spec.ts
+++ b/packages/inference/test/InferenceClient.spec.ts
@@ -2434,4 +2434,63 @@ describe.skip("InferenceClient", () => {
 		},
 		TIMEOUT,
 	);
+	describe.concurrent(
+		"Bridge",
+		() => {
+			const client = new InferenceClient(env.HF_BRIDGE_KEY ?? "dummy");
+
+			HARDCODED_MODEL_INFERENCE_MAPPING["bridge"] = {
+				"Qwen/Qwen3.8-27B": {
+					provider: "bridge",
+					hfModelId: "Qwen/Qwen3.8-27B",
+					providerId: "qwen3.8-27b-int4",
+					status: "live",
+					task: "conversational",
+				},
+			};
+
+			it("chatCompletion - Qwen3.8-27B", async () => {
+				const res = await client.chatCompletion({
+					model: "Qwen/Qwen3.8-27B",
+					provider: "bridge",
+					messages: [
+						{
+							role: "user",
+							content: "Complete this sentence with one word: one plus one equals",
+						},
+					],
+					max_tokens: 10,
+				});
+
+				if (res.choices && res.choices.length > 0) {
+					const completion = res.choices[0].message?.content;
+					expect(completion ?? "").toMatch(/two|2/i);
+				}
+			});
+
+			it("chatCompletion stream - Qwen3.8-27B", async () => {
+				const stream = client.chatCompletionStream({
+					model: "Qwen/Qwen3.8-27B",
+					provider: "bridge",
+					messages: [{ role: "user", content: "Say 'this is a test'" }],
+					max_tokens: 10,
+					stream: true,
+				}) as AsyncGenerator<ChatCompletionStreamOutput>;
+
+				let fullResponse = "";
+				for await (const chunk of stream) {
+					if (chunk.choices && chunk.choices.length > 0) {
+						const content = chunk.choices[0].delta?.content;
+						if (content) {
+							fullResponse += content;
+						}
+					}
+				}
+
+				expect(fullResponse).toBeTruthy();
+				expect(fullResponse.length).toBeGreaterThan(0);
+			});
+		},
+		TIMEOUT,
+	);
 });


### PR DESCRIPTION
Adds Bridge as an OpenAI-compatible conversational inference provider.

Bridge endpoint:
https://hf.38.60.227.125.sslip.io

Initial model mapping target:
Qwen/Qwen3.8-27B -> qwen3.8-27b-int4

Verified capabilities:
- chat completions
- SSE streaming
- streaming and non-streaming usage reporting
- tool calling
- structured JSON output
- unique Inference-Id header
- provider billing endpoint
- text-only inference
- 70K context / 8K max output

Provider Hub organization:
LanSeq-Bridge

Website:
https://chyyx.github.io/Bridge-ai/

Privacy policy:
https://chyyx.github.io/Bridge-ai/privacy.html

Model Mapping registration will follow once Bridge is enabled server-side by Hugging Face.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider registration and docs/tests only; no changes to shared inference routing beyond a new `bridge` entry and a fixed external base URL.
> 
> **Overview**
> Adds **Bridge** as a new third-party inference provider for **conversational** (OpenAI-compatible) chat via `provider: "bridge"`.
> 
> Wiring matches existing conversational partners: a thin `BridgeConversationalTask` on `BaseConversationalTask` pointing at `https://hf.38.60.227.125.sslip.io`, registration in `getProviderHelper`, `INFERENCE_PROVIDERS`, `PROVIDERS_HUB_ORGS` (`LanSeq-Bridge`), and an empty dev mapping slot in `HARDCODED_MODEL_INFERENCE_MAPPING`. The README provider list includes Bridge.
> 
> Integration tests cover non-streaming and streaming `chatCompletion` for `Qwen/Qwen3.8-27B` with a test-injected mapping to `qwen3.8-27b-int4` (Hub partner mapping is expected to land separately).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd8cacc770c1e83c105d354bba860f5a843bca93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->