### PR TITLE
Count Orukeet ONNX archive downloads for NeMo

### DIFF
--- a/packages/tasks/src/model-libraries.ts
+++ b/packages/tasks/src/model-libraries.ts
@@ -1076,7 +1076,7 @@ export const MODEL_LIBRARIES_UI_ELEMENTS = {
 		repoUrl: "https://github.com/NVIDIA/NeMo",
 		snippets: snippets.nemo,
 		filter: true,
-		countDownloads: `path_extension:"nemo" OR path:"model_config.yaml" OR path_extension:"json"`,
+		countDownloads: `path_extension:"nemo" OR path:"model_config.yaml" OR path_extension:"json" OR path:"onnx/sherpa-onnx-orukeet-v0.1.0-int8.tar.bz2"`,
 	},
 	ninfer: {
 		prettyLabel: "NInfer",


### PR DESCRIPTION
OpenWhispr v1.10.0 installs [Orukeet](https://huggingface.co/oruk/orukeet), a NeMo-derived model, by downloading one complete ONNX archive. The repository has `library_name: nemo`, but the existing NeMo counting rule does not match that archive.

This adds the exact path `onnx/sherpa-onnx-orukeet-v0.1.0-int8.tar.bz2` to the existing rule. It preserves all current matches and avoids a blanket rule for compressed archives. The bundle contains the encoder, decoder, joiner, and token files; OpenWhispr extracts these locally.

Evidence:
- [Released registry entry and pinned Hugging Face URL](https://github.com/OpenWhispr/openwhispr/blob/v1.10.0/src/models/modelRegistryData.json#L120-L165).
- [Archive download and local extraction](https://github.com/OpenWhispr/openwhispr/blob/v1.10.0/src/helpers/parakeet.js#L376-L424).
- [Manifest at the shipped revision](https://huggingface.co/oruk/orukeet/blob/55a984d46f68323301837194ce647c702f55facc/onnx/manifest.json).

The change is limited to download-counting metadata in this repository. OpenWhispr code, model artifacts, repository metadata, and pinned download URLs are unchanged; existing users need no application update.

Could retained Hub request logs also be used to recalculate earlier downloads of this archive after the rule is deployed? We are asking about the existing download requests, without generating additional client traffic.

Validation: all 31 package tests, TypeScript, ESLint, and formatting pass. Comparing the old and new exact-match rules against all 159 published repository paths adds only the archive and removes no existing matches. Hub-side counting and historical recalculation still require maintainer deployment/confirmation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata string change for analytics; no runtime or auth impact.
> 
> **Overview**
> Extends the **NeMo** library’s Hub download-counting Elasticsearch rule so downloads of the pinned Orukeet ONNX bundle are attributed to NeMo models.
> 
> The `countDownloads` query in `model-libraries.ts` gains one exact-path clause: `onnx/sherpa-onnx-orukeet-v0.1.0-int8.tar.bz2`. Existing matchers (`.nemo`, `model_config.yaml`, `.json`) are unchanged; there is no broad rule for compressed archives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fea5384c72809fb23186de02b99a8b3901eaff7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->