### PR TITLE
fix(jinja): lower-case the rest of the string in capitalize and title

### DIFF
--- a/packages/jinja/src/runtime.ts
+++ b/packages/jinja/src/runtime.ts
@@ -29,7 +29,7 @@ import type {
 	KeywordSpreadExpression,
 } from "./ast";
 import { Statement } from "./ast";
-import { range, replace, slice, strftime_now, titleCase } from "./utils";
+import { capitalizeFirst, range, replace, slice, strftime_now, titleCase } from "./utils";
 
 export type AnyRuntimeValue =
 	| IntegerValue
@@ -142,8 +142,7 @@ export class StringValue extends RuntimeValue<string> {
 			[
 				"capitalize",
 				new FunctionValue(() => {
-					// Python lower-cases everything after the first character.
-					return new StringValue(this.value.charAt(0).toUpperCase() + this.value.slice(1).toLowerCase());
+					return new StringValue(capitalizeFirst(this.value));
 				}),
 			],
 			["length", new IntegerValue(this.value.length)],

--- a/packages/jinja/src/runtime.ts
+++ b/packages/jinja/src/runtime.ts
@@ -142,7 +142,8 @@ export class StringValue extends RuntimeValue<string> {
 			[
 				"capitalize",
 				new FunctionValue(() => {
-					return new StringValue(this.value.charAt(0).toUpperCase() + this.value.slice(1));
+					// Python lower-cases everything after the first character.
+					return new StringValue(this.value.charAt(0).toUpperCase() + this.value.slice(1).toLowerCase());
 				}),
 			],
 			["length", new IntegerValue(this.value.length)],

--- a/packages/jinja/src/utils.ts
+++ b/packages/jinja/src/utils.ts
@@ -59,14 +59,40 @@ export function slice<T>(array: T[], start?: number, stop?: number, step = 1): T
  * @param value The string to title case.
  * @returns The title cased string.
  */
+// Jinja splits words on Python's `([-\s({\[<]+)`. The class is spelled out because JS and
+// Python disagree on `\s`: JS misses U+001C-U+001F and U+0085, and adds U+FEFF.
+// eslint-disable-next-line no-control-regex -- Python's `\s` matches these separators, so Jinja splits on them.
+const WORD_SEPARATOR = /([-\t\n\v\f\r\x1c-\x1f \x85\xa0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000({[<]+)/;
+
+/** Upper-case the first code point and lower-case the rest. Indexing by code point keeps an
+ *  astral letter such as Deseret "\u{10428}" intact instead of splitting its surrogate pair. */
+function upperFirstLowerRest(value: string): string {
+	const first = value.codePointAt(0);
+	if (first === undefined) {
+		return value;
+	}
+	const head = String.fromCodePoint(first);
+	return head.toUpperCase() + value.slice(head.length).toLowerCase();
+}
+
+/** Jinja's `title` filter: upper-case each word's first character, lower-case the rest. */
 export function titleCase(value: string): string {
-	// Mirrors Python's `str.title()` as Jinja implements it: split on runs of "-", whitespace,
-	// "(", "{", "[" or "<" (keeping the separators), then upper-case the first character of each
-	// piece and lower-case the rest. `\b` is not equivalent — it also breaks on "'" and ".".
-	return value
-		.split(/([-\s({[<]+)/)
-		.map((piece) => piece.charAt(0).toUpperCase() + piece.slice(1).toLowerCase())
-		.join("");
+	return value.split(WORD_SEPARATOR).map(upperFirstLowerRest).join("");
+}
+
+/** Python's `str.capitalize()`: title-case the first character, lower-case the rest. Title-case
+ *  is not upper-case where a character expands — "\u00df" title-cases to "Ss" but upper-cases to
+ *  "SS", which is why {@link titleCase} cannot be reused here. JS has no title-case mapping, so
+ *  the ~45 code points whose title-case is a distinct character (the "\u01f3" digraphs, and the
+ *  Greek iota-subscript block) still come out upper-cased. */
+export function capitalizeFirst(value: string): string {
+	const first = value.codePointAt(0);
+	if (first === undefined) {
+		return value;
+	}
+	const head = String.fromCodePoint(first);
+	const upper = head.toUpperCase();
+	return (upper.length > 1 ? upper[0] + upper.slice(1).toLowerCase() : upper) + value.slice(head.length).toLowerCase();
 }
 
 export function strftime_now(format: string): string {

--- a/packages/jinja/src/utils.ts
+++ b/packages/jinja/src/utils.ts
@@ -59,8 +59,13 @@ export function slice<T>(array: T[], start?: number, stop?: number, step = 1): T
  * @param value The string to title case.
  * @returns The title cased string.
  */
-// Jinja splits words on Python's `([-\s({\[<]+)`. The class is spelled out because JS and
-// Python disagree on `\s`: JS misses U+001C-U+001F and U+0085, and adds U+FEFF.
+// Jinja splits words on `([-\s({\[<]+)`:
+// https://github.com/pallets/jinja/blob/3.1.6/src/jinja2/filters.py#L328
+// `\s` is spelled out because the two languages define it differently. Python's `\s` matches
+// exactly what `str.isspace()` does — an "Other"/"Separator" category, or bidirectional class
+// WS, B or S (https://docs.python.org/3/library/stdtypes.html#str.isspace) — so it covers
+// U+001C-U+001F (bidi B/S) and U+0085 (bidi B). ECMAScript's is WhiteSpace + LineTerminator
+// (https://tc39.es/ecma262/#sec-white-space), which omits those four and adds U+FEFF.
 // eslint-disable-next-line no-control-regex -- Python's `\s` matches these separators, so Jinja splits on them.
 const WORD_SEPARATOR = /([-\t\n\v\f\r\x1c-\x1f \x85\xa0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000({[<]+)/;
 

--- a/packages/jinja/src/utils.ts
+++ b/packages/jinja/src/utils.ts
@@ -60,7 +60,13 @@ export function slice<T>(array: T[], start?: number, stop?: number, step = 1): T
  * @returns The title cased string.
  */
 export function titleCase(value: string): string {
-	return value.replace(/\b\w/g, (c) => c.toUpperCase());
+	// Mirrors Python's `str.title()` as Jinja implements it: split on runs of "-", whitespace,
+	// "(", "{", "[" or "<" (keeping the separators), then upper-case the first character of each
+	// piece and lower-case the rest. `\b` is not equivalent — it also breaks on "'" and ".".
+	return value
+		.split(/([-\s({[<]+)/)
+		.map((piece) => piece.charAt(0).toUpperCase() + piece.slice(1).toLowerCase())
+		.join("");
 }
 
 export function strftime_now(format: string): string {

--- a/packages/jinja/test/templates.test.js
+++ b/packages/jinja/test/templates.test.js
@@ -6437,6 +6437,17 @@ describe("Feature regressions", () => {
 			["3rd PLACE", "3rd place", "3rd Place"],
 			["ÉCOLE test", "École test", "École Test"],
 			["", "", ""],
+			// Astral letters: indexing by UTF-16 code unit would split the surrogate pair.
+			["\u{10428}bc", "\u{10400}bc", "\u{10400}bc"],
+			// `capitalize` title-cases the first character, `title` upper-cases it.
+			["\u00dfabc", "Ssabc", "SSabc"],
+			["\ufb01ne DAY", "Fine day", "FIne Day"],
+			["\u0131stanbul", "Istanbul", "Istanbul"],
+			// Python's `\s` covers U+0085 and U+001C-U+001F; JS's does not.
+			["a\u0085b", "A\u0085b", "A\u0085B"],
+			["a\u001cb", "A\u001cb", "A\u001cB"],
+			// ...and JS's `\s` covers U+FEFF, which Python does not treat as a separator.
+			["a\ufeffB", "A\ufeffb", "A\ufeffb"],
 		])("%o capitalizes and titles like Python", (input, capitalized, titled) => {
 			expect(new Template("{{ s|capitalize }}").render({ s: input })).toEqual(capitalized);
 			expect(new Template("{{ s|title }}").render({ s: input })).toEqual(titled);

--- a/packages/jinja/test/templates.test.js
+++ b/packages/jinja/test/templates.test.js
@@ -6421,6 +6421,31 @@ describe("Feature regressions", () => {
 		});
 	});
 
+	describe("String case filters", () => {
+		// Both filters lower-case everything after each word's first character, and `title`
+		// only breaks words on "-", whitespace, "(", "{", "[" and "<" — not on "'" or ".".
+		// Verified against Python jinja2 3.1.6.
+		it.each([
+			["hello WORLD", "Hello world", "Hello World"],
+			["HELLO", "Hello", "Hello"],
+			["hELLO wORLD", "Hello world", "Hello World"],
+			["ABC def", "Abc def", "Abc Def"],
+			["don't stop", "Don't stop", "Don't Stop"],
+			["x.y z", "X.y z", "X.y Z"],
+			["o'NEIL", "O'neil", "O'neil"],
+			["foo-bar baz", "Foo-bar baz", "Foo-Bar Baz"],
+			["3rd PLACE", "3rd place", "3rd Place"],
+			["ÉCOLE test", "École test", "École Test"],
+			["", "", ""],
+		])("%o capitalizes and titles like Python", (input, capitalized, titled) => {
+			expect(new Template("{{ s|capitalize }}").render({ s: input })).toEqual(capitalized);
+			expect(new Template("{{ s|title }}").render({ s: input })).toEqual(titled);
+			// The method forms share the same builtins as the filters.
+			expect(new Template("{{ s.capitalize() }}").render({ s: input })).toEqual(capitalized);
+			expect(new Template("{{ s.title() }}").render({ s: input })).toEqual(titled);
+		});
+	});
+
 	describe("Macros and call statements", () => {
 		it.each([
 			{


### PR DESCRIPTION
## What

`capitalize` and `title` only upper-cased characters; they never lower-cased the rest. Python does both, so rendering diverged from Jinja on any input that already contained upper-case letters.

```
                     python jinja2 3.1.6      @huggingface/jinja (before)
'hello WORLD' | capitalize   'Hello world'    'Hello WORLD'
'hello WORLD' | title        'Hello World'    'Hello WORLD'
'ABC def'     | capitalize   'Abc def'        'ABC def'
'HELLO'       | title        'Hello'          'HELLO'
```

While fixing `title` I also had to change how it finds word starts. It used `/\b\w/`, but Jinja splits on `([-\s({\[<]+)` — `\b` additionally breaks on `'` and `.`:

```
"don't stop" | title    python "Don't Stop"    before "Don'T Stop"
'x.y z'      | title    python 'X.y Z'         before 'X.Y Z'
```

Both filters resolve through the string builtins, so `s.capitalize()` and `s.title()` were wrong in the same way and are fixed by the same change.

## Why it went unnoticed

`FILTER_OPERATOR_2` is the only existing coverage, and it feeds both filters `'test test'` — already lower-case, so it renders identically whether or not the remainder is lowered. The expected value `|3|ABCD|abcd|Test test|Test Test|a b|4|` is correct under both the old and new code.

## Verification

Differentially tested against **python jinja2 3.1.6** over 22 inputs × 2 filters (mixed case, leading/trailing whitespace, `-`/`(`/`{`/`[`/`<` separators, apostrophes, periods, digits, non-ASCII, empty string):

```
before   31 / 44 mismatches
after     0 / 44
```

Red/green with only the two source files reverted and the new test kept:

```
without the fix   9 failed | 629 passed
with the fix      638 passed
```

Full package suite: **686 passed**. `tsc --noEmit`, `oxfmt --check` and `eslint` all clean.

One note on what I could not run: `test/e2e.test.js` fails to load `@huggingface/hub` in my environment because I installed only this package rather than the whole workspace. It fails identically on a clean checkout of `main`, so it is environmental and unrelated to this change — CI will cover it.

## AI disclosure

Written with Claude Opus 5 via Claude Code. The divergence was found by reading `runtime.ts`/`utils.ts` against Python's `do_title`/`str.capitalize`, then confirmed by running both implementations side by side; every expected value in the new test is the literal output of python jinja2 3.1.6, not hand-written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Jinja string filter semantics with broad regression tests; no auth, data, or infrastructure impact.
> 
> **Overview**
> **`capitalize` and `title`** (filters and `s.capitalize()` / `s.title()` builtins) now lower-case the rest of each affected segment after upper-casing the first character, matching Python Jinja2 instead of leaving existing capitals unchanged.
> 
> **`title`** no longer uses word-boundary regex; it splits on Jinja’s separator set (`-`, whitespace including Python-specific separators, `(`, `{`, `[`, `<`), so strings like `don't stop` and `x.y z` title-case like upstream rather than breaking on `'` or `.`.
> 
> Shared helpers in `utils.ts` (`titleCase`, new `capitalizeFirst`, code-point–aware casing) replace the old inline logic. A **String case filters** test block asserts behavior against Python jinja2 3.1.6, including Unicode edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd7916fed0bbd6c02fa0d376e49c53b25f9a7b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->