### PR TITLE
Remove warp agent harness from registry

### DIFF
--- a/packages/tasks/src/agent-harnesses.ts
+++ b/packages/tasks/src/agent-harnesses.ts
@@ -196,13 +196,6 @@ export const AGENT_HARNESSES = {
 			VTCODE: "1",
 		},
 	},
-	warp: {
-		prettyLabel: "Warp",
-		repoUrl: "https://github.com/warpdotdev/Warp",
-		docsUrl: "https://docs.warp.dev",
-		description: "AI-powered terminal with an agentic Agent Mode.",
-		envVars: { TERM_PROGRAM: "WarpTerminal" },
-	},
 	zed: {
 		prettyLabel: "Zed",
 		repoUrl: "https://github.com/zed-industries/zed",


### PR DESCRIPTION
Closes huggingface/huggingface_hub#4860 (hub-side detection is registry-driven).

## Problem

`warp: { envVars: { TERM_PROGRAM: "WarpTerminal" } }` matches **every** Warp shell, not only when Warp Agent Mode drives a command. Warp Agent Mode writes commands into the same already-running PTY/shell session as the human, so there is no agent-only env var to key on — the whole `WARP_*` set is present in a plain human shell:

```
TERM_PROGRAM=WarpTerminal
TERM_PROGRAM_VERSION=v0.2026.09.02.08.27.stable_01
WARP_CLIENT_VERSION=...
WARP_CLI_AGENT_PROTOCOL_VERSION=1   # set in every Warp shell, despite the name
WARP_IS_LOCAL_SHELL_SESSION=1
WARP_HONOR_PS1=1
WARP_TERMINAL_SESSION_UUID=...
WARP_FOCUS_URL=warp://session/...
```

Consequences for human Warp users (reported in huggingface/huggingface_hub#4860):

- `hf` CLI `auto` output mode silently becomes `agent`: no progress bars, no ANSI colors.
- `_headers.py` tags every human request as `agent/warp`, polluting agent-usage attribution data.

## Change

Remove the `warp` entry. If Warp later ships an agent-only marker (e.g. `AI_AGENT=warp` / `AGENT=warp` or a dedicated `WARP_AGENT_*` var), the registry's standard-var path picks it up without further changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry deletion with no auth or data-path changes; it fixes false-positive agent detection for Warp users.
> 
> **Overview**
> Removes the **`warp`** entry from `AGENT_HARNESSES` in `packages/tasks/src/agent-harnesses.ts`. Detection had keyed on `TERM_PROGRAM=WarpTerminal`, which is set in **every** Warp terminal session—not only when Agent Mode runs a command—so normal `hf` usage was misclassified as agent traffic (e.g. `auto` output mode and request headers tagged as `agent/warp`).
> 
> Hub-side detection stays registry-driven; without this entry, human Warp shells are no longer treated as the Warp agent harness. Warp can be re-added later if it exposes an agent-only env marker or uses `AI_AGENT` / `AGENT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e91434342cb8b8a238d807bc7482ce1f463d502f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->