### PR TITLE
🐛 fix(mcp-client): keep reasoning content across tool-call rounds

### DIFF
--- a/packages/mcp-client/src/McpClient.ts
+++ b/packages/mcp-client/src/McpClient.ts
@@ -142,6 +142,7 @@ export class McpClient {
 			role: "unknown",
 			content: "",
 		} satisfies ChatCompletionInputMessage;
+		let reasoningContent = "";
 		const finalToolCalls: Record<number, ChatCompletionStreamOutputDeltaToolCall> = {};
 		let numOfChunks = 0;
 
@@ -160,6 +161,9 @@ export class McpClient {
 			}
 			if (delta.content) {
 				message.content += delta.content;
+			}
+			if (typeof delta.reasoning_content === "string") {
+				reasoningContent += delta.reasoning_content;
 			}
 			for (const toolCall of delta.tool_calls ?? []) {
 				// aggregating chunks into an encoded arguments JSON object
@@ -189,6 +193,9 @@ export class McpClient {
 			role: "assistant",
 			content: message.content,
 		};
+		if (reasoningContent) {
+			assistantMessage.reasoning_content = reasoningContent;
+		}
 
 		const finalToolCallValues = Object.values(finalToolCalls);
 

--- a/packages/mcp-client/test/McpClient.spec.ts
+++ b/packages/mcp-client/test/McpClient.spec.ts
@@ -1,8 +1,58 @@
 import { describe, expect, it } from "vitest";
 import { McpClient } from "../src";
+import type { InferenceClient } from "@huggingface/inference";
+import type { ChatCompletionInputMessage } from "@huggingface/tasks/src/tasks/chat-completion/inference";
 
 if (!process.env.HF_TOKEN) {
 	console.warn("Set HF_TOKEN in the env to run the tests for better rate limits");
+}
+
+interface StubChunk {
+	choices: Array<{ delta: Record<string, unknown> }>;
+}
+
+/**
+ * `McpClient.client` is a protected member, so a subclass is the supported way to swap the
+ * inference client for a stub. One entry of `turns` is consumed per `chatCompletionStream` call,
+ * and the messages that call received are recorded in `seenMessages`.
+ */
+class StubbedMcpClient extends McpClient {
+	readonly seenMessages: ChatCompletionInputMessage[][] = [];
+
+	constructor(turns: StubChunk[][]) {
+		super({ provider: "together", model: "test" });
+
+		let turnIndex = 0;
+		const seenMessages = this.seenMessages;
+		this.client = {
+			async *chatCompletionStream(args: { messages: ChatCompletionInputMessage[] }): AsyncGenerator<StubChunk> {
+				seenMessages.push(structuredClone(args.messages));
+				for (const chunk of turns[turnIndex] ?? []) {
+					yield chunk;
+				}
+				turnIndex++;
+			},
+		} as unknown as InferenceClient;
+	}
+}
+
+const toolCallChunk = (reasoning: string): StubChunk => ({
+	choices: [
+		{
+			delta: {
+				role: "assistant",
+				reasoning_content: reasoning,
+				tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: "missing", arguments: "{}" } }],
+			},
+		},
+	],
+});
+
+async function drain(client: McpClient, messages: ChatCompletionInputMessage[]): Promise<void> {
+	for await (const event of client.processSingleTurnWithTools(messages)) {
+		// Exhaust the generator so the assistant replay message is recorded.
+		void event;
+	}
 }
 
 describe("McpClient", () => {
@@ -14,5 +64,50 @@ describe("McpClient", () => {
 		});
 		expect(client).toBeDefined();
 		expect(client.availableTools.length).toBe(0);
+	});
+
+	it("keeps streamed reasoning on the replayed assistant message", async () => {
+		const client = new StubbedMcpClient([
+			[{ choices: [{ delta: { role: "assistant", reasoning_content: "think " } }] }, toolCallChunk("more")],
+		]);
+		const messages: ChatCompletionInputMessage[] = [{ role: "user", content: "hello" }];
+
+		await drain(client, messages);
+
+		expect(messages[1]).toMatchObject({
+			role: "assistant",
+			content: "",
+			reasoning_content: "think more",
+		});
+		expect(messages[1]).toHaveProperty("tool_calls");
+	});
+
+	it("sends the reasoning back to the model on the next round", async () => {
+		const client = new StubbedMcpClient([
+			[toolCallChunk("first thought")],
+			[{ choices: [{ delta: { role: "assistant", content: "done" } }] }],
+		]);
+		const messages: ChatCompletionInputMessage[] = [{ role: "user", content: "hello" }];
+
+		await drain(client, messages);
+		await drain(client, messages);
+
+		// The point of the fix: the second inference call must see the reasoning of the first round.
+		const secondRoundInput = client.seenMessages[1];
+		expect(secondRoundInput.map((m) => m.role)).toEqual(["user", "assistant", "tool"]);
+		expect(secondRoundInput[1]).toMatchObject({
+			role: "assistant",
+			reasoning_content: "first thought",
+		});
+	});
+
+	it("leaves a turn without reasoning byte-identical", async () => {
+		const client = new StubbedMcpClient([[{ choices: [{ delta: { role: "assistant", content: "answer" } }] }]]);
+		const messages: ChatCompletionInputMessage[] = [{ role: "user", content: "hello" }];
+
+		await drain(client, messages);
+
+		expect(messages[1]).toEqual({ role: "assistant", content: "answer" });
+		expect(messages[1]).not.toHaveProperty("reasoning_content");
 	});
 });


### PR DESCRIPTION
## What goes wrong today

When a reasoning model drives a multi-round tool-calling loop through `McpClient`, its reasoning is dropped between rounds. The assistant message that the client pushes back onto `messages` carries only `content` and `tool_calls`, never the `reasoning_content` the model just streamed — so the next inference call is handed a conversation with the chain of thought cut out of it, and the model has to re-derive on every round what it already worked out on the previous one.

## Root cause

`processSingleTurnWithTools` in `packages/mcp-client/src/McpClient.ts` aggregates the stream by reading two fields off each delta. At `d766490`, `McpClient.ts:161-163`:

```ts
if (delta.content) {
	message.content += delta.content;
}
```

and then builds the replayed message at `McpClient.ts:188-191`:

```ts
const assistantMessage: ChatCompletionInputMessage = {
	role: "assistant",
	content: message.content,
};
```

`delta.reasoning_content` is never read, so there is nothing to attach. The compiler cannot catch this: `ChatCompletionStreamOutputDelta` (`packages/tasks/src/tasks/chat-completion/inference.ts:294`) and `ChatCompletionInputMessage` (`inference.ts:111`) both carry `[property: string]: unknown`, which is what makes the field reachable at runtime but invisible to type checking.

## The change

Seven added lines, none removed. Accumulate `delta.reasoning_content` across chunks, guarded by a `typeof === "string"` check because the index signature types it as `unknown`, and attach it to the assistant message only when the accumulated string is non-empty:

```ts
if (typeof delta.reasoning_content === "string") {
	reasoningContent += delta.reasoning_content;
}
...
if (reasoningContent) {
	assistantMessage.reasoning_content = reasoningContent;
}
```

**Scope**: no change to any message field other than the new `reasoning_content`. A turn that streams no reasoning produces a byte-identical message to before, which is asserted rather than asserted-by-hand-waving — the third new test is `expect(messages[1]).toEqual({ role: "assistant", content: "answer" })` plus `not.toHaveProperty("reasoning_content")`, so it fails if anything else on that message moves.

### Trade-off a reviewer should weigh

`reasoning_content` is not a declared field on `ChatCompletionInputMessage`; it rides the index signature, the same way the field arrives on the stream side. For a provider that ignores unknown message keys this is free, and for a reasoning provider it is the point of the PR. A provider that rejects unknown keys on input messages would now see one extra key on turns where the model actually streamed reasoning. I have not exercised any live provider, so I cannot tell you empirically that none of them do that — flagging it as the judgement call in this change rather than leaving it implicit.

### Tests

Three tests were added to `packages/mcp-client/test/McpClient.spec.ts`:

1. the reasoning lands on the replayed assistant message;
2. **the reasoning is present in the input of the *next* inference call** — the behaviour the PR actually claims to fix, asserted by running `processSingleTurnWithTools` twice over the same `messages` array and inspecting what the second `chatCompletionStream` call received;
3. a turn without reasoning is unchanged.

`McpClient.client` is `protected` (`McpClient.ts:30`), so the tests swap the inference client for a stub through a subclass (`class StubbedMcpClient extends McpClient`) rather than casting through `unknown` into the member from outside.

## Testing

All commands run on this branch alone on top of `d766490`, from the repository root.

```
$ pnpm --filter @huggingface/mcp-client test
 ✓ test/ResultFormatter.spec.ts  (5 tests) 5ms
 ✓ test/UrlConversion.spec.ts  (9 tests) 7ms
stderr | unknown test
Set HF_TOKEN in the env to run the tests for better rate limits

 ✓ test/McpClient.spec.ts  (4 tests) 5ms

 Test Files  3 passed (3)
      Tests  18 passed (18)

$ pnpm --filter @huggingface/mcp-client lint:check     # eslint --ext .cjs,.ts . -> exit 0, no output
$ pnpm --filter @huggingface/mcp-client check          # tsc -> exit 0, no output
$ pnpm --filter @huggingface/mcp-client format:check
Checking formatting...
All matched files use the correct format.
Finished in 135ms on 12 files using 15 threads.
```

The `HF_TOKEN` line on stderr is pre-existing and appears on `d766490` too.

CI also builds dependents, so `@huggingface/tiny-agents` (the only package depending on `mcp-client`) was run too: `check` exit 0, `lint:check` exit 0, `test` → `Tests 1 passed (1)`.

### The new tests fail without the fix

Restoring only `packages/mcp-client/src/McpClient.ts` to its `d766490` version and keeping the new spec:

```
$ git checkout d766490 -- packages/mcp-client/src/McpClient.ts
$ pnpm --filter @huggingface/mcp-client test
 FAIL  test/McpClient.spec.ts > McpClient > keeps streamed reasoning on the replayed assistant message
AssertionError: expected { Object (role, content, ...) } to match object { Object (role, content, ...) }
-   "reasoning_content": "think more",
 FAIL  test/McpClient.spec.ts > McpClient > sends the reasoning back to the model on the next round
AssertionError: expected { Object (role, content, ...) } to match object { role: 'assistant', …(1) }
-   "reasoning_content": "first thought",

 Test Files  1 failed | 2 passed (3)
      Tests  2 failed | 16 passed (18)
```

Restoring the fix returns `Tests 18 passed (18)`. Both reasoning tests fail on the base source, including the round-trip one. The third new test is the deliberate no-regression test and passes either way.

## What was not verified

- **No live provider, no real reasoning model.** Every test drives a stubbed `chatCompletionStream`. Nothing here proves that any particular provider emits `reasoning_content` in the shape the tests assume, or that it accepts the field back on input. The evidence is that this client drops a field the stream can carry, and that after this change it does not.
- **No live MCP server.** The tool call in the tests names a tool that is not registered, which is enough to exercise the replay path but is not an end-to-end tool round trip.
- **No measurement of token cost.** Echoing reasoning back grows the prompt on every round; the size of that effect is not quantified here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to message replay in the MCP client; main caveat is sending an extra `reasoning_content` key to providers that might reject unknown message fields.
> 
> **Overview**
> Fixes **reasoning being dropped** in multi-round MCP tool loops: `processSingleTurnWithTools` now **aggregates streamed `delta.reasoning_content`** (with a string guard) and **sets `reasoning_content` on the assistant message** pushed onto `messages` when non-empty, so the next `chatCompletionStream` call still sees the model’s chain of thought alongside `content` and `tool_calls`. Turns with no reasoning stay unchanged (no extra field).
> 
> Adds **stubbed unit tests** (`StubbedMcpClient`) covering chunked reasoning on replay, round-trip into the second inference call’s input, and a no-reasoning regression check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad026a85fc89c4d1d78d2c859f5c1af53908368b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->