### PR TITLE
📝 Replace removed conversational() snippets on Hub task pages

### DIFF
--- a/packages/tasks/src/about-snippets.spec.ts
+++ b/packages/tasks/src/about-snippets.spec.ts
@@ -1,0 +1,57 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const TASKS_DIR = join(process.cwd(), "src/tasks");
+const INFERENCE_TASKS_INDEX = join(process.cwd(), "../inference/src/tasks/index.ts");
+
+const JS_FENCE = /```(?:javascript|js|typescript|ts)\n([\s\S]*?)```/g;
+const INFERENCE_CALL = /\binference\.(\w+)\s*\(/g;
+const TASK_EXPORT = /export \* from "\.\/(?:[^"]+\/)*([^/"]+)\.js"/g;
+
+function inferenceClientMethods(): Set<string> {
+	const source = readFileSync(INFERENCE_TASKS_INDEX, "utf8");
+	const methods = new Set<string>();
+	for (const match of source.matchAll(TASK_EXPORT)) {
+		methods.add(match[1]);
+	}
+	return methods;
+}
+
+function jsSnippets(markdown: string): string[] {
+	return [...markdown.matchAll(JS_FENCE)].map((match) => match[1]);
+}
+
+describe("about.md huggingface.js snippets", () => {
+	it("call methods that exist on InferenceClient", () => {
+		const methods = inferenceClientMethods();
+		expect(methods.has("textGeneration")).toBe(true);
+		expect(methods.has("textClassification")).toBe(true);
+		expect(methods.has("conversational")).toBe(false);
+
+		const unknownCalls: string[] = [];
+
+		for (const entry of readdirSync(TASKS_DIR, { withFileTypes: true })) {
+			if (!entry.isDirectory()) {
+				continue;
+			}
+
+			const aboutPath = join(TASKS_DIR, entry.name, "about.md");
+			if (!existsSync(aboutPath)) {
+				continue;
+			}
+
+			const markdown = readFileSync(aboutPath, "utf8");
+			for (const snippet of jsSnippets(markdown)) {
+				for (const call of snippet.matchAll(INFERENCE_CALL)) {
+					const method = call[1];
+					if (!methods.has(method)) {
+						unknownCalls.push(`${entry.name}: inference.${method}()`);
+					}
+				}
+			}
+		}
+
+		expect(unknownCalls).toEqual([]);
+	});
+});

--- a/packages/tasks/src/tasks/text-classification/about.md
+++ b/packages/tasks/src/tasks/text-classification/about.md
@@ -118,7 +118,7 @@ You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to i
 import { InferenceClient } from "@huggingface/inference";
 
 const inference = new InferenceClient(HF_TOKEN);
-await inference.conversational({
+await inference.textClassification({
 	model: "distilbert-base-uncased-finetuned-sst-2-english",
 	inputs: "I love this movie!",
 });

--- a/packages/tasks/src/tasks/text-generation/about.md
+++ b/packages/tasks/src/tasks/text-generation/about.md
@@ -71,15 +71,15 @@ text2text_generator("translate from English to French: I'm very happy")
 [{'generated_text': 'Je suis très heureux'}]
 ```
 
-You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer text classification models on Hugging Face Hub.
+You can use [huggingface.js](https://github.com/huggingface/huggingface.js) to infer text generation models on Hugging Face Hub.
 
 ```javascript
 import { InferenceClient } from "@huggingface/inference";
 
 const inference = new InferenceClient(HF_TOKEN);
-await inference.conversational({
-	model: "distilbert-base-uncased-finetuned-sst-2-english",
-	inputs: "I love this movie!",
+await inference.textGeneration({
+	model: "HuggingFaceH4/zephyr-7b-beta",
+	inputs: "Hello, I'm a language model",
 });
 ```
 


### PR DESCRIPTION
## Summary

Replaced `InferenceClient.conversational()` on the Hub task pages for text generation and text classification with `textGeneration` and `textClassification`, same shape as the sibling task-page JS snippets (`summarization`, `translation`, `imageClassification`). `conversational()` was removed in #457. Those leftover calls are the TypeScript error in #586 (`Property 'conversational' does not exist on type 'HfInference'`).

On the text-generation page, also dropped the copy-pasted classification model and intro so the example matches the Python `text-generation` snippet above it.

Fixes #586.

Alternative: `chatCompletion` (current chatbot API; Hub model-page snippet templates already emit this) or `textGenerationStream` (named on #586 in 2024). Can switch the text-generation snippet in a follow-up if you want the chatbot API on that page instead.

## Test plan

- [x] `pnpm --filter tasks test` (32 passed), including a check that JS `about.md` snippets only call methods exported by `@huggingface/inference`
- [x] That check failed on the unreverted docs (`inference.conversational()` on both pages) and passed after the snippet update
- [x] `pnpm --filter tasks check`, `lint:check`, and `format:check`
- [ ] After merge/publish, confirm https://huggingface.co/tasks/text-generation and https://huggingface.co/tasks/text-classification no longer mention `conversational`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a Vitest guard only; no runtime or inference API changes.
> 
> **Overview**
> Updates Hub task-page **huggingface.js** examples that still called removed **`InferenceClient.conversational()`**, aligning them with current `@huggingface/inference` APIs.
> 
> On **text-classification**, the JS snippet now uses **`textClassification()`** with the same sentiment model and inputs. On **text-generation**, the intro text is corrected (generation vs classification), and the snippet switches to **`textGeneration()`** with `HuggingFaceH4/zephyr-7b-beta` to mirror the Python example above it.
> 
> Adds **`about-snippets.spec.ts`**, which scans every task `about.md` JS fence for `inference.<method>()` calls and fails if the method is not exported from the inference tasks index—preventing stale snippets after API removals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb6f65929c0b2b8c8d4f6b485d5c652abdcebbd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->