### PR TITLE
fix(safetensors): count FP4 experts declared in quantization config

### DIFF
--- a/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.spec.ts
@@ -317,6 +317,62 @@ describe("parseSafetensorsMetadata", () => {
 			assert.strictEqual(parse.parameterTotal, 200);
 		});
 
+		it.each([
+			{
+				location: "quantization_config",
+				config: { quantization_config: { quant_method: "fp8", expert_dtype: "fp4" } },
+			},
+			{
+				location: "text_config.quantization_config",
+				config: { text_config: { quantization_config: { quant_method: "fp8", expert_dtype: "fp4" } } },
+			},
+			{
+				location: "the model config",
+				config: { expert_dtype: "fp4", quantization_config: { quant_method: "fp8" } },
+			},
+			{
+				location: "text_config",
+				config: { text_config: { expert_dtype: "fp4", quantization_config: { quant_method: "fp8" } } },
+			},
+		])("reads expert_dtype from $location when counting packed weights", async ({ config }) => {
+			const fetch = fetchForFile(
+				{
+					__metadata__: { format: "pt", total_parameters: "30" },
+					"model.layers.0.mlp.experts.0.up_proj.weight": {
+						dtype: "I8",
+						shape: [2, 4],
+						data_offsets: [0, 8],
+					},
+					"model.layers.0.self_attn.q_proj.weight": {
+						dtype: "F8_E4M3",
+						shape: [2, 4],
+						data_offsets: [8, 16],
+					},
+					"model.layers.0.mlp.experts.0.up_proj.weight_scale_inv": {
+						dtype: "F8_E8M0",
+						shape: [1],
+						data_offsets: [16, 17],
+					},
+					"model.engram.embedding.weight": { dtype: "I8", shape: [2, 2], data_offsets: [17, 21] },
+					"model.norm.weight": { dtype: "BF16", shape: [2], data_offsets: [21, 25] },
+				},
+				25,
+				config,
+			);
+
+			const parse = await parseSafetensorsMetadata({
+				repo: "some-user/fp8-model-with-fp4-experts",
+				computeParametersCount: true,
+				fetch,
+			});
+
+			assert(!parse.sharded);
+			// Only the packed experts expand: 8 bytes hold 16 FP4 parameters. The Engram
+			// embedding and attention retain their original counts, and block scales are excluded.
+			assert.deepStrictEqual(parse.parameterCount, { I8: 20, F8_E4M3: 8, BF16: 2 });
+			assert.strictEqual(parse.parameterTotal, 30);
+		});
+
 		it("honors total_parameters for packed MLX weights without weakening the metadata cap", async () => {
 			const quantization = { group_size: 64, bits: 8, mode: "affine" };
 			const fetch = fetchForFile(
@@ -778,6 +834,22 @@ describe("parseSafetensorsMetadata", () => {
 				assert.strictEqual(getQuantizationMultiplier(EXPERT, "I8", fp8, "fp4"), 2);
 			});
 
+			it("reads the expert width from quantization_config for direct callers", () => {
+				assert.strictEqual(getQuantizationMultiplier(EXPERT, "I8", { ...fp8, expert_dtype: "fp4" }), 2);
+			});
+
+			it("prefers the quantizer's expert width over the legacy model-level fallback", () => {
+				assert.strictEqual(getQuantizationMultiplier(EXPERT, "I8", { ...fp8, expert_dtype: "fp8" }, "fp4"), 1);
+			});
+
+			it.each([4, {}, null])("ignores a malformed expert_dtype (%j)", (expertDtype) => {
+				// Config is parsed from untrusted JSON, which may not match the TypeScript interface.
+				assert.strictEqual(
+					getQuantizationMultiplier(EXPERT, "I8", { ...fp8, expert_dtype: expertDtype as unknown as string }),
+					1,
+				);
+			});
+
 			it("leaves shared experts alone — they're dense, not routed", () => {
 				const shared = "model.layers.0.ffn.shared_experts.w1.weight";
 				assert.strictEqual(getQuantizationMultiplier(shared, "I8", fp8, "fp4"), 1);
@@ -1035,5 +1107,31 @@ describe("parseSafetensorsMetadata", () => {
 		assert.deepStrictEqual(sum(Object.values(parse.parameterCount)), 1_598_839_674_782);
 		// the F8_E8M0 block scales (49_150_268_416) must not appear at all
 		assert.strictEqual(parse.parameterCount["F8_E8M0"], undefined);
+	});
+
+	it("counts fp4 experts declared inside quantization_config (deepseek-ai/DeepSeek-V4.1-Flash)", async () => {
+		// V4.1 moved expert_dtype into quantization_config. Ignoring it counted the packed I8
+		// expert weights once per byte, reporting 484.620B instead of 763.205B for the checkpoint.
+		// The card's 552B is the backbone (551.566B), excluding Engram (196.929B), DSpark
+		// draft weights (14.225B), and the vision encoder/projector (0.485B).
+		const parse = await parseSafetensorsMetadata({
+			repo: "deepseek-ai/DeepSeek-V4.1-Flash",
+			revision: "df42c109f1defefcbfcedbe7d905718a12266e40",
+			computeParametersCount: true,
+		});
+
+		assert(parse.sharded);
+		assert.strictEqual(Object.keys(parse.headers).length, 48);
+		assert.deepStrictEqual(
+			parse.headers["model-00003-of-00048.safetensors"]["layers.0.ffn.experts.0.w1.weight"].shape,
+			[2304, 2560],
+		);
+		assert.deepStrictEqual(parse.parameterCount, {
+			BF16: 1_976_441_856,
+			F32: 42_307_282,
+			F8_E4M3: 204_015_223_296,
+			I8: 557_171_343_360, // 278_585_671_680 packed bytes x 2
+		});
+		assert.strictEqual(sum(Object.values(parse.parameterCount)), 763_205_315_794);
 	});
 });

--- a/packages/hub/src/lib/parse-safetensors-metadata.ts
+++ b/packages/hub/src/lib/parse-safetensors-metadata.ts
@@ -156,7 +156,7 @@ function isRoutedExpertTensor(tensorName: string): boolean {
 
 /** Reads a bit width out of a free-form format/dtype string, e.g. `"mxfp4-pack-quantized"` -> 4. */
 function bitsFromFormatString(format: string | undefined): number | undefined {
-	if (!format) {
+	if (typeof format !== "string") {
 		return undefined;
 	}
 	const normalized = format.toLowerCase();
@@ -686,6 +686,8 @@ export async function parseSafetensorsMetadata(
 
 export interface QuantizationConfig {
 	quant_method?: string;
+	/** Routed expert precision when it differs from the main quantizer (e.g. FP4 experts with FP8 attention). */
+	expert_dtype?: string;
 	/** MLX quantization mode (e.g. `affine`); MLX configs do not declare `quant_method`. */
 	mode?: string;
 	group_size?: number;
@@ -718,8 +720,8 @@ export interface ModelConfig {
 	text_config?: Pick<ModelConfig, "expert_dtype" | "quantization" | "quantization_config">;
 	/**
 	 * Some MoEs store their experts at a narrower precision than the rest of the model and declare
-	 * it here, *outside* `quantization_config` (e.g. DeepSeek-V4 is `quant_method: "fp8"` for
-	 * attention but `expert_dtype: "fp4"` for the experts, which dominate the parameter count).
+	 * it here, outside `quantization_config` (e.g. DeepSeek-V4). Used as a fallback when the
+	 * quantization config does not declare its own `expert_dtype` (as DeepSeek-V4.1 does).
 	 */
 	expert_dtype?: string;
 }
@@ -1087,8 +1089,9 @@ export function getQuantizationMultiplier(
 
 		case "fp8": {
 			// fp8 weights live in F8_* dtypes at one value per byte, so nothing to do for them.
-			// But some fp8 MoEs keep their *experts* narrower still and declare it out-of-band in
-			// `expert_dtype` (DeepSeek-V4-Pro: "fp4"), storing them packed in an I8 container.
+			// But some fp8 MoEs keep their *experts* narrower still, storing them packed in I8.
+			// `expert_dtype` is in quantization_config for DeepSeek-V4.1, or in the model config
+			// for DeepSeek-V4-Pro. Both declare "fp4", i.e. two weights per byte.
 			// Those experts dominate the parameter count, so missing this halves the total.
 			//
 			// `expert_dtype` describes the experts and nothing else, so it must not be applied to
@@ -1097,7 +1100,7 @@ export function getQuantizationMultiplier(
 			if (!isRoutedExpertTensor(tensorName)) {
 				return 1;
 			}
-			return packingFactor(dtype, bitsFromFormatString(expertDtype));
+			return packingFactor(dtype, bitsFromFormatString(quantConfig.expert_dtype ?? expertDtype));
 		}
 
 		case "bitsandbytes":


### PR DESCRIPTION
Read `quantization_config.expert_dtype` to count packed FP4 experts correctly, fixing DeepSeek-V4.1-Flash from ~485 B to ~763 B total.

The [model card's 552 B figure](https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash) describes the backbone; the checkpoint also contains Engram, DSpark, and vision weights:

| Component | Parameters |
| --- | ---: |
| Backbone | 552 B |
| Engram | 197 B |
| DSpark | 14 B |
| Vision encoder and projector | 485 M |
| **Total** | **763 B** |
