### PR TITLE
✨ [Inference Providers] Add MiniMax H3 support to Novita

### DIFF
--- a/packages/inference/src/lib/getProviderHelper.ts
+++ b/packages/inference/src/lib/getProviderHelper.ts
@@ -128,6 +128,7 @@ export const PROVIDERS: Record<InferenceProvider, Partial<Record<InferenceTask, 
 	},
 	novita: {
 		conversational: new Novita.NovitaConversationalTask(),
+		"image-text-to-video": new Novita.NovitaImageTextToVideoTask(),
 		"text-generation": new Novita.NovitaTextGenerationTask(),
 		"text-to-video": new Novita.NovitaTextToVideoTask(),
 	},

--- a/packages/inference/src/providers/novita.ts
+++ b/packages/inference/src/providers/novita.ts
@@ -15,13 +15,16 @@
  * Thanks!
  */
 import { isUrl } from "../lib/isUrl.js";
+import type { ImageTextToVideoArgs } from "../tasks/cv/imageTextToVideo.js";
 import type { TextToVideoArgs } from "../tasks/index.js";
-import type { BodyParams, UrlParams } from "../types.js";
+import type { BodyParams, RequestArgs, UrlParams } from "../types.js";
+import { dataUrlFromBlob } from "../utils/dataUrlFromBlob.js";
 import { delay } from "../utils/delay.js";
 import { omit } from "../utils/omit.js";
 import {
 	BaseConversationalTask,
 	BaseTextGenerationTask,
+	type ImageTextToVideoTaskHelper,
 	TaskProviderHelper,
 	type TextToVideoTaskHelper,
 } from "./providerHelper.js";
@@ -32,9 +35,44 @@ import {
 } from "../errors.js";
 
 const NOVITA_API_BASE_URL = "https://api.novita.ai";
+const NOVITA_MINIMAX_H3_RATIOS = ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"] as const;
+
+function getMiniMaxH3Duration(numFrames?: number): number {
+	return numFrames === undefined ? 4 : Math.min(15, Math.max(4, Math.round(numFrames / 24)));
+}
+
+function getMiniMaxH3Resolution(targetSize?: { width: number; height: number }): "768P" | "2K" {
+	if (!targetSize) {
+		return "768P";
+	}
+	const shortEdge = Math.min(targetSize.width, targetSize.height);
+	return Math.abs(shortEdge - 768) <= Math.abs(shortEdge - 1440) ? "768P" : "2K";
+}
+
+function getMiniMaxH3Ratio(targetSize?: { width: number; height: number }): (typeof NOVITA_MINIMAX_H3_RATIOS)[number] {
+	if (!targetSize) {
+		return "16:9";
+	}
+	const targetRatio = targetSize.width / targetSize.height;
+	return NOVITA_MINIMAX_H3_RATIOS.reduce((closest, ratio) => {
+		const [width, height] = ratio.split(":").map(Number);
+		const [closestWidth, closestHeight] = closest.split(":").map(Number);
+		return Math.abs(targetRatio - width / height) < Math.abs(targetRatio - closestWidth / closestHeight)
+			? ratio
+			: closest;
+	});
+}
 
 export interface NovitaAsyncAPIOutput {
 	task_id: string;
+}
+
+interface NovitaImageTextToVideoResponse {
+	task: {
+		status: "queued" | "running" | "succeeded" | "failed" | "cancelled";
+		content?: { url: string };
+		error?: { message?: string };
+	};
 }
 
 export class NovitaTextGenerationTask extends BaseTextGenerationTask {
@@ -54,6 +92,116 @@ export class NovitaConversationalTask extends BaseConversationalTask {
 
 	override makeRoute(): string {
 		return "/v3/openai/chat/completions";
+	}
+}
+
+export class NovitaImageTextToVideoTask extends TaskProviderHelper implements ImageTextToVideoTaskHelper {
+	constructor() {
+		super("novita", NOVITA_API_BASE_URL);
+	}
+
+	override makeRoute(params: UrlParams): string {
+		if (params.model !== "MiniMax-H3") {
+			throw new InferenceClientInputError(`Unsupported Novita image-text-to-video model: ${params.model}`);
+		}
+		return "/v3/minimax/v2/video_generation";
+	}
+
+	override preparePayload(params: BodyParams<ImageTextToVideoArgs>): Record<string, unknown> {
+		const {
+			prompt,
+			num_frames,
+			target_size,
+			resolution = getMiniMaxH3Resolution(target_size),
+			duration = getMiniMaxH3Duration(num_frames),
+			ratio = getMiniMaxH3Ratio(target_size),
+			...restParameters
+		} = params.args.parameters ?? {};
+		const imageUrl = params.args.inputs;
+
+		return {
+			...omit(restParameters, ["guidance_scale", "negative_prompt", "num_inference_steps", "seed"]),
+			model: params.model,
+			content: [
+				...(prompt ? [{ type: "text", text: prompt }] : []),
+				...(imageUrl ? [{ type: "image_url", image_url: { url: imageUrl }, role: "first_frame" }] : []),
+			],
+			resolution,
+			duration,
+			ratio: imageUrl ? "adaptive" : ratio,
+		};
+	}
+
+	async preparePayloadAsync(args: ImageTextToVideoArgs): Promise<RequestArgs> {
+		if (!args.inputs) {
+			return args as RequestArgs;
+		}
+		return {
+			...args,
+			inputs: await dataUrlFromBlob(args.inputs, args.inputs.type || "image/png"),
+		} as RequestArgs;
+	}
+
+	override async getResponse(
+		response: NovitaAsyncAPIOutput,
+		url?: string,
+		headers?: Record<string, string>,
+		_outputType?: undefined,
+		signal?: AbortSignal,
+	): Promise<Blob> {
+		if (!url || !headers) {
+			throw new InferenceClientInputError("URL and headers are required for Novita API calls");
+		}
+
+		const parsedUrl = new URL(url);
+		const baseUrl = `${parsedUrl.protocol}//${parsedUrl.host}${
+			parsedUrl.host === "router.huggingface.co" ? "/novita" : ""
+		}`;
+		const resultUrl = `${baseUrl}/v3/minimax/v2/query/video_generation/${encodeURIComponent(response.task_id)}`;
+
+		while (true) {
+			const resultResponse = await fetch(resultUrl, { headers, signal });
+			if (!resultResponse.ok) {
+				throw new InferenceClientProviderApiError(
+					"Failed to fetch response status from Novita API",
+					{ url: resultUrl, method: "GET", headers },
+					{
+						requestId: resultResponse.headers.get("x-request-id") ?? "",
+						status: resultResponse.status,
+						body: await resultResponse.text(),
+					},
+				);
+			}
+
+			const result: NovitaImageTextToVideoResponse = await resultResponse.json();
+			const task = result.task;
+
+			switch (task.status) {
+				case "succeeded": {
+					if (!task.content?.url) {
+						throw new InferenceClientProviderOutputError("No output URL returned by Novita API");
+					}
+					const videoResponse = await fetch(task.content.url, { signal });
+					if (!videoResponse.ok) {
+						throw new InferenceClientProviderApiError(
+							"Failed to fetch generation output from Novita API",
+							{ url: task.content.url, method: "GET" },
+							{
+								requestId: videoResponse.headers.get("x-request-id") ?? "",
+								status: videoResponse.status,
+								body: await videoResponse.text(),
+							},
+						);
+					}
+					return videoResponse.blob();
+				}
+				case "failed":
+				case "cancelled":
+					throw new InferenceClientProviderOutputError(task.error?.message || `Novita task ${task.status}`);
+				default:
+					await delay(5000, signal);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds Novita support for the Hugging Face `image-text-to-video` task with `MiniMaxAI/MiniMax-H3`.

- Registers the Novita `image-text-to-video` provider helper.
- Maps HF `num_frames` and `target_size` parameters to MiniMax H3 `duration`, `resolution`, and `ratio` fields.
- Converts optional image `Blob` inputs to data URLs for the Novita JSON API.
- Uses the dedicated MiniMax H3 create and status endpoints for direct Novita and HF Router requests.
- Polls asynchronous tasks and downloads the generated video as a `Blob`.
- Omits HF-standard parameters that MiniMax H3 does not support while preserving provider-specific parameters.

The Novita provider mapping for `MiniMaxAI/MiniMax-H3` must be registered separately with task `image-text-to-video` and provider ID `MiniMax-H3`.

## Validation

- `pnpm --filter @huggingface/inference check`
- `pnpm --filter @huggingface/inference test`
- `pnpm --filter @huggingface/inference lint:check`
- `pnpm --filter @huggingface/inference format:check`
- `pnpm --filter @huggingface/inference build`
- Direct Novita API smoke test with a 4-second 768P generation, including status polling and output download.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New async inference path with external polling and user-supplied prompts/images, but scoped to the Novita provider with explicit validation and existing error types.
> 
> **Overview**
> Adds **Novita** as a provider for the Hugging Face **`image-text-to-video`** task, wired through **`NovitaImageTextToVideoTask`** and registered in **`getProviderHelper`**.
> 
> The helper targets **`MiniMax-H3`** only: it posts to MiniMax v2 **`/video_generation`**, maps HF **`num_frames`** / **`target_size`** into **`duration`**, **`resolution`**, and **`ratio`** (or **`adaptive`** when a first-frame image is present), strips unsupported HF params, and builds a **`content`** array from prompt plus optional **`image_url`**. **`preparePayloadAsync`** turns image **`Blob`** inputs into data URLs for the JSON API.
> 
> Completion is handled via a dedicated **status poll** on **`/query/video_generation/{task_id}`** (with HF Router **`/novita`** prefix when needed), then the result video is fetched and returned as a **`Blob`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 428216f906a6eaa3587a6223a27bffd12aaa9f8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->