### PR TITLE
🐛 fix(blob): probe range support when HEAD omits size or accept-ranges

### DIFF
--- a/packages/blob/src/utils/WebBlob.spec.ts
+++ b/packages/blob/src/utils/WebBlob.spec.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, beforeAll } from "vitest";
+import { describe, expect, it, beforeAll, vi } from "vitest";
 import { WebBlob } from "./WebBlob";
 
 describe("WebBlob", () => {
+	const url = new URL("https://example.test/object");
 	const resourceUrl = new URL("https://huggingface.co/spaces/aschen/push-model-from-web/raw/main/mobilenet/model.json");
 	let fullText: string;
 	let size: number;
@@ -86,5 +87,174 @@ describe("WebBlob", () => {
 
 		expect(() => webBlob.slice(-5)).toThrow(TypeError);
 		expect(() => webBlob.slice(0, -1)).toThrow(TypeError);
+	});
+
+	it("reports the real size when HEAD omits content-length", async () => {
+		const ranges: Array<string | undefined> = [];
+		const customFetch = vi.fn(async (_url: URL, init?: RequestInit) => {
+			if (init?.method === "HEAD") {
+				return new Response(null, { headers: { "accept-ranges": "bytes", "content-type": "text/plain" } });
+			}
+			ranges.push((init?.headers as Record<string, string> | undefined)?.Range);
+			return new Response("x", {
+				status: 206,
+				headers: { "content-range": "bytes 0-0/10", "content-type": "text/plain" },
+			});
+		});
+
+		// cacheBelow: 0 keeps the lazy path in play for a 10-byte resource, which is what makes the
+		// missing content-length observable: without the probe the blob reports size 0 and slices to
+		// a malformed `Range: bytes=0--1`.
+		const blob = await WebBlob.create(url, { cacheBelow: 0, fetch: customFetch as typeof fetch });
+
+		expect(blob).toBeInstanceOf(WebBlob);
+		expect(blob.size).toBe(10);
+		expect(blob.slice(0, 4).size).toBe(4);
+		expect(ranges).toEqual(["bytes=0-0"]);
+		await blob.slice(0, 4).text();
+		expect(ranges).toEqual(["bytes=0-0", "bytes=0-3"]);
+	});
+
+	it("uses the lazy path for a large resource whose HEAD omits accept-ranges", async () => {
+		const customFetch = vi.fn(async (_url: URL, init?: RequestInit) => {
+			if (init?.method === "HEAD") {
+				return new Response(null, { headers: { "content-length": "50000000", "content-type": "text/plain" } });
+			}
+			return new Response("x", {
+				status: 206,
+				headers: { "content-range": "bytes 0-0/50000000", "content-type": "text/plain" },
+			});
+		});
+
+		// Default cacheBelow: no options beyond the injected fetch.
+		const blob = await WebBlob.create(url, { fetch: customFetch as typeof fetch });
+
+		expect(blob).toBeInstanceOf(WebBlob);
+		expect(blob.size).toBe(50_000_000);
+		expect(customFetch).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not probe when HEAD already gives a size below cacheBelow", async () => {
+		const customFetch = vi.fn(async (_url: URL, init?: RequestInit) => {
+			if (init?.method === "HEAD") {
+				return new Response(null, { headers: { "content-length": "500", "content-type": "text/plain" } });
+			}
+			return new Response("small body");
+		});
+
+		const blob = await WebBlob.create(url, { fetch: customFetch as typeof fetch });
+
+		expect(await blob.text()).toBe("small body");
+		expect(customFetch).toHaveBeenCalledTimes(2);
+		expect(customFetch).toHaveBeenLastCalledWith(url);
+	});
+
+	it("issues an extra GET when the probe reveals a size below cacheBelow", async () => {
+		const customFetch = vi.fn(async (_url: URL, init?: RequestInit) => {
+			if (init?.method === "HEAD") {
+				return new Response(null, { headers: { "accept-ranges": "bytes" } });
+			}
+			if (init?.headers) {
+				return new Response("x", { status: 206, headers: { "content-range": "bytes 0-0/500" } });
+			}
+			return new Response("small body");
+		});
+
+		const blob = await WebBlob.create(url, { fetch: customFetch as typeof fetch });
+
+		expect(blob).not.toBeInstanceOf(WebBlob);
+		expect(await blob.text()).toBe("small body");
+		// HEAD + probe + GET: one round trip more than before, the price of learning the real size.
+		expect(customFetch).toHaveBeenCalledTimes(3);
+	});
+
+	it("reuses a full-body range probe when a server ignores Range", async () => {
+		const customFetch = vi.fn(async (_url: URL, init?: RequestInit) => {
+			if (init?.method === "HEAD") {
+				return new Response(null);
+			}
+			return new Response("full response", { status: 200, headers: { "content-type": "text/plain" } });
+		});
+
+		const blob = await WebBlob.create(url, { fetch: customFetch as typeof fetch });
+
+		expect(blob).not.toBeInstanceOf(WebBlob);
+		expect(await blob.text()).toBe("full response");
+		// HEAD + the probe itself: the probe body is reused instead of issuing a second plain GET.
+		expect(customFetch).toHaveBeenCalledTimes(2);
+		expect(customFetch).toHaveBeenLastCalledWith(url, { headers: { Range: "bytes=0-0" } });
+	});
+
+	it("handles an empty ranged resource without a fallback GET", async () => {
+		const customFetch = vi.fn(async (_url: URL, init?: RequestInit) => {
+			if (init?.method === "HEAD") {
+				return new Response(null);
+			}
+			return new Response(null, { status: 416, headers: { "content-range": "bytes */0" } });
+		});
+
+		const blob = await WebBlob.create(url, { fetch: customFetch as typeof fetch });
+
+		expect(blob.size).toBe(0);
+		expect(customFetch).toHaveBeenCalledTimes(2);
+		expect(customFetch).toHaveBeenLastCalledWith(url, { headers: { Range: "bytes=0-0" } });
+	});
+
+	it("falls back to GET for malformed range totals", async () => {
+		const customFetch = vi.fn(async (_url: URL, init?: RequestInit) => {
+			if (init?.method === "HEAD") {
+				return new Response(null);
+			}
+			if (init?.headers) {
+				return new Response("x", { status: 206, headers: { "content-range": "bytes 0-0/not-a-number" } });
+			}
+			return new Response("fallback");
+		});
+
+		const blob = await WebBlob.create(url, { fetch: customFetch as typeof fetch });
+
+		expect(await blob.text()).toBe("fallback");
+		// HEAD + probe + GET: the extra round trip when the probe tells us nothing usable.
+		expect(customFetch).toHaveBeenCalledTimes(3);
+	});
+
+	it("falls back to GET when a positive range header has the wrong status", async () => {
+		const customFetch = vi.fn(async (_url: URL, init?: RequestInit) => {
+			if (init?.method === "HEAD") {
+				return new Response(null);
+			}
+			if (init?.headers) {
+				return new Response("x", { status: 500, headers: { "content-range": "bytes 0-0/10" } });
+			}
+			return new Response("fallback");
+		});
+		expect(await (await WebBlob.create(url, { fetch: customFetch as typeof fetch })).text()).toBe("fallback");
+	});
+
+	it("falls back to GET when an empty range header has the wrong status", async () => {
+		const customFetch = vi.fn(async (_url: URL, init?: RequestInit) => {
+			if (init?.method === "HEAD") {
+				return new Response(null);
+			}
+			if (init?.headers) {
+				return new Response(null, { status: 500, headers: { "content-range": "bytes */0" } });
+			}
+			return new Response("fallback");
+		});
+		expect(await (await WebBlob.create(url, { fetch: customFetch as typeof fetch })).text()).toBe("fallback");
+	});
+
+	it("keeps a valid positive HEAD range signal on the lazy path", async () => {
+		const customFetch = vi.fn(async (_url: URL, init?: RequestInit) => {
+			if (init?.method === "HEAD") {
+				return new Response(null, { headers: { "content-length": "10", "accept-ranges": "bytes" } });
+			}
+			return new Response("0123456789", { status: 206 });
+		});
+
+		const blob = await WebBlob.create(url, { cacheBelow: 0, fetch: customFetch as typeof fetch });
+
+		expect(blob).toBeInstanceOf(WebBlob);
+		expect(customFetch).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/blob/src/utils/WebBlob.ts
+++ b/packages/blob/src/utils/WebBlob.ts
@@ -19,13 +19,45 @@ interface WebBlobCreateOptions {
 export class WebBlob extends Blob {
 	static async create(url: URL, opts?: WebBlobCreateOptions): Promise<Blob> {
 		const customFetch = opts?.fetch ?? fetch;
+		const cacheBelow = opts?.cacheBelow ?? 1_000_000;
 		const response = await customFetch(url, { method: "HEAD" });
+		let size = Number(response.headers.get("content-length"));
+		let contentType = response.headers.get("content-type") || "";
+		let supportRange = response.headers.get("accept-ranges") === "bytes";
+		const knownSize = Number.isFinite(size) && size > 0;
 
-		const size = Number(response.headers.get("content-length"));
-		const contentType = response.headers.get("content-type") || "";
-		const supportRange = response.headers.get("accept-ranges") === "bytes";
+		// A HEAD response can lack both `content-length` and `accept-ranges` (see #2118, which replaced the
+		// HEAD call in the packages/hub copy of this file for that reason), and neither absence means the
+		// server cannot serve ranges. Probe only when the answer can change the outcome: HEAD gave no usable
+		// size, or it withheld `accept-ranges` for a resource large enough to have taken the lazy path.
+		if (!knownSize || (!supportRange && size >= cacheBelow)) {
+			const probe = await customFetch(url, { headers: { Range: "bytes=0-0" } });
+			const contentRange = probe.headers.get("content-range");
+			const totalMatch = contentRange?.match(/^bytes\s+0-0\/(\d+)$/i);
 
-		if (!supportRange || size < (opts?.cacheBelow ?? 1_000_000)) {
+			if (probe.status === 200) {
+				// The server ignored `Range` and sent the whole body already.
+				return await probe.blob();
+			}
+
+			if (probe.status === 416 && contentRange?.match(/^bytes\s+\*\/0$/i)) {
+				await probe.body?.cancel();
+				return new Blob([], { type: probe.headers.get("content-type") || contentType });
+			}
+
+			if (probe.status !== 206 || !totalMatch || Number(totalMatch[1]) <= 0) {
+				// Nothing conclusive came back: keep the previous behaviour and GET the whole thing.
+				await probe.body?.cancel();
+				return await (await customFetch(url)).blob();
+			}
+
+			size = Number(totalMatch[1]);
+			contentType = probe.headers.get("content-type") || contentType;
+			supportRange = true;
+			await probe.body?.cancel();
+		}
+
+		if (!supportRange || size < cacheBelow) {
 			return await (await customFetch(url)).blob();
 		}
 


### PR DESCRIPTION
## What goes wrong today

`WebBlob.create()` reads two headers off a `HEAD` response and treats a missing header as a fact rather than as missing information. Two things follow from that.

**1. A large resource is downloaded and buffered in RAM whenever the origin does not send `accept-ranges: bytes` on `HEAD`.** This happens with the default options and is the reason for this PR. Measured at `d766490` against a stubbed fetch whose `HEAD` sends `content-length: 50000000` and no `accept-ranges`, with no options beyond the injected fetch:

```
{"isWebBlob":false,"size":50000000,"calls":2,"lastCallHadRangeHeader":false}
```

The caller asked for a blob and got 50 MB in memory. With this PR the same origin yields a lazy blob for the same two requests:

```
{"isWebBlob":true,"size":50000000,"calls":2}
```

**2. A missing `content-length` becomes `Number(null) === 0`.** To be clear about the blast radius: **the default path never produces the zero-size blob** — `0 < 1_000_000` is always true, so the default `cacheBelow` sends that caller down the full-download path and it gets a correct blob. Measured at `d766490`, `HEAD` sending `accept-ranges: bytes` and no `content-length`, default options:

```
A -> {"isWebBlob":false,"size":20,"text":"REAL BODY 1234567890","calls":2}
```

A caller that lowers `cacheBelow` below the resource size does get a broken blob. `cacheBelow: 0`, same stub:

```
C -> {"isWebBlob":true,"blobSize":0,"sliceSize":0,"ranges":["bytes=0--1"],"sliceText":"REAL BODY 1234567890"}
```

`size` is 0 for a 20-byte resource, `slice()` reports 0 bytes, and the request that goes out is a malformed `Range: bytes=0--1`. No caller inside this repo passes `cacheBelow` — `packages/blob/src/utils/createBlob.ts:16` is `return WebBlob.create(url, { fetch: opts?.fetch });` — but `WebBlob.spec.ts` itself uses `cacheBelow: 0`, so it is a reachable public-API state, not a hypothetical one.

## Root cause

At `d766490`, `packages/blob/src/utils/WebBlob.ts:22-30`:

```ts
const response = await customFetch(url, { method: "HEAD" });

const size = Number(response.headers.get("content-length"));
const contentType = response.headers.get("content-type") || "";
const supportRange = response.headers.get("accept-ranges") === "bytes";

if (!supportRange || size < (opts?.cacheBelow ?? 1_000_000)) {
	return await (await customFetch(url)).blob();
}
```

Both the size and the range capability come from `HEAD` alone. There is no way to distinguish "absent" from "zero" or from "not supported", and no fallback when the answer is absent.

This was already fixed once in this repository, in the other copy of the same file. Commit `ac452106` (`fix "browser" test (#2118)`) replaced the `HEAD` call in `packages/hub/src/utils/WebBlob.ts` with a `Range: bytes=0-0` probe. Its comment, `packages/hub/src/utils/WebBlob.ts:26-38`, states the observed cause:

> In browsers, when CloudFront gzips a response on the fly (typical for small text/JSON files behind `/api/resolve-cache/...`), the cached response loses both `Content-Length` and `Accept-Ranges`. Subsequent HEAD requests served from that cache inherit the missing headers, so the lib could not tell either the file size or whether ranges were supported, and silently fell back to buffering the whole blob in RAM.
>
> Range responses are never content-encoded, so `Content-Range` (carrying the total size) and the strong `ETag` always survive, regardless of the cached encoding state.

`packages/blob` still carries the pre-#2118 version. I am relying on that comment for the field report; I did not reproduce a CloudFront response myself (see "What was not verified").

## The change

Bring the same technique to `packages/blob`, but keep the `HEAD` request instead of dropping it as `packages/hub` does. Two reasons for the difference: the hub copy throws through `createApiError`, which `packages/blob` has no equivalent of, and dropping `HEAD` would change the request shape for every caller whose origin answers `HEAD` correctly. If maintainers would rather have the two copies converge exactly, say so and I will do it that way instead.

The probe is sent only when its answer can change the outcome — `packages/blob/src/utils/WebBlob.ts:33` on this branch:

```ts
if (!knownSize || (!supportRange && size >= cacheBelow)) {
```

where `knownSize` is `Number.isFinite(size) && size > 0`. The response is then interpreted rather than assumed:

- `206` with a well-formed `bytes 0-0/<total>`: real total size, range support proven, lazy path kept.
- `200`: the server ignored `Range` and already sent the whole body, so that body is reused instead of issuing a second `GET`.
- `416` with `bytes */0`: a genuinely empty resource, returned as an empty `Blob` with no further request.
- anything else — wrong status, malformed total, non-positive total: plain `GET`, which is the previous behaviour.

Unused probe bodies are cancelled so no response is left dangling.

### Trade-off a reviewer should weigh: request count

This is a download-path package, so the extra round trip is stated in full rather than summarised. "Before" is `d766490`, "after" is this branch.

| `HEAD` response | before | after | asserted by |
| --- | --- | --- | --- |
| positive `content-length` + `accept-ranges: bytes`, size ≥ `cacheBelow` | 1 | 1 — no probe | `keeps a valid positive HEAD range signal on the lazy path` |
| positive `content-length` below `cacheBelow` (`accept-ranges` absent) | 2 | 2 — no probe | `does not probe when HEAD already gives a size below cacheBelow` |
| positive `content-length`, no `accept-ranges`, size ≥ `cacheBelow` | 2, whole body buffered | 2, one byte of body, lazy blob | `uses the lazy path for a large resource whose HEAD omits accept-ranges` |
| no usable `content-length` (absent, zero or non-numeric), probe reveals size ≥ `cacheBelow` | 2, whole body buffered | 2, lazy blob | `reports the real size when HEAD omits content-length` |
| **no usable `content-length`, probe reveals size < `cacheBelow`** | 2 | **3** | `issues an extra GET when the probe reveals a size below cacheBelow` |
| probe answers `200` (server ignored `Range`) | 2 | 2 — probe body reused | `reuses a full-body range probe when a server ignores Range` |
| probe answers `416 bytes */0` | 2 | 2 — no fallback `GET` | `handles an empty ranged resource without a fallback GET` |
| **probe answer cannot be interpreted** (wrong status, malformed total) | 2 | **3** | `falls back to GET for malformed range totals` |

So: two named cases cost one extra round trip, and every row has a test asserting the count. A reviewer who considers that too expensive has a real alternative — converging on the hub implementation, which drops `HEAD` and is one request rather than two.

### A note on the browser case, stated accurately

Per the Fetch standard, `Content-Length` is a CORS-safelisted response header and is readable cross-origin without any `Access-Control-Expose-Headers` entry. `Accept-Ranges` and `Content-Range` are not safelisted. Against a cross-origin server that does not opt `Content-Range` in, `probe.headers.get("content-range")` is `null`, the probe is inconclusive, and control reaches the plain-`GET` fallback — previous behaviour plus one round trip. **This change does not fix that case.** It fixes the same-origin and header-exposing cases, which is what `packages/hub` has been shipping since #2118.

## Testing

All commands run on this branch alone on top of `d766490`, from the repository root.

```
$ pnpm --filter @huggingface/blob test
 ✓ src/utils/FileBlob.spec.ts  (3 tests) 9ms
 ✓ src/utils/WebBlob.spec.ts  (15 tests) 5607ms

 Test Files  2 passed (2)
      Tests  18 passed (18)

$ pnpm --filter @huggingface/blob test:browser
 ✓ src/utils/WebBlob.spec.ts  (15 tests) 5198ms

 Test Files  1 passed (1)
      Tests  15 passed (15)

$ pnpm --filter @huggingface/blob lint:check     # eslint --ext .cjs,.ts . -> exit 0, no output
$ pnpm --filter @huggingface/blob check          # tsc -> exit 0, no output
$ pnpm --filter @huggingface/blob format:check
Checking formatting...
All matched files use the correct format.
Finished in 113ms on 13 files using 15 threads.
```

CI also builds dependents, so `@huggingface/dduf` (the only package depending on `blob`) was run too: `check` exit 0, `lint:check` exit 0, `test` → `Tests 1 passed (1)`.

### The new tests fail without the fix

Restoring only `packages/blob/src/utils/WebBlob.ts` to its `d766490` version and keeping the new spec:

```
$ git checkout d766490 -- packages/blob/src/utils/WebBlob.ts
$ pnpm --filter @huggingface/blob test
 FAIL  src/utils/WebBlob.spec.ts > WebBlob > reports the real size when HEAD omits content-length
AssertionError: expected +0 to be 10 // Object.is equality
 FAIL  src/utils/WebBlob.spec.ts > WebBlob > uses the lazy path for a large resource whose HEAD omits accept-ranges
AssertionError: expected Blob { size: 1, type: 'text/plain' } to be an instance of WebBlob
 FAIL  src/utils/WebBlob.spec.ts > WebBlob > issues an extra GET when the probe reveals a size below cacheBelow
AssertionError: expected "spy" to be called 3 times, but got 2 times
 FAIL  src/utils/WebBlob.spec.ts > WebBlob > reuses a full-body range probe when a server ignores Range
AssertionError: expected last "spy" call to have been called with [ …(2) ]
 FAIL  src/utils/WebBlob.spec.ts > WebBlob > handles an empty ranged resource without a fallback GET
AssertionError: expected last "spy" call to have been called with [ …(2) ]
 FAIL  src/utils/WebBlob.spec.ts > WebBlob > falls back to GET for malformed range totals
AssertionError: expected "spy" to be called 3 times, but got 2 times

 Test Files  1 failed | 1 passed (2)
      Tests  6 failed | 12 passed (18)
```

Restoring the fix returns `Tests 18 passed (18)`. Six of the ten added tests fail on the base source. The other four — the no-probe path, the valid-HEAD lazy path and the two wrong-status fallbacks — assert behaviour that is deliberately unchanged and pass either way; they are regression guards, not evidence of the bug.

## What was not verified

- **No live CDN and no cross-origin browser response.** The CloudFront-gzip scenario is quoted from #2118's comment, not reproduced by me. If that premise is disputed, the motivation for this PR goes with it.
- **No CORS layer is exercised anywhere in the tests.** `test:browser` runs in headless Chrome, but all ten new tests use an injected fetch stub, so nothing here proves the probe can read `Content-Range` from a real cross-origin response. The paragraph above says so directly.
- **No performance measurement** of the extra round trip. Only request counts are asserted, not latency or bytes on the wire.
- **The spec file remains network-dependent, which this PR does not change.** `WebBlob.spec.ts` has a `describe`-level `beforeAll` that fetches `https://huggingface.co/spaces/aschen/push-model-from-web/raw/main/mobilenet/model.json`, and four of the five pre-existing tests hit the live network (three that URL, one the `stabilityai/stable-diffusion-xl-base-1.0` LFS file). That is essentially all of the ~5.2–5.6 s runtime. It was not introduced here, and rewriting those tests would be out of scope for this PR, but it does mean `test` and `test:browser` need network access in CI — including for the ten new tests, whose own bodies make no network calls but which still run after that shared `beforeAll`.
- **`packages/hub` is untouched.** After this PR the two copies of `WebBlob` remain divergent: hub probes always, blob probes conditionally. Deduplicating them would be a much larger change and is not attempted here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP behavior on the blob download path (conditional extra requests and new branching on range responses); mitigated by fallbacks to the prior full-GET behavior and broad mocked tests.
> 
> **Overview**
> **`WebBlob.create()`** no longer treats missing **`HEAD`** headers as definitive: when **`content-length`** is absent/invalid, or **`accept-ranges`** is missing for a resource at/above **`cacheBelow`**, it sends a **`Range: bytes=0-0`** probe and derives size/range support from **`Content-Range`** (or reuses the probe body on **`200`**, returns an empty blob on **`416 bytes */0`**, or falls back to a plain **`GET`** when the probe is inconclusive).
> 
> That fixes two regressions vs trusting **`HEAD`** alone: large files without **`accept-ranges`** were fully buffered instead of staying on the lazy **`WebBlob`** path, and with a low **`cacheBelow`** a missing **`content-length`** could yield **`size: 0`** and malformed slice ranges.
> 
> Ten new **`vitest`** cases with injected **`fetch`** assert probe vs no-probe paths and request counts; the happy **`HEAD`** lazy path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21af3e5e58fff021aef54df5d418a9d5451e95a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->