### PR TITLE
🐛 [blob] Probe WebBlob size with Range instead of HEAD

### DIFF
--- a/packages/blob/src/utils/WebBlob.spec.ts
+++ b/packages/blob/src/utils/WebBlob.spec.ts
@@ -8,10 +8,14 @@ describe("WebBlob", () => {
 	let contentType: string;
 
 	beforeAll(async () => {
-		const response = await fetch(resourceUrl, { method: "HEAD" });
-		size = Number(response.headers.get("content-length"));
+		// Compute the reference size from the response body itself; in browsers
+		// `Content-Length` is not reliably exposed when the response is gzipped
+		// on the fly by CloudFront.
+		const response = await fetch(resourceUrl);
+		const blob = await response.blob();
+		size = blob.size;
+		fullText = await blob.text();
 		contentType = response.headers.get("content-type") || "";
-		fullText = await (await fetch(resourceUrl)).text();
 	});
 
 	it("should create a WebBlob with a slice on the entire resource", async () => {
@@ -79,6 +83,48 @@ describe("WebBlob", () => {
 
 		const streamText = await new Response(slice.stream()).text();
 		expect(streamText).toBe(expectedText);
+	});
+
+	it("should learn size from Content-Range when HEAD omits Content-Length", async () => {
+		const body = "abcdefghijklmnopqrstuvwxyz";
+		const url = new URL("https://example.com/model.json");
+		const fetchMock = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+			const range = new Headers(init?.headers).get("range");
+
+			if (init?.method === "HEAD") {
+				return new Response(null, {
+					status: 200,
+					headers: {
+						"accept-ranges": "bytes",
+						"content-type": "text/plain",
+					},
+				});
+			}
+
+			if (range?.startsWith("bytes=")) {
+				const [start, endRaw] = range.slice("bytes=".length).split("-");
+				const startByte = Number(start);
+				const endByte = Math.min(Number(endRaw), body.length - 1);
+				return new Response(body.slice(startByte, endByte + 1), {
+					status: 206,
+					headers: {
+						"content-type": "text/plain",
+						"content-range": `bytes ${startByte}-${endByte}/${body.length}`,
+					},
+				});
+			}
+
+			return new Response(body, {
+				status: 200,
+				headers: { "content-type": "text/plain" },
+			});
+		}) as typeof fetch;
+
+		const webBlob = await WebBlob.create(url, { cacheBelow: 0, fetch: fetchMock });
+
+		expect(webBlob).toBeInstanceOf(WebBlob);
+		expect(webBlob.size).toBe(body.length);
+		expect(await webBlob.slice(10, 22).text()).toBe(body.slice(10, 22));
 	});
 
 	it("should throw a TypeError on negative start/end", () => {

--- a/packages/blob/src/utils/WebBlob.ts
+++ b/packages/blob/src/utils/WebBlob.ts
@@ -19,17 +19,45 @@ interface WebBlobCreateOptions {
 export class WebBlob extends Blob {
 	static async create(url: URL, opts?: WebBlobCreateOptions): Promise<Blob> {
 		const customFetch = opts?.fetch ?? fetch;
-		const response = await customFetch(url, { method: "HEAD" });
 
-		const size = Number(response.headers.get("content-length"));
-		const contentType = response.headers.get("content-type") || "";
-		const supportRange = response.headers.get("accept-ranges") === "bytes";
+		// Probe with `Range: bytes=0-0` rather than `HEAD` to learn the file size
+		// and confirm range support in a single round trip.
+		//
+		// In browsers, when CloudFront gzips a response on the fly (typical for
+		// small text/JSON files behind `/api/resolve-cache/...` and `/raw/`), the
+		// cached response loses both `Content-Length` and `Accept-Ranges`.
+		// Subsequent HEAD requests served from that cache inherit the missing
+		// headers, so `Number(null)` became `0` and the blob was created with
+		// `size === 0` (or, with the default `cacheBelow`, silently fell back to
+		// buffering the whole file in RAM).
+		//
+		// Range responses are never content-encoded, so `Content-Range`
+		// (carrying the total size) and the strong `ETag` always survive,
+		// regardless of the cached encoding state.
+		const probe = await customFetch(url, {
+			headers: {
+				Range: "bytes=0-0",
+			},
+		});
 
-		if (!supportRange || size < (opts?.cacheBelow ?? 1_000_000)) {
+		const contentType = probe.headers.get("content-type") || "";
+
+		// 206 → server honored the range request; total size is in `Content-Range`.
+		if (probe.status === 206) {
+			const totalSize = Number(probe.headers.get("content-range")?.split("/").pop());
+			await probe.body?.cancel();
+
+			if (Number.isFinite(totalSize) && totalSize >= (opts?.cacheBelow ?? 1_000_000)) {
+				return new WebBlob(url, 0, totalSize, contentType, true, customFetch);
+			}
+
+			// Small file (or unknown total) → buffer it in RAM.
 			return await (await customFetch(url)).blob();
 		}
 
-		return new WebBlob(url, 0, size, contentType, true, customFetch);
+		// 200 → server ignored `Range`; we've already started downloading the
+		// full body, so just consume it.
+		return probe.blob();
 	}
 
 	private url: URL;


### PR DESCRIPTION
## Summary

`WebBlob.create` in `@huggingface/blob` now probes size with `Range: bytes=0-0` and reads the total from `Content-Range`, the probe already shipped for `packages/hub` in #2118. `packages/dduf` uses this path via `createBlob()`.

In browsers, CloudFront-gzipped Hub `/raw/` (and `/api/resolve-cache/`) responses can omit `Content-Length` on a later `HEAD`. With `Accept-Ranges: bytes` still present and `cacheBelow: 0`, `Number(null)` became `0` and the lazy blob was empty (`#2366`).

Spec `beforeAll` now derives the reference size from the GET body (same as hub). Added a hermetic `fetch` mock for missing `Content-Length` + `Accept-Ranges`.

## Decision

`@huggingface/blob` uses hub's 206/200 Range probe, without `accessToken` / `createApiError`. It has no API-error helper, and callers already pass a custom `fetch` for auth headers. This is the discovery logic already merged for the other copy (`packages/hub/src/utils/WebBlob.ts`).

Alternative: keep `HEAD` and only fall back to GET when `Content-Length` is missing; throw Hub-style API errors on `!probe.ok`; or delete this copy and re-export hub's `WebBlob`. Can add error throwing, or unify the two `WebBlob` copies.

## Test plan

- [x] `pnpm --filter @huggingface/blob test` (Node)
- [x] `pnpm --filter @huggingface/blob test:browser` (headless Chrome)
- [x] Hermetic test fails with the old HEAD probe (`size` 0 vs 26) and passes with the Range probe
- Public Hub URLs; no token required. On current `main`'s HEAD probe, Chrome still fails the two `cacheBelow: 0` live tests (`end: 0`) plus the hermetic case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote fetch/discovery for all `WebBlob.create` callers (including dduf); behavior differs from HEAD but matches the hub implementation and fixes incorrect zero-size blobs in browsers.
> 
> **Overview**
> Fixes **`WebBlob.create`** in `@huggingface/blob` so lazy blobs get a correct size when **`HEAD`** responses omit **`Content-Length`** (e.g. browser-cached CloudFront gzip on Hub **`/raw/`** paths), which previously produced **`size === 0`** with **`cacheBelow: 0`**.
> 
> Discovery now uses a **`Range: bytes=0-0`** probe: on **206**, total size comes from **`Content-Range`** and large files still become range-backed **`WebBlob`** instances; small or unknown totals buffer via GET, and a **200** to the probe consumes the already-started full body. Integration tests derive reference size from the GET body instead of **`HEAD`**, and a hermetic **`fetch`** mock covers HEAD without **`Content-Length`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6dfa956a1429e32effda88e31139089346302db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->