### PR TITLE
➕ Add MJLab model library

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -985,7 +985,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 	},
 	mjlab: {
 		prettyLabel: "MJLab",
-		repoName: "mjlab",
+		repoName: "MJLab",
 		repoUrl: "https://github.com/mujocolab/mjlab",
 		docsUrl: "https://mujocolab.github.io/mjlab/",
 		filter: false,

--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -983,6 +983,14 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/mit-nlp/MITIE",
 		countDownloads: `path_filename:"total_word_feature_extractor"`,
 	},
+	mjlab: {
+		prettyLabel: "MJLab",
+		repoName: "mjlab",
+		repoUrl: "https://github.com/mujocolab/mjlab",
+		docsUrl: "https://mujocolab.github.io/mjlab/",
+		filter: false,
+		countDownloads: `path:"policy.onnx" OR path:"final.onnx"`,
+	},
 	"ml-agents": {
 		prettyLabel: "ml-agents",
 		repoName: "ml-agents",


### PR DESCRIPTION
## What this adds

Registers [MJLab](https://github.com/mujocolab/mjlab), the MuJoCo-Warp robotics RL framework, as a Hub model library.

The custom download query counts the canonical root policy artifact used by MJLab model repositories (`policy.onnx`, with `final.onnx` supported for the existing naming variant). Exact root paths deliberately avoid over-counting repositories that publish policy lineages or several task/robot variants in subdirectories.

Existing Hub examples include:
- https://huggingface.co/XenderYang/microduck-rl-ydx-walk (`library_name: mjlab`, `final.onnx`)
- https://huggingface.co/HannesVonEssen/microduck-running (`policy.onnx` plus a lineage artifact)
- https://huggingface.co/HannesVonEssen/microduck-stilts (one default policy plus size-specific policies)

## Validation

- `pnpm --filter @huggingface/tasks format:check`
- `pnpm --filter @huggingface/tasks check`
- `pnpm --filter @huggingface/tasks test` (31 tests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single additive registry entry in `@huggingface/tasks` with no changes to runtime logic or security-sensitive paths.
> 
> **Overview**
> Registers **MJLab** as a Hub model library under the `mjlab` key (aligned with `library_name` on repos), with display metadata pointing at the mujocolab repo and docs.
> 
> Download counting uses a custom Elasticsearch query for **root-level** `policy.onnx` or `final.onnx` only, so repos with extra policies or lineage files in subfolders are not over-counted. The library is **not** added to the public models filter (`filter: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65685a81cc53a705154aac91816a6230f0ddddab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->