### PR TITLE
Add AMD Radeon Pro 5300M to hardware list

### DIFF
--- a/packages/tasks/src/hardware-amd.ts
+++ b/packages/tasks/src/hardware-amd.ts
@@ -236,6 +236,14 @@ export const AMD_GPU_SKUS: Record<string, AmdGpuHardwareSpec> = {
 		power: 130,
 		releaseYear: 2019,
 	},
+	"Radeon Pro 5300M": {
+		tflops: 6.4,
+		memory: [4],
+		gfxVersion: "gfx1012",
+		msrp: 200,
+		power: 50,
+		releaseYear: 2019,
+	},
 	"Radeon Pro V620": {
 		tflops: 40.55,
 		memory: [32],


### PR DESCRIPTION
## Summary
- Adds **Radeon Pro 5300M** to `packages/tasks/src/hardware-amd.ts` so it can be selected in Hub Local Apps / My Hardware.
- Specs match [#2477](https://github.com/huggingface/huggingface.js/issues/2477): 6.4 FP16 TFLOPS, 4 GB VRAM, gfx1012, 50 W TGP, 2019. Same Navi 14 / gfx1012 family as the existing `RX 5500 XT` entry.

Closes #2477

## Test plan
- [ ] `Radeon Pro 5300M` appears in the AMD SKU object next to `RX 5500 XT`
- [ ] After merge, the GPU can be added at https://huggingface.co/settings/hardware

Made with [Cursor](https://cursor.com)