### PR TITLE
Add Core AI to model libraries

### DIFF
--- a/packages/tasks/src/model-libraries-snippets.ts
+++ b/packages/tasks/src/model-libraries-snippets.ts
@@ -247,6 +247,37 @@ print("R² Score:", r2)`;
 	return [installSnippet, classificationSnippet, regressionsSnippet];
 };
 
+export const coreai = (model: ModelData): string[] => {
+	const folder = model.id.split("/").pop() ?? "model";
+	const header = `// Apple Core AI (iOS 27 / macOS 27): this repo holds an .aimodel bundle that runs fully on-device.
+// 1. Download the bundle folder:  hf download ${model.id} --local-dir ./${folder}
+// 2. Load it with Apple's Swift package: https://github.com/apple/coreai-models`;
+	if (model.pipeline_tag === "text-generation") {
+		return [
+			`${header}
+import FoundationModels
+import CoreAILanguageModels
+
+let model = try await CoreAILanguageModel(resourcesAt: bundleFolderURL)   // folder with the .aimodel + tokenizer/
+let session = LanguageModelSession(model: model)
+print(try await session.respond(to: "Explain on-device AI in one sentence."))`,
+			`// Or with the community CoreAIKit package, which downloads from this repo on first use:
+// https://github.com/john-rocky/coreai-kit
+import CoreAIKit
+
+let chat = try await ChatSession(model: ModelID("${model.id}"))   // add path: "<subfolder>" if the bundle sits in one
+print(try await chat.respond(to: "Explain on-device AI in one sentence."))`,
+		];
+	}
+	return [
+		`${header}
+import CoreAI
+
+let model = try await AIModel(contentsOf: aimodelURL)   // the .aimodel inside the downloaded folder
+// Inputs, outputs and any companion files are described on this model's card.`,
+	];
+};
+
 export const cortiq = (model: ModelData): string[] => {
 	const setup = `# one Rust binary, no additional dependencies
 cargo install cortiq-cli   # or a prebuilt binary from github.com/infosave2007/cmf/releases

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -342,6 +342,15 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/Unbabel/COMET/",
 		countDownloads: `path:"hparams.yaml"`,
 	},
+	coreai: {
+		prettyLabel: "Core AI",
+		repoName: "coreai-models",
+		repoUrl: "https://github.com/apple/coreai-models",
+		docsUrl: "https://developer.apple.com/documentation/coreai",
+		snippets: snippets.coreai,
+		filter: false,
+		countDownloads: `path_extension:"mlirb"`,
+	},
 	cortiq: {
 		prettyLabel: "cortiq",
 		repoName: "cortiq",


### PR DESCRIPTION
Registers `coreai`, Apple's on-device runtime for iOS 27 / macOS 27, so that repos hosting `.aimodel` bundles get the library label, a Swift "Use this model" snippet, and download counting.

198 repos from 24 authors already carry `library_name: coreai` (https://huggingface.co/models?other=coreai). Without an entry they show as an unregistered tag, and most count no downloads, because a bundle folder usually carries no `config.json`.

Following the registration docs:

- Entry between `comet` and `cortiq`, `filter: false`. `repoUrl` points at Apple's runtime package ([apple/coreai-models](https://github.com/apple/coreai-models)), `docsUrl` at Apple's Core AI documentation.
- `countDownloads: path_extension:"mlirb"`: every `.aimodel` bundle contains one `main.mlirb`, so a bundle download counts once, the same shape as the `litert` and `litert-lm` rules.
- Snippets: text-generation shows Apple's `CoreAILanguageModels` loader first, then the community CoreAIKit package, which loads straight from the Hub repo. Other tasks get the generic `AIModel(contentsOf:)` loader and a pointer to the card for inputs and outputs.

Rendered for `mlboydaisuke/MiniCPM5-2B-CoreAI` (text-generation):

```swift
// Apple Core AI (iOS 27 / macOS 27): this repo holds an .aimodel bundle that runs fully on-device.
// 1. Download the bundle folder:  hf download mlboydaisuke/MiniCPM5-2B-CoreAI --local-dir ./MiniCPM5-2B-CoreAI
// 2. Load it with Apple's Swift package: https://github.com/apple/coreai-models
import FoundationModels
import CoreAILanguageModels

let model = try await CoreAILanguageModel(resourcesAt: bundleFolderURL)   // folder with the .aimodel + tokenizer/
let session = LanguageModelSession(model: model)
print(try await session.respond(to: "Explain on-device AI in one sentence."))
```

```swift
// Or with the community CoreAIKit package, which downloads from this repo on first use:
// https://github.com/john-rocky/coreai-kit
import CoreAIKit

let chat = try await ChatSession(model: ModelID("mlboydaisuke/MiniCPM5-2B-CoreAI"))   // add path: "<subfolder>" if the bundle sits in one
print(try await chat.respond(to: "Explain on-device AI in one sentence."))
```

For transparency: I maintain the community [Core AI model zoo](https://github.com/john-rocky/coreai-model-zoo) and CoreAIKit, where 78 of those repos come from; the other authors' repos use the same `.aimodel` layout. I am not affiliated with Apple. The key name, the snippet order, and the counting rule are all easy to change to whatever fits the Hub's conventions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds registry metadata and display snippets only; no runtime, auth, or data-handling logic changes.
> 
> **Overview**
> Registers **Apple Core AI** (`library_name: coreai`) in the Hub model-libraries registry so `.aimodel` repos get a proper **Core AI** label, docs/repo links, and download stats.
> 
> Adds a **`coreai` snippet generator** with Swift “use this model” examples: `hf download` plus Apple’s `CoreAILanguageModels` path for **text-generation**, an optional **CoreAIKit** Hub-based alternative, and a generic **`AIModel(contentsOf:)`** snippet for other tasks. Download counting uses **`path_extension:"mlirb"`** (one count per bundle via `main.mlirb`), with **`filter: false`** like other niche runtimes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d48cd868a6551149541004c7bb49c61fb2d78773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->